### PR TITLE
Whitelist web apps on NIC

### DIFF
--- a/ansible/roles/nginx/templates/site.j2
+++ b/ansible/roles/nginx/templates/site.j2
@@ -18,8 +18,9 @@ upstream {{ balancer.name }} {
 
 {% for var_map in item.server.get('mappings', []) %}
 map {{ var_map.variable }} {{ var_map.name }} {
-  ""     {{ var_map.value }};
-  default     "";
+  {% for mapping in var_map.mappings %}
+    {{ mapping.key }} {{ mapping.value }};
+  {% endfor %}
 }
 {% endfor %}
 

--- a/ansible/roles/nginx/templates/site.j2
+++ b/ansible/roles/nginx/templates/site.j2
@@ -16,6 +16,13 @@ upstream {{ balancer.name }} {
 }
 {% endfor %}
 
+geo $is_remote {
+  default 1;
+  {% for local_ips in item.server.get('local_ips', []) %}
+    {{ local_ips }} 0;
+  {% endfor %}
+}
+
 {% for var_map in item.server.get('mappings', []) %}
 map {{ var_map.variable }} {{ var_map.name }} {
   {% for mapping in var_map.mappings %}
@@ -61,7 +68,7 @@ server {
 {% endif %}
 
 {% for k,v in item.server.iteritems() %}
-  {% if k.find('location') == -1 and k not in ['file_name', 'balancers', 'proxy_set_headers', 'upstream_port', 'limit_req_zones', 'proxy_cache_path', 'mappings'] %}
+  {% if k.find('location') == -1 and k not in ['file_name', 'balancers', 'proxy_set_headers', 'upstream_port', 'limit_req_zones', 'proxy_cache_path', 'mappings', 'local_ips'] %}
   {{ k }} {{ v }};
   {% endif %}
 {% endfor %}

--- a/ansible/roles/nginx/templates/site.j2
+++ b/ansible/roles/nginx/templates/site.j2
@@ -16,12 +16,14 @@ upstream {{ balancer.name }} {
 }
 {% endfor %}
 
+{% if item.server.get('local_ips') %}
 geo $is_remote {
   default 1;
   {% for local_ips in item.server.get('local_ips', []) %}
     {{ local_ips }} 0;
   {% endfor %}
 }
+{% endif %}
 
 {% for var_map in item.server.get('mappings', []) %}
 map {{ var_map.variable }} {{ var_map.name }} {

--- a/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/ansible/roles/nginx/vars/cas_ssl.yml
@@ -18,7 +18,7 @@ nginx_sites:
     - name: "$digest_submission"
       variable: '"$is_remote:$http_authorization"'
       mappings:
-        - key: '"^1:"'
+        - key: '"~^1:"'
           value: "$server_name"
         - key: '"~^1:.+"'
           value: '""'

--- a/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/ansible/roles/nginx/vars/cas_ssl.yml
@@ -109,6 +109,11 @@ nginx_sites:
          - zone_name: "submissions"
            burst: 100
            nodelay: True
+     - name: "/hq/admin/session_details"
+       balancer: "{{ deploy_env }}_cas_commcare"
+       proxy_redirect: "http://{{ CAS_SITE_HOST }} https://{{ CAS_SITE_HOST }}"
+       proxy_next_upstream_tries: 1
+       proxy_read_timeout: 900s
      - name: /
        balancer: "{{ deploy_env }}_cas_commcare"
        proxy_redirect: "http://{{ CAS_SITE_HOST }} https://{{ CAS_SITE_HOST }}"

--- a/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/ansible/roles/nginx/vars/cas_ssl.yml
@@ -16,10 +16,12 @@ nginx_sites:
     - '10.247.24.0/24'
    mappings:
     - name: "$digest_submission"
-      variable: "$http_authorization"
+      variable: '"$is_remote:$http_authorization"'
       mappings:
-        - key: '""'
+        - key: '"^1:"'
           value: "$server_name"
+        - key: '"~^1:.+"'
+          value: '""'
         - key: "default"
           value: '""'
    limit_req_zones:

--- a/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/ansible/roles/nginx/vars/cas_ssl.yml
@@ -12,6 +12,8 @@ nginx_sites:
       hosts: formplayer
       port: "{{ formplayer_port }}"
       method: "hash $cookie_sessionid consistent"
+   local_ips:
+    - '10.247.24.0/24'
    mappings:
     - name: "$digest_submission"
       variable: "$http_authorization"

--- a/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/ansible/roles/nginx/vars/cas_ssl.yml
@@ -15,7 +15,11 @@ nginx_sites:
    mappings:
     - name: "$digest_submission"
       variable: "$http_authorization"
-      value: "$server_name"
+      mappings:
+        - key: '""'
+          value: "$server_name"
+        - key: "default"
+          value: '""'
    limit_req_zones:
     - name: "restore"
       zone: "$server_name"

--- a/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/ansible/roles/nginx/vars/cas_ssl.yml
@@ -20,8 +20,6 @@ nginx_sites:
       mappings:
         - key: '"~^1:"'
           value: "$server_name"
-        - key: '"~^1:.+"'
-          value: '""'
         - key: "default"
           value: '""'
    limit_req_zones:


### PR DESCRIPTION
Changes from this branch:

```
@@ -18,10 +18,16 @@
   server 10.247.24.20:8181;
 }
 

-map $http_authorization $digest_submission {
-  ""     $server_name;
-  default     "";
-}
+geo $is_remote {
+  default 1;
+      10.247.24.0/24 0;
+  }
+
+map "$is_remote:$http_authorization" $digest_submission {
+      "~^1:" $server_name;
+      "~^1:.+" "";
+      default "";
+  }
```

What this means to me:
1) assign $is_remote a value of 1 if remote or a value of 0 if a local IP
2) If a request is from a remote IP and has a blank HTTP authorization header, use $server_name to rate limit
3) if a request is from a remote IP and has an HTTP authorization header, do not rate limit
4) If it is a local IP do not rate limit

sources:
mapping multiple variables https://serverfault.com/questions/760380/how-to-specify-several-variables-in-the-map-directive-of-nginx
whitelisting by ip example: https://www.nginx.com/blog/rate-limiting-nginx/

@snopoke buddies @gcapalbo @calellowitz 