### PR TITLE
increase proxy buffer size to 64k

### DIFF
--- a/ansible/roles/nginx/vars/cchq_ssl.yml
+++ b/ansible/roles/nginx/vars/cchq_ssl.yml
@@ -30,6 +30,8 @@ nginx_sites:
       proxy_redirect: "http://{{ SITE_HOST }} https://{{ SITE_HOST }}"
       proxy_next_upstream_tries: 1
       proxy_read_timeout: 900s
+      proxy_buffers: 8 64k
+      proxy_buffer_size: 64k
     - name: "/static"
       alias: "{{ nginx_static_home }}"
       add_header: "Access-Control-Allow-Origin *"


### PR DESCRIPTION
@ctsims noticed a lot of warnings related to this in enikshay logs. The default limits seem super low, so I'm upping this a bit to see if it changes the volume of these errors (which we can see in datadog).