### PR TITLE
Run bower commands on web workers

### DIFF
--- a/fab/fab/operations/staticfiles.py
+++ b/fab/fab/operations/staticfiles.py
@@ -40,7 +40,7 @@ def _version_static():
 
 
 @parallel
-@roles(ROLES_STATIC)
+@roles(set(ROLES_STATIC + ROLES_DJANGO))
 def bower_install():
     with cd(env.code_root):
         config = {


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?267467

Bower commands need to run on webworkers because build_requirejs runs on webworkers and needs access to r.js

@dannyroberts 
code buddy @calellowitz 