### PR TITLE
use ip address

### DIFF
--- a/ansible/roles/couchdb/templates/local.ini.j2
+++ b/ansible/roles/couchdb/templates/local.ini.j2
@@ -15,7 +15,7 @@ view_index_dir = {{ couch_data_dir }}
 
 [httpd]
 port = 5984
-bind_address = {{ inventory_hostname|ipaddr }}
+bind_address = {{ ansible_default_ipv4.address }}
 ; Options for the MochiWeb HTTP server.
 ;server_options = [{backlog, 128}, {acceptor_pool_size, 16}]
 ; For more socket options, consult Erlang's module 'inet' man page.


### PR DESCRIPTION
ipaddr filter returns False if not an IP address.
i've changed it to ansible_default_ipv4, which works in monoliths, not sure if it works in prod.
perhaps we could just use {{ inventory_hostname }} ?