### PR TITLE
Allow for commcare-cloud command aliases

### DIFF
--- a/commcare-cloud/commcare_cloud/argparse14.py
+++ b/commcare-cloud/commcare_cloud/argparse14.py
@@ -1,3 +1,13 @@
+"""
+This file allows us to import argparse 1.4, a future version
+
+not available in the python 2.7's standard library (but is in python3).
+This file allows us to use the following relative import statement
+
+  from .argparse14 import ArgumentParser
+
+rather than inlining this manual import magic.
+"""
 from __future__ import print_function
 from __future__ import absolute_import
 import pkgutil

--- a/commcare-cloud/commcare_cloud/argparse14.py
+++ b/commcare-cloud/commcare_cloud/argparse14.py
@@ -11,14 +11,10 @@ rather than inlining this manual import magic.
 from __future__ import print_function
 from __future__ import absolute_import
 import pkgutil
-import sys
-import os
+from commcare_cloud.environment import get_virtualenv_site_packages_path
 
-for filepath in sys.path:
-    if os.path.isdir(filepath) and 'argparse.py' in os.listdir(filepath):
-        argparse = pkgutil.get_importer(filepath).find_module('argparse').load_module('argparse')
-else:
-    import argparse
+site_packages = get_virtualenv_site_packages_path()
+argparse = pkgutil.get_importer(site_packages).find_module('argparse').load_module('argparse')
 
 ArgumentParser = argparse.ArgumentParser
 

--- a/commcare-cloud/commcare_cloud/argparse14.py
+++ b/commcare-cloud/commcare_cloud/argparse14.py
@@ -1,0 +1,15 @@
+from __future__ import print_function
+from __future__ import absolute_import
+import pkgutil
+import sys
+import os
+
+for filepath in sys.path:
+    if os.path.isdir(filepath) and 'argparse.py' in os.listdir(filepath):
+        argparse = pkgutil.get_importer(filepath).find_module('argparse').load_module('argparse')
+else:
+    import argparse
+
+ArgumentParser = argparse.ArgumentParser
+
+__all__ = ['ArgumentParser']

--- a/commcare-cloud/commcare_cloud/commands/ansible/ansible_playbook.py
+++ b/commcare-cloud/commcare_cloud/commands/ansible/ansible_playbook.py
@@ -21,6 +21,7 @@ class AnsiblePlaybook(CommandBase):
         "but with boilerplate settings already set based on your <environment>. "
         "By default, you will see --check output and then asked whether to apply. "
     )
+    aliases = ('ap',)
 
     @classmethod
     def make_parser(cls, parser):

--- a/commcare-cloud/commcare_cloud/commands/ansible/ansible_playbook.py
+++ b/commcare-cloud/commcare_cloud/commands/ansible/ansible_playbook.py
@@ -124,7 +124,7 @@ class AnsiblePlaybook(CommandBase):
         exit(exit_code)
 
 
-class _AnsiblePlaybookAlias(AnsiblePlaybook):
+class _AnsiblePlaybookAlias(CommandBase):
     def make_parser(self):
         arg_skip_check(self.parser)
         arg_quiet(self.parser)
@@ -142,7 +142,7 @@ class UpdateConfig(_AnsiblePlaybookAlias):
     def run(self, args, unknown_args):
         args.playbook = 'deploy_localsettings.yml'
         unknown_args += ('--tags=localsettings',)
-        super(UpdateConfig, self).run(args, unknown_args)
+        AnsiblePlaybook(self.parser).run(args, unknown_args)
 
 
 class AfterReboot(_AnsiblePlaybookAlias):
@@ -160,7 +160,7 @@ class AfterReboot(_AnsiblePlaybookAlias):
         args.playbook = 'deploy_stack.yml'
         args.skip_check = True
         unknown_args += ('--tags=after-reboot', '--limit', args.inventory_group)
-        super(AfterReboot, self).run(args, unknown_args)
+        AnsiblePlaybook(self.parser).run(args, unknown_args)
 
 
 class RestartElasticsearch(_AnsiblePlaybookAlias):
@@ -178,7 +178,7 @@ class RestartElasticsearch(_AnsiblePlaybookAlias):
             "except in a few cases where an index is replicated across multiple nodes."))
         if not ask('Do a rolling restart of the ES cluster?', strict=True, quiet=args.quiet):
             exit(0)
-        super(RestartElasticsearch, self).run(args, unknown_args)
+        AnsiblePlaybook(self.parser).run(args, unknown_args)
 
 
 class BootstrapUsers(_AnsiblePlaybookAlias):
@@ -195,4 +195,4 @@ class BootstrapUsers(_AnsiblePlaybookAlias):
         unknown_args += ('--tags=users', '-u', root_user)
         if not public_vars.get('commcare_cloud_pem'):
             unknown_args += ('--ask-pass',)
-        super(BootstrapUsers, self).run(args, unknown_args)
+        AnsiblePlaybook(self.parser).run(args, unknown_args)

--- a/commcare-cloud/commcare_cloud/commands/ansible/run_module.py
+++ b/commcare-cloud/commcare_cloud/commands/ansible/run_module.py
@@ -146,14 +146,14 @@ class RunAnsibleModule(CommandBase):
         exit(exit_code)
 
 
-class RunShellCommand(RunAnsibleModule):
+class RunShellCommand(CommandBase):
     command = 'run-shell-command'
     help = 'Run an arbitrary command via the shell module.'
 
     def make_parser(self):
         arg_inventory_group(self.parser)
         self.parser.add_argument('shell_command', help="The shell command you want to run")
-        super(RunShellCommand, self).add_non_positional_arguments()
+        RunAnsibleModule(self.parser).add_non_positional_arguments()
 
     def run(self, args, unknown_args):
         if args.shell_command.strip().startswith('sudo '):
@@ -168,4 +168,4 @@ class RunShellCommand(RunAnsibleModule):
         args.skip_check = True
         args.quiet = True
         del args.shell_command
-        super(RunShellCommand, self).run(args, unknown_args)
+        RunAnsibleModule(self.parser).run(args, unknown_args)

--- a/commcare-cloud/commcare_cloud/commands/ansible/run_module.py
+++ b/commcare-cloud/commcare_cloud/commands/ansible/run_module.py
@@ -6,6 +6,7 @@ from clint.textui import puts, colored
 from commcare_cloud.cli_utils import ask
 from commcare_cloud.commands.ansible.helpers import AnsibleContext, DEPRECATED_ANSIBLE_ARGS, \
     get_common_ssh_args
+from commcare_cloud.commands.command_base import CommandBase
 from commcare_cloud.commands.shared_args import arg_inventory_group, arg_skip_check, arg_quiet, \
     arg_stdout_callback
 from commcare_cloud.parse_help import add_to_help_text, filtered_help_message
@@ -13,21 +14,21 @@ from commcare_cloud.environment import ANSIBLE_DIR, get_inventory_filepath, get_
     get_public_vars_filepath, get_public_vars
 
 
-class RunAnsibleModule(object):
+class RunAnsibleModule(CommandBase):
     command = 'run-module'
     help = (
         'Run an arbitrary Ansible module.'
     )
 
-    @staticmethod
-    def make_parser(parser):
+    @classmethod
+    def make_parser(cls, parser):
         arg_inventory_group(parser)
         parser.add_argument('module', help="The module to run")
         parser.add_argument('module_args', help="The arguments to pass to the module")
         RunAnsibleModule.add_non_positional_arguments(parser)
 
-    @staticmethod
-    def add_non_positional_arguments(parser):
+    @classmethod
+    def add_non_positional_arguments(cls, parser):
         parser.add_argument('-u', '--user', dest='remote_user', default='ansible', help=(
             "connect as this user (default=ansible)"
         ))
@@ -62,8 +63,8 @@ class RunAnsibleModule(object):
             )
         ))
 
-    @staticmethod
-    def run(args, unknown_args):
+    @classmethod
+    def run(cls, args, unknown_args):
         ansible_context = AnsibleContext(args)
         public_vars = get_public_vars(args.environment)
 
@@ -148,18 +149,18 @@ class RunAnsibleModule(object):
         exit(exit_code)
 
 
-class RunShellCommand(object):
+class RunShellCommand(CommandBase):
     command = 'run-shell-command'
     help = 'Run an arbitrary command via the shell module.'
 
-    @staticmethod
-    def make_parser(parser):
+    @classmethod
+    def make_parser(cls, parser):
         arg_inventory_group(parser)
         parser.add_argument('shell_command', help="The shell command you want to run")
         RunAnsibleModule.add_non_positional_arguments(parser)
 
-    @staticmethod
-    def run(args, unknown_args):
+    @classmethod
+    def run(cls, args, unknown_args):
         if args.shell_command.strip().startswith('sudo '):
             puts(colored.yellow(
                 "To run as another user use `--become` (for root) or `--become-user <user>`.\n"

--- a/commcare-cloud/commcare_cloud/commands/ansible/run_module.py
+++ b/commcare-cloud/commcare_cloud/commands/ansible/run_module.py
@@ -20,28 +20,26 @@ class RunAnsibleModule(CommandBase):
         'Run an arbitrary Ansible module.'
     )
 
-    @classmethod
-    def make_parser(cls, parser):
-        arg_inventory_group(parser)
-        parser.add_argument('module', help="The module to run")
-        parser.add_argument('module_args', help="The arguments to pass to the module")
-        RunAnsibleModule.add_non_positional_arguments(parser)
+    def make_parser(self):
+        arg_inventory_group(self.parser)
+        self.parser.add_argument('module', help="The module to run")
+        self.parser.add_argument('module_args', help="The arguments to pass to the module")
+        self.add_non_positional_arguments()
 
-    @classmethod
-    def add_non_positional_arguments(cls, parser):
-        parser.add_argument('-u', '--user', dest='remote_user', default='ansible', help=(
+    def add_non_positional_arguments(self):
+        self.parser.add_argument('-u', '--user', dest='remote_user', default='ansible', help=(
             "connect as this user (default=ansible)"
         ))
-        parser.add_argument('-b', '--become', action='store_true', help=(
+        self.parser.add_argument('-b', '--become', action='store_true', help=(
             "run operations with become (implies vault password prompting if necessary)"
         ))
-        parser.add_argument('--become-user', help=(
+        self.parser.add_argument('--become-user', help=(
             "run operations as this user (default=root)"
         ))
-        arg_skip_check(parser)
-        arg_quiet(parser)
-        arg_stdout_callback(parser)
-        add_to_help_text(parser, "\n{}\n{}".format(
+        arg_skip_check(self.parser)
+        arg_quiet(self.parser)
+        arg_stdout_callback(self.parser)
+        add_to_help_text(self.parser, "\n{}\n{}".format(
             "The ansible options below are available as well",
             filtered_help_message(
                 "ansible -h",
@@ -63,8 +61,7 @@ class RunAnsibleModule(CommandBase):
             )
         ))
 
-    @classmethod
-    def run(cls, args, unknown_args):
+    def run(self, args, unknown_args):
         ansible_context = AnsibleContext(args)
         public_vars = get_public_vars(args.environment)
 
@@ -149,18 +146,16 @@ class RunAnsibleModule(CommandBase):
         exit(exit_code)
 
 
-class RunShellCommand(CommandBase):
+class RunShellCommand(RunAnsibleModule):
     command = 'run-shell-command'
     help = 'Run an arbitrary command via the shell module.'
 
-    @classmethod
-    def make_parser(cls, parser):
-        arg_inventory_group(parser)
-        parser.add_argument('shell_command', help="The shell command you want to run")
-        RunAnsibleModule.add_non_positional_arguments(parser)
+    def make_parser(self):
+        arg_inventory_group(self.parser)
+        self.parser.add_argument('shell_command', help="The shell command you want to run")
+        super(RunShellCommand, self).add_non_positional_arguments()
 
-    @classmethod
-    def run(cls, args, unknown_args):
+    def run(self, args, unknown_args):
         if args.shell_command.strip().startswith('sudo '):
             puts(colored.yellow(
                 "To run as another user use `--become` (for root) or `--become-user <user>`.\n"
@@ -173,4 +168,4 @@ class RunShellCommand(CommandBase):
         args.skip_check = True
         args.quiet = True
         del args.shell_command
-        RunAnsibleModule.run(args, unknown_args)
+        super(RunShellCommand, self).run(args, unknown_args)

--- a/commcare-cloud/commcare_cloud/commands/command_base.py
+++ b/commcare-cloud/commcare_cloud/commands/command_base.py
@@ -1,0 +1,19 @@
+import abc
+import six
+
+# this is just to document intent; the subclass will use @classmethod
+abstractclassmethod = abc.abstractmethod
+
+
+@six.add_metaclass(abc.ABCMeta)
+class CommandBase(object):
+    command = None
+    help = None
+
+    @abstractclassmethod
+    def make_parser(cls, parser):
+        pass
+
+    @abstractclassmethod
+    def run(cls, args, unknown_args):
+        pass

--- a/commcare-cloud/commcare_cloud/commands/command_base.py
+++ b/commcare-cloud/commcare_cloud/commands/command_base.py
@@ -1,9 +1,6 @@
 import abc
 import six
 
-# this is just to document intent; the subclass will use @classmethod
-abstractclassmethod = abc.abstractmethod
-
 
 @six.add_metaclass(abc.ABCMeta)
 class CommandBase(object):
@@ -11,10 +8,14 @@ class CommandBase(object):
     help = None
     aliases = ()
 
-    @abstractclassmethod
-    def make_parser(cls, parser):
+    def __init__(self, parser):
+        self.parser = parser
+        self.make_parser()
+
+    @abc.abstractmethod
+    def make_parser(self):
         pass
 
-    @abstractclassmethod
-    def run(cls, args, unknown_args):
+    @abc.abstractmethod
+    def run(self, args, unknown_args):
         pass

--- a/commcare-cloud/commcare_cloud/commands/command_base.py
+++ b/commcare-cloud/commcare_cloud/commands/command_base.py
@@ -10,7 +10,6 @@ class CommandBase(object):
 
     def __init__(self, parser):
         self.parser = parser
-        self.make_parser()
 
     @abc.abstractmethod
     def make_parser(self):

--- a/commcare-cloud/commcare_cloud/commands/command_base.py
+++ b/commcare-cloud/commcare_cloud/commands/command_base.py
@@ -9,6 +9,7 @@ abstractclassmethod = abc.abstractmethod
 class CommandBase(object):
     command = None
     help = None
+    aliases = ()
 
     @abstractclassmethod
     def make_parser(cls, parser):

--- a/commcare-cloud/commcare_cloud/commands/fab.py
+++ b/commcare-cloud/commcare_cloud/commands/fab.py
@@ -10,12 +10,10 @@ class Fab(CommandBase):
         "Run a fab command as you would with fab"
     )
 
-    @classmethod
-    def make_parser(cls, parser):
-        parser.add_argument(dest='fab_command', help="fab command", default=None)
+    def make_parser(self):
+        self.parser.add_argument(dest='fab_command', help="fab command", default=None)
 
-    @classmethod
-    def run(cls, args, unknown_args):
+    def run(self, args, unknown_args):
         cmd_parts = (
             'fab', '-f', FABFILE,
             args.environment,

--- a/commcare-cloud/commcare_cloud/commands/fab.py
+++ b/commcare-cloud/commcare_cloud/commands/fab.py
@@ -1,20 +1,21 @@
 import os
+from .command_base import CommandBase
 from ..environment import FABFILE
 from six.moves import shlex_quote
 
 
-class Fab(object):
+class Fab(CommandBase):
     command = 'fab'
     help = (
         "Run a fab command as you would with fab"
     )
 
-    @staticmethod
-    def make_parser(parser):
+    @classmethod
+    def make_parser(cls, parser):
         parser.add_argument(dest='fab_command', help="fab command", default=None)
 
-    @staticmethod
-    def run(args, unknown_args):
+    @classmethod
+    def run(cls, args, unknown_args):
         cmd_parts = (
             'fab', '-f', FABFILE,
             args.environment,

--- a/commcare-cloud/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/commcare-cloud/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -9,45 +9,40 @@ class Lookup(CommandBase):
     command = 'lookup'
     help = "Lookup remote hostname or IP address"
 
-    @classmethod
-    def make_parser(cls, parser):
-        cls.parser = parser
-        parser.add_argument("server",
+    def make_parser(self):
+        self.parser.add_argument("server",
             help="Server name/group: postgresql, proxy, webworkers, ... The server "
                  "name/group may be prefixed with 'username@' to login as a specific "
                  "user and may be terminated with ':<n>' to choose one of "
                  "multiple servers if there is more than one in the group. "
                  "For example: webworkers:0 will pick the first webworker.")
 
-    @classmethod
-    def lookup_server_address(cls, args):
+    def lookup_server_address(self, args):
         def exit(message):
-            cls.parser.error("\n" + message)
+            self.parser.error("\n" + message)
         return get_server_address(args.environment, args.server, exit)
 
-    @classmethod
-    def run(cls, args, unknown_args):
+    def run(self, args, unknown_args):
         if unknown_args:
             sys.stderr.write(
                 "Ignoring extra argument(s): {}\n".format(unknown_args)
             )
-        print(cls.lookup_server_address(args))
+        print(self.lookup_server_address(args))
 
 
 class Ssh(Lookup):
     command = 'ssh'
     help = "Connect to a remote host with ssh"
 
-    @classmethod
-    def run(cls, args, ssh_args):
-        address = cls.lookup_server_address(args)
+    def run(self, args, ssh_args):
+        address = self.lookup_server_address(args)
         if ':' in address:
             address, port = address.split(':')
             ssh_args = ['-p', port] + ssh_args
-        cmd_parts = [cls.command, address] + ssh_args
+        cmd_parts = [self.command, address] + ssh_args
         cmd = ' '.join(shlex_quote(arg) for arg in cmd_parts)
         print(cmd)
-        os.execvp(cls.command, cmd_parts)
+        os.execvp(self.command, cmd_parts)
 
 
 class Mosh(Ssh):

--- a/commcare-cloud/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/commcare-cloud/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -1,10 +1,11 @@
 import os
 import sys
+from commcare_cloud.commands.command_base import CommandBase
 from .getinventory import get_server_address
 from six.moves import shlex_quote
 
 
-class Lookup(object):
+class Lookup(CommandBase):
     command = 'lookup'
     help = "Lookup remote hostname or IP address"
 

--- a/commcare-cloud/commcare_cloud/commcare_cloud.py
+++ b/commcare-cloud/commcare_cloud/commcare_cloud.py
@@ -2,13 +2,14 @@
 from __future__ import print_function
 from __future__ import absolute_import
 import os
-from argparse import ArgumentParser
+from .argparse14 import ArgumentParser
 
 from .commands.ansible.ansible_playbook import AnsiblePlaybook, \
     UpdateConfig, AfterReboot, RestartElasticsearch, BootstrapUsers
 from .commands.ansible.run_module import RunAnsibleModule, RunShellCommand
 from .commands.fab import Fab
 from .commands.inventory_lookup.inventory_lookup import Lookup, Ssh, Mosh
+from commcare_cloud.commands.command_base import CommandBase
 from .environment import (
     get_available_envs,
     get_virtualenv_path,
@@ -40,11 +41,13 @@ def main():
     subparsers = parser.add_subparsers(dest='command')
 
     for standard_arg in STANDARD_ARGS:
-        standard_arg.make_parser(subparsers.add_parser(standard_arg.command, help=standard_arg.help))
+        assert issubclass(standard_arg, CommandBase), standard_arg
+        standard_arg.make_parser(subparsers.add_parser(
+            standard_arg.command, help=standard_arg.help, aliases=standard_arg.aliases))
 
     args, unknown_args = parser.parse_known_args()
     for standard_arg in STANDARD_ARGS:
-        if args.command == standard_arg.command:
+        if args.command == standard_arg.command or args.command in standard_arg.aliases:
             standard_arg.run(args, unknown_args)
 
 if __name__ == '__main__':

--- a/commcare-cloud/commcare_cloud/commcare_cloud.py
+++ b/commcare-cloud/commcare_cloud/commcare_cloud.py
@@ -52,7 +52,6 @@ def main():
             commands[alias] = cmd
 
     args, unknown_args = parser.parse_known_args()
-    print(args, unknown_args)
     commands[args.command].run(args, unknown_args)
 
 if __name__ == '__main__':

--- a/commcare-cloud/commcare_cloud/commcare_cloud.py
+++ b/commcare-cloud/commcare_cloud/commcare_cloud.py
@@ -46,12 +46,13 @@ def main():
         assert issubclass(command_type, CommandBase), command_type
         cmd = command_type(subparsers.add_parser(
             command_type.command, help=command_type.help, aliases=command_type.aliases))
-
+        cmd.make_parser()
         commands[cmd.command] = cmd
         for alias in cmd.aliases:
             commands[alias] = cmd
 
     args, unknown_args = parser.parse_known_args()
+    print(args, unknown_args)
     commands[args.command].run(args, unknown_args)
 
 if __name__ == '__main__':

--- a/commcare-cloud/commcare_cloud/commcare_cloud.py
+++ b/commcare-cloud/commcare_cloud/commcare_cloud.py
@@ -16,7 +16,7 @@ from .environment import (
 )
 
 
-STANDARD_ARGS = [
+COMMAND_TYPES = [
     AnsiblePlaybook,
     UpdateConfig,
     AfterReboot,
@@ -40,15 +40,19 @@ def main():
     ))
     subparsers = parser.add_subparsers(dest='command')
 
-    for standard_arg in STANDARD_ARGS:
-        assert issubclass(standard_arg, CommandBase), standard_arg
-        standard_arg.make_parser(subparsers.add_parser(
-            standard_arg.command, help=standard_arg.help, aliases=standard_arg.aliases))
+    commands = {}
+
+    for command_type in COMMAND_TYPES:
+        assert issubclass(command_type, CommandBase), command_type
+        cmd = command_type(subparsers.add_parser(
+            command_type.command, help=command_type.help, aliases=command_type.aliases))
+
+        commands[cmd.command] = cmd
+        for alias in cmd.aliases:
+            commands[alias] = cmd
 
     args, unknown_args = parser.parse_known_args()
-    for standard_arg in STANDARD_ARGS:
-        if args.command == standard_arg.command or args.command in standard_arg.aliases:
-            standard_arg.run(args, unknown_args)
+    commands[args.command].run(args, unknown_args)
 
 if __name__ == '__main__':
     main()

--- a/commcare-cloud/commcare_cloud/environment.py
+++ b/commcare-cloud/commcare_cloud/environment.py
@@ -25,6 +25,12 @@ def get_virtualenv_path():
     return os.path.dirname(sys.executable)
 
 
+def get_virtualenv_site_packages_path():
+    for filepath in sys.path:
+        if filepath.startswith(os.path.dirname(get_virtualenv_path())) and filepath.endswith('site-packages'):
+            return filepath
+
+
 def get_available_envs():
     return sorted(
         env for env in os.listdir(ENVIRONMENTS_DIR)

--- a/commcare-cloud/setup.py
+++ b/commcare-cloud/setup.py
@@ -15,6 +15,6 @@ setup(
     install_requires=(
         'six',
         'clint',
-        'argparse',
+        'argparse==1.4',
     ),
 )

--- a/commcare-cloud/setup.py
+++ b/commcare-cloud/setup.py
@@ -14,6 +14,7 @@ setup(
     },
     install_requires=(
         'six',
-        'clint'
+        'clint',
+        'argparse',
     ),
 )

--- a/control/.bash_completion
+++ b/control/.bash_completion
@@ -2,7 +2,7 @@ _envs()
 {
     if [[ -z "$COMMCARE_CLOUD_ENVS" ]]
     then
-        COMMCARE_CLOUD_ENVS=$(commcare-cloud -h | head -n2 | tail -n1 | cut -d'{' -f2 | cut -d'}' -f1 | sed 's/,/ /g')
+        COMMCARE_CLOUD_ENVS=$(commcare-cloud -h | head -n3 | tail -n1 | cut -d'{' -f2 | cut -d'}' -f1 | sed 's/,/ /g')
     fi
     echo $COMMCARE_CLOUD_ENVS
 }
@@ -11,7 +11,7 @@ _cmds()
 {
     if [[ -z "$COMMCARE_CLOUD_CMDS" ]]
     then
-        COMMCARE_CLOUD_CMDS=$(commcare-cloud -h | head -n3 | tail -n1 | cut -d'{' -f2 | cut -d'}' -f1 | sed 's/,/ /g')
+        COMMCARE_CLOUD_CMDS=$(commcare-cloud -h | head -n4 | tail -n1 | cut -d'{' -f2 | cut -d'}' -f1 | sed 's/,/ /g')
     fi
     echo $COMMCARE_CLOUD_CMDS
 }


### PR DESCRIPTION
This PR adds an alias `ap` for `ansible-playbook`

```
commcare-cloud <env> ap <playbook> ...
```

as well as doing some restructuring that makes adding other aliases trivial.

This required adding the latest pip argparse, which comes with python3 but not python2, as a dependency, and then doing a few lines of black magic to manually import that instead of the standard library argparse. (Python 2 Standard library `argparse` doesn't include support for aliases.) If this feels too gross to people, I can always scrap the alias feature and just PR the first commit (which which gives all command classes a shared base class), which is a nice change in itself.