### PR TITLE
add deploy-stack commmand with alias aps

### DIFF
--- a/commcare-cloud/commcare_cloud/commands/ansible/ansible_playbook.py
+++ b/commcare-cloud/commcare_cloud/commands/ansible/ansible_playbook.py
@@ -132,6 +132,19 @@ class _AnsiblePlaybookAlias(CommandBase):
         arg_stdout_callback(self.parser)
 
 
+class DeployStack(_AnsiblePlaybookAlias):
+    command = 'deploy-stack'
+    aliases = ('aps',)
+    help = (
+        "Run the ansible playbook for deploying the entire stack. "
+        "Often used in conjunction with --limit and/or --tag for a more specific update."
+    )
+
+    def run(self, args, unknown_args):
+        args.playbook = 'deploy_stack.yml'
+        AnsiblePlaybook(self.parser).run(args, unknown_args)
+
+
 class UpdateConfig(_AnsiblePlaybookAlias):
     command = 'update-config'
     help = (

--- a/commcare-cloud/commcare_cloud/commcare_cloud.py
+++ b/commcare-cloud/commcare_cloud/commcare_cloud.py
@@ -5,7 +5,7 @@ import os
 from .argparse14 import ArgumentParser
 
 from .commands.ansible.ansible_playbook import AnsiblePlaybook, \
-    UpdateConfig, AfterReboot, RestartElasticsearch, BootstrapUsers
+    UpdateConfig, AfterReboot, RestartElasticsearch, BootstrapUsers, DeployStack
 from .commands.ansible.run_module import RunAnsibleModule, RunShellCommand
 from .commands.fab import Fab
 from .commands.inventory_lookup.inventory_lookup import Lookup, Ssh, Mosh
@@ -18,6 +18,7 @@ from .environment import (
 
 COMMAND_TYPES = [
     AnsiblePlaybook,
+    DeployStack,
     UpdateConfig,
     AfterReboot,
     RestartElasticsearch,


### PR DESCRIPTION
Adds

```
commcare-cloud <env> deploy-stack <...>
```
with the alias `aps` as well. In its shortest form (also using the `cchq` alias) it could be

```
cchq <env> aps <...>
```