### PR TITLE
put each inventory variable on a different line (typo)

### DIFF
--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -12,7 +12,8 @@ hqdb0.internal-va.commcarehq.org
 [hqdb0:vars]
 hot_standby_server=hqstandby0.internal-va.commcarehq.org
 postgresql_replication_slots=['standby','spare']
-datavol_device=/dev/xvdb datadog_integration_cloudant=true
+datavol_device=/dev/xvdb
+datadog_integration_cloudant=true
 
 [hqdb1]
 hqdb1.internal-va.commcarehq.org


### PR DESCRIPTION
just stumbled across this, pretty sure this was just an oversight.
Not sure if the before and after are semantically equivalent or not,
but I think either way it is unlikely to have made a difference,
and the new way is surely the right one.