### PR TITLE
increase ICDS slow log threshold

### DIFF
--- a/ansible/roles/postgresql/defaults/main.yml
+++ b/ansible/roles/postgresql/defaults/main.yml
@@ -31,6 +31,7 @@ postgresql_wal_buffers: '-1'
 postgresql_default_statistics_target: '100'
 postgresql_checkpoint_segments: '16'  # V <= 9.4
 postgresql_max_wal_size: '256MB'  # V >= 9.6
+postgresql_slow_log_threshold: 300
 
 pgbouncer_max_connections: 100
 pgbouncer_default_pool: 15

--- a/ansible/roles/postgresql/templates/postgresql.conf.j2
+++ b/ansible/roles/postgresql/templates/postgresql.conf.j2
@@ -84,7 +84,7 @@ log_rotation_size = 100000
 client_min_messages = notice
 log_min_messages = warning
 log_min_error_statement = error
-log_min_duration_statement = 300
+log_min_duration_statement = {{ postgresql_slow_log_threshold }}
 
 log_checkpoints = on
 log_connections = on

--- a/environments/icds-new/public.yml
+++ b/environments/icds-new/public.yml
@@ -70,6 +70,7 @@ postgresql_version: '9.6'
 postgresql_shared_buffers: '8GB'
 postgresql_max_stack_depth: '6MB'
 postgresql_effective_cache_size: '16GB'
+postgresql_slow_log_threshold: 1000
 pgbouncer_reserve_pool: 5
 pgbouncer_pool_timeout: 1
 pgbouncer_pool_mode: transaction


### PR DESCRIPTION
Current long queries are around 600ms. We could just turn it off but this seemed like a good first move