### PR TITLE
increase concurrency of background_queue on production

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -64,7 +64,7 @@ celery_processes:
       concurrency: 4
       max_tasks_per_child: 1
     background_queue:
-      concurrency: 4
+      concurrency: 8
       max_tasks_per_child: 1
 pillows:
   hqpillowtop2:


### PR DESCRIPTION
To help background_queue recover:
https://app.datadoghq.com/monitors#1704065?group=celery_queue%3Abackground_queue%2Cenvironment%3Aproduction&from_ts=1517493547197&to_ts=1518098347197