### PR TITLE
Set riak backend and ring size on prod

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -23,10 +23,8 @@ active_sites:
   cas_ssl: False
   couchdb2: False
 
-riak_backend: "leveldb-bad-config"
-riak_ring_size: 64
-riak_new_backend: "leveldb"
-riak_new_ring_size: 128
+riak_backend: "leveldb"
+riak_ring_size: 128
 
 # This sets production_commcare as the default endpoint for ssl connections
 primary_ssl_env: "production"


### PR DESCRIPTION
These settings were overlooked when the old cluster was decommissioned. See PR #1224 and branch dm/rm-old-riak-cluster.

@nickpell cc @emord 