### PR TITLE
fix datadog integrations

### DIFF
--- a/ansible/roles/datadog/templates/celery.yaml.j2
+++ b/ansible/roles/datadog/templates/celery.yaml.j2
@@ -2,3 +2,4 @@ init_config:
 
 instances:
   - flower_url: "{{ localsettings.CELERY_FLOWER_URL }}"
+    timeout: 10

--- a/ansible/roles/datadog/templates/nginx.yaml.j2
+++ b/ansible/roles/datadog/templates/nginx.yaml.j2
@@ -7,3 +7,4 @@ instances:
   - nginx_status_url: http://localhost/nginx_stub_status/
     tags:
       - environment:{{ env_name|default(deploy_env) }}
+    no_proxy: True

--- a/ansible/roles/datadog/templates/rabbitmq.yaml.j2
+++ b/ansible/roles/datadog/templates/rabbitmq.yaml.j2
@@ -11,3 +11,4 @@ instances:
       - environment:{{ env_name|default(deploy_env) }}
     vhosts:
       - {{ AMQP_NAME }}
+    no_proxy: True


### PR DESCRIPTION
On ICDS we have proxy settings applied to the OS environment which get picked up by these checks requiring a settings change to force disable using the proxy settings.