### PR TITLE
Remove query_stats for icds p6

### DIFF
--- a/environments/icds-new/public.yml
+++ b/environments/icds-new/public.yml
@@ -111,7 +111,6 @@ postgresql_dbs:
     name: commcarehq_p6
     shards: [515, 617]
     host: "{{ hostvars[groups.pgshard1.0].inventory_hostname }}"
-    query_stats: True
   - django_alias: p7
     name: commcarehq_p7
     shards: [618, 720]


### PR DESCRIPTION
@dimagi/scale-team as I mentioned in the meeting this morning. We'll see if this helps. Will retro if it fixes all our issues

manually dropped the extension