### PR TITLE
fix when so that --check doens't crash

### DIFF
--- a/ansible/roles/ecryptfs/tasks/main.yml
+++ b/ansible/roles/ecryptfs/tasks/main.yml
@@ -76,7 +76,7 @@
 - name: Mount data drive
   become: yes
   shell: "mount -t ecryptfs -o key=passphrase:passphrase_passwd={{ ECRYPTFS_PASSWORD }},user,noauto,ecryptfs_cipher=aes,ecryptfs_key_bytes=32,ecryptfs_unlink_sigs,ecryptfs_enable_filename_crypto=y,ecryptfs_fnek_sig={{ password_hash.stdout }},verbosity=0 {{ encrypted_root }}/ {{ encrypted_root }}/"
-  when: encrypted_root not in mtab_contents.stdout
+  when: (password_hash.stdout is defined) and (encrypted_root not in mtab_contents.stdout)
   tags:
     - mount-ecryptfs
     - after-reboot

--- a/ansible/roles/elasticsearch/tasks/main.yml
+++ b/ansible/roles/elasticsearch/tasks/main.yml
@@ -100,7 +100,7 @@
   become: yes
   service: name=elasticsearch state=started
   register: result
-  failed_when: result.state != "started"
+  failed_when: (result.state is defined) and (result.state != "started")
   tags: after-reboot
 
 - name: Restart Elasticsearch


### PR DESCRIPTION
this  is just to avoid initial --check crashing due to undefined values.