### PR TITLE
Add commcare-cloud <env> django-manage <command>

### DIFF
--- a/commcare-cloud/commcare_cloud/cli_utils.py
+++ b/commcare-cloud/commcare_cloud/cli_utils.py
@@ -1,5 +1,8 @@
+from __future__ import print_function
 import re
 import subprocess
+
+import sys
 from clint.textui import puts, colored
 from .environment import ANSIBLE_DIR
 from six.moves import input
@@ -54,3 +57,12 @@ def check_branch(args):
         else:
             puts(colored.red("You are on branch master. To deploy, remove --branch={}".format(args.branch)))
         exit(-1)
+
+
+def print_command(command):
+    """
+    commcare-cloud commands by convention print the underlying command they execute
+
+    Use this function to do so
+    """
+    print(command, file=sys.stderr)

--- a/commcare-cloud/commcare_cloud/commands/ansible/ansible_playbook.py
+++ b/commcare-cloud/commcare_cloud/commands/ansible/ansible_playbook.py
@@ -3,7 +3,7 @@ import os
 import subprocess
 from six.moves import shlex_quote
 from clint.textui import puts, colored
-from commcare_cloud.cli_utils import ask, has_arg, check_branch
+from commcare_cloud.cli_utils import ask, has_arg, check_branch, print_command
 from commcare_cloud.commands.ansible.helpers import AnsibleContext, DEPRECATED_ANSIBLE_ARGS, \
     get_common_ssh_args
 from commcare_cloud.commands.command_base import CommandBase
@@ -80,7 +80,7 @@ class AnsiblePlaybook(CommandBase):
 
             cmd_parts += get_common_ssh_args(public_vars)
             cmd = ' '.join(shlex_quote(arg) for arg in cmd_parts)
-            print(cmd)
+            print_command(cmd)
             p = subprocess.Popen(cmd, stdin=subprocess.PIPE, shell=True, env=ansible_context.env_vars)
             if ask_vault_pass:
                 p.communicate(input='{}\n'.format(ansible_context.get_ansible_vault_password()))

--- a/commcare-cloud/commcare_cloud/commands/ansible/run_module.py
+++ b/commcare-cloud/commcare_cloud/commands/ansible/run_module.py
@@ -3,7 +3,7 @@ import os
 import subprocess
 from six.moves import shlex_quote
 from clint.textui import puts, colored
-from commcare_cloud.cli_utils import ask
+from commcare_cloud.cli_utils import ask, print_command
 from commcare_cloud.commands.ansible.helpers import AnsibleContext, DEPRECATED_ANSIBLE_ARGS, \
     get_common_ssh_args
 from commcare_cloud.commands.command_base import CommandBase
@@ -102,7 +102,7 @@ class RunAnsibleModule(CommandBase):
 
             cmd_parts += get_common_ssh_args(public_vars)
             cmd = ' '.join(shlex_quote(arg) for arg in cmd_parts)
-            print(cmd)
+            print_command(cmd)
             p = subprocess.Popen(cmd, stdin=subprocess.PIPE, shell=True, env=ansible_context.env_vars)
             if ask_vault_pass:
                 p.communicate(input='{}\n'.format(ansible_context.get_ansible_vault_password()))

--- a/commcare-cloud/commcare_cloud/commands/fab.py
+++ b/commcare-cloud/commcare_cloud/commands/fab.py
@@ -1,4 +1,5 @@
 import os
+from commcare_cloud.cli_utils import print_command
 from .command_base import CommandBase
 from ..environment import FABFILE
 from six.moves import shlex_quote
@@ -21,5 +22,5 @@ class Fab(CommandBase):
             (args.fab_command,) if args.fab_command else ()
         ) + tuple(unknown_args)
         cmd = ' '.join(shlex_quote(arg) for arg in cmd_parts)
-        print(cmd)
+        print_command(cmd)
         os.execvp('fab', cmd_parts)

--- a/commcare-cloud/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/commcare-cloud/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -1,6 +1,8 @@
 from __future__ import print_function
 import os
 import sys
+
+from commcare_cloud.cli_utils import print_command
 from commcare_cloud.commands.command_base import CommandBase
 from commcare_cloud.environment import get_public_vars
 from .getinventory import get_server_address
@@ -29,7 +31,7 @@ class Lookup(CommandBase):
             sys.stderr.write(
                 "Ignoring extra argument(s): {}\n".format(unknown_args)
             )
-        print(self.lookup_server_address(args))
+        print_command(self.lookup_server_address(args))
 
 
 class Ssh(Lookup):
@@ -43,7 +45,7 @@ class Ssh(Lookup):
             ssh_args = ['-p', port] + ssh_args
         cmd_parts = [self.command, address] + ssh_args
         cmd = ' '.join(shlex_quote(arg) for arg in cmd_parts)
-        print(cmd)
+        print_command(cmd)
         os.execvp(self.command, cmd_parts)
 
 

--- a/commcare-cloud/commcare_cloud/commcare_cloud.py
+++ b/commcare-cloud/commcare_cloud/commcare_cloud.py
@@ -8,7 +8,7 @@ from .commands.ansible.ansible_playbook import AnsiblePlaybook, \
     UpdateConfig, AfterReboot, RestartElasticsearch, BootstrapUsers, DeployStack, UpdateUsers
 from .commands.ansible.run_module import RunAnsibleModule, RunShellCommand
 from .commands.fab import Fab
-from .commands.inventory_lookup.inventory_lookup import Lookup, Ssh, Mosh
+from .commands.inventory_lookup.inventory_lookup import Lookup, Ssh, Mosh, DjangoManage
 from commcare_cloud.commands.command_base import CommandBase
 from .environment import (
     get_available_envs,
@@ -30,6 +30,7 @@ COMMAND_TYPES = [
     Lookup,
     Ssh,
     Mosh,
+    DjangoManage,
 ]
 
 


### PR DESCRIPTION
Similar to `commcare-cloud <env> fab manage:<command>` but (1) with nicer syntax and (2) without adding anything to stdout. (Fab has a bunch of extra output, and prefixes every line of manage command output with the host name, etc.)

Example:
```
$ cchq production django-manage list_couchdbs
ssh hqdjango0.internal-va.commcarehq.org 'sudo -u cchq /home/cchq/www/production/current/python_env/bin/python /home/cchq/www/production/current/manage.py list_couchdbs'
2018-02-16 20:02:25,702 INFO AXES: BEGIN LOG
commcarehq
commcarehq__domains
commcarehq__auditcare
commcarehq__users
commcarehq__meta
commcarehq__receiverwrapper
commcarehq__mvp-indicators
commcarehq__m4change
commcarehq__fluff-mc
commcarehq__apps
commcarehq__fixtures
commcarehq__synclogs_2017-11-01
commcarehq__fluff-bihar
```

Note that the first couple lines in this output go to stderr, so it doesn't affect ability to use stdout programatically.