### PR TITLE
start github pages project site

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,3 @@
+Check out the following docs
+- The [commcare-cloud Repo README](https://github.com/dimagi/commcare-cloud/blob/master/README.md)
+- The [ansible README](https://github.com/dimagi/commcare-cloud/blob/master/ansible/README.md) (somewhat outdated)


### PR DESCRIPTION
see if github pages supports markdown

Looks like anything at `docs/` should be available at https://dimagi.github.io/commcare-cloud (see https://help.github.com/articles/user-organization-and-project-pages/)