### PR TITLE
increase number of case search pillows on enikshay

### DIFF
--- a/environments/enikshay/app-processes.yml
+++ b/environments/enikshay/app-processes.yml
@@ -82,7 +82,7 @@ pillows:
     LedgerToElasticsearchPillow:
       num_processes: 1
     CaseSearchToElasticsearchPillow:
-      num_processes: 4
+      num_processes: 8
     kafka-ucr-static:
       num_processes: 6
     SqlSMSPillow:


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?270131#BugEvent.1457531

@proteusvacuum concluded that the CaseSearchToElasticsearchPillow was behind when users were reporting cases missing from the case search, so I'm bumping up the number of pillows.   The machine has plenty of [capacity](https://app.datadoghq.com/dash/host/328223540?live=true&from_ts=1516652242819&to_ts=1519244242819&page=0&is_auto=false&tile_size=m) to support the extra pillows.