### PR TITLE
change supervisor logfile_maxbytes from 50M to 20M

### DIFF
--- a/ansible/roles/supervisor/templates/supervisord.conf.j2
+++ b/ansible/roles/supervisor/templates/supervisord.conf.j2
@@ -20,7 +20,7 @@ password={{ supervisor_http_password }}               ; (default is no password 
 
 [supervisord]
 logfile=/tmp/supervisord.log ; (main log file;default $CWD/supervisord.log)
-logfile_maxbytes=50MB        ; (max main logfile bytes b4 rotation;default 50MB)
+logfile_maxbytes=20MB        ; (max main logfile bytes b4 rotation;default 50MB)
 logfile_backups=10           ; (num of main logfile rotation backups;default 10)
 loglevel=info                ; (log level;default info; others: debug,warn,trace)
 pidfile=/tmp/supervisord.pid ; (supervisord pidfile;default supervisord.pid)


### PR DESCRIPTION
with logfile_backups=10, this will now save 200M per process
rather than 500M per process

production hqpillowtop0 logs were filling up disk
and with the current settings were going back almost a year