### PR TITLE
commcare cloud install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,10 @@ before_install:
   - sudo apt-get update -qq
 
 install:
-  - ./install.sh
+  - pip install pip --upgrade
+  - pip install -r requirements.txt
+  - ansible-galaxy install -r ansible/requirements.yml
+  - ./control/check_install.sh
   - pip install -r test_requirements.txt
 
 script:

--- a/README.md
+++ b/README.md
@@ -19,66 +19,20 @@ Docs at [https://dimagi.github.io/commcare-cloud/](https://dimagi.github.io/comm
 
 
 # Install and setup
-You will need python 2.7 and `virtualenvwrapper` installed
-to follow these instructions.
-
-Clone the commcare-cloud repo
-(suggested location alongside commcare-hq, if you have that repo cloned as well):
+You will need python 2.7 and `virtualenvwrapper` installed to follow these instructions:
 
 ```
-git clone https://github.com/dimagi/commcare-cloud.git
-cd commcare-cloud
+sudo apt-get install git python-dev python-pip
+sudo pip install virtualenv virtualenvwrapper
 ```
 
-Now make a virtualenv for ansible:
-
+# Quick setup
+This should be run from your home director:
 ```
-mkvirtualenv ansible
-```
-
-If you want `workon ansible` to always bring you to this directory, then you can also run
-
-```
-setvirtualenvproject
-```
-
-at this time.
-
-**Note**: If you already have commcare-cloud cloned, then just enter that directory
-and update it with
-
-```
-git pull
-```
-
-# Install commcare-cloud
-
-You must be in your virtualenv for the install script to work
-```
-workon ansible
-```
-
-Then, simply run:
-
-```
-./install.sh
+bash <(curl -s https://raw.githubusercontent.com/dimagi/commcare-cloud/master/control/init.sh)
 ```
 
 You may now use `commcare-cloud` or its shorter alias `cchq` whenever you're in the virtualenv.
-
-# Optional: Hook up the bells and whistles
-
-To be able to
-- use `commcare-cloud` (and its alias `cchq`) from anywhere
-- use `commcare-cloud` bash completion
-
-add the following to your bash profile:
-
-```
-export PATH=$PATH:~/.commcare-cloud/bin
-source ~/.commcare-cloud/repo/control/.bash_completion
-```
-
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ sudo pip install virtualenv virtualenvwrapper
 # Quick setup
 This should be run from your home director:
 ```
-bash <(curl -s https://raw.githubusercontent.com/dimagi/commcare-cloud/master/control/init.sh)
+source <(curl -s https://raw.githubusercontent.com/dimagi/commcare-cloud/master/control/init.sh)
 ```
 
 You may now use `commcare-cloud` or its shorter alias `cchq` whenever you're in the virtualenv.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ sudo pip install virtualenv virtualenvwrapper
 ```
 
 # Quick setup
-This should be run from your home director:
+This should be run from your home directory:
 ```
 source <(curl -s https://raw.githubusercontent.com/dimagi/commcare-cloud/master/control/init.sh)
 ```

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -160,23 +160,7 @@ You cannot use ssh forwarding with `mosh`, so you cannot use mosh for ansible.
 [troubleshooting](https://developer.github.com/guides/using-ssh-agent-forwarding/)
 
 ### Setting up a dev account on ansible control machine
-
-You must ssh in as your dev user, with SSH `ForwardAgent` enabled (see above).
-
-```bash
-git clone https://github.com/dimagi/commcare-cloud.git
-. commcare-cloud/control/init.sh
-update-code
-
-# optional: make subsequent logins a bit more convenient
-echo '[ -t 1 ] && source ~/init-ansible' >> ~/.profile
-```
-
-On subsequent logins if optional step was not done.
-
-```bash
-. init-ansible
-```
+See main [README](../README.md) file.
 
 ### Simulate dev user setup on vagrant control machine
 
@@ -195,7 +179,6 @@ Login as your user: `vagrant ssh control -- -l $USER -A
 ```bash
 ln -s /vagrant ~/commcare-cloud
 . commcare-cloud/control/init.sh
-echo '[ -t 1 ] && source ~/init-ansible' >> ~/.profile
 
 # run ansible
 ansible-playbook -u ansible --ask-sudo-pass -i inventories/development \

--- a/control/check_install.sh
+++ b/control/check_install.sh
@@ -17,43 +17,50 @@ OLD_ORIGIN_HTTPS="https://github.com/dimagi/commcarehq-ansible.git"
 OLD_ORIGIN_SSH="git@github.com:dimagi/commcarehq-ansible.git"
 NEW_ORIGIN_HTTPS="https://github.com/dimagi/commcare-cloud.git"
 NEW_ORIGIN_SSH="git@github.com:dimagi/commcare-cloud.git"
+
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
 if [[ "${ORIGIN}" =~ ${OLD_ORIGIN_HTTPS_RE} ]]
 then
     git remote set-url origin ${NEW_ORIGIN_HTTPS}
-    echo "→ Set origin to ${NEW_ORIGIN_HTTPS}"
+    printf "${YELLOW}→ Set origin to ${NEW_ORIGIN_HTTPS}\n"
 elif [[ "${ORIGIN}" =~ ${OLD_ORIGIN_SSH_RE} ]]
 then
     git remote set-url origin ${NEW_ORIGIN_SSH}
-    echo "→ Set origin to ${NEW_ORIGIN_SSH}"
+    printf "${YELLOW}→ Set origin to ${NEW_ORIGIN_SSH}\n"
 elif [ "${ORIGIN}" = ${NEW_ORIGIN_HTTPS} -o "${ORIGIN}" = ${NEW_ORIGIN_SSH} ]
 then
-    echo "✓ origin already set to ${ORIGIN}"
+    printf "${GREEN}✓ origin already set to ${ORIGIN}\n"
 else
-    echo "✗ origin is not recognized: ${ORIGIN}"
+    printf "${RED} origin is not recognized: ${ORIGIN}\n"
 fi
 
 if [ ! -d ~/.commcare-cloud ]
 then
     mkdir ~/.commcare-cloud
-    echo "→ Created ~/.commcare-cloud"
+    printf "${YELLOW}→ Created ~/.commcare-cloud\n"
 else
-    echo "✓ ~/.commcare-cloud exists"
+    printf "${GREEN}✓ ~/.commcare-cloud exists\n"
 fi
 
 if [ ! -d ~/.commcare-cloud/repo ]
 then
     ln -sf "${ANSIBLE_REPO}" ~/.commcare-cloud/repo
-    echo "→ Linked this repo to ~/.commcare-cloud/repo"
+    printf "${YELLOW}→ Linked this repo to ~/.commcare-cloud/repo\n"
 else
-    echo "✓ ~/.commcare-cloud/repo exists"
+    printf "${GREEN}✓ ~/.commcare-cloud/repo exists\n"
 fi
 
 if [ ! -d ~/.commcare-cloud/bin ]
 then
     mkdir ~/.commcare-cloud/bin
-    echo "→ Created ~/.commcare-cloud/bin"
+    printf "${YELLOW}→ Created ~/.commcare-cloud/bin\n"
 else
-    echo "✓ ~/.commcare-cloud/bin exists"
+    printf "${GREEN}✓ ~/.commcare-cloud/bin exists\n"
 fi
 
 for executable in commcare-cloud cchq
@@ -68,13 +75,13 @@ do
         fi
         if [ -z "$(which ${executable})" ]
         then
-            echo "✗ No executable found for ${executable}. Skipping"
+            printf "${RED}✗ No executable found for ${executable}. Skipping\n"
         else
             ln -sf $(which ${executable}) ~/.commcare-cloud/bin/
-            echo "→ Created ~/.commcare-cloud/bin/${executable}"
+            printf "${YELLOW}→ Created ~/.commcare-cloud/bin/${executable}\n"
         fi
     else
-        echo "✓ ~/.commcare-cloud/bin/${executable} exists"
+        printf "${GREEN}✓ ~/.commcare-cloud/bin/${executable} exists\n"
     fi
 done
 
@@ -88,18 +95,18 @@ then
             if [ -f "${OLD_FAB_CONFIG}" ]
             then
                 cp "${OLD_FAB_CONFIG}" "${FAB_CONFIG}"
-                echo "→ Copied $(realpath ${OLD_FAB_CONFIG}) to ${FAB_CONFIG}"
+                printf "${YELLOW}→ Copied $(realpath ${OLD_FAB_CONFIG}) to ${FAB_CONFIG}\n"
                 break
             fi
         fi
     done
 else
-    echo "✓ ${FAB_CONFIG} exists"
+    printf "${GREEN}✓ ${FAB_CONFIG} exists\n"
 fi
 # fab config _still_ doesn't exist, note that we were unsuccessful in inferring it
 if [ ! -f "${FAB_CONFIG}" ]
 then
-    echo "✗ ${FAB_CONFIG} does not exist and suitable location to copy it from was not found."
-    echo "  This file is just a convenience, so this is a non-critical error."
-    echo "  If you have fab/config.py in a previous location, then copy it to ${FAB_CONFIG}."
+    printf "${RED}✗ ${FAB_CONFIG} does not exist and suitable location to copy it from was not found.\n"
+    printf "${BLUE}  This file is just a convenience, so this is a non-critical error.\n"
+    printf "${BLUE}  If you have fab/config.py in a previous location, then copy it to ${FAB_CONFIG}.${NC}\n"
 fi

--- a/control/init.sh
+++ b/control/init.sh
@@ -23,10 +23,6 @@ if [ -d ~/commcarehq-ansible ]; then
     [ ! -f ~/init-ansible ] && rm -f ~/init-ansible
 fi
 
-if [ ! -d ~/commcare-cloud/config ]; then
-    git clone /home/ansible/commcarehq-ansible-secrets.git ~/commcare-cloud/config || mkdir ~/commcare-cloud/config
-fi
-
 echo "Downloading dependencies from galaxy and pip"
 export ANSIBLE_ROLES_PATH=~/.ansible/roles
 ansible-galaxy install -r ~/commcare-cloud/ansible/requirements.yml &

--- a/control/init.sh
+++ b/control/init.sh
@@ -31,9 +31,7 @@ fi
 echo "Downloading dependencies from galaxy and pip"
 export ANSIBLE_ROLES_PATH=~/.ansible/roles
 ansible-galaxy install -r ~/commcare-cloud/ansible/requirements.yml &
-pip install -r ~/commcare-cloud/ansible/requirements.txt &
-pip install -e ~/commcare-cloud/commcare-cloud &
-pip install -r ~/commcare-cloud/fab/requirements.txt &
+pip install -r ~/commcare-cloud/requirements.txt &
 pip install pip --upgrade &
 wait
 

--- a/control/init.sh
+++ b/control/init.sh
@@ -26,13 +26,16 @@ fi
 if [ ! -d ~/commcarehq-cloud ]; then
     echo "Checking out CommCare Cloud Repo"
     git clone https://github.com/dimagi/commcare-cloud.git
+    # first time install need requiremnts installed in serial
+    cd ~/commcare-cloud && pip install -r ~/commcare-cloud/requirements.txt && cd -
+else
+    cd ~/commcare-cloud && pip install -r ~/commcare-cloud/requirements.txt && cd - &
 fi
 
 echo "Downloading dependencies from galaxy and pip"
 export ANSIBLE_ROLES_PATH=~/.ansible/roles
-ansible-galaxy install -r ~/commcare-cloud/ansible/requirements.yml &
-pip install -r ~/commcare-cloud/requirements.txt &
 pip install pip --upgrade &
+ansible-galaxy install -r ~/commcare-cloud/ansible/requirements.yml &
 wait
 
 # convenience: . init-ansible

--- a/control/init.sh
+++ b/control/init.sh
@@ -2,8 +2,9 @@
 if ! hash virtualenvwrapper.sh 2>/dev/null; then
     echo "Please install virtualenvwrapper and make sure it is in your PATH"
     echo ""
-    echo "  sudo apt-get install git python-dev python-pip"
     echo "  sudo pip install virtualenv virtualenvwrapper"
+    echo ""
+    echo "Other requirements: git, python-dev, python-pip"
     return 1
 fi
 

--- a/control/init.sh
+++ b/control/init.sh
@@ -60,7 +60,7 @@ if ! grep -q init-ansible ~/.profile; then
             printf "${YELLOW}→ Added init script to ~/.profile"
         ;;
         * )
-            printf "${BLUE}You can always set it up later by running this command:\n'
+            printf "${BLUE}You can always set it up later by running this command:\n"
             printf "${BLUE}'[ -t 1 ] && source ~/init-ansible' >> ~/.profile${NC}\n"
         ;;
     esac

--- a/control/init.sh
+++ b/control/init.sh
@@ -35,17 +35,11 @@ wait
 # convenience: . init-ansible
 [ ! -f ~/init-ansible ] && ln -s ~/commcare-cloud/control/init.sh ~/init-ansible
 cd ~/commcare-cloud && ./control/check_install.sh && cd -
-alias ap='ansible-playbook -u ansible -i ~/commcare-cloud/fab/fab/inventory/$ENV -e "@vars/$ENV/${ENV}_vault.yml" -e "@vars/$ENV/${ENV}_public.yml" --ask-vault-pass'
-alias aps='ap deploy_stack.yml'
 alias update-code='~/commcare-cloud/control/update_code.sh && . ~/init-ansible'
 alias update_code='~/commcare-cloud/control/update_code.sh && . ~/init-ansible'
 
 export PATH=$PATH:~/.commcare-cloud/bin
 source ~/.commcare-cloud/repo/control/.bash_completion
-
-function ae() {
-    ansible $1 -m shell -a "$2" -u ansible -i ~/commcare-cloud/fab/fab/inventory/$ENV
-}
 
 # It aint pretty, but it gets the job done
 function ansible-deploy-control() {

--- a/control/init.sh
+++ b/control/init.sh
@@ -52,7 +52,7 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 if ! grep -q init-ansible ~/.profile; then
-    printf "${YELLOW}"Do you want to have the CommCare Cloud environment setup on login?${NC}"
+    printf "${YELLOW}Do you want to have the CommCare Cloud environment setup on login?${NC}"
     read -t 30 -p "(y/n): " yn
     case $yn in
         [Yy]* )

--- a/control/init.sh
+++ b/control/init.sh
@@ -52,15 +52,15 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 if ! grep -q init-ansible ~/.profile; then
-    printf "${YELLOW}Do you want to have the CommCare Cloud environment setup on login?${NC}"
+    printf "${YELLOW}Do you want to have the CommCare Cloud environment setup on login?${NC}\n"
     read -t 30 -p "(y/n): " yn
     case $yn in
         [Yy]* )
             echo '[ -t 1 ] && source ~/init-ansible' >> ~/.profile
-            printf "${YELLOW}→ Added init script to ~/.profile"
+            printf "${YELLOW}→ Added init script to ~/.profile\n"
         ;;
         * )
-            printf "${BLUE}You can always set it up later by running this command:\n"
+            printf "\n${BLUE}You can always set it up later by running this command:\n"
             printf "${BLUE}'[ -t 1 ] && source ~/init-ansible' >> ~/.profile${NC}\n"
         ;;
     esac

--- a/control/init.sh
+++ b/control/init.sh
@@ -68,8 +68,8 @@ function ansible-control-banner() {
     printf "                 See ${YELLOW}commcare-cloud -h${NC} for more details.\n"
     printf "                 See ${YELLOW}commcare-cloud <env> <command> -h${NC} for command details.\n"
     printf -- "\n${GREEN}Deprecated Commands${NC}\n"
-    printf "ap - Use ${YELLOW}commcare-cloud <env> ansible-playbook${NC} instead.\n"
-    printf "aps - Use ${YELLOW}commcare-cloud <env> ansible-playbook deploy_stack.yml${NC} instead.\n"
+    printf "ap - Use ${YELLOW}commcare-cloud <env> ap{NC} instead.\n"
+    printf "aps - Use ${YELLOW}commcare-cloud <env> aps${NC} instead.\n"
     printf "ae - Use ${YELLOW}commcare-cloud <env> run-shell-command${NC} instead.\n"
 }
 

--- a/control/init.sh
+++ b/control/init.sh
@@ -23,6 +23,11 @@ if [ -d ~/commcarehq-ansible ]; then
     [ ! -f ~/init-ansible ] && rm -f ~/init-ansible
 fi
 
+if [ ! -d ~/commcarehq-cloud ]; then
+    echo "Checking out CommCare Cloud Repo"
+    git clone https://github.com/dimagi/commcare-cloud.git
+fi
+
 echo "Downloading dependencies from galaxy and pip"
 export ANSIBLE_ROLES_PATH=~/.ansible/roles
 ansible-galaxy install -r ~/commcare-cloud/ansible/requirements.yml &

--- a/control/init.sh
+++ b/control/init.sh
@@ -47,15 +47,21 @@ alias update_code='~/commcare-cloud/control/update_code.sh && . ~/init-ansible'
 export PATH=$PATH:~/.commcare-cloud/bin
 source ~/.commcare-cloud/repo/control/.bash_completion
 
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
 if ! grep -q init-ansible ~/.profile; then
-    read -t 30 -p "Do you want to have the CommCare Cloud environment setup on login? (y/n): " yn
+    printf "${YELLOW}"Do you want to have the CommCare Cloud environment setup on login?${NC}"
+    read -t 30 -p "(y/n): " yn
     case $yn in
         [Yy]* )
             echo '[ -t 1 ] && source ~/init-ansible' >> ~/.profile
+            printf "${YELLOW}→ Added init script to ~/.profile"
         ;;
         * )
-            echo 'You can always set it up later by running this command:'
-            echo "'[ -t 1 ] && source ~/init-ansible' >> ~/.profile"
+            printf "${BLUE}You can always set it up later by running this command:\n'
+            printf "${BLUE}'[ -t 1 ] && source ~/init-ansible' >> ~/.profile${NC}\n"
         ;;
     esac
 fi

--- a/control/init.sh
+++ b/control/init.sh
@@ -47,7 +47,7 @@ alias update_code='~/commcare-cloud/control/update_code.sh && . ~/init-ansible'
 export PATH=$PATH:~/.commcare-cloud/bin
 source ~/.commcare-cloud/repo/control/.bash_completion
 
-if ! grep -q init-ansible "~/.profile"; then
+if ! grep -q init-ansible ~/.profile; then
     read -t 30 -p "Do you want to have the CommCare Cloud environment setup on login? (y/n): " yn
     case $yn in
         [Yy]* )

--- a/control/init.sh
+++ b/control/init.sh
@@ -46,6 +46,19 @@ alias update_code='~/commcare-cloud/control/update_code.sh && . ~/init-ansible'
 export PATH=$PATH:~/.commcare-cloud/bin
 source ~/.commcare-cloud/repo/control/.bash_completion
 
+if ! grep -q init-ansible "~/.profile"; then
+    read -t 5 -n 1 -p "Do you want to have the CommCare Cloud environment setup on login? (y/n): " yn
+    case $yn in
+        [Yy]* )
+            echo '[ -t 1 ] && source ~/init-ansible' >> ~/.profile
+        ;;
+        * )
+            echo 'You can always set it up later by running this command:'
+            echo "'[ -t 1 ] && source ~/init-ansible' >> ~/.profile"
+        ;;
+    esac
+fi
+
 # It aint pretty, but it gets the job done
 function ansible-deploy-control() {
     if [ -z "$1" ]; then

--- a/control/init.sh
+++ b/control/init.sh
@@ -48,7 +48,7 @@ export PATH=$PATH:~/.commcare-cloud/bin
 source ~/.commcare-cloud/repo/control/.bash_completion
 
 if ! grep -q init-ansible "~/.profile"; then
-    read -t 5 -n 1 -p "Do you want to have the CommCare Cloud environment setup on login? (y/n): " yn
+    read -t 30 -p "Do you want to have the CommCare Cloud environment setup on login? (y/n): " yn
     case $yn in
         [Yy]* )
             echo '[ -t 1 ] && source ~/init-ansible' >> ~/.profile

--- a/control/init.sh
+++ b/control/init.sh
@@ -23,7 +23,7 @@ if [ -d ~/commcarehq-ansible ]; then
     [ ! -f ~/init-ansible ] && rm -f ~/init-ansible
 fi
 
-if [ ! -d ~/commcarehq-cloud ]; then
+if [ ! -d ~/commcare-cloud ]; then
     echo "Checking out CommCare Cloud Repo"
     git clone https://github.com/dimagi/commcare-cloud.git
     # first time install need requiremnts installed in serial

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-pip install pip --upgrade
-pip install -r requirements.txt
-ansible-galaxy install -r ansible/requirements.yml
-./control/check_install.sh


### PR DESCRIPTION
I just had to setup my account on PNA and found some conflicting / differing instructions in `README.md` and `ansible/README.md`

There seems to be quite a bit of overlap between the two regarding setting up the environment. Any reason not to consolidate the install instructions into `README.md` and leave `ansible/REAMDE.md` for purely ansible info?

I was also thinking that it would be nice to have a script that you can just run from the web to do the full setup for you. Something like `bash <(curl -s https://raw.githubusercontent.com/dimagi/commcare-cloud/master/control/init.sh)`.

It seems like `init.sh` is basically there. Curious to hear others thoughts.

other buddy @esoergel 