### PR TITLE
update to Ansible 2.4.3

### DIFF
--- a/ansible/requirements.txt
+++ b/ansible/requirements.txt
@@ -1,4 +1,4 @@
-ansible==2.4.1
+ansible==2.4.3
 netaddr
 dnspython
 passlib

--- a/commcare-cloud/commcare_cloud/help_cache/ansible-playbook.txt
+++ b/commcare-cloud/commcare_cloud/help_cache/ansible-playbook.txt
@@ -18,9 +18,8 @@ Options:
                         (default=5)
   -h, --help            show this help message and exit
   -i INVENTORY, --inventory=INVENTORY, --inventory-file=INVENTORY
-                        specify inventory host path
-                        (default=[[u'/etc/ansible/hosts']]) or comma separated
-                        host list. --inventory-file is deprecated
+                        specify inventory host path or comma separated host
+                        list. --inventory-file is deprecated
   -l SUBSET, --limit=SUBSET
                         further limit selected hosts to an additional pattern
   --list-hosts          outputs a list of matching hosts; does not execute
@@ -31,10 +30,6 @@ Options:
                         prepend colon-separated path(s) to module library
                         (default=[u'/home/travis/.ansible/plugins/modules',
                         u'/usr/share/ansible/plugins/modules'])
-  --new-vault-id=NEW_VAULT_ID
-                        the new vault identity to use for rekey
-  --new-vault-password-file=NEW_VAULT_PASSWORD_FILES
-                        new vault password file for rekey
   --skip-tags=SKIP_TAGS
                         only run plays and tasks whose tags do not match these
                         values

--- a/commcare-cloud/commcare_cloud/help_cache/ansible.txt
+++ b/commcare-cloud/commcare_cloud/help_cache/ansible.txt
@@ -21,9 +21,8 @@ Options:
                         (default=5)
   -h, --help            show this help message and exit
   -i INVENTORY, --inventory=INVENTORY, --inventory-file=INVENTORY
-                        specify inventory host path
-                        (default=[[u'/etc/ansible/hosts']]) or comma separated
-                        host list. --inventory-file is deprecated
+                        specify inventory host path or comma separated host
+                        list. --inventory-file is deprecated
   -l SUBSET, --limit=SUBSET
                         further limit selected hosts to an additional pattern
   --list-hosts          outputs a list of matching hosts; does not execute
@@ -34,10 +33,6 @@ Options:
                         prepend colon-separated path(s) to module library
                         (default=[u'/home/travis/.ansible/plugins/modules',
                         u'/usr/share/ansible/plugins/modules'])
-  --new-vault-id=NEW_VAULT_ID
-                        the new vault identity to use for rekey
-  --new-vault-password-file=NEW_VAULT_PASSWORD_FILES
-                        new vault password file for rekey
   -o, --one-line        condense output
   -P POLL_INTERVAL, --poll=POLL_INTERVAL
                         set the poll interval if using -B (default=15)

--- a/fab/requirements.txt
+++ b/fab/requirements.txt
@@ -1,5 +1,5 @@
 Fabric==1.10.2
-ansible==2.4.1
+ansible==2.4.3
 github3.py==1.0.0a4
 pytz==2017.2
 pycrypto==2.6.1


### PR DESCRIPTION
No idea if this will fix the

```
 [ERROR]: failed to download the file: Failed to validate the SSL certificate
for github.com:443. Make sure your managed systems have a valid CA certificate
installed. You can use validate_certs=False if you do not need to confirm the
servers identity but this is unsafe and not recommended. Paths checked for this
platform: /etc/ssl/certs, /etc/pki/ca-trust/extracted/pem, /etc/pki/tls/certs,
/usr/share/ca-certificates/cacert.org, /etc/ansible. The exception msg was:
("bad handshake: Error([('SSL routines', 'ssl3_read_bytes', 'tlsv1 alert
protocol version')],)",).
```

error, but it's just a patch release so it "can't" hurt.
