### PR TITLE
support additional mount points

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -129,4 +129,6 @@
   tags: cron
 
 - include: mount.yml
-  tags: mount
+  tags:
+    - mount
+    - after-reboot

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -124,5 +124,9 @@
   tags:
     - antivirus
     - after-reboot
-- include: cron.yml 
+
+- include: cron.yml
   tags: cron
+
+- include: mount.yml
+  tags: mount

--- a/ansible/roles/common/tasks/mount.yml
+++ b/ansible/roles/common/tasks/mount.yml
@@ -1,0 +1,11 @@
+- name: "Mount additional disks"
+  become: yes
+  mount:
+    src: "{{ item.partition }}"
+    path: "{{ item.dest }}"
+    fstype: "{{ item.fstype }}"
+    state: mounted
+  with_items: "{{ mount_points }}"
+  when: mount_points is defined
+  tags:
+    - mount

--- a/ansible/roles/common/tasks/mount.yml
+++ b/ansible/roles/common/tasks/mount.yml
@@ -9,3 +9,4 @@
   when: mount_points is defined
   tags:
     - mount
+    - after-reboot

--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -1,6 +1,9 @@
 [proxy]
 hqproxy0.internal-va.commcarehq.org
 
+[proxy:vars]
+mount_points="[{'partition':'/dev/xvdb1', 'dest':'/mnt/storage', 'fstype':'ext4'}]"
+
 [webworkers]
 hqdjango0.internal-va.commcarehq.org
 hqdjango1.internal-va.commcarehq.org


### PR DESCRIPTION
In some clusters you may need to add an additional disk, specially if there's no support for LVM and need to mount it, currently, this process is manual, creating potential issues like the one when the proxy machine was rebooted and /mnt/storage not mounted.  This provides a fix for that, Ideally, we should migrate to LVM. @dannyroberts 