### PR TITLE
Fix proxy definition

### DIFF
--- a/fab/fab/operations/supervisor.py
+++ b/fab/fab/operations/supervisor.py
@@ -294,8 +294,7 @@ def _format_env(current_env, extra=None):
         'newrelic_javaagent',
     ]
 
-    inventory = env.ccc_environment.inventory_manager
-    all_hosts = [host.name for host in inventory.groups['all'].hosts]
+    all_hosts = env.ccc_environment.inventory_hosts_by_group['all']
 
     ret['supervisor_env_vars'] = {}
     if env.http_proxy:


### PR DESCRIPTION
@dannyroberts I think this was introduced https://github.com/dimagi/commcare-cloud/pull/1415 but there were a lot of changes and I don't have an understanding of why this broke. Basically `inventory.groups['all'].hosts` is an empty list.

I think the real/ideal fix is not defining supervisor configs during deploy. I have an idea that I'll look to PR in the next week

@czue @nickpell should fix the issue we were talking about the past couple of days