### PR TITLE
Move prod static UCR pillow

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -76,9 +76,9 @@ pillows:
   hqpillowtop2.internal-va.commcarehq.org:
     kafka-ucr-main:
       num_processes: 4
+  hqpillowtop0.internal-va.commcarehq.org:
     kafka-ucr-static:
       num_processes: 1
-  hqpillowtop0.internal-va.commcarehq.org:
     AppDbChangeFeedPillow:
       num_processes: 1
     ApplicationBlobDeletionPillow:


### PR DESCRIPTION
hqpillowtop2 is really high in memory. UCR pillows on prod take ludicrous amounts of memory. probably due to number of data sources. should probably go through and prune unused ones, but I'm not sure how easy that would be

buddy @czue 