### PR TITLE
remove 'encrypted_root' var from public.yml files

### DIFF
--- a/environments/enikshay/public.yml
+++ b/environments/enikshay/public.yml
@@ -63,8 +63,6 @@ supervisor_http_enabled: True
 
 keystore_file: '../config/DimagiKeyStore'
 
-encrypted_root: '/opt/data'
-
 backup_blobdb: False
 backup_postgres: plain
 postgresql_backup_days: 1

--- a/environments/icds-new/public.yml
+++ b/environments/icds-new/public.yml
@@ -152,7 +152,7 @@ redis_database_save_times: []
 redis_max_clients: 10000
 redis_maxmemory_policy: allkeys-lru
 
-kafka_log_dir: '/opt/data/kafka'
+kafka_log_dir: '{{ encrypted_root }}/kafka'
 
 KSPLICE_ACTIVE: no
 

--- a/environments/softlayer/inventory.ini
+++ b/environments/softlayer/inventory.ini
@@ -17,13 +17,13 @@
 datadog_integration_cloudant=true
 
 [es2]
-10.162.36.221 elasticsearch_node_name=es2 encrypted_root_override=/opt/data/ecrypt
+10.162.36.221 elasticsearch_node_name=es2 encrypted_root=/opt/data/ecrypt
 
 [es3]
-10.162.36.200 elasticsearch_node_name=es3 datavol_device=/dev/xvdc encrypted_root_override=/opt/data/ecrypt
+10.162.36.200 elasticsearch_node_name=es3 datavol_device=/dev/xvdc encrypted_root=/opt/data/ecrypt
 
 [kafka0]
-10.162.36.207 hostaname=kafka0 datavol_device=/dev/xvdc encrypted_root_override=/opt/data/ecrypt
+10.162.36.207 hostaname=kafka0 datavol_device=/dev/xvdc encrypted_root=/opt/data/ecrypt
 
 [pillow1]
 10.162.36.253
@@ -35,25 +35,25 @@ datadog_integration_cloudant=true
 10.162.36.203
 
 [formplayer0]
-10.162.36.248 encrypted_root_override=/opt/data/ecrypt
+10.162.36.248 encrypted_root=/opt/data/ecrypt
 
 [formplayer1]
-10.162.36.231 encrypted_root_override=/opt/data/ecrypt
+10.162.36.231 encrypted_root=/opt/data/ecrypt
 
 [riak15]
-10.162.36.235 encrypted_root_override=/opt/data/ecrypt
+10.162.36.235 encrypted_root=/opt/data/ecrypt
 
 [riak16]
-10.162.36.225 encrypted_root_override=/opt/data/ecrypt
+10.162.36.225 encrypted_root=/opt/data/ecrypt
 
 [riak17]
-10.162.36.244 encrypted_root_override=/opt/data/ecrypt
+10.162.36.244 encrypted_root=/opt/data/ecrypt
 
 [riak18]
-10.162.36.211 encrypted_root_override=/opt/data/ecrypt
+10.162.36.211 encrypted_root=/opt/data/ecrypt
 
 [riak19]
-10.162.36.202 encrypted_root_override=/opt/data/ecrypt
+10.162.36.202 encrypted_root=/opt/data/ecrypt
 
 [touch0]
 10.162.36.215
@@ -65,16 +65,16 @@ datadog_integration_cloudant=true
 devices='["/dev/xvde","/dev/xvdc"]'
 partitions=["/dev/xvde1","/dev/xvdc1"]
 datavol_device='/dev/mapper/consolidated-data'
-encrypted_root_override=/opt/data/ecrypt
+encrypted_root=/opt/data/ecrypt
 
 [couch2]
-10.162.36.254 datavol_device=/dev/xvdc encrypted_root_override=/opt/data/ecrypt
+10.162.36.254 datavol_device=/dev/xvdc encrypted_root=/opt/data/ecrypt
 
 [couch3]
-10.162.36.198 datavol_device=/dev/xvdc encrypted_root_override=/opt/data/ecrypt
+10.162.36.198 datavol_device=/dev/xvdc encrypted_root=/opt/data/ecrypt
 
 [couch4]
-10.162.36.220 datavol_device=/dev/xvdc encrypted_root_override=/opt/data/ecrypt
+10.162.36.220 datavol_device=/dev/xvdc encrypted_root=/opt/data/ecrypt
 
 [proxy:children]
 proxy0

--- a/environments/softlayer/inventory.ini
+++ b/environments/softlayer/inventory.ini
@@ -15,16 +15,15 @@
 
 [db0:vars]
 datadog_integration_cloudant=true
-encrypted_root_override=/opt/data
 
 [es2]
-10.162.36.221 elasticsearch_node_name=es2
+10.162.36.221 elasticsearch_node_name=es2 encrypted_root_override=/opt/data/ecrypt
 
 [es3]
-10.162.36.200 elasticsearch_node_name=es3 datavol_device=/dev/xvdc
+10.162.36.200 elasticsearch_node_name=es3 datavol_device=/dev/xvdc encrypted_root_override=/opt/data/ecrypt
 
 [kafka0]
-10.162.36.207 hostaname=kafka0 datavol_device=/dev/xvdc
+10.162.36.207 hostaname=kafka0 datavol_device=/dev/xvdc encrypted_root_override=/opt/data/ecrypt
 
 [pillow1]
 10.162.36.253
@@ -36,25 +35,25 @@ encrypted_root_override=/opt/data
 10.162.36.203
 
 [formplayer0]
-10.162.36.248
+10.162.36.248 encrypted_root_override=/opt/data/ecrypt
 
 [formplayer1]
-10.162.36.231
+10.162.36.231 encrypted_root_override=/opt/data/ecrypt
 
 [riak15]
-10.162.36.235
+10.162.36.235 encrypted_root_override=/opt/data/ecrypt
 
 [riak16]
-10.162.36.225
+10.162.36.225 encrypted_root_override=/opt/data/ecrypt
 
 [riak17]
-10.162.36.244
+10.162.36.244 encrypted_root_override=/opt/data/ecrypt
 
 [riak18]
-10.162.36.211
+10.162.36.211 encrypted_root_override=/opt/data/ecrypt
 
 [riak19]
-10.162.36.202
+10.162.36.202 encrypted_root_override=/opt/data/ecrypt
 
 [touch0]
 10.162.36.215
@@ -66,15 +65,16 @@ encrypted_root_override=/opt/data
 devices='["/dev/xvde","/dev/xvdc"]'
 partitions=["/dev/xvde1","/dev/xvdc1"]
 datavol_device='/dev/mapper/consolidated-data'
+encrypted_root_override=/opt/data/ecrypt
 
 [couch2]
-10.162.36.254 datavol_device=/dev/xvdc
+10.162.36.254 datavol_device=/dev/xvdc encrypted_root_override=/opt/data/ecrypt
 
 [couch3]
-10.162.36.198 datavol_device=/dev/xvdc
+10.162.36.198 datavol_device=/dev/xvdc encrypted_root_override=/opt/data/ecrypt
 
 [couch4]
-10.162.36.220 datavol_device=/dev/xvdc
+10.162.36.220 datavol_device=/dev/xvdc encrypted_root_override=/opt/data/ecrypt
 
 [proxy:children]
 proxy0
@@ -126,7 +126,6 @@ riak16
 riak17
 riak18
 riak19
-
 
 [riakcs:vars]
 datavol_device=/dev/xvdc

--- a/environments/softlayer/public.yml
+++ b/environments/softlayer/public.yml
@@ -124,7 +124,7 @@ KSPLICE_ACTIVE: yes
 AMQP_HOST: "{{ groups.rabbitmq.0 }}"
 AMQP_NAME: commcarehq
 
-encrypted_root: "{{ encrypted_root_override|default('/opt/data/ecrypt') }}"
+encrypted_root: "{{ encrypted_root_override|default('/opt/data') }}"
 
 kafka_broker_id: 0
 kafka_log_dir: "{{ encrypted_root }}/kafka"

--- a/environments/softlayer/public.yml
+++ b/environments/softlayer/public.yml
@@ -124,8 +124,6 @@ KSPLICE_ACTIVE: yes
 AMQP_HOST: "{{ groups.rabbitmq.0 }}"
 AMQP_NAME: commcarehq
 
-encrypted_root: "{{ encrypted_root_override|default('/opt/data') }}"
-
 kafka_broker_id: 0
 kafka_log_dir: "{{ encrypted_root }}/kafka"
 


### PR DESCRIPTION
Changes based on feedback from https://github.com/dimagi/commcare-cloud/pull/1429#issuecomment-370682229

Validated this config with the following playbook:
```
- name: test
  hosts:
    - postgresql
    - couchdb
    - couchdb2
    - redis
    - elasticsearch
    - rabbitmq
    - zookeeper
    - riakcs
    - formplayer
    - pg_standby
  tasks:
    - shell: mount | grep ecryptfs | cut -d" " -f 1
      register: mount
      check_mode: no
    - assert: { that: "encrypted_root == mount.stdout"}
    - debug: msg="{{encrypted_root}} == {{mount.stdout}}"
```