### PR TITLE
Changed configuration for netvault user

### DIFF
--- a/ansible/roles/postgresql/templates/pg_hba.conf.j2
+++ b/ansible/roles/postgresql/templates/pg_hba.conf.j2
@@ -7,8 +7,8 @@ local   all             postgres                                peer
 
 {% if postgres_users.get('netvault') %}
 # Netvault required configuration
-host    all             netvault        127.0.0.1/32            md5
-local   all             netvault                                md5
+host    all             netvault        127.0.0.1/32            trust
+local   all             netvault                                trust
 {% endif %}
 
 # Allow replication connections from localhost, by a user with the replication privilege.

--- a/ansible/roles/postgresql/templates/postgresql.conf.j2
+++ b/ansible/roles/postgresql/templates/postgresql.conf.j2
@@ -60,6 +60,9 @@ wal_keep_segments = {{ postgresql_wal_keep_segments|default(8) }}
 # REPLICATION
 
 hot_standby = on    # ignored on masters
+{% if postgres_users.get('netvault') %}
+hot_standby_feedback = on
+{% endif %}
 max_replication_slots = 8
 
 {% if is_pg_standby|default(false) and postgresql_max_standby_delay|default(false) %}


### PR DESCRIPTION
**Changes**
1) Changing auth-method to `trust` for Netvault user. 
2) Added directive `hot_standby_feedback = on`
     I am concerned if it could have a negative impact on our Master nodes when a backup is happening.
     According to https://www.postgresql.org/docs/9.6/static/runtime-config-replication.html `but can cause database bloat on the primary for some workloads` 
