### PR TITLE
getting rid of 'include'

### DIFF
--- a/ansible/deploy_cleanup.yml
+++ b/ansible/deploy_cleanup.yml
@@ -5,7 +5,7 @@
   vars_files:
     - roles/shared_dir/vars/main.yml
   tasks:
-    - include: roles/shared_dir/tasks/cleanup_client.yml
+    - import_tasks: roles/shared_dir/tasks/cleanup_client.yml
 
 - name: Cleanup shared dir host
   hosts: shared_dir_host
@@ -13,28 +13,28 @@
   vars_files:
     - roles/shared_dir/vars/main.yml
   tasks:
-    - include: roles/shared_dir/tasks/cleanup_host.yml
+    - import_tasks: roles/shared_dir/tasks/cleanup_host.yml
 
 - name: Cleanup Formplayer cron jobs
   hosts:
     - all:!formplayer
   become: true
   tasks:
-    - {include: 'roles/formplayer/tasks/cleanup.yml', tags: ['formplayer', 'cleanup']}
+    - {import_tasks: 'roles/formplayer/tasks/cleanup.yml', tags: ['formplayer', 'cleanup']}
 
 - name: Cleanup PostgreSQL backup tasks
   hosts:
     - all
   become: true
   tasks:
-    - {include: 'roles/pg_backup/tasks/cleanup.yml', tags: ['postgresql', 'pg_backup', 'cleanup']}
+    - {import_tasks: 'roles/pg_backup/tasks/cleanup.yml', tags: ['postgresql', 'pg_backup', 'cleanup']}
 
 - name: Cleanup blobdb backup tasks
   hosts:
     - all
   become: true
   tasks:
-    - {include: 'roles/backups/tasks/cleanup.yml', tags: ['backups', 'cleanup']}
+    - {import_tasks: 'roles/backups/tasks/cleanup.yml', tags: ['backups', 'cleanup']}
 
 - name: Cleanup tochforms tasks
   hosts:
@@ -43,4 +43,4 @@
   tasks:
     - {include_vars: '../roles/touchforms/defaults/main.yml', tags: ['touchforms', 'cleanup']}
     - {include_vars: '../roles/touchforms/vars/main.yml', tags: ['touchforms', 'cleanup']}
-    - {include: 'roles/touchforms/tasks/cleanup.yml', tags: ['touchforms', 'cleanup']}
+    - {import_tasks: 'roles/touchforms/tasks/cleanup.yml', tags: ['touchforms', 'cleanup']}

--- a/ansible/deploy_common.yml
+++ b/ansible/deploy_common.yml
@@ -14,7 +14,7 @@
   hosts: 'proxy:cas_proxy:enikshay_proxy:pna_proxy:couchdb2_proxy'
   become: true
   tasks:
-    - include: roles/ufw/tasks/proxy_ufw.yml tags=ufw-proxy
+    - import_tasks: roles/ufw/tasks/proxy_ufw.yml tags=ufw-proxy
       when: ufw_private_interface is defined or is_monolith|bool
 
 - name: ufw off (firewall)

--- a/ansible/deploy_db.yml
+++ b/ansible/deploy_db.yml
@@ -36,7 +36,7 @@
     - hostTo: "{{ hot_standby_server }}"
     - state: 'present'
   tasks:
-    - include: roles/setup_auth_keys.yml
+    - import_tasks: roles/setup_auth_keys.yml
       when: hot_standby_server is defined
   tags:
     - pg_standby
@@ -131,7 +131,7 @@
   roles:
     - {role: kafka, tags: 'kafka'}
 
-- include: deploy_riakcs.yml
+- import_playbook: deploy_riakcs.yml
   tags: riakcs
 
 # Note other machines also have java installed, but are initiated through the meta task

--- a/ansible/deploy_load_test.yml
+++ b/ansible/deploy_load_test.yml
@@ -6,7 +6,7 @@
     - roles/postgresql/defaults/main.yml
   become: true
   tasks:
-    - include: roles/load_test/tasks/install_runner.yml
+    - import_tasks: roles/load_test/tasks/install_runner.yml
   roles:
     - {role: load_test, tags: 'load_test'}
 
@@ -17,7 +17,7 @@
     - roles/postgresql/defaults/main.yml
   become: true
   tasks:
-    - include: roles/load_test/tasks/install_host.yml
+    - import_tasks: roles/load_test/tasks/install_host.yml
   roles:
     - {role: load_test, tags: 'load_test'}
 
@@ -29,6 +29,6 @@
     - roles/load_test/defaults/main.yml
     - roles/postgresql/defaults/main.yml
   tasks:
-    - include: roles/load_test/tasks/install_prototype.yml
+    - import_tasks: roles/load_test/tasks/install_prototype.yml
   roles:
     - {role: load_test, tags: ['prototype']}

--- a/ansible/deploy_localsettings.yml
+++ b/ansible/deploy_localsettings.yml
@@ -1,7 +1,7 @@
 ---
-# deploy-stack.yml
+# deploy-localsettings.yml
 
-- include: deploy_riakcs.yml
-- include: deploy_commcarehq.yml
-- include: deploy_touchforms.yml
-- include: deploy_formplayer.yml
+- import_playbook: deploy_riakcs.yml
+- import_playbook: deploy_commcarehq.yml
+- import_playbook: deploy_touchforms.yml
+- import_playbook: deploy_formplayer.yml

--- a/ansible/deploy_riakcs.yml
+++ b/ansible/deploy_riakcs.yml
@@ -77,7 +77,7 @@
   vars_files:
     - roles/riakcs/install/defaults/main.yml
   tasks:
-    - include: roles/riakcs/get_admin_keys.yml
+    - import_tasks: roles/riakcs/get_admin_keys.yml
       tags: localsettings
 
 - name: Install Riak and Riak CS
@@ -127,7 +127,7 @@
   become: true
   hosts: riakcs
   tasks:
-    - include: roles/riakcs/join_cluster.yml
+    - include_tasks: roles/riakcs/join_cluster.yml
       when: inventory_hostname != riakcs_control and _force_riak_config
 
 - name: Configure and start Stanchion

--- a/ansible/deploy_riakcs_new.yml
+++ b/ansible/deploy_riakcs_new.yml
@@ -78,7 +78,7 @@
   vars_files:
     - roles/riakcs/install/defaults/main.yml
   tasks:
-    - include: roles/riakcs/get_admin_keys.yml tags=localsettings
+    - import_tasks: roles/riakcs/get_admin_keys.yml tags=localsettings
 
 - name: Install Riak and Riak CS
   become: true
@@ -127,7 +127,7 @@
   become: true
   hosts: riakcs_new
   tasks:
-    - include: roles/riakcs/join_cluster.yml
+    - import_tasks: roles/riakcs/join_cluster.yml
       when: inventory_hostname != riakcs_control and _force_riak_config
 
 - name: Configure and start Stanchion

--- a/ansible/deploy_shared_dir.yml
+++ b/ansible/deploy_shared_dir.yml
@@ -1,2 +1,2 @@
 ---
-- include: roles/shared_dir.yml
+- import_playbook: roles/shared_dir.yml

--- a/ansible/es_rolling_restart.yml
+++ b/ansible/es_rolling_restart.yml
@@ -4,6 +4,6 @@
   become: true
   serial: 1
   tasks:
-    - include: roles/elasticsearch/tasks/rolling_restart.yml
+    - import_tasks: roles/elasticsearch/tasks/rolling_restart.yml
       vars:
          es_host: "{% if inventory_hostname|ipaddr %}{{ inventory_hostname }}{% else %}{{ lookup('dig', inventory_hostname, wantlist=True)[0] }}{% endif %}"

--- a/ansible/roles/datadog/tasks/main.yml
+++ b/ansible/roles/datadog/tasks/main.yml
@@ -44,7 +44,7 @@
     update: yes
   notify: restart datadog
 
-- include: add_integrations.yml
+- include_tasks: add_integrations.yml
   when: DATADOG_INTEGRATIONS_ENABLED|default(DATADOG_ENABLED)
 
-- include: remove_integrations.yml
+- include_tasks: remove_integrations.yml

--- a/ansible/roles/riakcs/create_admin_user/handlers/main.yml
+++ b/ansible/roles/riakcs/create_admin_user/handlers/main.yml
@@ -1,1 +1,1 @@
-- include: ../../configure/handlers/main.yml
+- import_tasks: ../../configure/handlers/main.yml

--- a/ansible/roles/riakcs/sync_keys/handlers/main.yml
+++ b/ansible/roles/riakcs/sync_keys/handlers/main.yml
@@ -1,4 +1,4 @@
-- include: ../../configure/handlers/main.yml
+- import_tasks: ../../configure/handlers/main.yml
 
 - name: restart datadog
   action: service name=datadog-agent state=restarted

--- a/ansible/roles/shared_dir.yml
+++ b/ansible/roles/shared_dir.yml
@@ -7,8 +7,8 @@
     - ../group_vars/all.yml
     - shared_dir/vars/main.yml
   tasks:
-    - include: shared_dir/tasks/install.yml
-    - include: shared_dir/tasks/setup_host.yml
+    - import_tasks: shared_dir/tasks/install.yml
+    - import_tasks: shared_dir/tasks/setup_host.yml
 
 - name: SharedDirClient
   hosts: webworkers:proxy:celery:pillowtop:shared_dir_host
@@ -17,5 +17,5 @@
     - ../group_vars/all.yml
     - shared_dir/vars/main.yml
   tasks:
-    - include: shared_dir/tasks/install.yml
-    - include: shared_dir/tasks/setup_client.yml
+    - import_tasks: shared_dir/tasks/install.yml
+    - import_tasks: shared_dir/tasks/setup_client.yml

--- a/ansible/roles/zabbix_integrations/tasks/main.yml
+++ b/ansible/roles/zabbix_integrations/tasks/main.yml
@@ -19,24 +19,24 @@
     mode: 0755
     state: directory
 
-- include: diskstats.yml
+- import_tasks: diskstats.yml
 
-- include: es.yml
+- import_tasks: es.yml
   when: "'elasticsearch' in group_names"
   tags:
     zabbix_es
 
-- include: postgres.yml
+- import_tasks: postgres.yml
   when: "'postgresql' in group_names"
   tags:
     zabbix_postgres
 
-- include: pgbouncer.yml
+- import_tasks: pgbouncer.yml
   when: "'postgresql' in group_names"
   tags:
     zabbix_pgbouncer
 
-- include: nginx.yml
+- import_tasks: nginx.yml
   when: "'proxy' in group_names"
   tags:
     zabbix_nginx

--- a/ansible/setup_bidirectional_auth.yml
+++ b/ansible/setup_bidirectional_auth.yml
@@ -16,7 +16,7 @@
     - hostTo: "{{ hostB }}"
     - state: "{{ 'present' if action == 'add' else 'absent' }}"
   tasks:
-    - include: roles/setup_auth_keys.yml
+    - import_tasks: roles/setup_auth_keys.yml
 
 - name: Setup auth from {{ hostB }} to {{ hostA }}
   gather_facts: True
@@ -26,4 +26,4 @@
     - hostTo: "{{ hostA }}"
     - state: "{{ 'present' if action == 'add' else 'absent' }}"
   tasks:
-    - include: roles/setup_auth_keys.yml
+    - import_tasks: roles/setup_auth_keys.yml


### PR DESCRIPTION
include is deprecated and "confusing" according to docs.
i have not tested riakcs playbook, but hanlders are supposed to be allowed to import tasks, so it should work.