### PR TITLE
tmp'ly remove production hqdjango0.internal-va.commcarehq.org

### DIFF
--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -5,7 +5,7 @@ hqproxy0.internal-va.commcarehq.org
 mount_points="[{'partition':'/dev/xvdb1', 'dest':'/mnt/storage', 'fstype':'ext4'}]"
 
 [webworkers]
-hqdjango0.internal-va.commcarehq.org
+# hqdjango0.internal-va.commcarehq.org
 hqdjango1.internal-va.commcarehq.org
 hqdjango2.internal-va.commcarehq.org
 


### PR DESCRIPTION
This PR is just to document the current state of things on production. We'll either actually remove or swap back in by the end of the day.