### PR TITLE
Two more tweaks for a smooth deploy-stack

### DIFF
--- a/ansible/roles/common_installs/tasks/main.yml
+++ b/ansible/roles/common_installs/tasks/main.yml
@@ -105,11 +105,3 @@
   pip:
     name: virtualenv-clone
     version: 0.2.6
-
-- name: Install npm (only) a second time
-  npm: name="{{ item.name }}" version="{{ item.version }}" state=present global=yes
-  become: yes
-  with_items:
-    - {name: 'npm', version: '3.6.0'}
-  tags:
-    - npm

--- a/ansible/roles/common_installs/tasks/main.yml
+++ b/ansible/roles/common_installs/tasks/main.yml
@@ -78,9 +78,10 @@
   npm: name="{{ item.name }}" version="{{ item.version }}" state=present global=yes
   become: yes
   with_items:
+    - {name: 'n', version: '1.3.0'}
+    # must come after 'n', otherwise the wrong version of npm ends up installed on first pass
     - {name: 'npm', version: '3.6.0'}
     - {name: 'less', version: '2.7.2'}
-    - {name: 'n', version: '1.3.0'}
     - {name: 'bower', version: '1.5.3'}
     - {name: 'uglify-js', version: '2.6.1'}
   tags:
@@ -104,3 +105,11 @@
   pip:
     name: virtualenv-clone
     version: 0.2.6
+
+- name: Install npm (only) a second time
+  npm: name="{{ item.name }}" version="{{ item.version }}" state=present global=yes
+  become: yes
+  with_items:
+    - {name: 'npm', version: '3.6.0'}
+  tags:
+    - npm

--- a/ansible/roles/postgresql/tasks/main.yml
+++ b/ansible/roles/postgresql/tasks/main.yml
@@ -90,11 +90,15 @@
   tags: postgresql_conf
   notify: Reload postgres
 
-- name: start postgresql
+- name: Restart postgresql
   become: true
-  service: name=postgresql state=started args="{{ postgresql_version }}"
+  service: name=postgresql state=restarted args="{{ postgresql_version }}"
   tags: after-reboot
   register: start_postgresql
+
+- name: Reload postgresql
+  become: true
+  service: name=postgresql state=reloaded args="{{ postgresql_version }}"
 
 - name: wait after restarting postgres
   when: start_postgresql.changed

--- a/ansible/roles/postgresql/tasks/main.yml
+++ b/ansible/roles/postgresql/tasks/main.yml
@@ -96,10 +96,6 @@
   tags: after-reboot
   register: start_postgresql
 
-- name: Reload postgresql
-  become: true
-  service: name=postgresql state=reloaded args="{{ postgresql_version }}"
-
 - name: wait after restarting postgres
   when: start_postgresql.changed
   wait_for:


### PR DESCRIPTION
Getting closer to a smooth `deploy-stack`; in the last run I still had the following issues:

- What seemed like a short network connectivity error made me have to restart the process (at task `jython : Install Jython`)
- When I ran fab the way it failed made me notice supervisor wasn't properly set up, and running with `--tags=supervisor` fixed it—odd error both because that doesn't make a lot of sense and because this didn't happen in a previous run (yesterday)
- after trying again, I was then unable to connect to the celery machine. This has happened a couple times before, weirdly always to the celery machine

will keep investigating, but wanted to get these two fixes in anyway.