### PR TITLE
always include -A on ssh control

### DIFF
--- a/commcare-cloud/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/commcare-cloud/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -43,6 +43,9 @@ class Ssh(Lookup):
         if ':' in address:
             address, port = address.split(':')
             ssh_args = ['-p', port] + ssh_args
+        if args.server == 'control':
+            # Always include ssh agent forwarding on control machine
+            ssh_args = ['-A'] + ssh_args
         cmd_parts = [self.command, address] + ssh_args
         cmd = ' '.join(shlex_quote(arg) for arg in cmd_parts)
         print_command(cmd)


### PR DESCRIPTION
adds -A to `commcare-cloud <env> ssh control`:
```
$ commcare-cloud production ssh control
ssh control.internal-va.commcarehq.org -A
```
fails over to `ssh` when using `mosh` (since it doesn't support ssh agent forwarding):
```
$ commcare-cloud production mosh control
! mosh does not support ssh agent forwarding, using ssh instead.
ssh control.internal-va.commcarehq.org -A
```