### PR TITLE
Copy sentry.properties to formplayer dir

### DIFF
--- a/fab/fab/operations/release.py
+++ b/fab/fab/operations/release.py
@@ -399,6 +399,7 @@ def copy_formplayer_properties():
     sudo(
         'cp {} {}'.format(
             os.path.join(env.code_current, FORMPLAYER_BUILD_DIR, 'application.properties'),
+            os.path.join(env.code_current, FORMPLAYER_BUILD_DIR, 'sentry.properties'),
             os.path.join(env.code_root, FORMPLAYER_BUILD_DIR)
         ))
 


### PR DESCRIPTION
In December I submitted [this PR](https://github.com/dimagi/commcare-cloud/pull/1116) to silence a very verbose Sentry warning. This required adding a new file `sentry.properties` at the same level as the existing `application.properties`. So I copied the pattern used for `application.properties` in that PR and added the single property needed in the file. Unfortunately that change doesn't seem to have worked as there is no `sentry.properties` file in the `formplayer` build directory. `grep`ing the code this seems to be what's missing, however I'd appreciate someone verifying that (or letting me know if Im way off) 