### PR TITLE
don't require 'server' arg for monoliths

### DIFF
--- a/commcare-cloud/commcare_cloud/commands/inventory_lookup/getinventory.py
+++ b/commcare-cloud/commcare_cloud/commands/inventory_lookup/getinventory.py
@@ -13,6 +13,16 @@ def get_instance_group(environment, group):
     return env.inventory_hosts_by_group[group]
 
 
+def get_monolith_address(environment, exit=sys.exit):
+    env = get_environment(environment)
+    hosts = env.inventory_manager.get_hosts()
+    if len(hosts) != 1:
+        exit("There are {} servers in the environment. Please include the 'server'"
+             "argument to select one.".format(len(hosts)))
+    else:
+        return hosts[0].address
+
+
 def get_server_address(environment, group, exit=sys.exit):
     if "@" in group:
         username, group = group.split('@', 1)

--- a/commcare-cloud/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/commcare-cloud/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -5,7 +5,7 @@ import sys
 from commcare_cloud.cli_utils import print_command
 from commcare_cloud.commands.command_base import CommandBase
 from commcare_cloud.environment.main import get_environment
-from .getinventory import get_server_address
+from .getinventory import get_server_address, get_monolith_address
 from six.moves import shlex_quote
 
 
@@ -14,16 +14,19 @@ class Lookup(CommandBase):
     help = "Lookup remote hostname or IP address"
 
     def make_parser(self):
-        self.parser.add_argument("server",
+        self.parser.add_argument("server", nargs="?",
             help="Server name/group: postgresql, proxy, webworkers, ... The server "
                  "name/group may be prefixed with 'username@' to login as a specific "
                  "user and may be terminated with ':<n>' to choose one of "
                  "multiple servers if there is more than one in the group. "
-                 "For example: webworkers:0 will pick the first webworker.")
+                 "For example: webworkers:0 will pick the first webworker. May also"
+                 "be ommitted for environments with only a single server.")
 
     def lookup_server_address(self, args):
         def exit(message):
             self.parser.error("\n" + message)
+        if not args.server:
+            return get_monolith_address(args.environment, exit)
         return get_server_address(args.environment, args.server, exit)
 
     def run(self, args, unknown_args):


### PR DESCRIPTION
enables this shortcut `cchq <env> ssh` for envs with only 1 server

buddies @sravfeyn @esoergel 