### PR TITLE
use newer github api library so deploy fails fast when api key doesn't have the right scope

### DIFF
--- a/fab/fab/utils.py
+++ b/fab/fab/utils.py
@@ -79,13 +79,9 @@ class DeployMetadata(object):
             )))
         tag_name = "{}-{}-deploy".format(self.timestamp, self._environment)
         msg = "{} deploy at {}".format(self._environment, self.timestamp)
-        repo.create_git_tag_and_release(
-            tag=tag_name,
-            tag_message=msg,
-            release_name=tag_name,
-            release_message=msg,
-            object=self.deploy_ref,
-            type='commit',
+        repo.create_git_ref(
+            ref='refs/tags/' + tag_name,
+            sha=self.deploy_ref,
         )
         self._deploy_tag = tag_name
 

--- a/fab/fab/utils.py
+++ b/fab/fab/utils.py
@@ -84,7 +84,7 @@ class DeployMetadata(object):
             tag_message=msg,
             release_name=tag_name,
             release_message=msg,
-            object=self._deploy_ref,
+            object=self.deploy_ref,
             type='commit',
         )
         self._deploy_tag = tag_name

--- a/fab/fab/utils.py
+++ b/fab/fab/utils.py
@@ -82,6 +82,8 @@ class DeployMetadata(object):
         repo.create_git_tag_and_release(
             tag=tag_name,
             tag_message=msg,
+            release_name=tag_name,
+            release_message=msg,
             object=self._deploy_ref,
             type='commit',
         )

--- a/fab/fab/utils.py
+++ b/fab/fab/utils.py
@@ -11,7 +11,7 @@ from fabric.api import local
 import re
 from getpass import getpass
 
-from github3 import login
+from github import Github
 from fabric.api import execute, env
 from fabric.colors import magenta
 
@@ -66,8 +66,8 @@ class DeployMetadata(object):
 
         pattern = ".*-{}-.*".format(re.escape(self._environment))
         github = _get_github()
-        repo = github.repository('dimagi', 'commcare-hq')
-        for tag in repo.tags(self._max_tags):
+        repo = github.get_organization('dimagi').get_repo('commcare-hq')
+        for tag in repo.get_tags()[:self._max_tags]:
             if re.match(pattern, tag.name):
                 self._last_tag = tag.name
                 break
@@ -79,17 +79,11 @@ class DeployMetadata(object):
             )))
         tag_name = "{}-{}-deploy".format(self.timestamp, self._environment)
         msg = "{} deploy at {}".format(self._environment, self.timestamp)
-        user = github.me()
-        repo.create_tag(
+        repo.create_git_tag_and_release(
             tag=tag_name,
-            message=msg,
-            sha=self.deploy_ref,
-            obj_type='commit',
-            tagger={
-                'name': user.login,
-                'email': user.email or '{}@dimagi.com'.format(user.login),
-                'date': datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
-            }
+            tag_message=msg,
+            object=self._deploy_ref,
+            type='commit',
         )
         self._deploy_tag = tag_name
 
@@ -135,10 +129,10 @@ class DeployMetadata(object):
             return self._deploy_ref
 
         github = _get_github()
-        repo = github.repository('dimagi', 'commcare-hq')
+        repo = github.get_organization('dimagi').get_repo('commcare-hq')
 
         # turn whatever `code_branch` is into a commit hash
-        branch = repo.branch(self._code_branch)
+        branch = repo.get_branch(self._code_branch)
         self._deploy_ref = branch.commit.sha
         return self._deploy_ref
 
@@ -163,13 +157,13 @@ def _get_github():
         ).format(project_root=PROJECT_ROOT))
         username = input('Github username: ')
         password = getpass('Github password: ')
-        global_github = login(
-            username=username,
+        global_github = Github(
+            login_or_token=username,
             password=password,
         )
     else:
-        global_github = login(
-            token=GITHUB_APIKEY,
+        global_github = Github(
+            login_or_token=GITHUB_APIKEY,
         )
 
     return global_github

--- a/fab/requirements.txt
+++ b/fab/requirements.txt
@@ -1,6 +1,6 @@
 Fabric==1.10.2
 ansible==2.4.3
-github3.py==1.0.0a4
+PyGithub==1.37
 pytz==2017.2
 pycrypto==2.6.1
 cryptography==2.1.4


### PR DESCRIPTION
This addresses https://manage.dimagi.com/default.asp?266529 by making sure the deploy fails fast instead of silently failing to create the release tag, and later failing hard when the release tag is not found on github.

If the github api key doesn't have the scope ```public_repo```, then the deploy fails right at the start with a 401 error.

Example release generated with new code: https://github.com/dimagi/commcare-hq/releases/tag/2018-03-19_23.08-staging-deploy