### PR TITLE
Make auditcare configurable

### DIFF
--- a/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -729,6 +729,30 @@ MAX_RULE_UPDATES_IN_ONE_RUN = {{ localsettings.MAX_RULE_UPDATES_IN_ONE_RUN }}
 REPEATERS_WHITELIST = {{ localsettings.REPEATERS_WHITELIST }}
 {% endif %}
 
+{% if localsettings.AUDIT_MODEL_SAVE is defined %}
+AUDIT_MODEL_SAVE= [
+  {% for model in localsettings.get("AUDIT_MODEL_SAVE") -%}
+  '{{ model }}',
+  {% endfor -%}
+]
+{% endif %}
+
+{% if localsettings.AUDIT_MODULES is defined %}
+AUDIT_MODULES= [
+  {% for module in localsettings.get("AUDIT_MODULES") -%}
+  '{{ module }}',
+  {% endfor -%}
+]
+{% endif %}
+
+{% if localsettings.AUDIT_VIEWS is defined %}
+AUDIT_VIEWS= [
+  {% for view in localsettings.get("AUDIT_VIEWS") -%}
+  '{{ view }}',
+  {% endfor -%}
+]
+{% endif %}
+
 SERVER_EMAIL = '{{ server_email }}'
 DEFAULT_FROM_EMAIL = '{{ default_from_email }}'
 SUPPORT_EMAIL = '{{ support_email }}'

--- a/environments/icds-new/public.yml
+++ b/environments/icds-new/public.yml
@@ -251,7 +251,6 @@ localsettings:
     - '{{ SITE_HOST }}'
     - '{{ CAS_SITE_HOST }}'
     - '{{ hostvars[groups.proxy.0].public_ip }}'
-
   ASYNC_INDICATORS_TO_QUEUE: 60000
   ASYNC_INDICATOR_QUEUE_TIMES:
     '*':
@@ -259,6 +258,9 @@ localsettings:
       - [0, 3]
     7:
       - [0, 24]
+  AUDIT_MODEL_SAVE: []
+  AUDIT_MODULES: []
+  AUDIT_VIEWS: []
   BANK_ACCOUNT_NUMBER: "{{ localsettings_private.BANK_ACCOUNT_NUMBER }}"
   BANK_ADDRESS: { 'first_line': "1 Citizens Drive", 'city': "Riverside", 'region': "RI", 'postal_code': "02915" }
   BANK_NAME: "RBS Citizens N.A."


### PR DESCRIPTION
@snopoke I've seen some talk about taking this off of ICDS and this should do it, but I'm skeptical it will solve the issue. I tried to find correlation with any of the couchdb metrics we have in datadog, but couldn't find anything in particular.

My feeling is that https://github.com/dimagi/commcare-hq/blob/je/comp-feeding-forms-agg-script/corehq/ex-submodules/pillowtop/processors/form.py#L18 introduces too much churn on the users db but I have nothing to prove it other than at the end of the users DB is 15 GB and is then compacted to ~2 GB