### PR TITLE
fail fast during setup_release

### DIFF
--- a/fab/fab/utils.py
+++ b/fab/fab/utils.py
@@ -78,7 +78,6 @@ class DeployMetadata(object):
                 self._environment
             )))
         tag_name = "{}-{}-deploy".format(self.timestamp, self._environment)
-        msg = "{} deploy at {}".format(self._environment, self.timestamp)
         repo.create_git_ref(
             ref='refs/tags/' + tag_name,
             sha=self.deploy_ref,

--- a/fab/fab/utils.py
+++ b/fab/fab/utils.py
@@ -132,6 +132,13 @@ class DeployMetadata(object):
         # turn whatever `code_branch` is into a commit hash
         branch = repo.get_branch(self._code_branch)
         self._deploy_ref = branch.commit.sha
+
+        # Causes setup_release to fail fast if the right github permissions aren't set
+        repo.create_git_ref(
+            ref='refs/tags/' + '{}-{}-setup_release'.format(self.timestamp, self._environment),
+            sha=self._deploy_ref,
+        )
+
         return self._deploy_ref
 
 


### PR DESCRIPTION
I thought https://github.com/dimagi/commcare-cloud/pull/1499 would be enough but there was an error when I was testing this.  The only way to know if you have permission to create a release is to try to - unfortunately you can't query this using the github api if you're using a token: https://developer.github.com/v3/oauth_authorizations/#oauth-authorizations-api