### PR TITLE
Corrected upload file name to include tar extension and reduce backup…

### DIFF
--- a/ansible/roles/backups/templates/create_blobdb_backup.sh.j2
+++ b/ansible/roles/backups/templates/create_blobdb_backup.sh.j2
@@ -1,7 +1,7 @@
 #!/bin/bash
 BACKUP_TYPE=$1
 DAYS_TO_RETAIN_BACKUPS=$2
-
+HOSTNAME=$(hostname)
 TODAY=$(date +"%Y_%m_%d")
 BACKUP_FILE="blobdb_${BACKUP_TYPE}_${TODAY}.tar.gz"
 
@@ -11,5 +11,5 @@ tar -Pzcf "{{ blobdb_backup_dir }}/${BACKUP_FILE}" "{{ blobdb_dir_path }}"
 find {{ blobdb_backup_dir }} -mtime "+${DAYS_TO_RETAIN_BACKUPS}" -name "blobdb_${BACKUP_TYPE}_*" -delete;
 
 {% if blobdb_s3 %}
-( cd {{ blobdb_backup_dir }} && /usr/local/sbin/backup_snapshots.py "${BACKUP_FILE}" "blobdb" {{ blobdb_snapshot_bucket }} {{aws_endpoint}} )
+( cd {{ blobdb_backup_dir }} && /usr/local/sbin/backup_snapshots.py "${BACKUP_FILE}" "blobdb_${BACKUP_TYPE}_${HOSTNAME}.tar.gz" {{ blobdb_snapshot_bucket }} {{aws_endpoint}} )
 {% endif %}

--- a/ansible/roles/couchdb/templates/create_couchdb_backup.sh.j2
+++ b/ansible/roles/couchdb/templates/create_couchdb_backup.sh.j2
@@ -1,7 +1,7 @@
 #!/bin/bash
 BACKUP_TYPE=$1
 DAYS_TO_RETAIN_BACKUPS=$2
-
+HOSTNAME=$(hostname)
 TODAY=$(date +"%Y_%m_%d")
 BACKUP_FILE="couchdb_${BACKUP_TYPE}_${TODAY}.tar.gz"
 
@@ -15,5 +15,5 @@ rsync -avH --delete {{ couch_backup_dir }}/ {{ remote_couch_backup }}:{{ couch_b
 {% endif %}
 
 {% if couch_s3 %}
-( cd {{ couch_backup_dir }} && /usr/local/sbin/backup_snapshots.py "${BACKUP_FILE}" "couchdb" {{ couchdb_snapshot_bucket }} {{aws_endpoint}} )
+( cd {{ couch_backup_dir }} && /usr/local/sbin/backup_snapshots.py "${BACKUP_FILE}" "couchdb_${BACKUP_TYPE}_${HOSTNAME}.tar.gz" {{ couchdb_snapshot_bucket }} {{aws_endpoint}} )
 {% endif %}

--- a/ansible/roles/couchdb2/templates/create_couchdb_backup.sh.j2
+++ b/ansible/roles/couchdb2/templates/create_couchdb_backup.sh.j2
@@ -1,7 +1,7 @@
 #!/bin/bash
 BACKUP_TYPE=$1
 DAYS_TO_RETAIN_BACKUPS=$2
-
+HOSTNAME=$(hostname)
 TODAY=$(date +"%Y_%m_%d")
 BACKUP_FILE="couchdb_${BACKUP_TYPE}_${TODAY}.tar.gz"
 
@@ -15,5 +15,5 @@ rsync -avH --delete --exclude="commcarehq__synclogs.*.couch" {{ couch_backup_dir
 {% endif %}
 
 {% if couch_s3 %}
-( cd {{ couch_backup_dir }} && /usr/local/sbin/backup_snapshots.py "${BACKUP_FILE}" "couchdb" {{ couchdb_snapshot_bucket }} {{aws_endpoint}} )
+( cd {{ couch_backup_dir }} && /usr/local/sbin/backup_snapshots.py "${BACKUP_FILE}" "couchdb_${BACKUP_TYPE}_${HOSTNAME}.tar.gz" {{ couchdb_snapshot_bucket }} {{aws_endpoint}} )
 {% endif %}

--- a/ansible/roles/pg_backup/templates/plain/create_postgres_dump.sh.j2
+++ b/ansible/roles/pg_backup/templates/plain/create_postgres_dump.sh.j2
@@ -2,7 +2,7 @@
 BACKUP_TYPE=$1
 DAYS_TO_RETAIN_BACKUPS=$2
 ENV="{{ deploy_env }}"
-
+HOSTNAME=$(hostname)
 TODAY=$(date +"%Y_%m_%d")
 FILENAME="postgres_${ENV}_${BACKUP_TYPE}_${TODAY}"
 DIRECTORY="{{ postgresql_backup_dir }}/${FILENAME}"
@@ -47,10 +47,10 @@ fi
 
 {% if postgres_s3 %}
 if [ -f "${DIRECTORY}.gz" ]; then
-    ( cd {{ postgresql_backup_dir }} && /usr/local/sbin/backup_snapshots.py "${FILENAME}.gz" "postgres_${BACKUP_TYPE}" {{ postgres_snapshot_bucket }} {{aws_endpoint}}  )
+    ( cd {{ postgresql_backup_dir }} && /usr/local/sbin/backup_snapshots.py "${FILENAME}.gz" "postgres_${BACKUP_TYPE}_${HOSTNAME}.gz" {{ postgres_snapshot_bucket }} {{aws_endpoint}}  )
 fi
 if [ -f "${DIRECTORY}.tar.gz" ]; then
-    ( cd {{ postgresql_backup_dir }} && /usr/local/sbin/backup_snapshots.py "${FILENAME}.tar.gz" "postgres_${BACKUP_TYPE}" {{ postgres_snapshot_bucket }} {{aws_endpoint}}  )
+    ( cd {{ postgresql_backup_dir }} && /usr/local/sbin/backup_snapshots.py "${FILENAME}.tar.gz" "postgres_${BACKUP_TYPE}_${HOSTNAME}.tar.gz" {{ postgres_snapshot_bucket }} {{aws_endpoint}}  )
 fi
 {% endif %}
 

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -63,7 +63,7 @@ backup_es: True
 postgres_s3: True
 
 aws_region: 'us-east-1'
-postgresql_backup_days: 2
+postgresql_backup_days: 1
 postgresql_version: '9.4'
 postgresql_max_connections: 300
 pgbouncer_max_connections: 800


### PR DESCRIPTION
corrected upload file name to include tar extension and reduce backup days to 1
1) Number of back-ups to keep on prod do not need to be high since we have backups on s3.
2) Since multiple standbys upload their backups to s3 to the same name object. they should do it in different objects. 