### PR TITLE
Added db0 in pg_standby

### DIFF
--- a/environments/softlayer/inventory.ini
+++ b/environments/softlayer/inventory.ini
@@ -149,3 +149,4 @@ couch1
 10.162.36.196
 
 [pg_standby]
+db0

--- a/environments/softlayer/inventory.ini
+++ b/environments/softlayer/inventory.ini
@@ -149,4 +149,6 @@ couch1
 10.162.36.196
 
 [pg_standby]
+
+[pg_backup:children]
 db0


### PR DESCRIPTION
Because presently Backups are done only from standby.
and softlayer has no standby. Softlayer was not doing backups from September 2017 (_If I checked correctly_). That's a major issue.
I have here put db0 in the pg_standby group that enables backup scripts to be uploaded to db0. 
Though It is making a  change in `pg_hba.conf` that I think is not breaking anything. 
```

+# db0
+host   commcarehq	commcarehq	NXDOMAIN/32	md5
+host   commcarehq_p1	commcarehq	NXDOMAIN/32	md5
+host   commcarehq_p2	commcarehq	NXDOMAIN/32	md5
+host   commcarehq_p3	commcarehq	NXDOMAIN/32	md5
+host   commcarehq_p4	commcarehq	NXDOMAIN/32	md5
+host   commcarehq_p5	commcarehq	NXDOMAIN/32	md5
+host   commcarehq_proxy	commcarehq	NXDOMAIN/32	md5
+host   commcarehq_synclogs	commcarehq	NXDOMAIN/32	md5
+host   commcarehq_ucr	commcarehq	NXDOMAIN/32	md5
+host   formplayer	commcarehq	NXDOMAIN/32	md5
+host   icds-ucr	commcarehq	NXDOMAIN/32	md5
``` 
