### PR TITLE
datadog check for serverup

### DIFF
--- a/ansible/group_vars/proxy.yml
+++ b/ansible/group_vars/proxy.yml
@@ -1,1 +1,2 @@
 datadog_integration_nginx: true
+datadog_integration_http: true

--- a/ansible/roles/datadog/tasks/add_integrations.yml
+++ b/ansible/roles/datadog/tasks/add_integrations.yml
@@ -54,3 +54,4 @@
     - {"name": "couch", "enabled": "{{ datadog_integration_couch or inventory_hostname == couchdb2_first_host }}"}
     - {"name": "cloudant", "enabled": "{{ datadog_integration_cloudant }}"}
     - {"name": "shell", "enabled": "{{ datadog_integration_vmware }}"}
+    - {"name": "http", "enabled": "{{ datadog_integration_http }}"}

--- a/ansible/roles/datadog/tasks/remove_integrations.yml
+++ b/ansible/roles/datadog/tasks/remove_integrations.yml
@@ -51,5 +51,6 @@
     - {"name": "couch", "enabled": "{{ datadog_integration_couch or inventory_hostname == couchdb2_first_host }}"}
     - {"name": "couchdb2", "enabled": false}
     - {"name": "cloudant", "enabled": "{{ datadog_integration_cloudant }}"}
+    - {"name": "http", "enabled": "{{ datadog_integration_http }}"}
     # "Datadog Integration Graveyard": list globally removed integrations below
     - {"name": "process", "enabled": false}

--- a/ansible/roles/datadog/templates/http.yaml.j2
+++ b/ansible/roles/datadog/templates/http.yaml.j2
@@ -8,5 +8,6 @@ instances:
     days_warning: 28
     days_critical: 14
     timeout: 20
-  - name: {{ env_monitoring_id }} Heartbeat
-    url: https://{{ SITE_HOST }}/serverup.txt?only=heartbeat
+{#  wait for https://github.com/dimagi/commcare-hq/commit/22a1c1205ac48757996b45d2b6e5fdbc39b9ff31 #}
+{#  - name: {{ env_monitoring_id }} Heartbeat#}
+{#    url: https://{{ SITE_HOST }}/serverup.txt?only=heartbeat#}

--- a/ansible/roles/datadog/templates/http.yaml.j2
+++ b/ansible/roles/datadog/templates/http.yaml.j2
@@ -1,0 +1,12 @@
+init_config:
+
+instances:
+  - name: {{ env_monitoring_id }}
+    url: https://{{ SITE_HOST }}/serverup.txt
+    disable_ssl_validation: false
+    check_certificate_expiration: true
+    days_warning: 28
+    days_critical: 14
+    timeout: 20
+  - name: {{ env_monitoring_id }} Heartbeat
+    url: https://{{ SITE_HOST }}/serverup.txt?only=heartbeat


### PR DESCRIPTION
I want to test this out as a possible replacement for pingdom.

I've split out the `heartbeat` check from the others since that's usually the one that's flaky and has a lot of false positives.

Combine with https://github.com/dimagi/commcare-hq/pull/19880