### PR TITLE
incorrect usages of ipaddr

### DIFF
--- a/ansible/roles/couchdb2/templates/monit.couchdb2.j2
+++ b/ansible/roles/couchdb2/templates/monit.couchdb2.j2
@@ -3,4 +3,4 @@
    group couchdb2
    start program = "/etc/init.d/couchdb2 start"
    stop program = "/etc/init.d/couchdb2 stop"
-   if failed host {{ inventory_hostname|ipaddr }} port {{ couchdb2_port }} then restart
+   if failed host {{ inventory_hostname }} port {{ couchdb2_port }} then restart

--- a/ansible/roles/couchdb2/vars/main.yml
+++ b/ansible/roles/couchdb2/vars/main.yml
@@ -6,7 +6,7 @@ couchdb_data_dir: '{{ encrypted_root }}/couchdb2'
 couchdb_secure: False
 couchdb_bind:
   ty: static
-  host: '{{ inventory_hostname|ipaddr }}'
+  host: '{{ inventory_hostname }}'
 couchdb_socket_options: '[{recbuf, 262144}, {sndbuf, 262144}, {nodelay, true}]'
 
 couchdb_install_parent_dir: /usr/local/couchdb2

--- a/ansible/roles/redis/templates/monit.redis.j2
+++ b/ansible/roles/redis/templates/monit.redis.j2
@@ -3,4 +3,4 @@
    group redis
    start program = "/etc/init.d/{{ redis_service_name }} start"
    stop program = "/etc/init.d/{{ redis_service_name }} stop"
-   if failed host {{ inventory_hostname|ipaddr }} port {{ redis_port }} then restart
+   if failed host {{ inventory_hostname }} port {{ redis_port }} then restart


### PR DESCRIPTION
`ipaddr` filter can test for IP addresses and convert between various formats. If the value passed in isn't an IP address it returns false: https://docs.ansible.com/ansible/latest/playbooks_filters_ipaddr.html

These usages seem incorrect, at best they are a noop and at worse the convert a hostname like `hqdb0.internal....` to `False`.