### PR TITLE
Remove control from  staging

### DIFF
--- a/environments/staging/inventory.ini
+++ b/environments/staging/inventory.ini
@@ -45,4 +45,6 @@ hqkafka0-staging.internal-va.commcarehq.org
 hqriak00-staging.internal-va.commcarehq.org
 hqriak01-staging.internal-va.commcarehq.org
 
+[control]
+
 [pg_standby]

--- a/environments/staging/inventory.ini
+++ b/environments/staging/inventory.ini
@@ -45,7 +45,4 @@ hqkafka0-staging.internal-va.commcarehq.org
 hqriak00-staging.internal-va.commcarehq.org
 hqriak01-staging.internal-va.commcarehq.org
 
-[control]
-control.internal-va.commcarehq.org
-
 [pg_standby]


### PR DESCRIPTION
This is deployed through prod so on staging commands it fails because there's a different ansible/vault password.

buddy @proteusvacuum 