### PR TITLE
Fix django worker name

### DIFF
--- a/fab/fab/operations/supervisor.py
+++ b/fab/fab/operations/supervisor.py
@@ -177,7 +177,7 @@ def set_djangoapp_supervisorconf():
     if _check_in_roles(ROLES_DJANGO):
         _rebuild_supervisor_conf_file('make_supervisor_conf',
                                       'supervisor_django.conf',
-                                      {django_worker_name: django_worker_name}
+                                      {"django_worker_name": django_worker_name}
                                       )
 
 


### PR DESCRIPTION
FYI @mkangia @dannyroberts 
This was causing the supervisor process name to be a blank string. 