### PR TITLE
remove inventory host check in couch datadog config

### DIFF
--- a/ansible/roles/datadog/templates/couch.yaml.j2
+++ b/ansible/roles/datadog/templates/couch.yaml.j2
@@ -2,9 +2,7 @@ init_config:
 
 instances:
 {% for couch_config in couch_dbs.values() %}
-{% if couch_config.host == inventory_hostname %}
     - server: "http{% if couch_config.is_https %}s{% endif %}://{{ couch_config.host }}:{{ couch_config.port }}"
       user: {{ couch_config.username }}
       password: {{ couch_config.password }}
-{% endif %}
 {% endfor %}


### PR DESCRIPTION
This check isn't necessary since in couch v1.0 environments there is only one couch server and in v2.0 environments the check here makes sure this only runs on a single host: https://github.com/dimagi/commcare-cloud/blob/462bb5a1feca95aba04a13e56aec38ee2a8fc32d/ansible/roles/datadog/tasks/add_integrations.yml#L54

The current check breaks PNA which uses `127.0.0.1` as the couch IP which is not what's in the inventory.