### PR TITLE
Added datadog_integration_http.

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -93,6 +93,7 @@ datadog_integration_riakcs: false
 datadog_integration_zk: false
 datadog_integration_jmx: false
 datadog_integration_vmware: false
+datadog_integration_http: false
 
 root_email: commcarehq-ops+root@dimagi.com
 server_email: commcarehq-noreply@dimagi.com


### PR DESCRIPTION
Datadog is skipping configs 
in https://github.com/dimagi/commcare-cloud/blob/ee1692663eddb6e10870cbf8c05f7991c1abfd0a/ansible/roles/datadog/tasks/add_integrations.yml#L38
since variable `datadog_integration_http` was not defined. 