### PR TITLE
Disable pg_backup on icds

### DIFF
--- a/environments/icds-new/public.yml
+++ b/environments/icds-new/public.yml
@@ -54,7 +54,7 @@ elasticsearch_cluster_name: 'icds-2.0'
 supervisor_http_enabled: True
 
 backup_blobdb: False
-backup_postgres: plain
+backup_postgres: False
 backup_es: False
 postgres_s3: False
 couch_s3: False
@@ -182,11 +182,11 @@ site_locations:
     try_files: "$uri $uri/index.html $uri/ =404"
     auth_basic: '"Restricted Content"'
     auth_basic_user_file: '/etc/nginx/.htpasswd'
-  - name: /bihar_ls_files 
+  - name: /bihar_ls_files
     try_files: "$uri $uri/index.html $uri/ =404"
     auth_basic: '"Restricted Content"'
     auth_basic_user_file: "/etc/nginx/.htpasswd_bihar"
-  - name: /maharashtra_icds-cas_files 
+  - name: /maharashtra_icds-cas_files
     try_files: "$uri $uri/index.html $uri/ =404"
     auth_basic: '"Restricted Content"'
     auth_basic_user_file: "/etc/nginx/.htpasswd_maharashtra"
@@ -194,27 +194,27 @@ site_locations:
     try_files: "$uri $uri/index.html $uri/ =404"
     auth_basic: '"Restricted Content"'
     auth_basic_user_file: "/etc/nginx/.htpasswd_mp"
-  - name: /ls_hindi 
+  - name: /ls_hindi
     try_files: "$uri $uri/index.html $uri/ =404"
     auth_basic: '"Restricted Content"'
     auth_basic_user_file: "/etc/nginx/.htpasswd_ls_hindi"
-  - name: /ls_marathi 
+  - name: /ls_marathi
     try_files: "$uri $uri/index.html $uri/ =404"
     auth_basic: '"Restricted Content"'
     auth_basic_user_file: "/etc/nginx/.htpasswd_ls_marathi"
-  - name: /ls_telugu 
+  - name: /ls_telugu
     try_files: "$uri $uri/index.html $uri/ =404"
     auth_basic: '"Restricted Content"'
     auth_basic_user_file: "/etc/nginx/.htpasswd_ls_telugu"
-  - name: /hindi_files 
+  - name: /hindi_files
     try_files: "$uri $uri/index.html $uri/ =404"
     auth_basic: '"Restricted Content"'
     auth_basic_user_file: "/etc/nginx/.htpasswd_hindi_files"
-  - name: /marathi_files 
+  - name: /marathi_files
     try_files: "$uri $uri/index.html $uri/ =404"
     auth_basic: '"Restricted Content"'
     auth_basic_user_file: "/etc/nginx/.htpasswd_marathi_files"
-  - name: /telugu_files 
+  - name: /telugu_files
     try_files: "$uri $uri/index.html $uri/ =404"
     auth_basic: '"Restricted Content"'
     auth_basic_user_file: "/etc/nginx/.htpasswd_telugu_files"
@@ -400,7 +400,7 @@ localsettings:
   SENTRY_QUERY_URL: "{{ localsettings_private.SENTRY_QUERY_URL }}"
   SENTRY_API_KEY: "{{ localsettings_private.SENTRY_API_KEY }}"
   SMS_GATEWAY_PARAMS:
-  SMS_GATEWAY_URL: 
+  SMS_GATEWAY_URL:
   SMS_QUEUE_ENABLED: True
   SUMOLOGIC_URL: "{{ localsettings_private.SUMOLOGIC_URL }}"
   STRIPE_PRIVATE_KEY: "{{ localsettings_private.STRIPE_PRIVATE_KEY }}"


### PR DESCRIPTION
Disabled pg_backup on icds , since NIC is taking it now. 
FYI : newly added nodes `pgsynclog , pgshard4 ` not having a backup now. 
Do not merge till that's done 