### PR TITLE
have --control run in interactive mode

### DIFF
--- a/commcare-cloud/commcare_cloud/commcare_cloud.py
+++ b/commcare-cloud/commcare_cloud/commcare_cloud.py
@@ -50,7 +50,7 @@ def run_on_control_instead(args, sys_argv):
     argv.remove('--control')
     executable = 'commcare-cloud'
     cmd_parts = [
-        executable, args.env_name, 'ssh', 'control',
+        executable, args.env_name, 'ssh', 'control', '-t'
         'source ~/init-ansible && git checkout master && control/update_code.sh && source ~/init-ansible && {} {}'
         .format(executable, ' '.join([shlex_quote(arg) for arg in argv]))
     ]

--- a/control/check_install.sh
+++ b/control/check_install.sh
@@ -108,5 +108,7 @@ if [ ! -f "${FAB_CONFIG}" ]
 then
     printf "${RED}✗ ${FAB_CONFIG} does not exist and suitable location to copy it from was not found.\n"
     printf "${BLUE}  This file is just a convenience, so this is a non-critical error.\n"
-    printf "${BLUE}  If you have fab/config.py in a previous location, then copy it to ${FAB_CONFIG}.${NC}\n"
+    printf "${BLUE}  If you have fab/config.py in a previous location, then copy it to ${FAB_CONFIG}.\n"
 fi
+
+printf "${NC}"


### PR DESCRIPTION
This lets you run `cchq --control <env> fab deploy` and still be able to interact with prompts on the remote control machine.

I think I originally played around with this and then I let it slip and it didn't make it into the final (original) PR.