### PR TITLE
fix bash_completion

### DIFF
--- a/commcare-cloud/commcare_cloud/commcare_cloud.py
+++ b/commcare-cloud/commcare_cloud/commcare_cloud.py
@@ -82,7 +82,7 @@ def main():
     os.environ['PATH'] = '{}:{}'.format(get_virtualenv_path(), os.environ['PATH'])
     parser = ArgumentParser()
     available_envs = get_available_envs()
-    parser.add_argument('env_name', choices=available_envs, metavar='environment', help=(
+    parser.add_argument('env_name', choices=available_envs, help=(
         "server environment to run against"
     ))
     parser.add_argument('--control', action='store_true', help=(


### PR DESCRIPTION
this "metavar" thing (which changes the name of the variable in the help text) was something I did thinking I was clever when I renamed `environment` to `env_name`. But I wasn't being clever.