### PR TITLE
postgresql variable refactor

### DIFF
--- a/.travis/environments/travis/public.yml
+++ b/.travis/environments/travis/public.yml
@@ -130,8 +130,6 @@ formplayer_db_name: formplayer
 #    django_alias: "default" # if present this DB will be configured for django under this alias
 #    shards: [0, 99] # pl_proxy shards assigned to this DB (total across all DB's must be power of 2)
 
-DEFAULT_POSTGRESQL_HOST: "{{ groups.postgresql.0 }}"
-DEFAULT_POSTGRESQL_NAME: commcarehq
 DEFAULT_POSTGRESQL_PASSWORD: commcarehq
 DEFAULT_POSTGRESQL_USER: commcarehq
 

--- a/.travis/environments/travis/public.yml
+++ b/.travis/environments/travis/public.yml
@@ -64,7 +64,7 @@ postgresql_version: 9.6
 
 postgres_users:
   commcare:
-    username: "{{ localsettings.PG_DATABASE_USER }}"
+    username: "{{ DEFAULT_POSTGRESQL_USER }}"
     password: commcarehq
   devreadonly:
     username: "devreadonly"
@@ -122,19 +122,24 @@ formplayer_db_name: formplayer
 #
 #postgresql_dbs:
 #  - name: "database_name"
-#    host: "db_host" # defaults to localsettings.PG_DATABASE_HOST
-#    port: "db_port" # defaults to  localsettings.get('PG_DATABASE_PORT', 5432))
-#    user: "db user for django" # defaults to localsettings.PG_DATABASE_USER
-#    password: "db user password for django" # defaults to localsettings.PG_DATABASE_PASSWORD
-#    options: "django db options dict" # defaults to localsettings.get('PG_DATABASE_OPTIONS', {})
+#    host: "db_host" # defaults to DEFAULT_POSTGRESQL_HOST
+#    port: "db_port" # defaults to DEFAULT_POSTGRESQL_PORT
+#    user: "db user for django" # defaults to DEFAULT_POSTGRESQL_USER
+#    password: "db user password for django" # defaults to DEFAULT_POSTGRESQL_PASSWORD
+#    options: "django db options dict" # defaults to DEFAULT_POSTGRESQL_OPTIONS
 #    django_alias: "default" # if present this DB will be configured for django under this alias
-#    shards: [0, 99] # pl_proxy shards assigned to this DB (total accross all DB's must be power of 2)
+#    shards: [0, 99] # pl_proxy shards assigned to this DB (total across all DB's must be power of 2)
+
+DEFAULT_POSTGRESQL_HOST: "{{ groups.postgresql.0 }}"
+DEFAULT_POSTGRESQL_NAME: commcarehq
+DEFAULT_POSTGRESQL_PASSWORD: commcarehq
+DEFAULT_POSTGRESQL_USER: commcarehq
 
 postgresql_dbs:
   - name: commcarehq_ucr
     django_alias: ucr
     django_migrate: False
-  - name: "{{localsettings.PG_DATABASE_NAME}}"
+  - name: "{{DEFAULT_POSTGRESQL_NAME}}"
     django_alias: default
   - name: "{{ formplayer_db_name }}"
 
@@ -143,7 +148,7 @@ postgresql_dbs:
 #
 #postgresql_dbs:
 #  - django_alias: default
-#    name: "{{localsettings.PG_DATABASE_NAME}}"
+#    name: "{{DEFAULT_POSTGRESQL_NAME}}"
 #  - django_alias: proxy
 #    name: commcarehq_proxy
 #  - django_alias: p1
@@ -255,10 +260,6 @@ localsettings:
 #  MAPS_LAYERS:
 #  MEDIA_ROOT:
   OPEN_EXCHANGE_RATES_API_ID: "{{ localsettings_private.OPEN_EXCHANGE_RATES_API_ID }}"
-  PG_DATABASE_HOST: "{{ groups.postgresql.0 }}"
-  PG_DATABASE_NAME: commcarehq
-  PG_DATABASE_PASSWORD: commcarehq
-  PG_DATABASE_USER: commcarehq
 #  PILLOWTOP_MACHINE_ID:
 #  PILLOW_RETRY_QUEUE_ENABLED:
   REDIS_DB: '0'

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -142,3 +142,7 @@ es_snapshot_bucket: "dimagi-{{ deploy_env }}-es-snapshots"
 aws_region: None
 # this reads "'s3.{{ aws_region }}.amazonaws.com' if aws_region else None"
 aws_endpoint: '{{ aws_region and "s3." + aws_region + ".amazonaws.com" }}'
+
+
+DEFAULT_POSTGRESQL_PORT: 6432
+DEFAULT_POSTGRESQL_OPTIONS: {}

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -144,5 +144,9 @@ aws_region: None
 aws_endpoint: '{{ aws_region and "s3." + aws_region + ".amazonaws.com" }}'
 
 
+DEFAULT_POSTGRESQL_HOST: "{{ groups.postgresql.0 }}"
+DEFAULT_POSTGRESQL_NAME: commcarehq
+DEFAULT_POSTGRESQL_USER: "{{ secrets.POSTGRES_USERS.commcare.username }}"
+DEFAULT_POSTGRESQL_PASSWORD: "{{ secrets.POSTGRES_USERS.commcare.password }}"
 DEFAULT_POSTGRESQL_PORT: 6432
 DEFAULT_POSTGRESQL_OPTIONS: {}

--- a/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -21,11 +21,11 @@ DATABASES = { {% for config in postgresql_dbs %}
     '{{config.django_alias}}': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'NAME': '{{ config.name }}',
-        'USER': '{{ config.get('user', localsettings.PG_DATABASE_USER) }}',
-        'PASSWORD': '{{ config.get('password', localsettings.PG_DATABASE_PASSWORD) }}',
-        'HOST': '{{ config.get('host', localsettings.PG_DATABASE_HOST) }}',
-        'PORT': {{ config.get('port', localsettings.get('PG_DATABASE_PORT', 5432)) }},
-        'OPTIONS': {{ config.get('options', localsettings.get('PG_DATABASE_OPTIONS', {}))|to_json }},
+        'USER': '{{ config.get('user', DEFAULT_POSTGRESQL_USER) }}',
+        'PASSWORD': '{{ config.get('password', DEFAULT_POSTGRESQL_PASSWORD) }}',
+        'HOST': '{{ config.get('host', DEFAULT_POSTGRESQL_HOST) }}',
+        'PORT': {{ config.get('port', DEFAULT_POSTGRESQL_PORT) }},
+        'OPTIONS': {{ config.get('options', DEFAULT_POSTGRESQL_OPTIONS)|to_json }},
         {% if 'django_migrate' in config -%}
         'MIGRATE': {{ config.django_migrate }},
         {% endif -%}

--- a/ansible/roles/formplayer/vars/main.yml
+++ b/ansible/roles/formplayer/vars/main.yml
@@ -3,7 +3,7 @@ formplayer_data_dir: "{{ encrypted_root }}/formplayer"
 # formplayer_sentry_dsn: ..defined in secret file
 # formplayer_db_name: ..defined in secret file
 hq_main_db_host: "{% for config in postgresql_dbs -%}
-  {%- if config.name == localsettings.PG_DATABASE_NAME -%}
+  {%- if config.name == DEFAULT_POSTGRESQL_NAME -%}
   {%- if 'host' in config -%}{{ config.host }}
   {%- else -%}{{ groups.postgresql.0 }}
   {%- endif -%}

--- a/ansible/roles/postgresql/tasks/main.yml
+++ b/ansible/roles/postgresql/tasks/main.yml
@@ -142,13 +142,13 @@
     name: "{{ item.name }}"
     state: present
     port: "{{ postgresql_port }}"
-    owner: "{{ item.get('user', localsettings.PG_DATABASE_USER) }}"
+    owner: "{{ item.get('user', DEFAULT_POSTGRESQL_USER) }}"
     encoding: 'UTF-8'
     lc_collate: 'en_US.UTF-8'
     lc_ctype: 'en_US.UTF-8'
     template: 'template0'
   with_items: "{{ postgresql_dbs }}"
-  when: item.create|default(True) and ((item.get('host', localsettings.PG_DATABASE_HOST) == inventory_hostname) or is_monolith|bool)
+  when: item.create|default(True) and ((item.get('host', DEFAULT_POSTGRESQL_HOST) == inventory_hostname) or is_monolith|bool)
 
 # restart / reload if necessary to make sure replication slot config updated
 - meta: flush_handlers
@@ -257,7 +257,7 @@
     name: plproxy
     db: "{{item.name}}"
     port: "{{ postgresql_port }}"
-  when: (item.get('django_alias') == 'proxy' and item.get('host', localsettings.PG_DATABASE_HOST) == inventory_hostname) or is_monolith|bool
+  when: (item.get('django_alias') == 'proxy' and item.get('host', DEFAULT_POSTGRESQL_HOST) == inventory_hostname) or is_monolith|bool
   with_items: "{{ postgresql_dbs }}"
 
 - name: Create pghashlib extension
@@ -270,7 +270,7 @@
     db: "{{item.name}}"
     port: "{{ postgresql_port }}"
   with_items: "{{ postgresql_dbs }}"
-  when: item.create|default(True) and not is_pg_standby|default(False) and ((item.get('host', localsettings.PG_DATABASE_HOST) == inventory_hostname) or is_monolith|bool)
+  when: item.create|default(True) and not is_pg_standby|default(False) and ((item.get('host', DEFAULT_POSTGRESQL_HOST) == inventory_hostname) or is_monolith|bool)
   tags: pghashlib
 
 - name: Make plproxy a trusted language
@@ -283,7 +283,7 @@
     trust: True
     db: "{{item.name}}"
     port: "{{ postgresql_port }}"
-  when: (item.get('django_alias') == 'proxy' and item.get('host', localsettings.PG_DATABASE_HOST) == inventory_hostname) or is_monolith|bool
+  when: (item.get('django_alias') == 'proxy' and item.get('host', DEFAULT_POSTGRESQL_HOST) == inventory_hostname) or is_monolith|bool
   with_items: "{{ postgresql_dbs }}"
 
 - name: Grant usage on plproxy FDW
@@ -291,8 +291,8 @@
   become_user: postgres
   vars:
     ansible_ssh_pipelining: true
-  shell: "{{postgres_install_dir}}/bin/psql -U postgres -p {{postgresql_port}} {{item.name}} -c \"GRANT USAGE on FOREIGN DATA WRAPPER plproxy to {{item.get('user', localsettings.PG_DATABASE_USER)}}\""
-  when: (item.get('django_alias') == 'proxy' and item.get('host', localsettings.PG_DATABASE_HOST) == inventory_hostname) or is_monolith|bool
+  shell: "{{postgres_install_dir}}/bin/psql -U postgres -p {{postgresql_port}} {{item.name}} -c \"GRANT USAGE on FOREIGN DATA WRAPPER plproxy to {{item.get('user', DEFAULT_POSTGRESQL_USER)}}\""
+  when: (item.get('django_alias') == 'proxy' and item.get('host', DEFAULT_POSTGRESQL_HOST) == inventory_hostname) or is_monolith|bool
   with_items: "{{ postgresql_dbs }}"
 
 - name: Enable query stat collection
@@ -301,7 +301,7 @@
   vars:
     ansible_ssh_pipelining: true
   shell: "{{postgres_install_dir}}/bin/psql -U postgres -p {{postgresql_port}} {{item.name}} -c \"CREATE EXTENSION IF NOT EXISTS pg_stat_statements\""
-  when: pg_query_stats|default(False) and item.query_stats|default(False) and not is_pg_standby|default(False) and (item.get('host', localsettings.PG_DATABASE_HOST) == inventory_hostname) or is_monolith|bool
+  when: pg_query_stats|default(False) and item.query_stats|default(False) and not is_pg_standby|default(False) and (item.get('host', DEFAULT_POSTGRESQL_HOST) == inventory_hostname) or is_monolith|bool
   with_items: "{{ postgresql_dbs }}"
 
 - name: Copy log rotation script

--- a/ansible/roles/postgresql/templates/pg_hba.conf.j2
+++ b/ansible/roles/postgresql/templates/pg_hba.conf.j2
@@ -29,7 +29,7 @@ host    all     {{ postgres_users.tableau_readonly.username }}   {{ tableau_serv
 {% if cluster_ip_range is defined %}
 {% for db_name, db_list in postgresql_dbs|groupby('name') %}
 {% set db = db_list[0] %}
-{% if db.get('host', localsettings.PG_DATABASE_HOST) == inventory_hostname or db.get('host', localsettings.PG_DATABASE_HOST) == hot_standby_master|default(None) or is_monolith|bool %}
+{% if db.get('host', DEFAULT_POSTGRESQL_HOST) == inventory_hostname or db.get('host', DEFAULT_POSTGRESQL_HOST) == hot_standby_master|default(None) or is_monolith|bool %}
 {% for user_key in postgres_users | reject('in', ['netvault', 'replication'])  %}
 {% set user = postgres_users[user_key] %}
 host{% if postgresql_ssl_enabled %}ssl{% endif %}    {{ db.name }}    {{ user.username }}    {{ cluster_ip_range }}    md5
@@ -42,11 +42,11 @@ host{% if postgresql_ssl_enabled %}ssl{% endif %}    {{ db.name }}    {{ user.us
 # {{ host }}
 {% for db_name, db_list in postgresql_dbs|groupby('name') %}
 {% set db = db_list[0] %}
-{% if db.get('host', localsettings.PG_DATABASE_HOST) == inventory_hostname or db.get('host', localsettings.PG_DATABASE_HOST) == hot_standby_master|default(None) or is_monolith|bool %}
+{% if db.get('host', DEFAULT_POSTGRESQL_HOST) == inventory_hostname or db.get('host', DEFAULT_POSTGRESQL_HOST) == hot_standby_master|default(None) or is_monolith|bool %}
 {% if host | ipaddr %}
-host   {{ db.name }}	{{ db.get('user', localsettings.PG_DATABASE_USER) }}	{{ host }}/32   md5
+host   {{ db.name }}	{{ db.get('user', DEFAULT_POSTGRESQL_USER) }}	{{ host }}/32   md5
 {% else %}
-host   {{ db.name }}	{{ db.get('user', localsettings.PG_DATABASE_USER) }}	{{ lookup('dig', host, wantlist=True)[0] }}/32	md5
+host   {{ db.name }}	{{ db.get('user', DEFAULT_POSTGRESQL_USER) }}	{{ lookup('dig', host, wantlist=True)[0] }}/32	md5
 {% endif %}
 {% endif %}
 {% endfor %}

--- a/ansible/roles/postgresql/templates/pgbouncer.ini.j2
+++ b/ansible/roles/postgresql/templates/pgbouncer.ini.j2
@@ -9,7 +9,7 @@
 [databases]
 {% for db in postgresql_dbs %}
 {% if db.create|default(True) %}
-{% set db_host = db.get('host', localsettings.PG_DATABASE_HOST) %}
+{% set db_host = db.get('host', DEFAULT_POSTGRESQL_HOST) %}
 {% if db_host == inventory_hostname or db_host == hot_standby_master|default(None) or is_monolith|bool %}
 {{ db.name }} = host=localhost port={{postgresql_port}}
 {% endif %}
@@ -53,7 +53,7 @@ auth_file = /etc/pgbouncer/userlist.txt
 ;;;
 
 ; comma-separated list of users, who are allowed to change settings
-admin_users = postgres,{{ localsettings.PG_DATABASE_USER }},{{ postgres_users.devreadonly.username }}
+admin_users = postgres,{{ DEFAULT_POSTGRESQL_USER }},{{ postgres_users.devreadonly.username }}
 
 ; comma-separated list of users who are just allowed to use SHOW command
 ;stats_users = stats, root

--- a/ansible/roles/touchforms/templates/localsettings.py.j2
+++ b/ansible/roles/touchforms/templates/localsettings.py.j2
@@ -25,11 +25,11 @@ POSTGRES_TABLE = "formplayer_session"
 POSTGRES_JDBC_JAR = "{{ code_home }}/submodules/touchforms-src/touchforms/backend/jrlib/postgresql-9.4-1201.jdbc41.jar"
 
 POSTGRES_DATABASE = {
-        'HOST': '{{ localsettings.PG_DATABASE_HOST }}',
-        'PORT': '{{ localsettings.PG_DATABASE_PORT }}',
-        'NAME': '{{ localsettings.PG_DATABASE_NAME }}',
-        'USER': '{{ localsettings.PG_DATABASE_USER }}',
-        'PASSWORD': '{{ localsettings.PG_DATABASE_PASSWORD }}',
+        'HOST': '{{ DEFAULT_POSTGRESQL_HOST }}',
+        'PORT': '{{ DEFAULT_POSTGRESQL_PORT }}',
+        'NAME': '{{ DEFAULT_POSTGRESQL_NAME }}',
+        'USER': '{{ DEFAULT_POSTGRESQL_USER }}',
+        'PASSWORD': '{{ DEFAULT_POSTGRESQL_PASSWORD }}',
         'PREPARE_THRESHOLD': 0
 }
 ### END POSTGRES CONFIG ###

--- a/commcare-cloud-bootstrap/environment/public.yml
+++ b/commcare-cloud-bootstrap/environment/public.yml
@@ -129,11 +129,8 @@ formplayer_db_name: formplayer
 #    django_alias: "default" # if present this DB will be configured for django under this alias
 #    shards: [0, 99] # pl_proxy shards assigned to this DB (total across all DB's must be power of 2)
 
-DEFAULT_POSTGRESQL_HOST: "{{ groups.postgresql.0 }}"
-DEFAULT_POSTGRESQL_NAME: commcarehq
 DEFAULT_POSTGRESQL_PASSWORD: commcarehq
 DEFAULT_POSTGRESQL_USER: commcarehq
-DEFAULT_POSTGRESQL_PORT: 6432
 
 postgresql_dbs:
   - name: commcarehq_ucr

--- a/commcare-cloud-bootstrap/environment/public.yml
+++ b/commcare-cloud-bootstrap/environment/public.yml
@@ -121,19 +121,25 @@ formplayer_db_name: formplayer
 #
 #postgresql_dbs:
 #  - name: "database_name"
-#    host: "db_host" # defaults to localsettings.PG_DATABASE_HOST
-#    port: "db_port" # defaults to  localsettings.get('PG_DATABASE_PORT', 5432))
-#    user: "db user for django" # defaults to localsettings.PG_DATABASE_USER
-#    password: "db user password for django" # defaults to localsettings.PG_DATABASE_PASSWORD
-#    options: "django db options dict" # defaults to localsettings.get('PG_DATABASE_OPTIONS', {})
+#    host: "db_host" # defaults to DEFAULT_POSTGRESQL_HOST
+#    port: "db_port" # defaults to DEFAULT_POSTGRESQL_PORT
+#    user: "db user for django" # defaults to DEFAULT_POSTGRESQL_USER
+#    password: "db user password for django" # defaults to DEFAULT_POSTGRESQL_PASSWORD
+#    options: "django db options dict" # defaults to DEFAULT_POSTGRESQL_OPTIONS
 #    django_alias: "default" # if present this DB will be configured for django under this alias
-#    shards: [0, 99] # pl_proxy shards assigned to this DB (total accross all DB's must be power of 2)
+#    shards: [0, 99] # pl_proxy shards assigned to this DB (total across all DB's must be power of 2)
+
+DEFAULT_POSTGRESQL_HOST: "{{ groups.postgresql.0 }}"
+DEFAULT_POSTGRESQL_NAME: commcarehq
+DEFAULT_POSTGRESQL_PASSWORD: commcarehq
+DEFAULT_POSTGRESQL_USER: commcarehq
+DEFAULT_POSTGRESQL_PORT: 6432
 
 postgresql_dbs:
   - name: commcarehq_ucr
     django_alias: ucr
     django_migrate: False
-  - name: "{{localsettings.PG_DATABASE_NAME}}"
+  - name: "{{DEFAULT_POSTGRESQL_NAME}}"
     django_alias: default
   - name: "{{ formplayer_db_name }}"
 
@@ -142,7 +148,7 @@ postgresql_dbs:
 #
 #postgresql_dbs:
 #  - django_alias: default
-#    name: "{{localsettings.PG_DATABASE_NAME}}"
+#    name: "{{DEFAULT_POSTGRESQL_NAME}}"
 #  - django_alias: proxy
 #    name: commcarehq_proxy
 #  - django_alias: p1
@@ -264,11 +270,6 @@ localsettings:
 #  MAPS_LAYERS:
 #  MEDIA_ROOT:
   OPEN_EXCHANGE_RATES_API_ID: "{{ localsettings_private.OPEN_EXCHANGE_RATES_API_ID }}"
-  PG_DATABASE_HOST: "{{ groups.postgresql.0 }}"
-  PG_DATABASE_NAME: commcarehq
-  PG_DATABASE_PASSWORD: commcarehq
-  PG_DATABASE_USER: commcarehq
-  PG_DATABASE_PORT: 6432
 #  PILLOWTOP_MACHINE_ID:
 #  PILLOW_RETRY_QUEUE_ENABLED:
   REDIS_DB: '0'

--- a/environments/development/public.yml
+++ b/environments/development/public.yml
@@ -129,11 +129,8 @@ formplayer_db_name: formplayer
 #    django_alias: "default" # if present this DB will be configured for django under this alias
 #    shards: [0, 99] # pl_proxy shards assigned to this DB (total across all DB's must be power of 2)
 
-DEFAULT_POSTGRESQL_HOST: "{{ groups.postgresql.0 }}"
-DEFAULT_POSTGRESQL_NAME: commcarehq
 DEFAULT_POSTGRESQL_PASSWORD: commcarehq
 DEFAULT_POSTGRESQL_USER: commcarehq
-DEFAULT_POSTGRESQL_PORT: 6432
 
 postgresql_dbs:
   - name: commcarehq_ucr

--- a/environments/development/public.yml
+++ b/environments/development/public.yml
@@ -121,19 +121,25 @@ formplayer_db_name: formplayer
 #
 #postgresql_dbs:
 #  - name: "database_name"
-#    host: "db_host" # defaults to localsettings.PG_DATABASE_HOST
-#    port: "db_port" # defaults to  localsettings.get('PG_DATABASE_PORT', 5432))
-#    user: "db user for django" # defaults to localsettings.PG_DATABASE_USER
-#    password: "db user password for django" # defaults to localsettings.PG_DATABASE_PASSWORD
-#    options: "django db options dict" # defaults to localsettings.get('PG_DATABASE_OPTIONS', {})
+#    host: "db_host" # defaults to DEFAULT_POSTGRESQL_HOST
+#    port: "db_port" # defaults to DEFAULT_POSTGRESQL_PORT
+#    user: "db user for django" # defaults to DEFAULT_POSTGRESQL_USER
+#    password: "db user password for django" # defaults to DEFAULT_POSTGRESQL_PASSWORD
+#    options: "django db options dict" # defaults to DEFAULT_POSTGRESQL_OPTIONS
 #    django_alias: "default" # if present this DB will be configured for django under this alias
-#    shards: [0, 99] # pl_proxy shards assigned to this DB (total accross all DB's must be power of 2)
+#    shards: [0, 99] # pl_proxy shards assigned to this DB (total across all DB's must be power of 2)
+
+DEFAULT_POSTGRESQL_HOST: "{{ groups.postgresql.0 }}"
+DEFAULT_POSTGRESQL_NAME: commcarehq
+DEFAULT_POSTGRESQL_PASSWORD: commcarehq
+DEFAULT_POSTGRESQL_USER: commcarehq
+DEFAULT_POSTGRESQL_PORT: 6432
 
 postgresql_dbs:
   - name: commcarehq_ucr
     django_alias: ucr
     django_migrate: False
-  - name: "{{localsettings.PG_DATABASE_NAME}}"
+  - name: "{{DEFAULT_POSTGRESQL_NAME}}"
     django_alias: default
   - name: "{{ formplayer_db_name }}"
 
@@ -142,7 +148,7 @@ postgresql_dbs:
 #
 #postgresql_dbs:
 #  - django_alias: default
-#    name: "{{localsettings.PG_DATABASE_NAME}}"
+#    name: "{{DEFAULT_POSTGRESQL_NAME}}"
 #  - django_alias: proxy
 #    name: commcarehq_proxy
 #  - django_alias: p1
@@ -264,11 +270,6 @@ localsettings:
 #  MAPS_LAYERS:
 #  MEDIA_ROOT:
   OPEN_EXCHANGE_RATES_API_ID: "{{ localsettings_private.OPEN_EXCHANGE_RATES_API_ID }}"
-  PG_DATABASE_HOST: "{{ groups.postgresql.0 }}"
-  PG_DATABASE_NAME: commcarehq
-  PG_DATABASE_PASSWORD: commcarehq
-  PG_DATABASE_USER: commcarehq
-  PG_DATABASE_PORT: 6432
 #  PILLOWTOP_MACHINE_ID:
 #  PILLOW_RETRY_QUEUE_ENABLED:
   REDIS_DB: '0'

--- a/environments/enikshay/public.yml
+++ b/environments/enikshay/public.yml
@@ -76,11 +76,6 @@ formplayer_db_name: formplayer
 formplayer_archive_time_spec: '10m'
 formplayer_purge_time_spec: '8d'
 
-DEFAULT_POSTGRESQL_HOST: "{{ groups.postgresql.0 }}"
-DEFAULT_POSTGRESQL_NAME: commcarehq
-DEFAULT_POSTGRESQL_PASSWORD: "{{ secrets.POSTGRES_USERS.commcare.password }}"
-DEFAULT_POSTGRESQL_USER: "{{ secrets.POSTGRES_USERS.commcare.username }}"
-DEFAULT_POSTGRESQL_PORT: 6432
 
 postgresql_dbs:
   - django_alias: default

--- a/environments/enikshay/public.yml
+++ b/environments/enikshay/public.yml
@@ -76,9 +76,15 @@ formplayer_db_name: formplayer
 formplayer_archive_time_spec: '10m'
 formplayer_purge_time_spec: '8d'
 
+DEFAULT_POSTGRESQL_HOST: "{{ groups.postgresql.0 }}"
+DEFAULT_POSTGRESQL_NAME: commcarehq
+DEFAULT_POSTGRESQL_PASSWORD: "{{ secrets.POSTGRES_USERS.commcare.password }}"
+DEFAULT_POSTGRESQL_USER: "{{ secrets.POSTGRES_USERS.commcare.username }}"
+DEFAULT_POSTGRESQL_PORT: 6432
+
 postgresql_dbs:
   - django_alias: default
-    name: "{{localsettings.PG_DATABASE_NAME}}"
+    name: "{{DEFAULT_POSTGRESQL_NAME}}"
     host: "{{ groups.postgresql.0 }}"
   - django_alias: proxy
     name: commcarehq_proxy
@@ -239,11 +245,6 @@ localsettings:
   MAX_RULE_UPDATES_IN_ONE_RUN: 500000
   MIA_THE_DEPLOY_BOT_API: "{{ localsettings_private.MIA_THE_DEPLOY_BOT_API }}"
   OPEN_EXCHANGE_RATES_API_ID: "{{ localsettings_private.OPEN_EXCHANGE_RATES_API_ID }}"
-  PG_DATABASE_HOST: "{{ groups.postgresql.0 }}"
-  PG_DATABASE_NAME: commcarehq
-  PG_DATABASE_PASSWORD: "{{ secrets.POSTGRES_USERS.commcare.password }}"
-  PG_DATABASE_USER: "{{ secrets.POSTGRES_USERS.commcare.username }}"
-  PG_DATABASE_PORT: 6432
   PILLOWTOP_MACHINE_ID: enikshaycloud
   PILLOW_RETRY_QUEUE_ENABLED: True
   REDIS_DB: '0'

--- a/environments/icds-new/public.yml
+++ b/environments/icds-new/public.yml
@@ -61,9 +61,15 @@ formplayer_db_name: formplayer
 
 nofile_limit: 65536
 
+DEFAULT_POSTGRESQL_HOST: "{{ hostvars[groups.pgmain.0].inventory_hostname }}"
+DEFAULT_POSTGRESQL_NAME: commcarehq
+DEFAULT_POSTGRESQL_PASSWORD: "{{ secrets.POSTGRES_USERS.commcare.password }}"
+DEFAULT_POSTGRESQL_USER: "{{ secrets.POSTGRES_USERS.commcare.username }}"
+DEFAULT_POSTGRESQL_PORT: 6432
+
 postgresql_dbs:
   - django_alias: default
-    name: "{{localsettings.PG_DATABASE_NAME}}"
+    name: "{{DEFAULT_POSTGRESQL_NAME}}"
     host: "{{ hostvars[groups.pgmain.0].inventory_hostname }}"
   - django_alias: "{{localsettings.SYNCLOGS_SQL_DB_ALIAS}}"
     name: commcarehq_synclogs
@@ -358,11 +364,6 @@ localsettings:
             - 'static-it_report_follow_issue'
   MIA_THE_DEPLOY_BOT_API: "{{ localsettings_private.MIA_THE_DEPLOY_BOT_API }}"
   OPEN_EXCHANGE_RATES_API_ID: "{{ localsettings_private.OPEN_EXCHANGE_RATES_API_ID }}"
-  PG_DATABASE_HOST: "{{ hostvars[groups.pgmain.0].inventory_hostname }}"
-  PG_DATABASE_NAME: commcarehq
-  PG_DATABASE_PASSWORD: "{{ secrets.POSTGRES_USERS.commcare.password }}"
-  PG_DATABASE_USER: "{{ secrets.POSTGRES_USERS.commcare.username }}"
-  PG_DATABASE_PORT: 6432
   PILLOWTOP_MACHINE_ID: pil0
   PILLOW_RETRY_QUEUE_ENABLED: True
   REDIS_DB: '0'

--- a/environments/icds-new/public.yml
+++ b/environments/icds-new/public.yml
@@ -62,10 +62,6 @@ formplayer_db_name: formplayer
 nofile_limit: 65536
 
 DEFAULT_POSTGRESQL_HOST: "{{ hostvars[groups.pgmain.0].inventory_hostname }}"
-DEFAULT_POSTGRESQL_NAME: commcarehq
-DEFAULT_POSTGRESQL_PASSWORD: "{{ secrets.POSTGRES_USERS.commcare.password }}"
-DEFAULT_POSTGRESQL_USER: "{{ secrets.POSTGRES_USERS.commcare.username }}"
-DEFAULT_POSTGRESQL_PORT: 6432
 
 postgresql_dbs:
   - django_alias: default

--- a/environments/l10k/public.yml
+++ b/environments/l10k/public.yml
@@ -34,10 +34,6 @@ postgres_config:
 formplayer_db_name: formplayer
 
 DEFAULT_POSTGRESQL_HOST: "127.0.0.1"
-DEFAULT_POSTGRESQL_NAME: commcarehq
-DEFAULT_POSTGRESQL_PASSWORD: "{{ secrets.POSTGRES_USERS.commcare.password }}"
-DEFAULT_POSTGRESQL_USER: "{{ secrets.POSTGRES_USERS.commcare.username }}"
-DEFAULT_POSTGRESQL_PORT: 6432
 
 postgresql_dbs:
   - name: commcarehq_ucr

--- a/environments/l10k/public.yml
+++ b/environments/l10k/public.yml
@@ -33,10 +33,16 @@ postgres_config:
 
 formplayer_db_name: formplayer
 
+DEFAULT_POSTGRESQL_HOST: "127.0.0.1"
+DEFAULT_POSTGRESQL_NAME: commcarehq
+DEFAULT_POSTGRESQL_PASSWORD: "{{ secrets.POSTGRES_USERS.commcare.password }}"
+DEFAULT_POSTGRESQL_USER: "{{ secrets.POSTGRES_USERS.commcare.username }}"
+DEFAULT_POSTGRESQL_PORT: 6432
+
 postgresql_dbs:
   - name: commcarehq_ucr
     django_alias: ucr
-  - name: "{{ localsettings.PG_DATABASE_NAME }}"
+  - name: "{{ DEFAULT_POSTGRESQL_NAME }}"
     django_alias: default
   - name: "{{ formplayer_db_name }}"
   - django_alias: "{{localsettings.SYNCLOGS_SQL_DB_ALIAS}}"
@@ -142,11 +148,6 @@ localsettings:
   MAPS_LAYERS: "{{ localsettings_private.MAPS_LAYERS }}"
   MIA_THE_DEPLOY_BOT_API: "{{ localsettings_private.MIA_THE_DEPLOY_BOT_API }}"
   OPEN_EXCHANGE_RATES_API_ID: "{{ localsettings_private.OPEN_EXCHANGE_RATES_API_ID }}"
-  PG_DATABASE_HOST: "127.0.0.1"
-  PG_DATABASE_NAME: commcarehq
-  PG_DATABASE_PASSWORD: "{{ secrets.POSTGRES_USERS.commcare.password }}"
-  PG_DATABASE_USER: "{{ secrets.POSTGRES_USERS.commcare.username }}"
-  PG_DATABASE_PORT: 6432
 #  PILLOWTOP_MACHINE_ID:
   PILLOW_RETRY_QUEUE_ENABLED: True
   REDIS_DB: '0'

--- a/environments/pna/public.yml
+++ b/environments/pna/public.yml
@@ -48,10 +48,6 @@ pg_query_stats: False
 formplayer_db_name: formplayer
 
 DEFAULT_POSTGRESQL_HOST: "127.0.0.1"
-DEFAULT_POSTGRESQL_NAME: commcarehq
-DEFAULT_POSTGRESQL_PASSWORD: "{{ secrets.POSTGRES_USERS.commcare.password }}"
-DEFAULT_POSTGRESQL_USER: "{{ secrets.POSTGRES_USERS.commcare.username }}"
-DEFAULT_POSTGRESQL_PORT: 6432
 
 postgresql_dbs:
   - django_alias: default

--- a/environments/pna/public.yml
+++ b/environments/pna/public.yml
@@ -47,9 +47,15 @@ pg_query_stats: False
 
 formplayer_db_name: formplayer
 
+DEFAULT_POSTGRESQL_HOST: "127.0.0.1"
+DEFAULT_POSTGRESQL_NAME: commcarehq
+DEFAULT_POSTGRESQL_PASSWORD: "{{ secrets.POSTGRES_USERS.commcare.password }}"
+DEFAULT_POSTGRESQL_USER: "{{ secrets.POSTGRES_USERS.commcare.username }}"
+DEFAULT_POSTGRESQL_PORT: 6432
+
 postgresql_dbs:
   - django_alias: default
-    name: "{{localsettings.PG_DATABASE_NAME}}"
+    name: "{{DEFAULT_POSTGRESQL_NAME}}"
     host: "{{ groups.postgresql.0 }}"
   - django_alias: "{{localsettings.SYNCLOGS_SQL_DB_ALIAS}}"
     name: commcarehq_synclogs
@@ -213,11 +219,6 @@ localsettings:
   MAPS_LAYERS: "{{ localsettings_private.MAPS_LAYERS }}"
   MIA_THE_DEPLOY_BOT_API: "{{ localsettings_private.MIA_THE_DEPLOY_BOT_API }}"
   OPEN_EXCHANGE_RATES_API_ID: "{{ localsettings_private.OPEN_EXCHANGE_RATES_API_ID }}"
-  PG_DATABASE_HOST: "127.0.0.1"
-  PG_DATABASE_NAME: commcarehq
-  PG_DATABASE_PASSWORD: "{{ secrets.POSTGRES_USERS.commcare.password }}"
-  PG_DATABASE_USER: "{{ secrets.POSTGRES_USERS.commcare.username }}"
-  PG_DATABASE_PORT: 6432
 #  PILLOWTOP_MACHINE_ID:
   PILLOW_RETRY_QUEUE_ENABLED: True
   REDIS_DB: '0'

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -69,10 +69,6 @@ formplayer_archive_time_spec: '10m'
 formplayer_purge_time_spec: '8d'
 
 DEFAULT_POSTGRESQL_HOST: "hqdb0.internal-va.commcarehq.org"
-DEFAULT_POSTGRESQL_NAME: commcarehq
-DEFAULT_POSTGRESQL_PASSWORD: "{{ secrets.POSTGRES_USERS.commcare.password }}"
-DEFAULT_POSTGRESQL_USER: "{{ secrets.POSTGRES_USERS.commcare.username }}"
-DEFAULT_POSTGRESQL_PORT: 6432
 
 postgresql_dbs:
   - django_alias: default

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -68,9 +68,15 @@ formplayer_db_name: formplayer
 formplayer_archive_time_spec: '10m'
 formplayer_purge_time_spec: '8d'
 
+DEFAULT_POSTGRESQL_HOST: "hqdb0.internal-va.commcarehq.org"
+DEFAULT_POSTGRESQL_NAME: commcarehq
+DEFAULT_POSTGRESQL_PASSWORD: "{{ secrets.POSTGRES_USERS.commcare.password }}"
+DEFAULT_POSTGRESQL_USER: "{{ secrets.POSTGRES_USERS.commcare.username }}"
+DEFAULT_POSTGRESQL_PORT: 6432
+
 postgresql_dbs:
   - django_alias: default
-    name: "{{localsettings.PG_DATABASE_NAME}}"
+    name: "{{DEFAULT_POSTGRESQL_NAME}}"
     host: "hqdb0.internal-va.commcarehq.org"
   - django_alias: proxy
     name: commcarehq_proxy
@@ -204,11 +210,6 @@ localsettings:
   MIA_THE_DEPLOY_BOT_API: "{{ localsettings_private.MIA_THE_DEPLOY_BOT_API }}"
   MOBILE_INTEGRATION_TEST_TOKEN: "{{ localsettings_private.MOBILE_INTEGRATION_TEST_TOKEN }}"
   OPEN_EXCHANGE_RATES_API_ID: "{{ localsettings_private.OPEN_EXCHANGE_RATES_API_ID }}"
-  PG_DATABASE_HOST: "hqdb0.internal-va.commcarehq.org"
-  PG_DATABASE_NAME: commcarehq
-  PG_DATABASE_PASSWORD: "{{ secrets.POSTGRES_USERS.commcare.password }}"
-  PG_DATABASE_USER: "{{ secrets.POSTGRES_USERS.commcare.username }}"
-  PG_DATABASE_PORT: 6432
   PILLOWTOP_MACHINE_ID: hqdb0
   PILLOW_RETRY_QUEUE_ENABLED: True
   REDIS_DB: '0'

--- a/environments/softlayer/public.yml
+++ b/environments/softlayer/public.yml
@@ -53,11 +53,6 @@ pgbouncer_pool_mode: transaction
 
 formplayer_db_name: formplayer
 
-DEFAULT_POSTGRESQL_HOST: "{{ groups.postgresql.0 }}"
-DEFAULT_POSTGRESQL_NAME: commcarehq
-DEFAULT_POSTGRESQL_PASSWORD: "{{ secrets.POSTGRES_USERS.commcare.password }}"
-DEFAULT_POSTGRESQL_USER: "{{ secrets.POSTGRES_USERS.commcare.username }}"
-DEFAULT_POSTGRESQL_PORT: 6432
 
 postgresql_dbs:
   - django_alias: default

--- a/environments/softlayer/public.yml
+++ b/environments/softlayer/public.yml
@@ -53,9 +53,15 @@ pgbouncer_pool_mode: transaction
 
 formplayer_db_name: formplayer
 
+DEFAULT_POSTGRESQL_HOST: "{{ groups.postgresql.0 }}"
+DEFAULT_POSTGRESQL_NAME: commcarehq
+DEFAULT_POSTGRESQL_PASSWORD: "{{ secrets.POSTGRES_USERS.commcare.password }}"
+DEFAULT_POSTGRESQL_USER: "{{ secrets.POSTGRES_USERS.commcare.username }}"
+DEFAULT_POSTGRESQL_PORT: 6432
+
 postgresql_dbs:
   - django_alias: default
-    name: "{{localsettings.PG_DATABASE_NAME}}"
+    name: "{{DEFAULT_POSTGRESQL_NAME}}"
   - django_alias: proxy
     name: commcarehq_proxy
   - django_alias: "{{localsettings.SYNCLOGS_SQL_DB_ALIAS}}"
@@ -192,11 +198,6 @@ localsettings:
 #  MAPS_LAYERS:
   MIA_THE_DEPLOY_BOT_API: "{{ localsettings_private.MIA_THE_DEPLOY_BOT_API }}"
   OPEN_EXCHANGE_RATES_API_ID: "{{ localsettings_private.OPEN_EXCHANGE_RATES_API_ID }}"
-  PG_DATABASE_HOST: "{{ groups.postgresql.0 }}"
-  PG_DATABASE_NAME: commcarehq
-  PG_DATABASE_PASSWORD: "{{ secrets.POSTGRES_USERS.commcare.password }}"
-  PG_DATABASE_USER: "{{ secrets.POSTGRES_USERS.commcare.username }}"
-  PG_DATABASE_PORT: 6432
   PILLOWTOP_MACHINE_ID: indiacloud
   PILLOW_RETRY_QUEUE_ENABLED: True
   REDIS_DB: '0'

--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -46,9 +46,15 @@ pg_query_stats: True
 formplayer_db_name: formplayer
 formplayer_archive_time_spec: '10m'
 
+DEFAULT_POSTGRESQL_HOST: "{{ groups.postgresql.0 }}"
+DEFAULT_POSTGRESQL_NAME: commcarehq
+DEFAULT_POSTGRESQL_PASSWORD: "{{ secrets.POSTGRES_USERS.commcare.password }}"
+DEFAULT_POSTGRESQL_USER: "{{ secrets.POSTGRES_USERS.commcare.username }}"
+DEFAULT_POSTGRESQL_PORT: 6432
+
 postgresql_dbs:
   - django_alias: default
-    name: "{{localsettings.PG_DATABASE_NAME}}"
+    name: "{{DEFAULT_POSTGRESQL_NAME}}"
     query_stats: True
   - django_alias: proxy
     name: commcarehq_proxy
@@ -174,11 +180,6 @@ localsettings:
   MAPS_LAYERS: "{{ localsettings_private.MAPS_LAYERS }}"
   MIA_THE_DEPLOY_BOT_API: "{{ localsettings_private.MIA_THE_DEPLOY_BOT_API }}"
   OPEN_EXCHANGE_RATES_API_ID: "{{ localsettings_private.OPEN_EXCHANGE_RATES_API_ID }}"
-  PG_DATABASE_HOST: "{{ groups.postgresql.0 }}"
-  PG_DATABASE_NAME: commcarehq
-  PG_DATABASE_PASSWORD: "{{ secrets.POSTGRES_USERS.commcare.password }}"
-  PG_DATABASE_USER: "{{ secrets.POSTGRES_USERS.commcare.username }}"
-  PG_DATABASE_PORT: 6432
   PILLOWTOP_MACHINE_ID: staging-hqdb0-ubuntu
   PILLOW_RETRY_QUEUE_ENABLED: True
   REDIS_DB: '0'

--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -46,11 +46,6 @@ pg_query_stats: True
 formplayer_db_name: formplayer
 formplayer_archive_time_spec: '10m'
 
-DEFAULT_POSTGRESQL_HOST: "{{ groups.postgresql.0 }}"
-DEFAULT_POSTGRESQL_NAME: commcarehq
-DEFAULT_POSTGRESQL_PASSWORD: "{{ secrets.POSTGRES_USERS.commcare.password }}"
-DEFAULT_POSTGRESQL_USER: "{{ secrets.POSTGRES_USERS.commcare.username }}"
-DEFAULT_POSTGRESQL_PORT: 6432
 
 postgresql_dbs:
   - django_alias: default

--- a/environments/swiss/public.yml
+++ b/environments/swiss/public.yml
@@ -48,10 +48,6 @@ postgresql_work_mem: '1MB'
 formplayer_db_name: formplayer
 
 DEFAULT_POSTGRESQL_HOST: "127.0.0.1"
-DEFAULT_POSTGRESQL_NAME: commcarehq
-DEFAULT_POSTGRESQL_PASSWORD: "{{ secrets.POSTGRES_USERS.commcare.password }}"
-DEFAULT_POSTGRESQL_USER: "{{ secrets.POSTGRES_USERS.commcare.username }}"
-DEFAULT_POSTGRESQL_PORT: 6432
 
 postgresql_dbs:
   - name: commcarehq_ucr

--- a/environments/swiss/public.yml
+++ b/environments/swiss/public.yml
@@ -47,12 +47,18 @@ postgresql_work_mem: '1MB'
 
 formplayer_db_name: formplayer
 
+DEFAULT_POSTGRESQL_HOST: "127.0.0.1"
+DEFAULT_POSTGRESQL_NAME: commcarehq
+DEFAULT_POSTGRESQL_PASSWORD: "{{ secrets.POSTGRES_USERS.commcare.password }}"
+DEFAULT_POSTGRESQL_USER: "{{ secrets.POSTGRES_USERS.commcare.username }}"
+DEFAULT_POSTGRESQL_PORT: 6432
+
 postgresql_dbs:
   - name: commcarehq_ucr
     query_stats: True
     django_alias: ucr
     django_migrate: False
-  - name: "{{ localsettings.PG_DATABASE_NAME }}"
+  - name: "{{ DEFAULT_POSTGRESQL_NAME }}"
     django_alias: default
   - name: "{{ formplayer_db_name }}"
   - django_alias: "{{localsettings.SYNCLOGS_SQL_DB_ALIAS}}"
@@ -143,11 +149,6 @@ localsettings:
   MAPS_LAYERS: "{{ localsettings_private.MAPS_LAYERS }}"
   MIA_THE_DEPLOY_BOT_API: "{{ localsettings_private.MIA_THE_DEPLOY_BOT_API }}"
   OPEN_EXCHANGE_RATES_API_ID: "{{ localsettings_private.OPEN_EXCHANGE_RATES_API_ID }}"
-  PG_DATABASE_HOST: "127.0.0.1"
-  PG_DATABASE_NAME: commcarehq
-  PG_DATABASE_PASSWORD: "{{ secrets.POSTGRES_USERS.commcare.password }}"
-  PG_DATABASE_USER: "{{ secrets.POSTGRES_USERS.commcare.username }}"
-  PG_DATABASE_PORT: 6432
 #  PILLOWTOP_MACHINE_ID:
   PILLOW_RETRY_QUEUE_ENABLED: True
   REDIS_DB: '0'


### PR DESCRIPTION
I eventually want to pull out database config into its own file that is mediated by commcare-cloud and put in `.generated.yml` so we don't have all this `item.get('host', DEFAULT_POSTGRESQL_HOST)` stuff and so that the configs are easier to read and write and less error-prone / repetitive / redundant, but I thought I'd start with this refactor. Even if I never get there or it doesn't pan out, I still this refactor is a good one.