### PR TITLE
remove remnants of commcarehq_icds_testdata

### DIFF
--- a/environments/icds-new/postgresql.yml
+++ b/environments/icds-new/postgresql.yml
@@ -57,8 +57,6 @@ postgresql_dbs:
     name: commcarehq_icds_aggregatedata
     host: pgucr
     query_stats: True
-  - name: commcarehq_icds_testdata
-    host: pgucr
   - name: "{{ formplayer_db_name }}"
     host: pgucr
   - django_alias: icds-ucr-standby1

--- a/environments/staging/postgresql.yml
+++ b/environments/staging/postgresql.yml
@@ -31,7 +31,3 @@ postgresql_dbs:
     django_alias: ucr
     django_migrate: False
   - name: "{{ formplayer_db_name }}"
-  - django_alias: icds-ucr
-    name: commcarehq_icds_testdata
-    query_stats: True
-    django_migrate: False


### PR DESCRIPTION
This doesn't actually delete these databases; just removes them from ansible's awareness