### PR TITLE
move other postgresql vars to postgresql.yml

### DIFF
--- a/.travis/environments/travis/postgresql.yml
+++ b/.travis/environments/travis/postgresql.yml
@@ -6,3 +6,19 @@ SEPARATE_FORM_PROCESSING_DBS: False
 dbs:
   synclogs: null
   form_processing: null
+
+override:
+  postgresql_version: '9.6'
+  postgresql_log_directory: "{{ encrypted_root }}/pg_log"
+  postgresql_ssl_enabled: False
+  postgresql_max_connections: 20
+  postgresql_work_mem: '8MB'
+  postgresql_shared_buffers: '128MB'
+  postgresql_max_stack_depth: '6MB'
+  postgresql_effective_cache_size: '4GB'
+  postgresql_max_standby_delay: -1
+  pgbouncer_max_connections: 100
+  pgbouncer_default_pool: 15
+  pgbouncer_reserve_pool: 4
+  pgbouncer_pool_timeout: 2
+  pgbouncer_pool_mode: session

--- a/.travis/environments/travis/public.yml
+++ b/.travis/environments/travis/public.yml
@@ -83,10 +83,6 @@ postgres_users:
       password: 'hqbackup'
       role_attr_flags: 'SUPERUSER'
 
-pg_replication_slots:
-  192.168.33.16:
-    - standby1
-
 encrypted_root: '/opt/data'
 postgresql_log_directory: "{{ encrypted_root }}/pg_log"
 postgresql_ssl_enabled: False

--- a/.travis/environments/travis/public.yml
+++ b/.travis/environments/travis/public.yml
@@ -60,8 +60,6 @@ AMQP_NAME: commcarehq
 
 backup_es: False
 
-postgresql_version: 9.6
-
 postgres_users:
   commcare:
     username: "{{ DEFAULT_POSTGRESQL_USER }}"
@@ -84,19 +82,6 @@ postgres_users:
       role_attr_flags: 'SUPERUSER'
 
 encrypted_root: '/opt/data'
-postgresql_log_directory: "{{ encrypted_root }}/pg_log"
-postgresql_ssl_enabled: False
-postgresql_max_connections: 20
-postgresql_work_mem: '8MB'
-postgresql_shared_buffers: '128MB'
-postgresql_max_stack_depth: '6MB'
-postgresql_effective_cache_size: '4GB'
-postgresql_max_standby_delay: '-1'
-pgbouncer_max_connections: 100
-pgbouncer_default_pool: 15
-pgbouncer_reserve_pool: 4
-pgbouncer_pool_timeout: 2
-pgbouncer_pool_mode: session
 
 shared_drive_enabled: True
 backup_postgres: dump

--- a/.travis/environments/travis/public.yml
+++ b/.travis/environments/travis/public.yml
@@ -101,8 +101,6 @@ pgbouncer_default_pool: 15
 pgbouncer_reserve_pool: 4
 pgbouncer_pool_timeout: 2
 pgbouncer_pool_mode: session
-postgresql_wal_keep_segments: 8
-pgstandby_wal_keep_segments: 8
 
 shared_drive_enabled: True
 backup_postgres: dump

--- a/ansible/roles/postgresql/defaults/main.yml
+++ b/ansible/roles/postgresql/defaults/main.yml
@@ -12,6 +12,9 @@ postgres_install_dir: "/usr/lib/postgresql/{{ postgresql_version }}"
 postgresql_archive_dir: "{{ postgresql_dir_path }}/wal_archive"
 postgresql_log_directory: "{{ postgresql_home }}/pg_log"
 postgresql_num_logs_to_keep: 20
+pgstandby_wal_keep_segments: 8
+postgresql_wal_keep_segments: 8
+
 
 pgbouncer_port: 6432
 pgbouncer_pid_file: "/var/run/postgresql/pgbouncer.pid"
@@ -25,6 +28,7 @@ postgresql_work_mem: '8MB'
 postgresql_shared_buffers: '1024MB'
 postgresql_max_stack_depth: '2MB'
 postgresql_effective_cache_size: '128MB'
+postgresql_max_standby_delay: 0  # 0 means don't set in postgresql.conf (leaving default value)
 postgresql_maintenance_work_mem: '64MB'
 postgresql_checkpoint_completion_target: '0.5'
 postgresql_wal_buffers: '-1'

--- a/ansible/roles/postgresql/defaults/main.yml
+++ b/ansible/roles/postgresql/defaults/main.yml
@@ -33,7 +33,7 @@ postgresql_maintenance_work_mem: '64MB'
 postgresql_checkpoint_completion_target: '0.5'
 postgresql_wal_buffers: '-1'
 postgresql_default_statistics_target: '100'
-postgresql_checkpoint_segments: '16'  # V <= 9.4
+postgresql_checkpoint_segments: 16  # V <= 9.4
 postgresql_max_wal_size: '256MB'  # V >= 9.6
 postgresql_slow_log_threshold: 300
 

--- a/ansible/roles/postgresql/templates/postgresql.conf.j2
+++ b/ansible/roles/postgresql/templates/postgresql.conf.j2
@@ -52,9 +52,9 @@ checkpoint_completion_target = {{ postgresql_checkpoint_completion_target }}
 wal_buffers = {{ postgresql_wal_buffers }}
 checkpoint_warning = 120s
 {% if is_pg_standby %}
-wal_keep_segments = {{ pgstandby_wal_keep_segments|default(8) }}
+wal_keep_segments = {{ pgstandby_wal_keep_segments }}
 {% else %}
-wal_keep_segments = {{ postgresql_wal_keep_segments|default(8) }}
+wal_keep_segments = {{ postgresql_wal_keep_segments }}
 {% endif %}
 
 # REPLICATION
@@ -65,7 +65,7 @@ hot_standby_feedback = on
 {% endif %}
 max_replication_slots = 8
 
-{% if is_pg_standby and postgresql_max_standby_delay|default(false) %}
+{% if is_pg_standby and postgresql_max_standby_delay %}
 max_standby_archive_delay = {{ postgresql_max_standby_delay }}
 max_standby_streaming_delay = {{ postgresql_max_standby_delay }}
 {% endif %}

--- a/commcare-cloud-bootstrap/environment/postgresql.yml
+++ b/commcare-cloud-bootstrap/environment/postgresql.yml
@@ -1,6 +1,22 @@
 DEFAULT_POSTGRESQL_PASSWORD: commcarehq
 DEFAULT_POSTGRESQL_USER: commcarehq
 SEPARATE_SYNCLOGS_DB: False
+SEPARATE_FORM_PROCESSING_DBS: False
+
+override:
+  postgresql_log_directory: "{{ encrypted_root }}/pg_log"
+  postgresql_ssl_enabled: False
+  postgresql_max_connections: 20
+  postgresql_work_mem: '8MB'
+  postgresql_shared_buffers: '128MB'
+  postgresql_max_stack_depth: '6MB'
+  postgresql_effective_cache_size: '4GB'
+  postgresql_max_standby_delay: '-1'
+  pgbouncer_max_connections: 100
+  pgbouncer_default_pool: 15
+  pgbouncer_reserve_pool: 4
+  pgbouncer_pool_timeout: 2
+  pgbouncer_pool_mode: session
 
 dbs:
   synclogs: null

--- a/commcare-cloud-bootstrap/environment/public.yml
+++ b/commcare-cloud-bootstrap/environment/public.yml
@@ -98,8 +98,6 @@ pgbouncer_default_pool: 15
 pgbouncer_reserve_pool: 4
 pgbouncer_pool_timeout: 2
 pgbouncer_pool_mode: session
-postgresql_wal_keep_segments: 8
-pgstandby_wal_keep_segments: 8
 
 shared_drive_enabled: True
 backup_postgres: plain

--- a/commcare-cloud-bootstrap/environment/public.yml
+++ b/commcare-cloud-bootstrap/environment/public.yml
@@ -81,19 +81,6 @@ postgres_users:
       role_attr_flags: 'LOGIN,REPLICATION'
 
 encrypted_root: '/opt/data'
-postgresql_log_directory: "{{ encrypted_root }}/pg_log"
-postgresql_ssl_enabled: False
-postgresql_max_connections: 20
-postgresql_work_mem: '8MB'
-postgresql_shared_buffers: '128MB'
-postgresql_max_stack_depth: '6MB'
-postgresql_effective_cache_size: '4GB'
-postgresql_max_standby_delay: '-1'
-pgbouncer_max_connections: 100
-pgbouncer_default_pool: 15
-pgbouncer_reserve_pool: 4
-pgbouncer_pool_timeout: 2
-pgbouncer_pool_mode: session
 
 shared_drive_enabled: True
 backup_postgres: plain

--- a/commcare-cloud-bootstrap/environment/public.yml
+++ b/commcare-cloud-bootstrap/environment/public.yml
@@ -80,10 +80,6 @@ postgres_users:
       password: 'hqrepl'
       role_attr_flags: 'LOGIN,REPLICATION'
 
-pg_replication_slots:
-  192.168.33.16:
-    - standby1
-
 encrypted_root: '/opt/data'
 postgresql_log_directory: "{{ encrypted_root }}/pg_log"
 postgresql_ssl_enabled: False

--- a/commcare-cloud/commcare_cloud/environment/main.py
+++ b/commcare-cloud/commcare_cloud/environment/main.py
@@ -4,7 +4,7 @@ import yaml
 from memoized import memoized, memoized_property
 
 from commcare_cloud.environment.constants import constants
-from commcare_cloud.environment.paths import DefaultPaths
+from commcare_cloud.environment.paths import DefaultPaths, get_role_defaults
 from commcare_cloud.environment.schemas.app_processes import AppProcessesConfig
 
 from ansible.inventory.manager import InventoryManager
@@ -22,7 +22,9 @@ class Environment(object):
         self.paths = paths
 
     def check(self):
-        self.public_vars
+
+        included_disallowed_public_variables = set(self.public_vars.keys()) & self._disallowed_public_variables
+        assert not included_disallowed_public_variables, included_disallowed_public_variables
         self.meta_config
         self.users_config
         self.raw_app_processes_config
@@ -41,6 +43,10 @@ class Environment(object):
         """contents of public.yml, as a dict"""
         with open(self.paths.public_yml) as f:
             return yaml.load(f)
+
+    @memoized_property
+    def _disallowed_public_variables(self):
+        return set(get_role_defaults('postgresql').keys())
 
     @memoized_property
     def meta_config(self):

--- a/commcare-cloud/commcare_cloud/environment/main.py
+++ b/commcare-cloud/commcare_cloud/environment/main.py
@@ -156,7 +156,7 @@ class Environment(object):
             'authorized_keys_dir': '{}/'.format(self.paths.authorized_keys_dir),
             'known_hosts_file': self.paths.known_hosts,
         }
-        generated_variables.update(self.postgresql_config.to_json())
+        generated_variables.update(self.postgresql_config.to_generated_variables())
         generated_variables.update(constants.to_json())
         with open(self.paths.generated_yml, 'w') as f:
             f.write(yaml.safe_dump(generated_variables))

--- a/commcare-cloud/commcare_cloud/environment/paths.py
+++ b/commcare-cloud/commcare_cloud/environment/paths.py
@@ -1,6 +1,7 @@
 import os
 import sys
 
+import yaml
 from memoized import memoized_property, memoized
 
 REPO_BASE = os.path.expanduser('~/.commcare-cloud/repo')
@@ -69,6 +70,17 @@ class DefaultPaths(object):
     @memoized
     def get_users_yml(self, org):
         return os.path.join(self.environments_dir, '_users', '{}.yml'.format(org))
+
+
+def get_role_defaults_yml(role):
+    return os.path.join(REPO_BASE, 'ansible', 'roles', role, 'defaults', 'main.yml')
+
+
+@memoized
+def get_role_defaults(role):
+    """contents of a role's defaults/main.yml, as a dict"""
+    with open(get_role_defaults_yml(role)) as f:
+        return yaml.load(f)
 
 
 def get_virtualenv_path():

--- a/commcare-cloud/commcare_cloud/environment/schemas/postgresql.py
+++ b/commcare-cloud/commcare_cloud/environment/schemas/postgresql.py
@@ -37,6 +37,8 @@ class PostgresqlConfig(jsonobject.JsonObject):
 
     @classmethod
     def wrap(cls, data):
+        # for better validation error message
+        PostgresqlOverride.wrap(data.get('override', {}))
         self = super(PostgresqlConfig, cls).wrap(data)
         for db in self.generate_postgresql_dbs():
             if not db.user:

--- a/commcare-cloud/commcare_cloud/environment/schemas/role_defaults.py
+++ b/commcare-cloud/commcare_cloud/environment/schemas/role_defaults.py
@@ -1,0 +1,29 @@
+import jsonobject
+from commcare_cloud.environment.paths import get_role_defaults
+
+
+def get_defaults_jsonobject(role, **kwargs):
+    """
+    Create a JsonObject subclass that has a property for every default variable in :role:
+
+    additionally, calling to_json() on an instance will exclude any variables
+    that are set to the original default
+
+    :param role: ansible role to look for defaults/main.yml file of.
+            Must be under ansible/roles/.
+    :param kwargs: extra properties to define explicitly.
+            Useful if autodetection is not enough.
+    :return: The new JsonObject subclass.
+    """
+    cls = type(jsonobject.JsonObject)(
+        '{}_Defaults'.format(role), (jsonobject.JsonObject,),
+        dict(get_role_defaults(role), _allow_dynamic_properties=False, **kwargs))
+
+    # exclude from to_json if set to the default value
+    def exclude(self, value):
+        return value == self.default()
+
+    for property_ in cls._properties_by_key.values():
+        property_.exclude = exclude.__get__(property_)
+
+    return cls

--- a/environments/development/postgresql.yml
+++ b/environments/development/postgresql.yml
@@ -3,6 +3,21 @@ DEFAULT_POSTGRESQL_USER: commcarehq
 SEPARATE_SYNCLOGS_DB: False
 SEPARATE_FORM_PROCESSING_DBS: False
 
+override:
+  postgresql_log_directory: "{{ encrypted_root }}/pg_log"
+  postgresql_ssl_enabled: False
+  postgresql_max_connections: 20
+  postgresql_work_mem: '8MB'
+  postgresql_shared_buffers: '128MB'
+  postgresql_max_stack_depth: '6MB'
+  postgresql_effective_cache_size: '4GB'
+  postgresql_max_standby_delay: -1
+  pgbouncer_max_connections: 100
+  pgbouncer_default_pool: 15
+  pgbouncer_reserve_pool: 4
+  pgbouncer_pool_timeout: 2
+  pgbouncer_pool_mode: session
+
 dbs:
   synclogs: null
   form_processing: null

--- a/environments/development/postgresql.yml
+++ b/environments/development/postgresql.yml
@@ -4,19 +4,11 @@ SEPARATE_SYNCLOGS_DB: False
 SEPARATE_FORM_PROCESSING_DBS: False
 
 override:
-  postgresql_log_directory: "{{ encrypted_root }}/pg_log"
-  postgresql_ssl_enabled: False
-  postgresql_max_connections: 20
-  postgresql_work_mem: '8MB'
-  postgresql_shared_buffers: '128MB'
-  postgresql_max_stack_depth: '6MB'
-  postgresql_effective_cache_size: '4GB'
+  postgresql_effective_cache_size: 4GB
+  postgresql_log_directory: '{{ encrypted_root }}/pg_log'
+  postgresql_max_stack_depth: 6MB
   postgresql_max_standby_delay: -1
-  pgbouncer_max_connections: 100
-  pgbouncer_default_pool: 15
-  pgbouncer_reserve_pool: 4
-  pgbouncer_pool_timeout: 2
-  pgbouncer_pool_mode: session
+  postgresql_shared_buffers: 128MB
 
 dbs:
   synclogs: null

--- a/environments/development/public.yml
+++ b/environments/development/public.yml
@@ -98,8 +98,6 @@ pgbouncer_default_pool: 15
 pgbouncer_reserve_pool: 4
 pgbouncer_pool_timeout: 2
 pgbouncer_pool_mode: session
-postgresql_wal_keep_segments: 8
-pgstandby_wal_keep_segments: 8
 
 shared_drive_enabled: True
 backup_postgres: plain

--- a/environments/development/public.yml
+++ b/environments/development/public.yml
@@ -81,19 +81,6 @@ postgres_users:
       role_attr_flags: 'LOGIN,REPLICATION'
 
 encrypted_root: '/opt/data'
-postgresql_log_directory: "{{ encrypted_root }}/pg_log"
-postgresql_ssl_enabled: False
-postgresql_max_connections: 20
-postgresql_work_mem: '8MB'
-postgresql_shared_buffers: '128MB'
-postgresql_max_stack_depth: '6MB'
-postgresql_effective_cache_size: '4GB'
-postgresql_max_standby_delay: '-1'
-pgbouncer_max_connections: 100
-pgbouncer_default_pool: 15
-pgbouncer_reserve_pool: 4
-pgbouncer_pool_timeout: 2
-pgbouncer_pool_mode: session
 
 shared_drive_enabled: True
 backup_postgres: plain

--- a/environments/development/public.yml
+++ b/environments/development/public.yml
@@ -80,10 +80,6 @@ postgres_users:
       password: 'hqrepl'
       role_attr_flags: 'LOGIN,REPLICATION'
 
-pg_replication_slots:
-  192.168.33.16:
-    - standby1
-
 encrypted_root: '/opt/data'
 postgresql_log_directory: "{{ encrypted_root }}/pg_log"
 postgresql_ssl_enabled: False

--- a/environments/enikshay/postgresql.yml
+++ b/environments/enikshay/postgresql.yml
@@ -1,3 +1,20 @@
+override:
+  postgresql_version: '9.4'
+  postgresql_num_logs_to_keep: 100
+  postgresql_shared_buffers: '10GB'
+  postgresql_max_stack_depth: '6MB'
+  postgresql_effective_cache_size: '32GB'
+  postgresql_work_mem: '16MB'
+  postgresql_max_connections: 600
+  postgresql_checkpoint_segments: 32
+  pgstandby_wal_keep_segments: 500
+  pgbouncer_max_connections: 1600
+  pgbouncer_default_pool: 500
+  pgbouncer_reserve_pool: 5
+  pgbouncer_pool_timeout: 1
+  pgbouncer_pool_mode: transaction
+  postgresql_ssl_enabled: False
+  postgresql_log_directory: "{{ encrypted_root }}/pg_log"
 
 dbs:
   ucr:

--- a/environments/enikshay/postgresql.yml
+++ b/environments/enikshay/postgresql.yml
@@ -1,20 +1,19 @@
 override:
-  postgresql_version: '9.4'
-  postgresql_num_logs_to_keep: 100
-  postgresql_shared_buffers: '10GB'
-  postgresql_max_stack_depth: '6MB'
-  postgresql_effective_cache_size: '32GB'
-  postgresql_work_mem: '16MB'
-  postgresql_max_connections: 600
-  postgresql_checkpoint_segments: 32
-  pgstandby_wal_keep_segments: 500
-  pgbouncer_max_connections: 1600
   pgbouncer_default_pool: 500
-  pgbouncer_reserve_pool: 5
-  pgbouncer_pool_timeout: 1
+  pgbouncer_max_connections: 1600
   pgbouncer_pool_mode: transaction
-  postgresql_ssl_enabled: False
-  postgresql_log_directory: "{{ encrypted_root }}/pg_log"
+  pgbouncer_pool_timeout: 1
+  pgbouncer_reserve_pool: 5
+  pgstandby_wal_keep_segments: 500
+  postgresql_checkpoint_segments: 32
+  postgresql_effective_cache_size: 32GB
+  postgresql_log_directory: '{{ encrypted_root }}/pg_log'
+  postgresql_max_connections: 600
+  postgresql_max_stack_depth: 6MB
+  postgresql_num_logs_to_keep: 100
+  postgresql_shared_buffers: 10GB
+  postgresql_version: '9.4'
+  postgresql_work_mem: 16MB
 
 dbs:
   ucr:

--- a/environments/enikshay/public.yml
+++ b/environments/enikshay/public.yml
@@ -61,7 +61,6 @@ postgresql_effective_cache_size: '32GB'
 postgresql_work_mem: '16MB'
 postgresql_max_connections: 600
 postgresql_checkpoint_segments: 32
-postgresql_wal_keep_segments: 8
 pgstandby_wal_keep_segments: 500
 pgbouncer_max_connections: 1600
 pgbouncer_default_pool: 500

--- a/environments/enikshay/public.yml
+++ b/environments/enikshay/public.yml
@@ -45,7 +45,6 @@ backup_postgres: plain
 postgresql_backup_days: 1
 postgresql_backup_weeks: 1
 postgresql_backup_master: False
-postgresql_log_directory: "{{ encrypted_root }}/pg_log"
 backup_es: False
 postgres_s3: False
 backup_couch: True
@@ -53,25 +52,8 @@ nadir_hour: 16
 
 nofile_limit: 65536
 
-postgresql_version: '9.4'
-postgresql_num_logs_to_keep: 100
-postgresql_shared_buffers: '10GB'
-postgresql_max_stack_depth: '6MB'
-postgresql_effective_cache_size: '32GB'
-postgresql_work_mem: '16MB'
-postgresql_max_connections: 600
-postgresql_checkpoint_segments: 32
-pgstandby_wal_keep_segments: 500
-pgbouncer_max_connections: 1600
-pgbouncer_default_pool: 500
-pgbouncer_reserve_pool: 5
-pgbouncer_pool_timeout: 1
-pgbouncer_pool_mode: transaction
-
 formplayer_archive_time_spec: '10m'
 formplayer_purge_time_spec: '8d'
-
-postgresql_ssl_enabled: False
 
 redis_appendonly: 'no'
 

--- a/environments/icds-new/postgresql.yml
+++ b/environments/icds-new/postgresql.yml
@@ -8,6 +8,16 @@ REPORTING_DATABASES:
       - [icds-ucr-standby1, 5]
   icds-test-ucr: icds-ucr
 
+override:
+  postgresql_version: '9.6'
+  postgresql_shared_buffers: '8GB'
+  postgresql_max_stack_depth: '6MB'
+  postgresql_effective_cache_size: '16GB'
+  postgresql_slow_log_threshold: 1000
+  pgbouncer_reserve_pool: 5
+  pgbouncer_pool_timeout: 1
+  pgbouncer_pool_mode: transaction
+
 dbs:
   main:
     host: pgmain

--- a/environments/icds-new/postgresql.yml
+++ b/environments/icds-new/postgresql.yml
@@ -9,14 +9,13 @@ REPORTING_DATABASES:
   icds-test-ucr: icds-ucr
 
 override:
-  postgresql_version: '9.6'
-  postgresql_shared_buffers: '8GB'
-  postgresql_max_stack_depth: '6MB'
-  postgresql_effective_cache_size: '16GB'
-  postgresql_slow_log_threshold: 1000
-  pgbouncer_reserve_pool: 5
-  pgbouncer_pool_timeout: 1
   pgbouncer_pool_mode: transaction
+  pgbouncer_pool_timeout: 1
+  pgbouncer_reserve_pool: 5
+  postgresql_effective_cache_size: 16GB
+  postgresql_max_stack_depth: 6MB
+  postgresql_shared_buffers: 8GB
+  postgresql_slow_log_threshold: 1000
 
 dbs:
   main:

--- a/environments/icds-new/public.yml
+++ b/environments/icds-new/public.yml
@@ -46,17 +46,6 @@ couch_s3: False
 backup_couch: False
 nadir_hour: 16
 
-
-postgresql_version: '9.6'
-postgresql_shared_buffers: '8GB'
-postgresql_max_stack_depth: '6MB'
-postgresql_effective_cache_size: '16GB'
-postgresql_slow_log_threshold: 1000
-pgbouncer_reserve_pool: 5
-pgbouncer_pool_timeout: 1
-pgbouncer_pool_mode: transaction
-
-
 nofile_limit: 65536
 
 redis_appendonly: 'no'

--- a/environments/pna/postgresql.yml
+++ b/environments/pna/postgresql.yml
@@ -1,3 +1,14 @@
+override:
+  postgresql_version: '9.6'
+  postgresql_shared_buffers: '2GB'
+  postgresql_max_stack_depth: '4MB'
+  postgresql_effective_cache_size: '8GB'
+  postgresql_max_connections: 300
+  pgbouncer_max_connections: 400
+  pgbouncer_default_pool: 290
+  pgbouncer_reserve_pool: 5
+  pgbouncer_pool_timeout: 1
+  pgbouncer_pool_mode: transaction
 
 dbs:
   form_processing:

--- a/environments/pna/postgresql.yml
+++ b/environments/pna/postgresql.yml
@@ -1,14 +1,13 @@
 override:
-  postgresql_version: '9.6'
-  postgresql_shared_buffers: '2GB'
-  postgresql_max_stack_depth: '4MB'
-  postgresql_effective_cache_size: '8GB'
-  postgresql_max_connections: 300
-  pgbouncer_max_connections: 400
   pgbouncer_default_pool: 290
-  pgbouncer_reserve_pool: 5
-  pgbouncer_pool_timeout: 1
+  pgbouncer_max_connections: 400
   pgbouncer_pool_mode: transaction
+  pgbouncer_pool_timeout: 1
+  pgbouncer_reserve_pool: 5
+  postgresql_effective_cache_size: 8GB
+  postgresql_max_connections: 300
+  postgresql_max_stack_depth: 4MB
+  postgresql_shared_buffers: 2GB
 
 dbs:
   form_processing:

--- a/environments/pna/public.yml
+++ b/environments/pna/public.yml
@@ -33,18 +33,6 @@ couch_s3: True
 
 aws_region: 'us-east-1'
 
-postgresql_version: '9.6'
-postgresql_shared_buffers: '2GB'
-postgresql_max_stack_depth: '4MB'
-postgresql_effective_cache_size: '8GB'
-postgresql_max_connections: 300
-pgbouncer_max_connections: 400
-pgbouncer_default_pool: 290
-pgbouncer_reserve_pool: 5
-pgbouncer_pool_timeout: 1
-pgbouncer_pool_mode: transaction
-
-
 couchdb2:
   username: "{{ localsettings_private.COUCH_USERNAME }}"
   password: "{{ localsettings_private.COUCH_PASSWORD }}"

--- a/environments/production/postgresql.yml
+++ b/environments/production/postgresql.yml
@@ -1,13 +1,13 @@
 DEFAULT_POSTGRESQL_HOST: hqdb0
 
 override:
-  postgresql_version: '9.4'
-  postgresql_max_connections: 300
-  pgbouncer_max_connections: 800
   pgbouncer_default_pool: 290
-  pgbouncer_reserve_pool: 5
-  pgbouncer_pool_timeout: 1
+  pgbouncer_max_connections: 800
   pgbouncer_pool_mode: transaction
+  pgbouncer_pool_timeout: 1
+  pgbouncer_reserve_pool: 5
+  postgresql_max_connections: 300
+  postgresql_version: '9.4'
 
 dbs:
   main:

--- a/environments/production/postgresql.yml
+++ b/environments/production/postgresql.yml
@@ -1,5 +1,14 @@
 DEFAULT_POSTGRESQL_HOST: hqdb0
 
+override:
+  postgresql_version: '9.4'
+  postgresql_max_connections: 300
+  pgbouncer_max_connections: 800
+  pgbouncer_default_pool: 290
+  pgbouncer_reserve_pool: 5
+  pgbouncer_pool_timeout: 1
+  pgbouncer_pool_mode: transaction
+
 dbs:
   main:
     host: hqdb0

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -50,16 +50,9 @@ backup_blobdb: False
 backup_postgres: plain
 backup_es: True
 postgres_s3: True
+postgresql_backup_days: 1
 
 aws_region: 'us-east-1'
-postgresql_backup_days: 1
-postgresql_version: '9.4'
-postgresql_max_connections: 300
-pgbouncer_max_connections: 800
-pgbouncer_default_pool: 290
-pgbouncer_reserve_pool: 5
-pgbouncer_pool_timeout: 1
-pgbouncer_pool_mode: transaction
 
 formplayer_archive_time_spec: '10m'
 formplayer_purge_time_spec: '8d'

--- a/environments/softlayer/postgresql.yml
+++ b/environments/softlayer/postgresql.yml
@@ -3,6 +3,16 @@ REPORTING_DATABASES:
   icds-ucr: icds-ucr
   icds-test-ucr: icds-ucr
 
+override:
+  postgresql_version: '9.6'
+  postgresql_max_connections: 300
+  pgbouncer_max_connections: 1000
+  pgbouncer_default_pool: 290
+  pgbouncer_reserve_pool: 5
+  pgbouncer_pool_timeout: 1
+  pgbouncer_pool_mode: transaction
+  postgresql_ssl_enabled: False
+
 dbs:
   form_processing:
     partitions:

--- a/environments/softlayer/postgresql.yml
+++ b/environments/softlayer/postgresql.yml
@@ -4,14 +4,12 @@ REPORTING_DATABASES:
   icds-test-ucr: icds-ucr
 
 override:
-  postgresql_version: '9.6'
-  postgresql_max_connections: 300
-  pgbouncer_max_connections: 1000
   pgbouncer_default_pool: 290
-  pgbouncer_reserve_pool: 5
-  pgbouncer_pool_timeout: 1
+  pgbouncer_max_connections: 1000
   pgbouncer_pool_mode: transaction
-  postgresql_ssl_enabled: False
+  pgbouncer_pool_timeout: 1
+  pgbouncer_reserve_pool: 5
+  postgresql_max_connections: 300
 
 dbs:
   form_processing:

--- a/environments/softlayer/public.yml
+++ b/environments/softlayer/public.yml
@@ -41,17 +41,6 @@ aws_region: 'ap-south-1'
 
 nofile_limit: 65536
 
-postgresql_version: '9.6'
-postgresql_max_connections: 300
-pgbouncer_max_connections: 1000
-pgbouncer_default_pool: 290
-pgbouncer_reserve_pool: 5
-pgbouncer_pool_timeout: 1
-pgbouncer_pool_mode: transaction
-
-
-postgresql_ssl_enabled: False
-
 redis_appendonly: 'no'
 
 KSPLICE_ACTIVE: yes

--- a/environments/staging/postgresql.yml
+++ b/environments/staging/postgresql.yml
@@ -1,11 +1,6 @@
 override:
-  postgresql_version: '9.4'
-  postgresql_max_connections: 20
-  pgbouncer_max_connections: 100
-  pgbouncer_default_pool: 15
-  pgbouncer_reserve_pool: 4
-  pgbouncer_pool_timeout: 2
   pgbouncer_pool_mode: transaction
+  postgresql_version: '9.4'
 
 dbs:
   main:

--- a/environments/staging/postgresql.yml
+++ b/environments/staging/postgresql.yml
@@ -1,3 +1,11 @@
+override:
+  postgresql_version: '9.4'
+  postgresql_max_connections: 20
+  pgbouncer_max_connections: 100
+  pgbouncer_default_pool: 15
+  pgbouncer_reserve_pool: 4
+  pgbouncer_pool_timeout: 2
+  pgbouncer_pool_mode: transaction
 
 dbs:
   main:

--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -32,14 +32,6 @@ postgres_s3: False
 
 aws_region: 'us-east-1'
 
-postgresql_version: '9.4'
-postgresql_max_connections: 20
-pgbouncer_max_connections: 100
-pgbouncer_default_pool: 15
-pgbouncer_reserve_pool: 4
-pgbouncer_pool_timeout: 2
-pgbouncer_pool_mode: transaction
-
 formplayer_archive_time_spec: '10m'
 
 KSPLICE_ACTIVE: yes

--- a/environments/swiss/postgresql.yml
+++ b/environments/swiss/postgresql.yml
@@ -2,7 +2,6 @@ DEFAULT_POSTGRESQL_HOST: "127.0.0.1"
 SEPARATE_FORM_PROCESSING_DBS: False
 
 override:
-  postgresql_version: '9.6'
   pgbouncer_default_pool: 290
   pgbouncer_max_connections: 400
   pgbouncer_pool_mode: transaction
@@ -10,7 +9,7 @@ override:
   pgbouncer_reserve_pool: 5
   postgresql_max_connections: 300
   postgresql_wal_keep_segments: 0
-  postgresql_work_mem: '1MB'
+  postgresql_work_mem: 1MB
 
 dbs:
   ucr:

--- a/environments/swiss/postgresql.yml
+++ b/environments/swiss/postgresql.yml
@@ -1,6 +1,17 @@
 DEFAULT_POSTGRESQL_HOST: "127.0.0.1"
 SEPARATE_FORM_PROCESSING_DBS: False
 
+override:
+  postgresql_version: '9.6'
+  pgbouncer_default_pool: 290
+  pgbouncer_max_connections: 400
+  pgbouncer_pool_mode: transaction
+  pgbouncer_pool_timeout: 1
+  pgbouncer_reserve_pool: 5
+  postgresql_max_connections: 300
+  postgresql_wal_keep_segments: 0
+  postgresql_work_mem: '1MB'
+
 dbs:
   ucr:
     query_stats: True

--- a/environments/swiss/public.yml
+++ b/environments/swiss/public.yml
@@ -35,17 +35,6 @@ couchdb_snapshot_bucket: commcare-almanach-backup
 
 aws_versioning_enabled: false
 
-postgresql_version: '9.6'
-pgbouncer_default_pool: 290
-pgbouncer_max_connections: 400
-pgbouncer_pool_mode: transaction
-pgbouncer_pool_timeout: 1
-pgbouncer_reserve_pool: 5
-postgresql_max_connections: 300
-postgresql_wal_keep_segments: 0
-postgresql_work_mem: '1MB'
-
-
 KSPLICE_ACTIVE: yes
 
 AMQP_HOST: "185.12.7.167"


### PR DESCRIPTION
This PR takes the tack of allowing you to override any `postgresql` role variable default (from `ansible/roles/postgresql/defaults/main.yml`) by putting it under `override` in `postgresql.yml`. In addition, it infers from the role's defaults file (1) what variables are allowed, (2) what the default value is, and (3) what the type is. This allows us to perform validation on these variables, including type validation, by hijacking built-in jsonobject behavior.

Generating this schema dynamically lets us treat this role's defaults file as a sort of "interface" to that module, and allow the schema validation to change as that interface changes, without having to add the same thing in a number of places. If we have success with this pattern, I've written it in such a way that we could use it for other roles as well.

What do you guys think of the patter?