### PR TITLE
make supervisor dependency of commcarehq not common

### DIFF
--- a/ansible/roles/commcarehq/meta/main.yml
+++ b/ansible/roles/commcarehq/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - {role: supervisor, tags: supervisor}

--- a/ansible/roles/common/meta/main.yml
+++ b/ansible/roles/common/meta/main.yml
@@ -1,7 +1,6 @@
 ---
 dependencies:
   - {role: common_installs, tags: common_installs}
-  - {role: supervisor, tags: supervisor}
   - {role: users, tags: users}
   - {role: ssh, tags: ssh}
   - role: edit


### PR DESCRIPTION
No reason why all machines have to have supervisord