### PR TITLE
Remove repetitive rabbitmq vars

### DIFF
--- a/.travis/environments/travis/public.yml
+++ b/.travis/environments/travis/public.yml
@@ -132,7 +132,6 @@ localsettings:
   BITLY_APIKEY: "{{ localsettings_private.BITLY_APIKEY }}"
   BITLY_LOGIN: "{{ localsettings_private.BITLY_LOGIN }}"
 #  BOOKKEEPER_CONTACT_EMAILS: "{{ localsettings_private.BOOKKEEPER_CONTACT_EMAILS }}"
-  BROKER_URL: 'amqp://{{ secrets.AMQP_USER }}:{{ secrets.AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
   CELERY_PERIODIC_QUEUE: 'celery_periodic'
 #  CELERY_REMINDER_CASE_UPDATE_QUEUE:
 #  CELERY_REMINDER_RULE_QUEUE:

--- a/.travis/environments/travis/public.yml
+++ b/.travis/environments/travis/public.yml
@@ -52,7 +52,6 @@ DATADOG_ENABLED: False
 
 CLOUDANT_CLUSTER_NAME: null
 
-AMQP_HOST: "{{ groups.celery.0 }}"
 
 # This dumps the dummy keystore, but allows the ansible script to continue, should be overriden for real deploys
 #keystore_file: 'DimagiKeyStore'

--- a/.travis/environments/travis/public.yml
+++ b/.travis/environments/travis/public.yml
@@ -133,7 +133,6 @@ localsettings:
   BITLY_LOGIN: "{{ localsettings_private.BITLY_LOGIN }}"
 #  BOOKKEEPER_CONTACT_EMAILS: "{{ localsettings_private.BOOKKEEPER_CONTACT_EMAILS }}"
   BROKER_URL: 'amqp://{{ AMQP_USER }}:{{ AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
-  CELERY_FLOWER_URL: "http://{{ groups.celery.0 }}:5555"
   CELERY_PERIODIC_QUEUE: 'celery_periodic'
 #  CELERY_REMINDER_CASE_UPDATE_QUEUE:
 #  CELERY_REMINDER_RULE_QUEUE:

--- a/.travis/environments/travis/public.yml
+++ b/.travis/environments/travis/public.yml
@@ -132,7 +132,7 @@ localsettings:
   BITLY_APIKEY: "{{ localsettings_private.BITLY_APIKEY }}"
   BITLY_LOGIN: "{{ localsettings_private.BITLY_LOGIN }}"
 #  BOOKKEEPER_CONTACT_EMAILS: "{{ localsettings_private.BOOKKEEPER_CONTACT_EMAILS }}"
-  BROKER_URL: 'amqp://{{ AMQP_USER }}:{{ AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
+  BROKER_URL: 'amqp://{{ secrets.AMQP_USER }}:{{ secrets.AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
   CELERY_PERIODIC_QUEUE: 'celery_periodic'
 #  CELERY_REMINDER_CASE_UPDATE_QUEUE:
 #  CELERY_REMINDER_RULE_QUEUE:

--- a/.travis/environments/travis/public.yml
+++ b/.travis/environments/travis/public.yml
@@ -53,7 +53,6 @@ DATADOG_ENABLED: False
 CLOUDANT_CLUSTER_NAME: null
 
 AMQP_HOST: "{{ groups.celery.0 }}"
-AMQP_NAME: commcarehq
 
 # This dumps the dummy keystore, but allows the ansible script to continue, should be overriden for real deploys
 #keystore_file: 'DimagiKeyStore'

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -117,6 +117,7 @@ soft_assert_email: commcarehq-ops+soft_asserts@dimagi.com
 daily_deploy_email: null
 
 
+AMQP_NAME: commcarehq
 AMQP_PASSWORD: "{{ secrets.AMQP_PASSWORD | default(None) }}"
 AMQP_USER: "{{ secrets.AMQP_USER | default(None) }}"
 DATADOG_API_KEY: "{{ secrets.DATADOG_API_KEY | default(None) }}"

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -118,8 +118,10 @@ daily_deploy_email: null
 
 
 AMQP_NAME: commcarehq
+AMQP_HOST: "{{ groups.rabbitmq.0 }}"
 AMQP_PASSWORD: "{{ secrets.AMQP_PASSWORD | default(None) }}"
 AMQP_USER: "{{ secrets.AMQP_USER | default(None) }}"
+
 DATADOG_API_KEY: "{{ secrets.DATADOG_API_KEY | default(None) }}"
 DATADOG_APP_KEY: "{{ secrets.DATADOG_APP_KEY | default(None) }}"
 ECRYPTFS_PASSWORD: "{{ secrets.ECRYPTFS_PASSWORD | default(None) }}"

--- a/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -296,7 +296,7 @@ CELERY_SEND_TASK_ERROR_EMAILS = {{ localsettings.get('CELERY_SEND_TASK_ERROR_EMA
 
 CELERY_RESULT_BACKEND = '{{ localsettings.CELERY_RESULT_BACKEND }}'
 CELERY_PERIODIC_QUEUE = '{{ localsettings.CELERY_PERIODIC_QUEUE }}'
-CELERY_FLOWER_URL = '{{ localsettings.CELERY_FLOWER_URL }}'
+CELERY_FLOWER_URL = '{{ CELERY_FLOWER_URL }}'
 {% if 'CELERY_TIMEZONE' in localsettings and localsettings.CELERY_TIMEZONE %}
 CELERY_TIMEZONE = '{{ localsettings.CELERY_TIMEZONE }}'
 {% endif %}

--- a/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -324,7 +324,7 @@ FORMTRANSLATE_TIMEOUT = 5
 TOUCHFORMS_API_USER = "{{ localsettings.TOUCHFORMS_API_USER|default('') }}"
 TOUCHFORMS_API_PASSWORD = "{{ localsettings.TOUCHFORMS_API_PASSWORD|default('') }}"
 
-BROKER_URL = '{{ localsettings.BROKER_URL }}'
+BROKER_URL = '{{ BROKER_URL }}'
 
 XFORMS_PLAYER_URL = "{{ localsettings.XFORMS_PLAYER_URL|default('') }}"
 

--- a/ansible/roles/commcarehq/vars/main.yml
+++ b/ansible/roles/commcarehq/vars/main.yml
@@ -2,3 +2,4 @@ code_releases: "{{ www_home }}/releases"
 code_source: "{{ code_releases }}/{{ ansible_date_time.date }}_{{ ansible_date_time.hour }}.{{ ansible_date_time.minute }}"
 virtualenv_source: "{{ code_source }}/python_env"
 virtualenv_home: "{{ code_home }}/python_env"
+BROKER_URL: 'amqp://{{ AMQP_USER }}:{{ AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'

--- a/ansible/roles/datadog/templates/celery.yaml.j2
+++ b/ansible/roles/datadog/templates/celery.yaml.j2
@@ -1,5 +1,5 @@
 init_config:
 
 instances:
-  - flower_url: "{{ localsettings.CELERY_FLOWER_URL }}"
+  - flower_url: "{{ CELERY_FLOWER_URL }}"
     timeout: 10

--- a/commcare-cloud-bootstrap/environment/private.yml
+++ b/commcare-cloud-bootstrap/environment/private.yml
@@ -4,6 +4,7 @@ secrets:
   KSPLICE_ACTIVATION_KEY:
   DATADOG_API_KEY: null
   DATADOG_APP_KEY: null
+  AMQP_USER: "{{ deploy_env }}_worker"
   AMQP_PASSWORD: '******'
   SUPERVISOR_HTTP_USERNAME: user
   SUPERVISOR_HTTP_PASSWORD: 123

--- a/commcare-cloud-bootstrap/environment/public.yml
+++ b/commcare-cloud-bootstrap/environment/public.yml
@@ -53,8 +53,6 @@ DATADOG_APP_KEY: "{{ secrets.DATADOG_API_KEY }}"
 
 CLOUDANT_CLUSTER_NAME: null
 
-AMQP_USER: "{{ deploy_env }}_worker"
-AMQP_PASSWORD: "{{ secrets.AMQP_PASSWORD }}"
 AMQP_HOST: "{{ groups.celery.0 }}"
 AMQP_NAME: commcarehq
 
@@ -142,7 +140,7 @@ localsettings:
   BITLY_APIKEY: "{{ localsettings_private.BITLY_APIKEY }}"
   BITLY_LOGIN: "{{ localsettings_private.BITLY_LOGIN }}"
 #  BOOKKEEPER_CONTACT_EMAILS: "{{ localsettings_private.BOOKKEEPER_CONTACT_EMAILS }}"
-  BROKER_URL: 'amqp://{{ AMQP_USER }}:{{ AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
+  BROKER_URL: 'amqp://{{ secrets.AMQP_USER }}:{{ secrets.AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
   CELERY_PERIODIC_QUEUE: 'celery_periodic'
 #  CELERY_REMINDER_CASE_UPDATE_QUEUE:
 #  CELERY_REMINDER_RULE_QUEUE:

--- a/commcare-cloud-bootstrap/environment/public.yml
+++ b/commcare-cloud-bootstrap/environment/public.yml
@@ -140,7 +140,6 @@ localsettings:
   BITLY_APIKEY: "{{ localsettings_private.BITLY_APIKEY }}"
   BITLY_LOGIN: "{{ localsettings_private.BITLY_LOGIN }}"
 #  BOOKKEEPER_CONTACT_EMAILS: "{{ localsettings_private.BOOKKEEPER_CONTACT_EMAILS }}"
-  BROKER_URL: 'amqp://{{ secrets.AMQP_USER }}:{{ secrets.AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
   CELERY_PERIODIC_QUEUE: 'celery_periodic'
 #  CELERY_REMINDER_CASE_UPDATE_QUEUE:
 #  CELERY_REMINDER_RULE_QUEUE:

--- a/commcare-cloud-bootstrap/environment/public.yml
+++ b/commcare-cloud-bootstrap/environment/public.yml
@@ -143,7 +143,6 @@ localsettings:
   BITLY_LOGIN: "{{ localsettings_private.BITLY_LOGIN }}"
 #  BOOKKEEPER_CONTACT_EMAILS: "{{ localsettings_private.BOOKKEEPER_CONTACT_EMAILS }}"
   BROKER_URL: 'amqp://{{ AMQP_USER }}:{{ AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
-  CELERY_FLOWER_URL: "http://{{ groups.celery.0 }}:5555"
   CELERY_PERIODIC_QUEUE: 'celery_periodic'
 #  CELERY_REMINDER_CASE_UPDATE_QUEUE:
 #  CELERY_REMINDER_RULE_QUEUE:

--- a/commcare-cloud-bootstrap/environment/public.yml
+++ b/commcare-cloud-bootstrap/environment/public.yml
@@ -54,7 +54,6 @@ DATADOG_APP_KEY: "{{ secrets.DATADOG_API_KEY }}"
 CLOUDANT_CLUSTER_NAME: null
 
 AMQP_HOST: "{{ groups.celery.0 }}"
-AMQP_NAME: commcarehq
 
 # This dumps the dummy keystore, but allows the ansible script to continue, should be overriden for real deploys
 #keystore_file: 'DimagiKeyStore'

--- a/commcare-cloud-bootstrap/environment/public.yml
+++ b/commcare-cloud-bootstrap/environment/public.yml
@@ -53,7 +53,6 @@ DATADOG_APP_KEY: "{{ secrets.DATADOG_API_KEY }}"
 
 CLOUDANT_CLUSTER_NAME: null
 
-AMQP_HOST: "{{ groups.celery.0 }}"
 
 # This dumps the dummy keystore, but allows the ansible script to continue, should be overriden for real deploys
 #keystore_file: 'DimagiKeyStore'

--- a/commcare-cloud/commcare_cloud/environment/main.py
+++ b/commcare-cloud/commcare_cloud/environment/main.py
@@ -153,7 +153,12 @@ class Environment(object):
             for host in hosts
         ] for group, hosts in self.inventory_manager.get_groups_dict().items()}
 
+    def _run_last_minute_checks(self):
+        assert len(self.groups.get('rabbitmq', [])) == 1, \
+            "You must have exactly one host in the [rabbitmq] group"
+
     def create_generated_yml(self):
+        self._run_last_minute_checks()
         generated_variables = {
             'deploy_env': self.meta_config.deploy_env,
             'env_monitoring_id': self.meta_config.env_monitoring_id,

--- a/commcare-cloud/commcare_cloud/environment/main.py
+++ b/commcare-cloud/commcare_cloud/environment/main.py
@@ -155,15 +155,16 @@ class Environment(object):
 
     def create_generated_yml(self):
         generated_variables = {
-            'app_processes_config': self.app_processes_config.to_json(),
             'deploy_env': self.meta_config.deploy_env,
             'env_monitoring_id': self.meta_config.env_monitoring_id,
             'dev_users': self.users_config.dev_users.to_json(),
             'authorized_keys_dir': '{}/'.format(self.paths.authorized_keys_dir),
             'known_hosts_file': self.paths.known_hosts,
         }
+        generated_variables.update(self.app_processes_config.to_generated_variables())
         generated_variables.update(self.postgresql_config.to_generated_variables())
         generated_variables.update(constants.to_json())
+
         with open(self.paths.generated_yml, 'w') as f:
             f.write(yaml.safe_dump(generated_variables))
 

--- a/environments/development/public.yml
+++ b/environments/development/public.yml
@@ -53,8 +53,6 @@ DATADOG_APP_KEY: "{{ secrets.DATADOG_API_KEY }}"
 
 CLOUDANT_CLUSTER_NAME: null
 
-AMQP_USER: "{{ deploy_env }}_worker"
-AMQP_PASSWORD: "{{ secrets.AMQP_PASSWORD }}"
 AMQP_HOST: "{{ groups.celery.0 }}"
 AMQP_NAME: commcarehq
 
@@ -142,7 +140,7 @@ localsettings:
   BITLY_APIKEY: "{{ localsettings_private.BITLY_APIKEY }}"
   BITLY_LOGIN: "{{ localsettings_private.BITLY_LOGIN }}"
 #  BOOKKEEPER_CONTACT_EMAILS: "{{ localsettings_private.BOOKKEEPER_CONTACT_EMAILS }}"
-  BROKER_URL: 'amqp://{{ AMQP_USER }}:{{ AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
+  BROKER_URL: 'amqp://{{ secrets.AMQP_USER }}:{{ secrets.AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
   CELERY_PERIODIC_QUEUE: 'celery_periodic'
 #  CELERY_REMINDER_CASE_UPDATE_QUEUE:
 #  CELERY_REMINDER_RULE_QUEUE:

--- a/environments/development/public.yml
+++ b/environments/development/public.yml
@@ -140,7 +140,6 @@ localsettings:
   BITLY_APIKEY: "{{ localsettings_private.BITLY_APIKEY }}"
   BITLY_LOGIN: "{{ localsettings_private.BITLY_LOGIN }}"
 #  BOOKKEEPER_CONTACT_EMAILS: "{{ localsettings_private.BOOKKEEPER_CONTACT_EMAILS }}"
-  BROKER_URL: 'amqp://{{ secrets.AMQP_USER }}:{{ secrets.AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
   CELERY_PERIODIC_QUEUE: 'celery_periodic'
 #  CELERY_REMINDER_CASE_UPDATE_QUEUE:
 #  CELERY_REMINDER_RULE_QUEUE:

--- a/environments/development/public.yml
+++ b/environments/development/public.yml
@@ -143,7 +143,6 @@ localsettings:
   BITLY_LOGIN: "{{ localsettings_private.BITLY_LOGIN }}"
 #  BOOKKEEPER_CONTACT_EMAILS: "{{ localsettings_private.BOOKKEEPER_CONTACT_EMAILS }}"
   BROKER_URL: 'amqp://{{ AMQP_USER }}:{{ AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
-  CELERY_FLOWER_URL: "http://{{ groups.celery.0 }}:5555"
   CELERY_PERIODIC_QUEUE: 'celery_periodic'
 #  CELERY_REMINDER_CASE_UPDATE_QUEUE:
 #  CELERY_REMINDER_RULE_QUEUE:

--- a/environments/development/public.yml
+++ b/environments/development/public.yml
@@ -54,7 +54,6 @@ DATADOG_APP_KEY: "{{ secrets.DATADOG_API_KEY }}"
 CLOUDANT_CLUSTER_NAME: null
 
 AMQP_HOST: "{{ groups.celery.0 }}"
-AMQP_NAME: commcarehq
 
 # This dumps the dummy keystore, but allows the ansible script to continue, should be overriden for real deploys
 #keystore_file: 'DimagiKeyStore'

--- a/environments/development/public.yml
+++ b/environments/development/public.yml
@@ -53,7 +53,6 @@ DATADOG_APP_KEY: "{{ secrets.DATADOG_API_KEY }}"
 
 CLOUDANT_CLUSTER_NAME: null
 
-AMQP_HOST: "{{ groups.celery.0 }}"
 
 # This dumps the dummy keystore, but allows the ansible script to continue, should be overriden for real deploys
 #keystore_file: 'DimagiKeyStore'

--- a/environments/development/vault.yml
+++ b/environments/development/vault.yml
@@ -4,6 +4,7 @@ secrets:
   KSPLICE_ACTIVATION_KEY:
   DATADOG_API_KEY: null
   DATADOG_APP_KEY: null
+  AMQP_USER: "{{ deploy_env }}_worker"
   AMQP_PASSWORD: '******'
   SUPERVISOR_HTTP_USERNAME: user
   SUPERVISOR_HTTP_PASSWORD: 123

--- a/environments/enikshay/public.yml
+++ b/environments/enikshay/public.yml
@@ -60,7 +60,6 @@ redis_appendonly: 'no'
 KSPLICE_ACTIVE: yes
 
 AMQP_HOST: "{{ groups.rabbitmq.0 }}"
-AMQP_NAME: commcarehq
 
 kafka_broker_id: 0
 

--- a/environments/enikshay/public.yml
+++ b/environments/enikshay/public.yml
@@ -107,7 +107,6 @@ localsettings:
   BITLY_APIKEY: "{{ localsettings_private.BITLY_APIKEY }}"
   BITLY_LOGIN: "{{ localsettings_private.BITLY_LOGIN }}"
   BOOKKEEPER_CONTACT_EMAILS: "{{ localsettings_private.BOOKKEEPER_CONTACT_EMAILS }}"
-  BROKER_URL: 'amqp://{{ secrets.AMQP_USER }}:{{ secrets.AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
   CELERY_PERIODIC_QUEUE: 'celery_periodic'
   CELERY_REMINDER_CASE_UPDATE_QUEUE: 'reminder_case_update_queue'
   CELERY_REMINDER_RULE_QUEUE: 'reminder_rule_queue'

--- a/environments/enikshay/public.yml
+++ b/environments/enikshay/public.yml
@@ -108,7 +108,6 @@ localsettings:
   BITLY_LOGIN: "{{ localsettings_private.BITLY_LOGIN }}"
   BOOKKEEPER_CONTACT_EMAILS: "{{ localsettings_private.BOOKKEEPER_CONTACT_EMAILS }}"
   BROKER_URL: 'amqp://{{ secrets.AMQP_USER }}:{{ secrets.AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
-  CELERY_FLOWER_URL: "http://{{ groups.celery.0 }}:5555"
   CELERY_PERIODIC_QUEUE: 'celery_periodic'
   CELERY_REMINDER_CASE_UPDATE_QUEUE: 'reminder_case_update_queue'
   CELERY_REMINDER_RULE_QUEUE: 'reminder_rule_queue'

--- a/environments/enikshay/public.yml
+++ b/environments/enikshay/public.yml
@@ -59,7 +59,6 @@ redis_appendonly: 'no'
 
 KSPLICE_ACTIVE: yes
 
-AMQP_HOST: "{{ groups.rabbitmq.0 }}"
 
 kafka_broker_id: 0
 

--- a/environments/icds-new/public.yml
+++ b/environments/icds-new/public.yml
@@ -55,7 +55,6 @@ kafka_log_dir: '{{ encrypted_root }}/kafka'
 KSPLICE_ACTIVE: no
 
 AMQP_HOST: "{{ groups.rabbit0.0 }}"
-AMQP_NAME: commcarehq
 
 DATADOG_ENABLED: True
 datadog_integration_cloudant: False

--- a/environments/icds-new/public.yml
+++ b/environments/icds-new/public.yml
@@ -176,7 +176,6 @@ localsettings:
   BITLY_APIKEY: "{{ localsettings_private.BITLY_APIKEY }}"
   BITLY_LOGIN: "{{ localsettings_private.BITLY_LOGIN }}"
   BOOKKEEPER_CONTACT_EMAILS: "{{ localsettings_private.BOOKKEEPER_CONTACT_EMAILS }}"
-  BROKER_URL: 'amqp://{{ secrets.AMQP_USER }}:{{ secrets.AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
   CELERY_PERIODIC_QUEUE: 'celery_periodic'
   CELERY_REMINDER_CASE_UPDATE_QUEUE: 'reminder_case_update_queue'
   CELERY_REMINDER_RULE_QUEUE: 'reminder_rule_queue'

--- a/environments/icds-new/public.yml
+++ b/environments/icds-new/public.yml
@@ -54,7 +54,6 @@ kafka_log_dir: '{{ encrypted_root }}/kafka'
 
 KSPLICE_ACTIVE: no
 
-AMQP_HOST: "{{ groups.rabbit0.0 }}"
 
 DATADOG_ENABLED: True
 datadog_integration_cloudant: False

--- a/environments/icds-new/public.yml
+++ b/environments/icds-new/public.yml
@@ -177,7 +177,6 @@ localsettings:
   BITLY_LOGIN: "{{ localsettings_private.BITLY_LOGIN }}"
   BOOKKEEPER_CONTACT_EMAILS: "{{ localsettings_private.BOOKKEEPER_CONTACT_EMAILS }}"
   BROKER_URL: 'amqp://{{ secrets.AMQP_USER }}:{{ secrets.AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
-  CELERY_FLOWER_URL: "http://{{ groups.celery0.0 }}:5555"
   CELERY_PERIODIC_QUEUE: 'celery_periodic'
   CELERY_REMINDER_CASE_UPDATE_QUEUE: 'reminder_case_update_queue'
   CELERY_REMINDER_RULE_QUEUE: 'reminder_rule_queue'

--- a/environments/l10k/public.yml
+++ b/environments/l10k/public.yml
@@ -54,7 +54,6 @@ redis_appendonly: 'no'
 KSPLICE_ACTIVE: yes
 
 AMQP_HOST: "192.168.0.10"
-AMQP_NAME: commcarehq
 
 shared_drive_enabled: false
 

--- a/environments/l10k/public.yml
+++ b/environments/l10k/public.yml
@@ -53,7 +53,6 @@ redis_appendonly: 'no'
 
 KSPLICE_ACTIVE: yes
 
-AMQP_HOST: "192.168.0.10"
 
 shared_drive_enabled: false
 

--- a/environments/l10k/public.yml
+++ b/environments/l10k/public.yml
@@ -74,7 +74,6 @@ localsettings:
   BITLY_APIKEY: "{{ localsettings_private.BITLY_APIKEY }}"
   BITLY_LOGIN: "{{ localsettings_private.BITLY_LOGIN }}"
   BOOKKEEPER_CONTACT_EMAILS: "{{ localsettings_private.BOOKKEEPER_CONTACT_EMAILS }}"
-  BROKER_URL: 'amqp://{{ secrets.AMQP_USER }}:{{ secrets.AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
   CELERY_PERIODIC_QUEUE: 'celery_periodic'
   CELERY_REMINDER_CASE_UPDATE_QUEUE: reminder_case_update_queue
   CELERY_REMINDER_RULE_QUEUE: reminder_rule_queue

--- a/environments/l10k/public.yml
+++ b/environments/l10k/public.yml
@@ -75,7 +75,6 @@ localsettings:
   BITLY_LOGIN: "{{ localsettings_private.BITLY_LOGIN }}"
   BOOKKEEPER_CONTACT_EMAILS: "{{ localsettings_private.BOOKKEEPER_CONTACT_EMAILS }}"
   BROKER_URL: 'amqp://{{ secrets.AMQP_USER }}:{{ secrets.AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
-  CELERY_FLOWER_URL: "http://{{ groups.celery.0 }}:5555"
   CELERY_PERIODIC_QUEUE: 'celery_periodic'
   CELERY_REMINDER_CASE_UPDATE_QUEUE: reminder_case_update_queue
   CELERY_REMINDER_RULE_QUEUE: reminder_rule_queue

--- a/environments/pna/public.yml
+++ b/environments/pna/public.yml
@@ -58,7 +58,6 @@ default_from_email: commcare@pna.sn
 KSPLICE_ACTIVE: yes
 
 AMQP_HOST: "127.0.0.1"
-AMQP_NAME: commcarehq
 
 nameservers:
   - 8.8.8.8

--- a/environments/pna/public.yml
+++ b/environments/pna/public.yml
@@ -85,7 +85,6 @@ localsettings:
   BITLY_APIKEY: "{{ localsettings_private.BITLY_APIKEY }}"
   BITLY_LOGIN: "{{ localsettings_private.BITLY_LOGIN }}"
   BOOKKEEPER_CONTACT_EMAILS: "{{ localsettings_private.BOOKKEEPER_CONTACT_EMAILS }}"
-  BROKER_URL: 'amqp://{{ secrets.AMQP_USER }}:{{ secrets.AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
   CELERY_PERIODIC_QUEUE: 'celery_periodic'
   CELERY_REMINDER_CASE_UPDATE_QUEUE: reminder_case_update_queue
   CELERY_REMINDER_RULE_QUEUE: reminder_rule_queue

--- a/environments/pna/public.yml
+++ b/environments/pna/public.yml
@@ -57,7 +57,6 @@ default_from_email: commcare@pna.sn
 
 KSPLICE_ACTIVE: yes
 
-AMQP_HOST: "127.0.0.1"
 
 nameservers:
   - 8.8.8.8

--- a/environments/pna/public.yml
+++ b/environments/pna/public.yml
@@ -86,7 +86,6 @@ localsettings:
   BITLY_LOGIN: "{{ localsettings_private.BITLY_LOGIN }}"
   BOOKKEEPER_CONTACT_EMAILS: "{{ localsettings_private.BOOKKEEPER_CONTACT_EMAILS }}"
   BROKER_URL: 'amqp://{{ secrets.AMQP_USER }}:{{ secrets.AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
-  CELERY_FLOWER_URL: "http://{{ groups.celery.0 }}:5555"
   CELERY_PERIODIC_QUEUE: 'celery_periodic'
   CELERY_REMINDER_CASE_UPDATE_QUEUE: reminder_case_update_queue
   CELERY_REMINDER_RULE_QUEUE: reminder_rule_queue

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -99,7 +99,6 @@ localsettings:
   BITLY_LOGIN: "{{ localsettings_private.BITLY_LOGIN }}"
   BOOKKEEPER_CONTACT_EMAILS: "{{ localsettings_private.BOOKKEEPER_CONTACT_EMAILS }}"
   BROKER_URL: 'amqp://{{ secrets.AMQP_USER }}:{{ secrets.AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
-  CELERY_FLOWER_URL: "http://{{ groups.celery.0 }}:5555"
   CELERY_PERIODIC_QUEUE: 'celery_periodic'
   CELERY_REMINDER_CASE_UPDATE_QUEUE: 'reminder_case_update_queue'
   CELERY_REMINDER_RULE_QUEUE: 'reminder_rule_queue'

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -59,7 +59,6 @@ formplayer_purge_time_spec: '8d'
 
 KSPLICE_ACTIVE: yes
 
-AMQP_HOST: "{{ groups.rabbitmq.0 }}"
 
 ufw_private_interface: eth1
 

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -98,7 +98,6 @@ localsettings:
   BITLY_APIKEY: "{{ localsettings_private.BITLY_APIKEY }}"
   BITLY_LOGIN: "{{ localsettings_private.BITLY_LOGIN }}"
   BOOKKEEPER_CONTACT_EMAILS: "{{ localsettings_private.BOOKKEEPER_CONTACT_EMAILS }}"
-  BROKER_URL: 'amqp://{{ secrets.AMQP_USER }}:{{ secrets.AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
   CELERY_PERIODIC_QUEUE: 'celery_periodic'
   CELERY_REMINDER_CASE_UPDATE_QUEUE: 'reminder_case_update_queue'
   CELERY_REMINDER_RULE_QUEUE: 'reminder_rule_queue'

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -60,7 +60,6 @@ formplayer_purge_time_spec: '8d'
 KSPLICE_ACTIVE: yes
 
 AMQP_HOST: "{{ groups.rabbitmq.0 }}"
-AMQP_NAME: commcarehq
 
 ufw_private_interface: eth1
 

--- a/environments/softlayer/public.yml
+++ b/environments/softlayer/public.yml
@@ -46,7 +46,6 @@ redis_appendonly: 'no'
 KSPLICE_ACTIVE: yes
 
 AMQP_HOST: "{{ groups.rabbitmq.0 }}"
-AMQP_NAME: commcarehq
 
 kafka_broker_id: 0
 kafka_log_dir: "{{ encrypted_root }}/kafka"

--- a/environments/softlayer/public.yml
+++ b/environments/softlayer/public.yml
@@ -45,7 +45,6 @@ redis_appendonly: 'no'
 
 KSPLICE_ACTIVE: yes
 
-AMQP_HOST: "{{ groups.rabbitmq.0 }}"
 
 kafka_broker_id: 0
 kafka_log_dir: "{{ encrypted_root }}/kafka"

--- a/environments/softlayer/public.yml
+++ b/environments/softlayer/public.yml
@@ -97,7 +97,6 @@ localsettings:
   BITLY_LOGIN: "{{ localsettings_private.BITLY_LOGIN }}"
   BOOKKEEPER_CONTACT_EMAILS: "{{ localsettings_private.BOOKKEEPER_CONTACT_EMAILS }}"
   BROKER_URL: 'amqp://{{ secrets.AMQP_USER }}:{{ secrets.AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
-  CELERY_FLOWER_URL: "http://{{ groups.celery.1 }}:5555"
   CELERY_PERIODIC_QUEUE: 'celery_periodic'
   CELERY_REMINDER_CASE_UPDATE_QUEUE: 'reminder_case_update_queue'
   CELERY_REMINDER_RULE_QUEUE: 'reminder_rule_queue'

--- a/environments/softlayer/public.yml
+++ b/environments/softlayer/public.yml
@@ -96,7 +96,6 @@ localsettings:
   BITLY_APIKEY: "{{ localsettings_private.BITLY_APIKEY }}"
   BITLY_LOGIN: "{{ localsettings_private.BITLY_LOGIN }}"
   BOOKKEEPER_CONTACT_EMAILS: "{{ localsettings_private.BOOKKEEPER_CONTACT_EMAILS }}"
-  BROKER_URL: 'amqp://{{ secrets.AMQP_USER }}:{{ secrets.AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
   CELERY_PERIODIC_QUEUE: 'celery_periodic'
   CELERY_REMINDER_CASE_UPDATE_QUEUE: 'reminder_case_update_queue'
   CELERY_REMINDER_RULE_QUEUE: 'reminder_rule_queue'

--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -74,7 +74,6 @@ localsettings:
   BITLY_APIKEY: "{{ localsettings_private.BITLY_APIKEY }}"
   BITLY_LOGIN: "{{ localsettings_private.BITLY_LOGIN }}"
   BOOKKEEPER_CONTACT_EMAILS: "{{ localsettings_private.BOOKKEEPER_CONTACT_EMAILS }}"
-  BROKER_URL: 'amqp://{{ secrets.AMQP_USER }}:{{ secrets.AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
   CELERY_PERIODIC_QUEUE: 'celery_null'
   CELERY_REMINDER_CASE_UPDATE_QUEUE:
   CELERY_REMINDER_RULE_QUEUE:

--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -37,7 +37,6 @@ formplayer_archive_time_spec: '10m'
 KSPLICE_ACTIVE: yes
 
 AMQP_HOST: "{{ groups.rabbitmq.0 }}"
-AMQP_NAME: commcarehq
 
 ufw_private_interface: eth1
 

--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -36,7 +36,6 @@ formplayer_archive_time_spec: '10m'
 
 KSPLICE_ACTIVE: yes
 
-AMQP_HOST: "{{ groups.rabbitmq.0 }}"
 
 ufw_private_interface: eth1
 

--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -75,7 +75,6 @@ localsettings:
   BITLY_LOGIN: "{{ localsettings_private.BITLY_LOGIN }}"
   BOOKKEEPER_CONTACT_EMAILS: "{{ localsettings_private.BOOKKEEPER_CONTACT_EMAILS }}"
   BROKER_URL: 'amqp://{{ secrets.AMQP_USER }}:{{ secrets.AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
-  CELERY_FLOWER_URL: "http://{{ groups.celery.0 }}:5555"
   CELERY_PERIODIC_QUEUE: 'celery_null'
   CELERY_REMINDER_CASE_UPDATE_QUEUE:
   CELERY_REMINDER_RULE_QUEUE:

--- a/environments/swiss/public.yml
+++ b/environments/swiss/public.yml
@@ -38,7 +38,6 @@ aws_versioning_enabled: false
 KSPLICE_ACTIVE: yes
 
 AMQP_HOST: "185.12.7.167"
-AMQP_NAME: commcarehq
 
 shared_drive_enabled: false
 

--- a/environments/swiss/public.yml
+++ b/environments/swiss/public.yml
@@ -37,7 +37,6 @@ aws_versioning_enabled: false
 
 KSPLICE_ACTIVE: yes
 
-AMQP_HOST: "185.12.7.167"
 
 shared_drive_enabled: false
 

--- a/environments/swiss/public.yml
+++ b/environments/swiss/public.yml
@@ -67,7 +67,6 @@ localsettings:
   BITLY_APIKEY: "{{ localsettings_private.BITLY_APIKEY }}"
   BITLY_LOGIN: "{{ localsettings_private.BITLY_LOGIN }}"
   BOOKKEEPER_CONTACT_EMAILS: "{{ localsettings_private.BOOKKEEPER_CONTACT_EMAILS }}"
-  BROKER_URL: 'amqp://{{ secrets.AMQP_USER }}:{{ secrets.AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
   CELERY_PERIODIC_QUEUE: 'celery_periodic'
   CELERY_REMINDER_CASE_UPDATE_QUEUE: reminder_case_update_queue
   CELERY_REMINDER_RULE_QUEUE: reminder_rule_queue

--- a/environments/swiss/public.yml
+++ b/environments/swiss/public.yml
@@ -68,7 +68,6 @@ localsettings:
   BITLY_LOGIN: "{{ localsettings_private.BITLY_LOGIN }}"
   BOOKKEEPER_CONTACT_EMAILS: "{{ localsettings_private.BOOKKEEPER_CONTACT_EMAILS }}"
   BROKER_URL: 'amqp://{{ secrets.AMQP_USER }}:{{ secrets.AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
-  CELERY_FLOWER_URL: "http://{{ groups.celery.0 }}:5555"
   CELERY_PERIODIC_QUEUE: 'celery_periodic'
   CELERY_REMINDER_CASE_UPDATE_QUEUE: reminder_case_update_queue
   CELERY_REMINDER_RULE_QUEUE: reminder_rule_queue


### PR DESCRIPTION
Includes https://github.com/dimagi/commcare-cloud/pull/1583 (because otherwise they'd have a minor annoying conflict).

This changes `AMQP_HOST` from `127.0.0.1` to IP address on pna and from IP address to FQDN on swiss, neither of which I think should be a problem. For other envs there is no change.