### PR TITLE
Move nginx / proxy vars to proxy.yml

### DIFF
--- a/.travis/environments/travis/proxy.yml
+++ b/.travis/environments/travis/proxy.yml
@@ -1,0 +1,1 @@
+SITE_HOST: '{{ groups.proxy.0 }}'

--- a/.travis/environments/travis/proxy.yml
+++ b/.travis/environments/travis/proxy.yml
@@ -1,1 +1,2 @@
 SITE_HOST: '{{ groups.proxy.0 }}'
+fake_ssl_cert: yes

--- a/.travis/environments/travis/public.yml
+++ b/.travis/environments/travis/public.yml
@@ -1,6 +1,5 @@
 # For a real deployment
 # should be e.g. 'www.commcarehq.org'
-SITE_HOST: '{{ groups.proxy.0 }}'
 internal_domain_name: 'localdomain'
 
 testing: True

--- a/.travis/environments/travis/public.yml
+++ b/.travis/environments/travis/public.yml
@@ -32,8 +32,6 @@ http_proxy_parent_port: '3128'
 riak_backend: "leveldb"
 riak_ring_size: 64
 
-fake_ssl_cert: yes
-
 elasticsearch_endpoint: '{{ groups.elasticsearch.0 }}'
 elasticsearch_memory: '128m'
 elasticsearch_cluster_name: 'deves'

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -191,3 +191,5 @@ aws_region: None
 # this reads "'s3.{{ aws_region }}.amazonaws.com' if aws_region else None"
 aws_endpoint: '{{ aws_region and "s3." + aws_region + ".amazonaws.com" }}'
 aws_versioning_enabled: true
+
+nofile_limit: 4096

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -10,7 +10,7 @@
     domain: "{{ item }}"
     limit_type: hard
     limit_item: nofile
-    value: "{{ nofile_limit|default(4096) }}"
+    value: "{{ nofile_limit }}"
   tags:
     - nofile_limits
   with_items:
@@ -23,7 +23,7 @@
     domain: "{{ item }}"
     limit_type: soft
     limit_item: nofile
-    value: "{{ nofile_limit|default(4096) }}"
+    value: "{{ nofile_limit }}"
   tags:
     - nofile_limits
   with_items:

--- a/ansible/roles/nginx/defaults/main.yml
+++ b/ansible/roles/nginx/defaults/main.yml
@@ -4,3 +4,6 @@ COMMTRACK_SITE_HOST: null
 TABLEAU_HOST: null
 tableau_server: null
 special_sites: []
+primary_ssl_env: ""
+nginx_hsts_max_age: null
+nginx_worker_rlimit_nofile: null

--- a/ansible/roles/nginx/templates/nginx.conf.j2
+++ b/ansible/roles/nginx/templates/nginx.conf.j2
@@ -3,9 +3,7 @@ user {{ nginx_user }};
 worker_processes  {{ ansible_processor_count }};
 pid        /var/run/nginx.pid;
 
-{% if nginx_worker_rlimit_nofile is defined%}
 worker_rlimit_nofile {{ nginx_worker_rlimit_nofile }};
-{% endif %}
 
 events {
     worker_connections  {{ nginx_max_clients }};

--- a/ansible/roles/nginx/vars/main.yml
+++ b/ansible/roles/nginx/vars/main.yml
@@ -3,7 +3,6 @@ nginx_ubuntu_pkg: nginx
 nginx_install: True
 nginx_user: www-data
 nginx_static_home: "{{ code_home }}/staticfiles"
-nginx_max_clients: 512
 nginx_access_log_name: nginx_access.log
 nginx_error_log_name: nginx_error.log
 ssl_base_dir: "/etc/pki/tls"

--- a/ansible/roles/nginx/vars/main.yml
+++ b/ansible/roles/nginx/vars/main.yml
@@ -36,11 +36,9 @@ nginx_http_params:
   types_hash_max_size: 2048
 
 nginx_separate_logs_per_site: True
-primary_ssl_env: ""
 commcarehq_errors_repository: "https://github.com/dimagi/commcare-hq-errorpages.git"
 commcare_errors_branch: "master"
 errors_home: "{{ www_home }}/error_root"
 error_pages:
   - "502 503 /errors/50x.html"
   - "400 /errors/400.html"
-nginx_hsts_max_age: null

--- a/commcare-cloud-bootstrap/environment/proxy.yml
+++ b/commcare-cloud-bootstrap/environment/proxy.yml
@@ -1,0 +1,2 @@
+SITE_HOST: '{{ hostvars[groups.proxy.0].ansible_host }}'
+fake_ssl_cert: yes

--- a/commcare-cloud-bootstrap/environment/public.yml
+++ b/commcare-cloud-bootstrap/environment/public.yml
@@ -84,7 +84,6 @@ postgres_s3: False
 nadir_hour: 18
 
 nofile_limit: 65536
-nginx_worker_rlimit_nofile: "{{ nofile_limit }}"
 
 supervisor_http_enabled: True
 supervisor_http_username: "{{ secrets.SUPERVISOR_HTTP_USERNAME }}"

--- a/commcare-cloud-bootstrap/environment/public.yml
+++ b/commcare-cloud-bootstrap/environment/public.yml
@@ -1,6 +1,5 @@
 # For a real deployment
 # should be e.g. 'www.commcarehq.org'
-SITE_HOST: '{{ hostvars[groups.proxy.0].ansible_host }}'
 internal_domain_name: 'localdomain'
 
 etc_hosts_lines: []
@@ -17,7 +16,6 @@ touchforms_enabled: false
 riak_backend: "bitcask"
 riak_ring_size: 64
 
-fake_ssl_cert: yes
 ansible_user_password_sha_512: "{{ secrets.ANSIBLE_USER_PASSWORD_SHA_512 }}"
 
 dev_users:

--- a/commcare-cloud/commcare_cloud/environment/main.py
+++ b/commcare-cloud/commcare_cloud/environment/main.py
@@ -25,7 +25,8 @@ class Environment(object):
     def check(self):
 
         included_disallowed_public_variables = set(self.public_vars.keys()) & self._disallowed_public_variables
-        assert not included_disallowed_public_variables, included_disallowed_public_variables
+        assert not included_disallowed_public_variables, \
+            "Disallowed variables in {}: {}".format(self.paths.public_yml, included_disallowed_public_variables)
         self.meta_config
         self.users_config
         self.raw_app_processes_config
@@ -48,7 +49,7 @@ class Environment(object):
 
     @memoized_property
     def _disallowed_public_variables(self):
-        return set(get_role_defaults('postgresql').keys())
+        return set(get_role_defaults('postgresql').keys()) | set(ProxyConfig().to_json())
 
     @memoized_property
     def meta_config(self):
@@ -178,6 +179,7 @@ class Environment(object):
         }
         generated_variables.update(self.app_processes_config.to_generated_variables())
         generated_variables.update(self.postgresql_config.to_generated_variables())
+        generated_variables.update(self.proxy_config.to_generated_variables())
         generated_variables.update(constants.to_json())
 
         with open(self.paths.generated_yml, 'w') as f:

--- a/commcare-cloud/commcare_cloud/environment/main.py
+++ b/commcare-cloud/commcare_cloud/environment/main.py
@@ -14,6 +14,7 @@ from ansible.vars.manager import VariableManager
 from commcare_cloud.environment.schemas.fab_settings import FabSettingsConfig
 from commcare_cloud.environment.schemas.meta import MetaConfig
 from commcare_cloud.environment.schemas.postgresql import PostgresqlConfig
+from commcare_cloud.environment.schemas.proxy import ProxyConfig
 from commcare_cloud.environment.users import UsersConfig
 
 
@@ -32,6 +33,7 @@ class Environment(object):
         self.fab_settings_config
         self.inventory_manager
         self.postgresql_config
+        self.proxy_config
         self.create_generated_yml()
 
     @memoized
@@ -62,6 +64,14 @@ class Environment(object):
         postgresql_config.replace_hosts(self)
         postgresql_config.check()
         return postgresql_config
+
+    @memoized_property
+    def proxy_config(self):
+        with open(self.paths.proxy_yml) as f:
+            proxy_json = yaml.load(f)
+        proxy_config = ProxyConfig.wrap(proxy_json)
+        proxy_config.check()
+        return proxy_config
 
     @memoized_property
     def users_config(self):

--- a/commcare-cloud/commcare_cloud/environment/main.py
+++ b/commcare-cloud/commcare_cloud/environment/main.py
@@ -49,7 +49,7 @@ class Environment(object):
 
     @memoized_property
     def _disallowed_public_variables(self):
-        return set(get_role_defaults('postgresql').keys()) | set(ProxyConfig().to_json())
+        return set(get_role_defaults('postgresql').keys()) | set(ProxyConfig.get_claimed_variables())
 
     @memoized_property
     def meta_config(self):

--- a/commcare-cloud/commcare_cloud/environment/paths.py
+++ b/commcare-cloud/commcare_cloud/environment/paths.py
@@ -44,6 +44,10 @@ class DefaultPaths(object):
         return os.path.join(self.environments_dir, self.env_name, 'postgresql.yml')
 
     @lazy_immutable_property
+    def proxy_yml(self):
+        return os.path.join(self.environments_dir, self.env_name, 'proxy.yml')
+
+    @lazy_immutable_property
     def app_processes_yml(self):
         return os.path.join(self.environments_dir, self.env_name, 'app-processes.yml')
 

--- a/commcare-cloud/commcare_cloud/environment/schemas/proxy.py
+++ b/commcare-cloud/commcare_cloud/environment/schemas/proxy.py
@@ -4,7 +4,7 @@ import jsonobject
 class ProxyConfig(jsonobject.JsonObject):
     _allow_dynamic_properties = False
 
-    SITE_HOST = jsonobject.StringProperty()
+    SITE_HOST = jsonobject.StringProperty(required=True)
     NO_WWW_SITE_HOST = jsonobject.StringProperty()
     J2ME_SITE_HOST = jsonobject.StringProperty()
     nginx_combined_cert_value = jsonobject.StringProperty()

--- a/commcare-cloud/commcare_cloud/environment/schemas/proxy.py
+++ b/commcare-cloud/commcare_cloud/environment/schemas/proxy.py
@@ -4,5 +4,38 @@ import jsonobject
 class ProxyConfig(jsonobject.JsonObject):
     _allow_dynamic_properties = False
 
+    SITE_HOST = jsonobject.StringProperty()
+    NO_WWW_SITE_HOST = jsonobject.StringProperty()
+    J2ME_SITE_HOST = jsonobject.StringProperty()
+    nginx_combined_cert_value = jsonobject.StringProperty()
+    nginx_key_value = jsonobject.StringProperty()
+    nginx_hsts_max_age = jsonobject.IntegerProperty()
+
+    special_sites = jsonobject.ListProperty(str)
+
+    COMMTRACK_SITE_HOST = jsonobject.StringProperty(exclude_if_none=True)
+    commtrack_nginx_combined_cert_value = jsonobject.StringProperty()
+    commtrack_key_value = jsonobject.StringProperty()
+
+    CAS_SITE_HOST = jsonobject.StringProperty(exclude_if_none=True)
+    cas_nginx_combined_cert_value = jsonobject.StringProperty()
+    cas_key_value = jsonobject.StringProperty()
+
+    TABLEAU_HOST = jsonobject.StringProperty(exclude_if_none=True)
+    tableau_nginx_combined_cert_value = jsonobject.StringProperty()
+    tableau_key_value = jsonobject.StringProperty()
+    tableau_server = jsonobject.StringProperty()
+
+    ENIKSHAY_SITE_HOST = jsonobject.StringProperty(exclude_if_none=True)
+    enikshay_nginx_combined_cert_value = jsonobject.StringProperty()
+    enikshay_key_value = jsonobject.StringProperty()
+
+    PNA_SITE_HOST = jsonobject.StringProperty(exclude_if_none=True)
+    pna_nginx_combined_cert_value = jsonobject.StringProperty()
+    pna_key_value = jsonobject.StringProperty()
+
     def check(self):
         pass
+
+    def to_generated_variables(self):
+        return self.to_json()

--- a/commcare-cloud/commcare_cloud/environment/schemas/proxy.py
+++ b/commcare-cloud/commcare_cloud/environment/schemas/proxy.py
@@ -10,8 +10,10 @@ class ProxyConfig(jsonobject.JsonObject):
     nginx_combined_cert_value = jsonobject.StringProperty()
     nginx_key_value = jsonobject.StringProperty()
     nginx_hsts_max_age = jsonobject.IntegerProperty()
+    nginx_worker_rlimit_nofile = jsonobject.IntegerProperty()
 
     fake_ssl_cert = jsonobject.BooleanProperty(default=False)
+
     special_sites = jsonobject.ListProperty(str)
 
     COMMTRACK_SITE_HOST = jsonobject.StringProperty(exclude_if_none=True)
@@ -39,4 +41,7 @@ class ProxyConfig(jsonobject.JsonObject):
         pass
 
     def to_generated_variables(self):
-        return self.to_json()
+        variables = self.to_json()
+        if self.nginx_worker_rlimit_nofile is None:
+            variables['nginx_worker_rlimit_nofile'] = "{{ nofile_limit }}"
+        return variables

--- a/commcare-cloud/commcare_cloud/environment/schemas/proxy.py
+++ b/commcare-cloud/commcare_cloud/environment/schemas/proxy.py
@@ -10,8 +10,8 @@ class ProxyConfig(jsonobject.JsonObject):
     nginx_combined_cert_value = jsonobject.StringProperty()
     nginx_key_value = jsonobject.StringProperty()
     nginx_hsts_max_age = jsonobject.IntegerProperty()
+    nginx_max_clients = jsonobject.IntegerProperty(default=512)
     nginx_worker_rlimit_nofile = jsonobject.IntegerProperty()
-
     fake_ssl_cert = jsonobject.BooleanProperty(default=False)
 
     special_sites = jsonobject.ListProperty(str)

--- a/commcare-cloud/commcare_cloud/environment/schemas/proxy.py
+++ b/commcare-cloud/commcare_cloud/environment/schemas/proxy.py
@@ -1,0 +1,8 @@
+import jsonobject
+
+
+class ProxyConfig(jsonobject.JsonObject):
+    _allow_dynamic_properties = False
+
+    def check(self):
+        pass

--- a/commcare-cloud/commcare_cloud/environment/schemas/proxy.py
+++ b/commcare-cloud/commcare_cloud/environment/schemas/proxy.py
@@ -17,25 +17,25 @@ class ProxyConfig(jsonobject.JsonObject):
     special_sites = jsonobject.ListProperty(str)
 
     COMMTRACK_SITE_HOST = jsonobject.StringProperty(exclude_if_none=True)
-    commtrack_nginx_combined_cert_value = jsonobject.StringProperty()
-    commtrack_key_value = jsonobject.StringProperty()
+    commtrack_nginx_combined_cert_value = jsonobject.StringProperty(exclude_if_none=True)
+    commtrack_key_value = jsonobject.StringProperty(exclude_if_none=True)
 
     CAS_SITE_HOST = jsonobject.StringProperty(exclude_if_none=True)
-    cas_nginx_combined_cert_value = jsonobject.StringProperty()
-    cas_key_value = jsonobject.StringProperty()
+    cas_nginx_combined_cert_value = jsonobject.StringProperty(exclude_if_none=True)
+    cas_key_value = jsonobject.StringProperty(exclude_if_none=True)
 
     TABLEAU_HOST = jsonobject.StringProperty(exclude_if_none=True)
-    tableau_nginx_combined_cert_value = jsonobject.StringProperty()
-    tableau_key_value = jsonobject.StringProperty()
-    tableau_server = jsonobject.StringProperty()
+    tableau_nginx_combined_cert_value = jsonobject.StringProperty(exclude_if_none=True)
+    tableau_key_value = jsonobject.StringProperty(exclude_if_none=True)
+    tableau_server = jsonobject.StringProperty(exclude_if_none=True)
 
     ENIKSHAY_SITE_HOST = jsonobject.StringProperty(exclude_if_none=True)
-    enikshay_nginx_combined_cert_value = jsonobject.StringProperty()
-    enikshay_key_value = jsonobject.StringProperty()
+    enikshay_nginx_combined_cert_value = jsonobject.StringProperty(exclude_if_none=True)
+    enikshay_key_value = jsonobject.StringProperty(exclude_if_none=True)
 
     PNA_SITE_HOST = jsonobject.StringProperty(exclude_if_none=True)
-    pna_nginx_combined_cert_value = jsonobject.StringProperty()
-    pna_key_value = jsonobject.StringProperty()
+    pna_nginx_combined_cert_value = jsonobject.StringProperty(exclude_if_none=True)
+    pna_key_value = jsonobject.StringProperty(exclude_if_none=True)
 
     def check(self):
         pass

--- a/commcare-cloud/commcare_cloud/environment/schemas/proxy.py
+++ b/commcare-cloud/commcare_cloud/environment/schemas/proxy.py
@@ -11,6 +11,7 @@ class ProxyConfig(jsonobject.JsonObject):
     nginx_key_value = jsonobject.StringProperty()
     nginx_hsts_max_age = jsonobject.IntegerProperty()
 
+    fake_ssl_cert = jsonobject.BooleanProperty(default=False)
     special_sites = jsonobject.ListProperty(str)
 
     COMMTRACK_SITE_HOST = jsonobject.StringProperty(exclude_if_none=True)

--- a/commcare-cloud/commcare_cloud/environment/schemas/proxy.py
+++ b/commcare-cloud/commcare_cloud/environment/schemas/proxy.py
@@ -45,3 +45,7 @@ class ProxyConfig(jsonobject.JsonObject):
         if self.nginx_worker_rlimit_nofile is None:
             variables['nginx_worker_rlimit_nofile'] = "{{ nofile_limit }}"
         return variables
+
+    @classmethod
+    def get_claimed_variables(cls):
+        return set(cls._properties_by_key.keys())

--- a/commcare-cloud/commcare_cloud/environment/schemas/proxy.py
+++ b/commcare-cloud/commcare_cloud/environment/schemas/proxy.py
@@ -13,6 +13,7 @@ class ProxyConfig(jsonobject.JsonObject):
     nginx_max_clients = jsonobject.IntegerProperty(default=512)
     nginx_worker_rlimit_nofile = jsonobject.IntegerProperty()
     fake_ssl_cert = jsonobject.BooleanProperty(default=False)
+    primary_ssl_env = jsonobject.StringProperty()
 
     special_sites = jsonobject.ListProperty(str)
 

--- a/environments/development/proxy.yml
+++ b/environments/development/proxy.yml
@@ -1,1 +1,2 @@
 SITE_HOST: "{{ hostvars[groups.proxy.0].ansible_hostname }}"
+fake_ssl_cert: yes

--- a/environments/development/proxy.yml
+++ b/environments/development/proxy.yml
@@ -1,0 +1,1 @@
+SITE_HOST: "{{ hostvars[groups.proxy.0].ansible_hostname }}"

--- a/environments/development/public.yml
+++ b/environments/development/public.yml
@@ -16,7 +16,6 @@ touchforms_enabled: false
 riak_backend: "bitcask"
 riak_ring_size: 64
 
-fake_ssl_cert: yes
 ansible_user_password_sha_512: "{{ secrets.ANSIBLE_USER_PASSWORD_SHA_512 }}"
 
 dev_users:

--- a/environments/development/public.yml
+++ b/environments/development/public.yml
@@ -1,6 +1,5 @@
 # For a real deployment
 # should be e.g. 'www.commcarehq.org'
-SITE_HOST: "{{ hostvars[groups.proxy.0].ansible_hostname }}"
 internal_domain_name: 'localdomain'
 
 etc_hosts_lines: []

--- a/environments/development/public.yml
+++ b/environments/development/public.yml
@@ -84,7 +84,6 @@ postgres_s3: False
 nadir_hour: 18
 
 nofile_limit: 65536
-nginx_worker_rlimit_nofile: "{{ nofile_limit }}"
 
 supervisor_http_enabled: True
 supervisor_http_username: "{{ secrets.SUPERVISOR_HTTP_USERNAME }}"

--- a/environments/enikshay/proxy.yml
+++ b/environments/enikshay/proxy.yml
@@ -1,0 +1,14 @@
+SITE_HOST: 'enikshay.in'
+J2ME_SITE_HOST: 'j2me.enikshay.in'
+
+nginx_key_value: '{{ ssl_secrets.private_keys.enikshay_in }}'
+# Nginx only accepts on cert, so cat the site cert and chain:
+# $ cat india.commcarehq.org.crt intermediate.crt > india.commcarehq.org.combined.crt
+nginx_combined_cert_value: "{{ ssl_secrets.certs.enikshay_in }}"
+
+ENIKSHAY_SITE_HOST: 'enikshay.commcarehq.org'
+enikshay_nginx_combined_cert_value: '{{ ssl_secrets.certs.enikshay_commcarehq_org }}'
+enikshay_key_value: '{{ ssl_secrets.private_keys.enikshay_commcarehq_org }}'
+
+special_sites:
+  - enikshay_ssl

--- a/environments/enikshay/proxy.yml
+++ b/environments/enikshay/proxy.yml
@@ -1,5 +1,6 @@
 SITE_HOST: 'enikshay.in'
 J2ME_SITE_HOST: 'j2me.enikshay.in'
+primary_ssl_env: "enikshay.in"
 
 nginx_key_value: '{{ ssl_secrets.private_keys.enikshay_in }}'
 # Nginx only accepts on cert, so cat the site cert and chain:

--- a/environments/enikshay/public.yml
+++ b/environments/enikshay/public.yml
@@ -13,7 +13,6 @@ riakcs_proxy_port_override: 9980
 primary_ssl_env: "enikshay.in"
 
 msp_users: "{{ secrets.MSP_USERS }}"
-fake_ssl_cert: no
 
 DATADOG_ENABLED: True
 datadog_integration_cloudant: False

--- a/environments/enikshay/public.yml
+++ b/environments/enikshay/public.yml
@@ -1,11 +1,5 @@
-SITE_HOST: 'enikshay.in'
-ENIKSHAY_SITE_HOST: 'enikshay.commcarehq.org'
-J2ME_SITE_HOST: 'j2me.enikshay.in'
 internal_domain_name: 'enikshay.in'
 daily_deploy_email: tech-announce-daily@dimagi.com
-
-special_sites:
-  - enikshay_ssl
 
 couchdb2:
   username: "{{ localsettings_private.COUCH_USERNAME }}"
@@ -28,15 +22,6 @@ datadog_integration_vmware: True
 elasticsearch_endpoint: '{{ groups.elasticsearch.0 }}'
 elasticsearch_memory: '8192m'
 elasticsearch_cluster_name: 'enikshayes-1.x'
-
-nginx_key_value: '{{ ssl_secrets.private_keys.enikshay_in }}'
-# Nginx only accepts on cert, so cat the site cert and chain:
-# $ cat india.commcarehq.org.crt intermediate.crt > india.commcarehq.org.combined.crt
-nginx_combined_cert_value: "{{ ssl_secrets.certs.enikshay_in }}"
-
-enikshay_nginx_combined_cert_value: '{{ ssl_secrets.certs.enikshay_commcarehq_org }}'
-enikshay_key_value: '{{ ssl_secrets.private_keys.enikshay_commcarehq_org }}'
-
 
 supervisor_http_enabled: True
 

--- a/environments/enikshay/public.yml
+++ b/environments/enikshay/public.yml
@@ -10,8 +10,6 @@ riak_ring_size: 128
 
 riakcs_proxy_port_override: 9980
 
-primary_ssl_env: "enikshay.in"
-
 msp_users: "{{ secrets.MSP_USERS }}"
 
 DATADOG_ENABLED: True

--- a/environments/icds-new/proxy.yml
+++ b/environments/icds-new/proxy.yml
@@ -3,6 +3,7 @@ NO_WWW_SITE_HOST: 'icds-cas.gov.in'
 
 nginx_combined_cert_value: "{{ ssl_secrets.certs.icds_cas_gov_in }}"
 nginx_key_value: '{{ ssl_secrets.private_keys.icds_cas_gov_in }}'
+nginx_max_clients: 1024
 nginx_worker_rlimit_nofile : 16384
 
 CAS_SITE_HOST: 'cas.commcarehq.org'

--- a/environments/icds-new/proxy.yml
+++ b/environments/icds-new/proxy.yml
@@ -1,0 +1,18 @@
+SITE_HOST: 'www.icds-cas.gov.in'
+NO_WWW_SITE_HOST: 'icds-cas.gov.in'
+
+nginx_combined_cert_value: "{{ ssl_secrets.certs.icds_cas_gov_in }}"
+nginx_key_value: '{{ ssl_secrets.private_keys.icds_cas_gov_in }}'
+
+CAS_SITE_HOST: 'cas.commcarehq.org'
+cas_nginx_combined_cert_value: "{{ ssl_secrets.certs.cas_commcarehq_org }}"
+cas_key_value: '{{ ssl_secrets.private_keys.cas_commcarehq_org }}'
+
+TABLEAU_HOST: 'reports.icds-cas.gov.in'
+tableau_nginx_combined_cert_value: "{{ ssl_secrets.certs.reports_icds_cas_gov_in }}"
+tableau_key_value: '{{ ssl_secrets.private_keys.reports_icds_cas_gov_in }}'
+tableau_server: 10.247.24.11:80
+
+special_sites:
+  - icds_tableau
+  - cas_ssl

--- a/environments/icds-new/proxy.yml
+++ b/environments/icds-new/proxy.yml
@@ -3,6 +3,7 @@ NO_WWW_SITE_HOST: 'icds-cas.gov.in'
 
 nginx_combined_cert_value: "{{ ssl_secrets.certs.icds_cas_gov_in }}"
 nginx_key_value: '{{ ssl_secrets.private_keys.icds_cas_gov_in }}'
+nginx_worker_rlimit_nofile : 16384
 
 CAS_SITE_HOST: 'cas.commcarehq.org'
 cas_nginx_combined_cert_value: "{{ ssl_secrets.certs.cas_commcarehq_org }}"

--- a/environments/icds-new/proxy.yml
+++ b/environments/icds-new/proxy.yml
@@ -1,5 +1,6 @@
 SITE_HOST: 'www.icds-cas.gov.in'
 NO_WWW_SITE_HOST: 'icds-cas.gov.in'
+primary_ssl_env: "cas"
 
 nginx_combined_cert_value: "{{ ssl_secrets.certs.icds_cas_gov_in }}"
 nginx_key_value: '{{ ssl_secrets.private_keys.icds_cas_gov_in }}'

--- a/environments/icds-new/public.yml
+++ b/environments/icds-new/public.yml
@@ -10,8 +10,6 @@ primary_ssl_env: "cas"
 nginx_max_clients: 1024
 nginx_worker_rlimit_nofile : 16384
 
-fake_ssl_cert: no
-
 elasticsearch_endpoint: '{{ groups.es0.0 }}'
 elasticsearch_cluster_name: 'icds-2.0'
 

--- a/environments/icds-new/public.yml
+++ b/environments/icds-new/public.yml
@@ -8,7 +8,6 @@ riak_ring_size: 64
 
 primary_ssl_env: "cas"
 nginx_max_clients: 1024
-nginx_worker_rlimit_nofile : 16384
 
 elasticsearch_endpoint: '{{ groups.es0.0 }}'
 elasticsearch_cluster_name: 'icds-2.0'

--- a/environments/icds-new/public.yml
+++ b/environments/icds-new/public.yml
@@ -7,11 +7,9 @@ riak_ring_size: 64
 
 
 primary_ssl_env: "cas"
-nginx_max_clients: 1024
 
 elasticsearch_endpoint: '{{ groups.es0.0 }}'
 elasticsearch_cluster_name: 'icds-2.0'
-
 
 supervisor_http_enabled: True
 

--- a/environments/icds-new/public.yml
+++ b/environments/icds-new/public.yml
@@ -1,26 +1,6 @@
-SITE_HOST: 'www.icds-cas.gov.in'
-CAS_SITE_HOST: 'cas.commcarehq.org'
-NO_WWW_SITE_HOST: 'icds-cas.gov.in'
 internal_domain_name: 'internal-icds-new.commcarehq.org'
 cluster_ip_range: '10.247.164.0/23'
-
-tableau_server: 10.247.24.11:80
 daily_deploy_email: tech-announce-daily@dimagi.com
-
-TABLEAU_HOST: 'reports.icds-cas.gov.in'
-
-nginx_combined_cert_value: "{{ ssl_secrets.certs.icds_cas_gov_in }}"
-nginx_key_value: '{{ ssl_secrets.private_keys.icds_cas_gov_in }}'
-
-cas_nginx_combined_cert_value: "{{ ssl_secrets.certs.cas_commcarehq_org }}"
-cas_key_value: '{{ ssl_secrets.private_keys.cas_commcarehq_org }}'
-
-tableau_nginx_combined_cert_value: "{{ ssl_secrets.certs.reports_icds_cas_gov_in }}"
-tableau_key_value: '{{ ssl_secrets.private_keys.reports_icds_cas_gov_in }}'
-
-special_sites:
-  - icds_tableau
-  - cas_ssl
 
 riak_backend: "bitcask"
 riak_ring_size: 64

--- a/environments/icds-new/public.yml
+++ b/environments/icds-new/public.yml
@@ -5,9 +5,6 @@ daily_deploy_email: tech-announce-daily@dimagi.com
 riak_backend: "bitcask"
 riak_ring_size: 64
 
-
-primary_ssl_env: "cas"
-
 elasticsearch_endpoint: '{{ groups.es0.0 }}'
 elasticsearch_cluster_name: 'icds-2.0'
 

--- a/environments/pna/proxy.yml
+++ b/environments/pna/proxy.yml
@@ -1,0 +1,11 @@
+SITE_HOST: 'commcare.pna.sn'
+
+special_sites:
+  - pna_ssl
+
+nginx_key_value: '{{ ssl_secrets.private_keys.commcare_pna_sn }}'
+nginx_combined_cert_value: "{{ ssl_secrets.certs.commcare_pna_sn }}"
+
+PNA_SITE_HOST: 'pna.commcarehq.org'
+pna_nginx_combined_cert_value: '{{ ssl_secrets.certs.pna_commcarehq_org }}'
+pna_key_value: '{{ ssl_secrets.private_keys.pna_commcarehq_org }}'

--- a/environments/pna/public.yml
+++ b/environments/pna/public.yml
@@ -1,6 +1,5 @@
 ssh_allow_password: True
 ssh_port: 1337
-fake_ssl_cert: no
 
 DATADOG_ENABLED: True
 datadog_extra_host_checks:

--- a/environments/pna/public.yml
+++ b/environments/pna/public.yml
@@ -1,9 +1,3 @@
-SITE_HOST: 'commcare.pna.sn'
-PNA_SITE_HOST: 'pna.commcarehq.org'
-
-special_sites:
-  - pna_ssl
-
 ssh_allow_password: True
 ssh_port: 1337
 fake_ssl_cert: no
@@ -16,12 +10,6 @@ elasticsearch_endpoint: '{{ groups.elasticsearch.0 }}'
 elasticsearch_memory: '2048m'
 elasticsearch_cluster_name: 'pna-es'
 #elasticsearch_node_name: '??'
-
-nginx_key_value: '{{ ssl_secrets.private_keys.commcare_pna_sn }}'
-nginx_combined_cert_value: "{{ ssl_secrets.certs.commcare_pna_sn }}"
-
-pna_nginx_combined_cert_value: '{{ ssl_secrets.certs.pna_commcarehq_org }}'
-pna_key_value: '{{ ssl_secrets.private_keys.pna_commcarehq_org }}'
 
 backup_blobdb: True
 backup_postgres: dump

--- a/environments/production/proxy.yml
+++ b/environments/production/proxy.yml
@@ -1,0 +1,23 @@
+SITE_HOST: 'www.commcarehq.org'
+NO_WWW_SITE_HOST: 'commcarehq.org'
+COMMTRACK_SITE_HOST: 'commtrack.org'
+J2ME_SITE_HOST: 'j2mewww.commcarehq.org'
+
+nginx_hsts_max_age: 300 # 5 minutes
+
+# commcarehq.org of certs
+nginx_combined_cert_value: "{{ ssl_secrets.certs.commcarehq_org }}"
+nginx_key_value: "{{ ssl_secrets.private_keys.commcarehq_org }}"
+
+# commtrack.org
+commtrack_nginx_combined_cert_value: "{{ ssl_secrets.certs.commtrack_org }}"
+commtrack_key_value: "{{ ssl_secrets.private_keys.commtrack_org }}"
+
+special_sites:
+  - commtrack_ssl
+  - commtrack_http
+  - tableau
+  - wiki
+  - wiki_http
+  - motech
+  - motech2

--- a/environments/production/proxy.yml
+++ b/environments/production/proxy.yml
@@ -2,6 +2,8 @@ SITE_HOST: 'www.commcarehq.org'
 NO_WWW_SITE_HOST: 'commcarehq.org'
 COMMTRACK_SITE_HOST: 'commtrack.org'
 J2ME_SITE_HOST: 'j2mewww.commcarehq.org'
+# This sets production_commcare as the default endpoint for ssl connections
+primary_ssl_env: "production"
 
 nginx_hsts_max_age: 300 # 5 minutes
 

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -1,17 +1,4 @@
-SITE_HOST: 'www.commcarehq.org'
-NO_WWW_SITE_HOST: 'commcarehq.org'
-COMMTRACK_SITE_HOST: 'commtrack.org'
-J2ME_SITE_HOST: 'j2mewww.commcarehq.org'
 daily_deploy_email: tech-announce-daily@dimagi.com
-
-special_sites:
-  - commtrack_ssl
-  - commtrack_http
-  - tableau
-  - wiki
-  - wiki_http
-  - motech
-  - motech2
 
 riak_backend: "leveldb"
 riak_ring_size: 128
@@ -31,16 +18,6 @@ elasticsearch_cluster_name: 'prodhqes-1.x'
 
 
 nofile_limit: 65536
-
-nginx_hsts_max_age: 300 # 5 minutes
-
-# commcarehq.org of certs
-nginx_combined_cert_value: "{{ ssl_secrets.certs.commcarehq_org }}"
-nginx_key_value: "{{ ssl_secrets.private_keys.commcarehq_org }}"
-
-# commtrack.org
-commtrack_nginx_combined_cert_value: "{{ ssl_secrets.certs.commtrack_org }}"
-commtrack_key_value: "{{ ssl_secrets.private_keys.commtrack_org }}"
 
 supervisor_http_enabled: True
 

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -6,8 +6,6 @@ riak_ring_size: 128
 # This sets production_commcare as the default endpoint for ssl connections
 primary_ssl_env: "production"
 
-fake_ssl_cert: no
-
 DATADOG_ENABLED: True
 CLOUDANT_CLUSTER_NAME: dimagi003
 

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -3,9 +3,6 @@ daily_deploy_email: tech-announce-daily@dimagi.com
 riak_backend: "leveldb"
 riak_ring_size: 128
 
-# This sets production_commcare as the default endpoint for ssl connections
-primary_ssl_env: "production"
-
 DATADOG_ENABLED: True
 CLOUDANT_CLUSTER_NAME: dimagi003
 

--- a/environments/softlayer/proxy.yml
+++ b/environments/softlayer/proxy.yml
@@ -1,0 +1,11 @@
+SITE_HOST: 'india.commcarehq.org'
+CAS_SITE_HOST: 'cas.commcarehq.org'
+ENIKSHAY_SITE_HOST: 'enikshay.commcarehq.org'
+J2ME_SITE_HOST: 'j2me-india.commcarehq.org'
+tableau_server: 'tableau2.internal.commcarehq.org'
+TABLEAU_HOST: 'icds.commcarehq.org'
+
+nginx_key_value: '{{ ssl_secrets.private_keys.india_commcarehq_org }}'
+# Nginx only accepts on cert, so cat the site cert and chain:
+# $ cat india.commcarehq.org.crt intermediate.crt > india.commcarehq.org.combined.crt
+nginx_combined_cert_value: '{{ ssl_secrets.certs.india_commcarehq_org }}'

--- a/environments/softlayer/proxy.yml
+++ b/environments/softlayer/proxy.yml
@@ -4,6 +4,7 @@ ENIKSHAY_SITE_HOST: 'enikshay.commcarehq.org'
 J2ME_SITE_HOST: 'j2me-india.commcarehq.org'
 tableau_server: 'tableau2.internal.commcarehq.org'
 TABLEAU_HOST: 'icds.commcarehq.org'
+primary_ssl_env: "softlayer"
 
 nginx_key_value: '{{ ssl_secrets.private_keys.india_commcarehq_org }}'
 # Nginx only accepts on cert, so cat the site cert and chain:

--- a/environments/softlayer/public.yml
+++ b/environments/softlayer/public.yml
@@ -8,8 +8,6 @@ riak_ring_size: 128
 
 primary_ssl_env: "softlayer"
 
-fake_ssl_cert: no
-
 DATADOG_ENABLED: True
 
 elasticsearch_endpoint: '{{ groups.elasticsearch.0 }}'

--- a/environments/softlayer/public.yml
+++ b/environments/softlayer/public.yml
@@ -1,10 +1,3 @@
-SITE_HOST: 'india.commcarehq.org'
-CAS_SITE_HOST: 'cas.commcarehq.org'
-ENIKSHAY_SITE_HOST: 'enikshay.commcarehq.org'
-J2ME_SITE_HOST: 'j2me-india.commcarehq.org'
-tableau_server: 'tableau2.internal.commcarehq.org'
-TABLEAU_HOST: 'icds.commcarehq.org'
-
 couchdb2:
   username: "{{ localsettings_private.COUCH_USERNAME }}"
   password: "{{ localsettings_private.COUCH_PASSWORD }}"
@@ -22,11 +15,6 @@ DATADOG_ENABLED: True
 elasticsearch_endpoint: '{{ groups.elasticsearch.0 }}'
 elasticsearch_memory: '8192m'
 elasticsearch_cluster_name: 'indiahqes-1.x'
-
-nginx_key_value: '{{ ssl_secrets.private_keys.india_commcarehq_org }}'
-# Nginx only accepts on cert, so cat the site cert and chain:
-# $ cat india.commcarehq.org.crt intermediate.crt > india.commcarehq.org.combined.crt
-nginx_combined_cert_value: '{{ ssl_secrets.certs.india_commcarehq_org }}'
 
 supervisor_http_enabled: True
 

--- a/environments/softlayer/public.yml
+++ b/environments/softlayer/public.yml
@@ -5,9 +5,6 @@ couchdb2:
 riak_backend: "leveldb"
 riak_ring_size: 128
 
-
-primary_ssl_env: "softlayer"
-
 DATADOG_ENABLED: True
 
 elasticsearch_endpoint: '{{ groups.elasticsearch.0 }}'

--- a/environments/staging/proxy.yml
+++ b/environments/staging/proxy.yml
@@ -1,0 +1,11 @@
+SITE_HOST: 'staging.commcarehq.org'
+J2ME_SITE_HOST: 'j2mestaging.commcarehq.org'
+
+# Nginx only accepts on cert, so cat the site cert and chain:
+# $ cat commcarehq.org.crt hq_thawtecabundle.crt > commcarehq.org.combined.crt
+nginx_combined_cert_value: "{{ ssl_secrets.certs.commcarehq_org }}"
+nginx_key_value: "{{ ssl_secrets.private_keys.commcarehq_org }}"
+
+# commtrack.org
+commtrack_nginx_combined_cert_value: "{{ ssl_secrets.certs.commtrack_org }}"
+commtrack_key_value: "{{ ssl_secrets.private_keys.commtrack_org }}"

--- a/environments/staging/proxy.yml
+++ b/environments/staging/proxy.yml
@@ -1,5 +1,6 @@
 SITE_HOST: 'staging.commcarehq.org'
 J2ME_SITE_HOST: 'j2mestaging.commcarehq.org'
+primary_ssl_env: "staging"
 
 # Nginx only accepts on cert, so cat the site cert and chain:
 # $ cat commcarehq.org.crt hq_thawtecabundle.crt > commcarehq.org.combined.crt

--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -3,8 +3,6 @@ riak_ring_size: 64
 
 primary_ssl_env: "staging"
 
-fake_ssl_cert: no
-
 DATADOG_ENABLED: False
 elasticsearch_endpoint: '{{ groups.elasticsearch.0 }}'
 elasticsearch_cluster_name: 'staginges'

--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -1,6 +1,3 @@
-SITE_HOST: 'staging.commcarehq.org'
-J2ME_SITE_HOST: 'j2mestaging.commcarehq.org'
-
 riak_backend: "leveldb"
 riak_ring_size: 64
 
@@ -11,15 +8,6 @@ fake_ssl_cert: no
 DATADOG_ENABLED: False
 elasticsearch_endpoint: '{{ groups.elasticsearch.0 }}'
 elasticsearch_cluster_name: 'staginges'
-
-# Nginx only accepts on cert, so cat the site cert and chain:
-# $ cat commcarehq.org.crt hq_thawtecabundle.crt > commcarehq.org.combined.crt
-nginx_combined_cert_value: "{{ ssl_secrets.certs.commcarehq_org }}"
-nginx_key_value: "{{ ssl_secrets.private_keys.commcarehq_org }}"
-
-# commtrack.org
-commtrack_nginx_combined_cert_value: "{{ ssl_secrets.certs.commtrack_org }}"
-commtrack_key_value: "{{ ssl_secrets.private_keys.commtrack_org }}"
 
 supervisor_http_enabled: True
 

--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -1,8 +1,6 @@
 riak_backend: "leveldb"
 riak_ring_size: 64
 
-primary_ssl_env: "staging"
-
 DATADOG_ENABLED: False
 elasticsearch_endpoint: '{{ groups.elasticsearch.0 }}'
 elasticsearch_cluster_name: 'staginges'

--- a/environments/swiss/proxy.yml
+++ b/environments/swiss/proxy.yml
@@ -1,0 +1,3 @@
+SITE_HOST: 'swiss.commcarehq.org'
+nginx_key_value: '{{ ssl_secrets.private_keys.swiss_commcarehq_org }}'
+nginx_combined_cert_value: '{{ ssl_secrets.certs.swiss_commcarehq_org }}'

--- a/environments/swiss/public.yml
+++ b/environments/swiss/public.yml
@@ -1,5 +1,3 @@
-SITE_HOST: 'swiss.commcarehq.org'
-
 msp_users: "{{ secrets.MSP_USERS }}"
 fake_ssl_cert: no
 
@@ -11,9 +9,6 @@ elasticsearch_memory: '4096m'
 elasticsearch_cluster_name: 'deves'
 #elasticsearch_node_name: '??'
 elastcsearch_backup_days: 3
-
-nginx_key_value: '{{ ssl_secrets.private_keys.swiss_commcarehq_org }}'
-nginx_combined_cert_value: '{{ ssl_secrets.certs.swiss_commcarehq_org }}'
 
 ssh_allow_password: True
 

--- a/environments/swiss/public.yml
+++ b/environments/swiss/public.yml
@@ -1,5 +1,4 @@
 msp_users: "{{ secrets.MSP_USERS }}"
-fake_ssl_cert: no
 
 DATADOG_ENABLED: True
 DATADOG_INTEGRATIONS_ENABLED: False


### PR DESCRIPTION
This is just refactoring without but also has the following change (lifted from the commit message):
> For envs that had nothing before, this adds a `worker_rlimit_nofile` directive to nginx confs
specifying the PAM file limit. I don't think in practice that changes anything.
a80e818

For example, staging `/etc/nginx/nginx.conf` will now have

```
worker_rlimit_nofile 4096;
```

Tested on
- [x] icds-new
- [x] pna
- [x] production
- [x] softlayer
- [x] staging
- [x] swiss