### PR TITLE
include from __future__ import * in localsettings

### DIFF
--- a/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -2,6 +2,11 @@
 # {{ ansible_managed }}
 #
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from datetime import time
 import hashlib
 import json


### PR DESCRIPTION
Tested on staging - no issues observed yet.  Including ```division``` and ```print_function``` is a little paranoid, but I'd rather air on the side of caution because ```modernize``` won't pass over this file.

@dimagi/py3 