### PR TITLE
add tmux and django-manage --tmux

### DIFF
--- a/commcare-cloud/commcare_cloud/commcare_cloud.py
+++ b/commcare-cloud/commcare_cloud/commcare_cloud.py
@@ -18,7 +18,7 @@ from .commands.ansible.ansible_playbook import (
 from commcare_cloud.commands.ansible.service import Service
 from .commands.ansible.run_module import RunAnsibleModule, RunShellCommand
 from .commands.fab import Fab
-from .commands.inventory_lookup.inventory_lookup import Lookup, Ssh, Mosh, DjangoManage
+from .commands.inventory_lookup.inventory_lookup import Lookup, Ssh, Mosh, DjangoManage, Tmux
 from commcare_cloud.commands.command_base import CommandBase
 from .environment.paths import (
     get_available_envs,
@@ -42,6 +42,7 @@ COMMAND_TYPES = [
     Ssh,
     Mosh,
     DjangoManage,
+    Tmux,
     Service,
     ValidateEnvironmentSettings,
     UpdateLocalKnownHosts,


### PR DESCRIPTION
to run commands in a new tmux window

Recently used to run

```
cchq production django-manage --tmux check_forms_have_xml hsph-ppiud-tanzania /home/cchq/hsph-ppiud-tanzania.check_forms_have_xml.csv
```

and reattach with

```
cchq production tmux -
```

the dash means "use the default machine (webworkers:0)"