### PR TITLE
remove refs to removed machines in icds inventory

### DIFF
--- a/environments/icds-new/inventory.ini
+++ b/environments/icds-new/inventory.ini
@@ -769,16 +769,13 @@ web9
 pgucr
 pgsynclog
 pgmain
-pgshard0
 pgshard1
-pgshard2
 pgshard3
 pgshard4
 pgshard5
 pgshard6
 pgshard7
 pgshard8
-pgshard9
 pgshard10
 pgshard11
 pgshard12
@@ -793,7 +790,7 @@ couch4
 couch5
 
 [couchdb2_proxy:children]
-couch0
+couch3
 
 [redis:children]
 rabbit0


### PR DESCRIPTION
Left over from https://github.com/dimagi/commcare-cloud/pull/1610 and https://github.com/dimagi/commcare-cloud/pull/1612.

Not sure if I did the right thing for `couchdb2_proxy`; I think you do need to specify that group, so I just arbitrarily picked the first `couchdb2` host.