### PR TITLE
Don't fail if previous deploy isn't found

### DIFF
--- a/fab/fab/utils.py
+++ b/fab/fab/utils.py
@@ -111,6 +111,8 @@ class DeployMetadata(object):
 
         if self._deploy_tag is None:
             raise Exception("You haven't tagged anything yet.")
+        if not self._last_tag:
+            return '"Previous deploy not found, cannot make comparison"'
         return "https://github.com/dimagi/commcare-hq/compare/{}...{}".format(
             self._last_tag,
             self._deploy_tag,


### PR DESCRIPTION
`__last_tag` can be `None`, if a matching tag isn't found in the last 100.  This URL gets passed to a HQ management command, which splits this string back up:
https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/hqadmin/management/utils.py#L22
Brittleness of that aside, that probably *should* fail, so I opted to catch this edge case here.

@jmtroth0 @millerdev @biyeun 