### PR TITLE
handling particular github exception

### DIFF
--- a/fab/fab/utils.py
+++ b/fab/fab/utils.py
@@ -11,7 +11,7 @@ from fabric.api import local
 import re
 from getpass import getpass
 
-from github import Github, UnknownObjectException
+from github import Github, UnknownObjectException, GithubException
 from fabric.api import execute, env
 from fabric.colors import magenta
 
@@ -146,6 +146,9 @@ class DeployMetadata(object):
                 'Github API key does not have the right settings. '
                 'Please create an API key with the public_repo scope enabled.'
             )
+        except GithubException as e:
+            if e.data.get('message') != 'Reference already exists':
+                raise
 
         return self._deploy_ref
 


### PR DESCRIPTION
When the deploy fails during setup_release, it attempts to create the ref again resulting in this exception, which is fine.

```Executed: sudo -S -p 'sudo password:' -H  -u "cchq"  /bin/bash -l -c "cd /home/cchq/www/production/releases/2018-04-17_20.19 >/dev/null && /home/cchq/www/production/releases/2018-04-17_20.19/python_env/bin/python manage.py mail_admins --subject 'Deploy to production failed. Try resuming with fab production deploy:resume=yes.' 'Traceback:
  File \"/home/jroth/.commcare-cloud/repo/fab/fab/fabfile.py\", line 505, in _deploy_without_asking
    deploy_checkpoint(index, command.__name__, execute_with_timing, command)
  File \"/home/jroth/.commcare-cloud/repo/fab/fab/fabfile.py\", line 471, in deploy_checkpoint
    fn(*args, **kwargs)
  File \"/home/jroth/.commcare-cloud/repo/fab/fab/utils.py\", line 34, in execute_with_timing
    execute(fn, *args, **kwargs)
  File \"/home/jroth/.virtualenvs/ansible/local/lib/python2.7/site-packages/fabric/tasks.py\", line 387, in execute
    multiprocessing
  File \"/home/jroth/.virtualenvs/ansible/local/lib/python2.7/site-packages/fabric/tasks.py\", line 277, in _execute
    return task.run(*args, **kwargs)
  File \"/home/jroth/.virtualenvs/ansible/local/lib/python2.7/site-packages/fabric/tasks.py\", line 174, in run
    return self.wrapped(*args, **kwargs)
  File \"/home/jroth/.commcare-cloud/repo/fab/fab/fabfile.py\", line 404, in setup_release
    deploy_ref = env.deploy_metadata.deploy_ref  # Make sure we have a valid commit
  File \"/home/jroth/.commcare-cloud/repo/fab/fab/utils.py\", line 142, in deploy_ref
    sha=self._deploy_ref,
  File \"/home/jroth/.virtualenvs/ansible/local/lib/python2.7/site-packages/github/Repository.py\", line 782, in create_git_ref
    input=post_parameters
  File \"/home/jroth/.virtualenvs/ansible/local/lib/python2.7/site-packages/github/Requester.py\", line 169, in requestJsonAndCheck
    return self.__check(*self.requestJson(verb, url, parameters, headers, input, cnx))
  File \"/home/jroth/.virtualenvs/ansible/local/lib/python2.7/site-packages/github/Requester.py\", line 182, in __check
    raise self.__createException(status, responseHeaders, output)
GithubException: 422 {u'\"'\"'documentation_url'\"'\"': u'\"'\"'https://developer.github.com/v3/git/refs/#create-a-reference'\"'\"', u'\"'\"'message'\"'\"': u'\"'\"'Reference already exists'\"'\"'}' --slack --environment production"```