### PR TITLE
Revert "standby reads for users and accounting"

### DIFF
--- a/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -70,8 +70,6 @@ REPORTING_DATABASES = json.loads('{{ REPORTING_DATABASES|to_json }}')
 
 WAREHOUSE_DATABASE_ALIAS = "{{ localsettings.WAREHOUSE_DATABASE_ALIAS|default('default') }}"
 
-LOAD_BALANCED_APPS = json.loads('{{ LOAD_BALANCED_APPS|to_json|default({}) }}')
-
 LOG_HOME = '{{ log_home }}'
 COUCH_LOG_FILE = os.path.join(LOG_HOME,"{{ localsettings.DEPLOY_MACHINE_NAME }}-commcarehq.couch.log")
 DJANGO_LOG_FILE = os.path.join(LOG_HOME,"{{ localsettings.DEPLOY_MACHINE_NAME }}-commcarehq.django.log")

--- a/commcare-cloud/commcare_cloud/environment/schemas/postgresql.py
+++ b/commcare-cloud/commcare_cloud/environment/schemas/postgresql.py
@@ -63,7 +63,6 @@ class PostgresqlConfig(jsonobject.JsonObject):
     DEFAULT_POSTGRESQL_USER = jsonobject.StringProperty(default="{{ secrets.POSTGRES_USERS.commcare.username }}")
     DEFAULT_POSTGRESQL_PASSWORD = jsonobject.StringProperty(default="{{ secrets.POSTGRES_USERS.commcare.password }}")
     REPORTING_DATABASES = jsonobject.DictProperty(default=lambda: {"ucr": "ucr"})
-    LOAD_BALANCED_APPS = jsonobject.DictProperty(default={})
     dbs = jsonobject.ObjectProperty(lambda: SmartDBConfig)
 
     override = jsonobject.ObjectProperty(PostgresqlOverride)

--- a/docs/env/postgresql_yml.md
+++ b/docs/env/postgresql_yml.md
@@ -249,27 +249,4 @@ READ:
 
 where `<weight>` is a low-ish integer.
 The probability of hitting a given database with weight W<sub>n</sub> is its normalized weight,
-i.e. W<sub>n</sub> / (W<sub>1</sub> + ... + W<sub>N</sub>).
-
-## `LOAD_BALANCED_APPS`
-
-- Type: dict
-- Default: `{}`
-- Status: Custom
-
-Specify a list of django apps that can be read from multiple dbs.
-
-The keys are the django app label. The values are a weighted list of databases to read from.
-
-This is formatted as:
-
-```
-<app_name>:
-  - [<django_alias>, <weight>]
-  - [<django_alias>, <weight>]
-  ...
-```
-
-where `<weight>` is a low-ish integer.
-The probability of hitting a given database with weight W<sub>n</sub> is its normalized weight,
-i.e. W<sub>n</sub> / (W<sub>1</sub> + ... + W<sub>N</sub>).
+i.e. W<sub>n</sub> / (W<sub>1</sub> + ... + W<sub>N</sub>).  

--- a/environments/icds-new/postgresql.yml
+++ b/environments/icds-new/postgresql.yml
@@ -8,17 +8,6 @@ REPORTING_DATABASES:
       - [icds-ucr-standby1, 7]
   icds-test-ucr: icds-ucr
 
-LOAD_BALANCED_APPS:
-  auth:
-    - [default, 5]
-    - [pgmainstandby, 5]
-  accounting:
-    - [default, 5]
-    - [pgmainstandby, 5]
-  locations:
-    - [default, 5]
-    - [pgmainstandby, 5]
-
 override:
   pgbouncer_pool_mode: transaction
   pgbouncer_pool_timeout: 1
@@ -80,10 +69,5 @@ dbs:
     - django_alias: icds-ucr-standby1
       name: commcarehq_icds_aggregatedata
       host: pgucrstandby
-      create: False
-      django_migrate: False
-    - django_alias: pgmainstandby
-      name: commcarehq
-      host: pgmainstandby
       create: False
       django_migrate: False


### PR DESCRIPTION
Reverts dimagi/commcare-cloud#1624

@calellowitz @snopoke 

This breaks everything because you can't actually read app configs at this point https://github.com/dimagi/commcare-hq/blob/99d0cca8925caeaf6c30e88b9248ab4427dd63cd/corehq/sql_db/connections.py#L169

Error stack trace:

```
(python_env) cchq@web0:~/www/icds/releases/2018-04-20_17.45$ ./manage.py showmigrations
Traceback (most recent call last):
  File "./manage.py", line 134, in <module>
    execute_from_command_line(sys.argv)
  File "/home/cchq/www/icds/releases/2018-04-19_07.29/python_env/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 364, in execute_from_command_line
    utility.execute()
  File "/home/cchq/www/icds/releases/2018-04-19_07.29/python_env/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 338, in execute
    django.setup()
  File "./manage.py", line 51, in _setup_once
    _setup_once.setup(*args, **kw)
  File "/home/cchq/www/icds/releases/2018-04-19_07.29/python_env/local/lib/python2.7/site-packages/django/__init__.py", line 27, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/home/cchq/www/icds/releases/2018-04-19_07.29/python_env/local/lib/python2.7/site-packages/django/apps/registry.py", line 85, in populate
    app_config = AppConfig.create(entry)
  File "/home/cchq/www/icds/releases/2018-04-19_07.29/python_env/local/lib/python2.7/site-packages/django/apps/config.py", line 94, in create
    module = import_module(entry)
  File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "./corehq/ex-submodules/fluff/__init__.py", line 5, in <module>
    from fluff.signals import BACKEND_SQL, BACKEND_COUCH
  File "./corehq/ex-submodules/fluff/signals.py", line 15, in <module>
    from corehq.sql_db.connections import connection_manager
  File "/home/cchq/www/icds/releases/2018-04-20_17.45/corehq/sql_db/connections.py", line 217, in <module>
    connection_manager = ConnectionManager()
  File "/home/cchq/www/icds/releases/2018-04-20_17.45/corehq/sql_db/connections.py", line 73, in __init__
    self._populate_connection_map()
  File "/home/cchq/www/icds/releases/2018-04-20_17.45/corehq/sql_db/connections.py", line 169, in _populate_connection_map
    apps.get_app_config(app)
  File "/home/cchq/www/icds/releases/2018-04-19_07.29/python_env/local/lib/python2.7/site-packages/django/apps/registry.py", line 147, in get_app_config
    self.check_apps_ready()
  File "/home/cchq/www/icds/releases/2018-04-19_07.29/python_env/local/lib/python2.7/site-packages/django/apps/registry.py", line 125, in check_apps_ready
    raise AppRegistryNotReady("Apps aren't loaded yet.")
django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet.
```