### PR TITLE
Chown virtualenv after upgrading python packages

### DIFF
--- a/ansible/roles/commcarehq/tasks/main.yml
+++ b/ansible/roles/commcarehq/tasks/main.yml
@@ -97,6 +97,15 @@
     - six
     - pip
     - setuptools
+        
+- name: chown virtualenv
+  become: true
+  file:
+    path: "{{ virtualenv_home }}"
+    state: directory
+    owner: "{{ cchq_user }}"
+    group: "{{ cchq_user }}"
+    recurse: yes
 
 - name: copy localsettings
   become: true


### PR DESCRIPTION
For some reason when we upgrade python packages (like pip) it gets owned by root

fyi @NitigyaS 