### PR TITLE
make service status report all subservices

### DIFF
--- a/src/commcare_cloud/commands/ansible/ansible_playbook.py
+++ b/src/commcare_cloud/commands/ansible/ansible_playbook.py
@@ -89,10 +89,6 @@ class AnsiblePlaybook(CommandBase):
             if not has_arg(unknown_args, '-f', '--forks'):
                 cmd_parts += ('--forks', '15')
 
-            known_hosts_filepath = environment.paths.known_hosts
-            if os.path.exists(known_hosts_filepath):
-                cmd_parts += ("--ssh-common-args='-o=UserKnownHostsFile=%s'" % (known_hosts_filepath,), )
-
             if has_arg(unknown_args, '-D', '--diff') or has_arg(unknown_args, '-C', '--check'):
                 puts(colored.red("Options --diff and --check not allowed. Please remove -D, --diff, -C, --check."))
                 puts("These ansible-playbook options are managed automatically by commcare-cloud and cannot be set manually.")
@@ -101,7 +97,7 @@ class AnsiblePlaybook(CommandBase):
             if ask_vault_pass:
                 cmd_parts += ('--vault-password-file=/bin/cat',)
 
-            cmd_parts += get_common_ssh_args(public_vars)
+            cmd_parts += get_common_ssh_args(environment)
             cmd = ' '.join(shlex_quote(arg) for arg in cmd_parts)
             print_command(cmd)
             if ask_vault_pass:

--- a/src/commcare_cloud/commands/ansible/helpers.py
+++ b/src/commcare_cloud/commands/ansible/helpers.py
@@ -34,15 +34,19 @@ class AnsibleContext(object):
         return env
 
 
-def get_common_ssh_args(public_vars):
-    pem = public_vars.get('commcare_cloud_pem', None)
-    strict_host_key_checking = public_vars.get('commcare_cloud_strict_host_key_checking', True)
+def get_common_ssh_args(environment):
+    pem = environment.public_vars.get('commcare_cloud_pem', None)
+    strict_host_key_checking = environment.public_vars.get('commcare_cloud_strict_host_key_checking', True)
 
     common_ssh_args = []
     if pem:
         common_ssh_args.extend(['-i', pem])
     if not strict_host_key_checking:
         common_ssh_args.append('-o StrictHostKeyChecking=no')
+
+    known_hosts_filepath = environment.paths.known_hosts
+    if os.path.exists(known_hosts_filepath):
+        common_ssh_args.append('-o=UserKnownHostsFile={}'.format(known_hosts_filepath))
 
     cmd_parts = tuple()
     if common_ssh_args:

--- a/src/commcare_cloud/commands/ansible/run_module.py
+++ b/src/commcare_cloud/commands/ansible/run_module.py
@@ -120,7 +120,7 @@ def run_ansible_module(environment, ansible_context, inventory_group, module, mo
     if ask_vault_pass:
         cmd_parts += ('--vault-password-file=/bin/cat',)
 
-    cmd_parts += get_common_ssh_args(public_vars)
+    cmd_parts += get_common_ssh_args(environment)
     cmd = ' '.join(shlex_quote(arg) for arg in cmd_parts)
     print_command(cmd)
     p = subprocess.Popen(cmd, stdin=subprocess.PIPE, shell=True, env=ansible_context.env_vars)

--- a/src/commcare_cloud/commands/ansible/service.py
+++ b/src/commcare_cloud/commands/ansible/service.py
@@ -198,7 +198,7 @@ class Service(_AnsiblePlaybookAlias):
         if service_group in ["touchforms", "formplayer", "webworkers"]:
             exit_code = self.run_supervisor_action_for_service_group(service_group, 'status', args, unknown_args)
         else:
-            exit_codes = []
+            failed_exit_codes = []
             for service in self.services(service_group, args):
                 if service == "celery":
                     exit_code = self.run_for_celery(service_group, 'status', args, unknown_args)
@@ -210,12 +210,10 @@ class Service(_AnsiblePlaybookAlias):
                     args.inventory_group = self.get_inventory_group_for_service(service, args.service_group)
                     exit_code = RunShellCommand(self.parser).run(args, unknown_args)
                 if exit_code is not 0:
-
-                    exit_codes.append(exit_code)
-            if exit_codes:
+                    failed_exit_codes.append(exit_code)
+            if failed_exit_codes:
                 # if any service status check doesn't go smoothly, return the first exit code
-                return exit_codes[0]
-
+                return failed_exit_codes[0]
         return exit_code
 
     def run_ansible_module_for_service_group(self, service_group, args, unknown_args, inventory_group=None):


### PR DESCRIPTION
even when one of them is down. Previous behavior was to stop checking others
as soon as one of them was down (and thus returned a non-zero status).

Fixes #1634