### PR TITLE
add deprecation message if you try to use fab directly

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -1,0 +1,10 @@
+from sys import argv
+from time import sleep
+
+print("\nRunning fab directly isn't supported anymore for commcare deploys.\n")
+
+sleep(2)
+print("Try running\n")
+print("  commcare-cloud {} fab deploy".format(argv[1]))
+print("\ninstead.")
+exit(0)


### PR DESCRIPTION
we've been running fab via commcare-cloud for a while now.
The recent reorganization for pip install broke the fab shim,
so this makes the fabfile just tell you what command you should be running