### PR TITLE
revert change that broke set_celery_supervisorconf in fab

### DIFF
--- a/src/commcare_cloud/fab/operations/supervisor.py
+++ b/src/commcare_cloud/fab/operations/supervisor.py
@@ -80,8 +80,8 @@ def set_celery_supervisorconf():
             )
             continue
 
-        pooling = params['pooling']
-        max_tasks_per_child = params['max_tasks_per_child']
+        pooling = params.get('pooling', 'prefork')
+        max_tasks_per_child = params.get('max_tasks_per_child', 50)
         num_workers = params.get('num_workers', 1)
 
         params.update({


### PR DESCRIPTION
https://github.com/dimagi/commcare-cloud/pull/1646/files#diff-ce4f14cae5d0b7b4c316c8c3ce4bbe5f
thought it would be innocuous, but it seems to be breaking