### PR TITLE
add num_workers to celery config

### DIFF
--- a/src/commcare_cloud/environment/schemas/app_processes.py
+++ b/src/commcare_cloud/environment/schemas/app_processes.py
@@ -18,6 +18,7 @@ class CeleryOptions(jsonobject.JsonObject):
     pooling = jsonobject.StringProperty(choices=['gevent', 'prefork'], default='prefork')
     max_tasks_per_child = jsonobject.IntegerProperty(default=50)
     server_whitelist = IpAddressProperty()
+    num_workers = jsonobject.IntegerProperty(default=1)
 
 
 class AppProcessesConfig(jsonobject.JsonObject):


### PR DESCRIPTION
I did a bit of testing it doesn't appear that the `CeleryOptions` class every wraps the raw dict. I played with it a bit but couldn't figure out how to get the wrapping to work (without manually wrapping each one).