### PR TITLE
Revert 1658 revert 1651 jr/single release

### DIFF
--- a/src/commcare_cloud/fab/const.py
+++ b/src/commcare_cloud/fab/const.py
@@ -34,6 +34,7 @@ ROLES_POSTGRESQL = ['pg', 'pgstandby', 'django_monolith']
 ROLES_ELASTICSEARCH = ['elasticsearch', 'django_monolith']
 ROLES_RIAKCS = ['riakcs', 'django_monolith']
 ROLES_DEPLOY = ['deploy', 'django_monolith']
+ROLES_MANAGE = ['django_manage']
 ROLES_CONTROL = ['control']
 
 RELEASE_RECORD = 'RELEASES.txt'

--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -281,7 +281,7 @@ def preindex_views():
     Creates a new release that runs preindex_everything. Clones code from
     `current` release and updates it.
     """
-    setup_release()
+    _setup_release()
     db.preindex_views()
 
 
@@ -418,7 +418,7 @@ def setup_release(keep_days=0):
     _setup_release(parse_int_or_exit(keep_days), full_cluster=True)
 
 
-def _setup_release(keep_days, full_cluster):
+def _setup_release(keep_days=0, full_cluster=True):
     """
     Setup a release in the releases directory with the most recent code.
     Useful for running management commands. These releases will automatically
@@ -777,7 +777,7 @@ def silent_services_restart(use_current_release=False):
 
 @task
 def set_supervisor_config():
-    setup_release()
+    _setup_release()
     execute_with_timing(supervisor.set_supervisor_config)
 
 
@@ -814,7 +814,7 @@ def start_pillows():
 @task
 def reset_mvp_pillows():
     _require_target()
-    setup_release()
+    _setup_release()
     mvp_pillows = [
         'MVPFormIndicatorPillow',
         'MVPCaseIndicatorPillow',
@@ -844,7 +844,7 @@ def reset_pillow(pillow):
 
 
 ONLINE_DEPLOY_COMMANDS = [
-    setup_release,
+    _setup_release,
     announce_deploy_start,
     db.preindex_views,
     # Compute version statics while waiting for preindex

--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -221,7 +221,7 @@ def env_common():
     all = servers['all']
     proxy = servers['proxy']
     webworkers = servers['webworkers']
-    django_manage = servers.get('django_manage', webworkers[0])
+    django_manage = servers.get('django_manage', [webworkers[0]])
     riakcs = servers.get('riakcs', [])
     postgresql = servers['postgresql']
     pg_standby = servers.get('pg_standby', [])

--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -221,6 +221,7 @@ def env_common():
     all = servers['all']
     proxy = servers['proxy']
     webworkers = servers['webworkers']
+    django_manage = servers.get('django_manage', webworkers[0])
     riakcs = servers.get('riakcs', [])
     postgresql = servers['postgresql']
     pg_standby = servers.get('pg_standby', [])
@@ -243,6 +244,7 @@ def env_common():
         'rabbitmq': rabbitmq,
         'django_celery': celery,
         'django_app': webworkers,
+        'django_manage': django_manage,
         'django_pillowtop': pillowtop,
         'formsplayer': touchforms,
         'formplayer': formplayer,
@@ -382,8 +384,41 @@ def prepare_offline_deploy():
     offline_ops.prepare_formplayer_build()
 
 
+def parse_int_or_exit(val):
+    try:
+        return int(val)
+    except ValueError:
+        print(red("Unable to parse '{}' into an integer".format(val)))
+        exit()
+
+
+@task
+def setup_limited_release(keep_days=1):
+    """ Sets up a release on a single machine
+    defaults to webworkers:0
+
+    See :func:`_setup_release` for more info
+
+    Example:
+    fab <env> setup_limited_release:keep_days=10  # Makes a new release that will last for 10 days
+    """
+    _setup_release(parse_int_or_exit(keep_days), full_cluster=False)
+
+
 @task
 def setup_release(keep_days=0):
+    """ Sets up a full release across the cluster
+
+    See :func:`_setup_release` for info
+
+    Example:
+    fab <env> setup_release:keep_days=10  # Makes a new release that will last for 10 days
+    """
+
+    _setup_release(parse_int_or_exit(keep_days), full_cluster=True)
+
+
+def _setup_release(keep_days, full_cluster):
     """
     Setup a release in the releases directory with the most recent code.
     Useful for running management commands. These releases will automatically
@@ -391,25 +426,17 @@ def setup_release(keep_days=0):
     last past a deploy use the `keep_days` param.
 
     :param keep_days: The number of days to keep this release before it will be purged
-
-    Example:
-    fab <env> setup_release:keep_days=10  # Makes a new release that will last for 10 days
+    :param full_cluster: If True, only setup on webworkers[0] where the command will be run
     """
-    try:
-        keep_days = int(keep_days)
-    except ValueError:
-        print(red("Unable to parse '{}' into an integer".format(keep_days)))
-        exit()
-
     deploy_ref = env.deploy_metadata.deploy_ref  # Make sure we have a valid commit
-    execute_with_timing(release.create_code_dir)
-    execute_with_timing(release.update_code, deploy_ref)
-    execute_with_timing(release.update_virtualenv)
+    execute_with_timing(release.create_code_dir, full_cluster)
+    execute_with_timing(release.update_code, deploy_ref, full_cluster=full_cluster)
+    execute_with_timing(release.update_virtualenv, full_cluster)
 
-    execute_with_timing(copy_release_files)
+    execute_with_timing(copy_release_files, full_cluster)
 
     if keep_days > 0:
-        execute_with_timing(release.mark_keep_until, keep_days)
+        execute_with_timing(release.mark_keep_until, keep_days, full_cluster)
 
     print(blue("Your private release is located here: "))
     print(blue(env.code_root))
@@ -550,13 +577,14 @@ def unlink_current():
         sudo('unlink {}'.format(env.code_current))
 
 
-def copy_release_files():
-    execute(release.copy_localsettings)
-    execute(release.copy_tf_localsettings)
-    execute(release.copy_formplayer_properties)
-    execute(release.copy_components)
-    execute(release.copy_node_modules)
-    execute(release.copy_compressed_js_staticfiles)
+def copy_release_files(full_cluster=True):
+    execute(release.copy_localsettings, full_cluster)
+    if full_cluster:
+        execute(release.copy_tf_localsettings)
+        execute(release.copy_formplayer_properties)
+        execute(release.copy_components)
+        execute(release.copy_node_modules)
+        execute(release.copy_compressed_js_staticfiles)
 
 
 @task

--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -387,7 +387,7 @@ def prepare_offline_deploy():
 def parse_int_or_exit(val):
     try:
         return int(val)
-    except ValueError:
+    except (ValueError, TypeError):
         print(red("Unable to parse '{}' into an integer".format(val)))
         exit()
 

--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -426,17 +426,17 @@ def _setup_release(keep_days=0, full_cluster=True):
     last past a deploy use the `keep_days` param.
 
     :param keep_days: The number of days to keep this release before it will be purged
-    :param full_cluster: If True, only setup on webworkers[0] where the command will be run
+    :param full_cluster: If False, only setup on webworkers[0] where the command will be run
     """
     deploy_ref = env.deploy_metadata.deploy_ref  # Make sure we have a valid commit
-    execute_with_timing(release.create_code_dir, full_cluster)
-    execute_with_timing(release.update_code, deploy_ref, full_cluster=full_cluster)
-    execute_with_timing(release.update_virtualenv, full_cluster)
+    execute_with_timing(release.create_code_dir(full_cluster))
+    execute_with_timing(release.update_code(full_cluster), deploy_ref)
+    execute_with_timing(release.update_virtualenv(full_cluster))
 
     execute_with_timing(copy_release_files, full_cluster)
 
     if keep_days > 0:
-        execute_with_timing(release.mark_keep_until, keep_days, full_cluster)
+        execute_with_timing(release.mark_keep_until(full_cluster), keep_days)
 
     print(blue("Your private release is located here: "))
     print(blue(env.code_root))
@@ -578,7 +578,7 @@ def unlink_current():
 
 
 def copy_release_files(full_cluster=True):
-    execute(release.copy_localsettings, full_cluster)
+    execute(release.copy_localsettings(full_cluster))
     if full_cluster:
         execute(release.copy_tf_localsettings)
         execute(release.copy_formplayer_properties)

--- a/src/commcare_cloud/fab/operations/release.py
+++ b/src/commcare_cloud/fab/operations/release.py
@@ -32,12 +32,12 @@ from commcare_cloud.fab.utils import pip_install
 GitConfig = namedtuple('GitConfig', 'key value')
 
 
-def update_code(git_tag, use_current_release=False, full_cluster=True):
+def update_code(full_cluster=True):
     roles_to_use = _get_roles(full_cluster)
 
     @roles(roles_to_use)
     @parallel
-    def update(git_tag, use_current_release):
+    def update(git_tag, use_current_release=False):
         # If not updating current release,  we are making a new release and thus have to do cloning
         # we should only ever not make a new release when doing a hotfix deploy
         if not use_current_release:
@@ -54,7 +54,7 @@ def update_code(git_tag, use_current_release=False, full_cluster=True):
             # remove all .pyc files in the project
             sudo("find . -name '*.pyc' -delete")
 
-    update(git_tag, use_current_release)
+    return update
 
 
 @roles(ROLES_ALL_SRC)
@@ -268,7 +268,7 @@ def update_virtualenv(full_cluster=True):
                 posixpath.join(requirements, 'requirements.txt'),
             ])
 
-    update()
+    return update
 
 def create_code_dir(full_cluster=True):
     roles_to_use = _get_roles(full_cluster)
@@ -278,7 +278,7 @@ def create_code_dir(full_cluster=True):
     def create():
         sudo('mkdir -p {}'.format(env.code_root))
 
-    create()
+    return create
 
 @roles(ROLES_DEPLOY)
 def kill_stale_celery_workers(delay=0):
@@ -396,7 +396,7 @@ def copy_localsettings(full_cluster=True):
     def copy():
         sudo('cp {}/localsettings.py {}/localsettings.py'.format(env.code_current, env.code_root))
 
-    copy()
+    return copy
 
 
 @parallel
@@ -471,7 +471,7 @@ def ensure_release_exists(release):
     return files.exists(release)
 
 
-def mark_keep_until(keep_days, full_cluster=True):
+def mark_keep_until(full_cluster=True):
     roles_to_use = _get_roles(full_cluster)
 
     @roles(roles_to_use)
@@ -481,7 +481,7 @@ def mark_keep_until(keep_days, full_cluster=True):
         with cd(env.code_root):
             sudo('touch {}{}'.format(KEEP_UNTIL_PREFIX, until_date))
 
-    mark(keep_days)
+    return mark
 
 
 @roles(ROLES_ALL_SRC)

--- a/src/commcare_cloud/fab/operations/release.py
+++ b/src/commcare_cloud/fab/operations/release.py
@@ -22,6 +22,7 @@ from ..const import (
     ROLES_FORMPLAYER,
     ROLES_STATIC,
     ROLES_DEPLOY,
+    ROLES_MANAGE,
     DATE_FMT,
     KEEP_UNTIL_PREFIX,
     FORMPLAYER_BUILD_DIR,
@@ -31,24 +32,29 @@ from commcare_cloud.fab.utils import pip_install
 GitConfig = namedtuple('GitConfig', 'key value')
 
 
-@roles(ROLES_ALL_SRC)
-@parallel
-def update_code(git_tag, use_current_release=False):
-    # If not updating current release,  we are making a new release and thus have to do cloning
-    # we should only ever not make a new release when doing a hotfix deploy
-    if not use_current_release:
-        _update_code_from_previous_release()
-    with cd(env.code_root if not use_current_release else env.code_current):
-        sudo('git remote prune origin')
-        sudo('git fetch origin --tags -q')
-        sudo('git checkout {}'.format(git_tag))
-        sudo('git reset --hard {}'.format(git_tag))
-        sudo('git submodule sync')
-        sudo('git submodule update --init --recursive -q')
-        # remove all untracked files, including submodules
-        sudo("git clean -ffd")
-        # remove all .pyc files in the project
-        sudo("find . -name '*.pyc' -delete")
+def update_code(git_tag, use_current_release=False, full_cluster=True):
+    roles_to_use = _get_roles(full_cluster)
+
+    @roles(roles_to_use)
+    @parallel
+    def update(git_tag, use_current_release):
+        # If not updating current release,  we are making a new release and thus have to do cloning
+        # we should only ever not make a new release when doing a hotfix deploy
+        if not use_current_release:
+            _update_code_from_previous_release()
+        with cd(env.code_root if not use_current_release else env.code_current):
+            sudo('git remote prune origin')
+            sudo('git fetch origin --tags -q')
+            sudo('git checkout {}'.format(git_tag))
+            sudo('git reset --hard {}'.format(git_tag))
+            sudo('git submodule sync')
+            sudo('git submodule update --init --recursive -q')
+            # remove all untracked files, including submodules
+            sudo("git clean -ffd")
+            # remove all .pyc files in the project
+            sudo("find . -name '*.pyc' -delete")
+
+    update(git_tag, use_current_release)
 
 
 @roles(ROLES_ALL_SRC)
@@ -232,39 +238,47 @@ def clone_virtualenv():
     _clone_virtual_env()
 
 
-@roles(ROLES_ALL_SRC)
-@parallel
-def update_virtualenv():
+def update_virtualenv(full_cluster=True):
     """
     update external dependencies on remote host
 
     assumes you've done a code update
 
     """
-    requirements = posixpath.join(env.code_root, 'requirements')
+    roles_to_use = _get_roles(full_cluster)
 
-    # Optimization if we have current setup (i.e. not the first deploy)
-    if files.exists(env.virtualenv_current):
-        _clone_virtual_env()
+    @roles(roles_to_use)
+    @parallel
+    def update():
+        requirements = posixpath.join(env.code_root, 'requirements')
 
-    with cd(env.code_root):
-        cmd_prefix = 'export HOME=/home/%s && source %s/bin/activate && ' % (
-            env.sudo_user, env.virtualenv_root)
-        # uninstall requirements in uninstall-requirements.txt
-        # but only the ones that are actually installed (checks pip freeze)
-        sudo("%s bash scripts/uninstall-requirements.sh" % cmd_prefix,
-             user=env.sudo_user)
-        pip_install(cmd_prefix, timeout=60, quiet=True, proxy=env.http_proxy, requirements=[
-            posixpath.join(requirements, 'prod-requirements.txt'),
-            posixpath.join(requirements, 'requirements.txt'),
-        ])
+        # Optimization if we have current setup (i.e. not the first deploy)
+        if files.exists(env.virtualenv_current):
+            _clone_virtual_env()
 
+        with cd(env.code_root):
+            cmd_prefix = 'export HOME=/home/%s && source %s/bin/activate && ' % (
+                env.sudo_user, env.virtualenv_root)
+            # uninstall requirements in uninstall-requirements.txt
+            # but only the ones that are actually installed (checks pip freeze)
+            sudo("%s bash scripts/uninstall-requirements.sh" % cmd_prefix,
+                 user=env.sudo_user)
+            pip_install(cmd_prefix, timeout=60, quiet=True, proxy=env.http_proxy, requirements=[
+                posixpath.join(requirements, 'prod-requirements.txt'),
+                posixpath.join(requirements, 'requirements.txt'),
+            ])
 
-@roles(ROLES_ALL_SRC)
-@parallel
-def create_code_dir():
-    sudo('mkdir -p {}'.format(env.code_root))
+    update()
 
+def create_code_dir(full_cluster=True):
+    roles_to_use = _get_roles(full_cluster)
+
+    @roles(roles_to_use)
+    @parallel
+    def create():
+        sudo('mkdir -p {}'.format(env.code_root))
+
+    create()
 
 @roles(ROLES_DEPLOY)
 def kill_stale_celery_workers(delay=0):
@@ -374,10 +388,15 @@ def clean_releases(keep=3):
     git_gc_current()
 
 
-@parallel
-@roles(ROLES_ALL_SRC)
-def copy_localsettings():
-    sudo('cp {}/localsettings.py {}/localsettings.py'.format(env.code_current, env.code_root))
+def copy_localsettings(full_cluster=True):
+    roles_to_use = _get_roles(full_cluster)
+
+    @parallel
+    @roles(roles_to_use)
+    def copy():
+        sudo('cp {}/localsettings.py {}/localsettings.py'.format(env.code_current, env.code_root))
+
+    copy()
 
 
 @parallel
@@ -452,12 +471,17 @@ def ensure_release_exists(release):
     return files.exists(release)
 
 
-@roles(ROLES_ALL_SRC)
-@parallel
-def mark_keep_until(keep_days):
-    until_date = (datetime.utcnow() + timedelta(days=keep_days)).strftime(DATE_FMT)
-    with cd(env.code_root):
-        sudo('touch {}{}'.format(KEEP_UNTIL_PREFIX, until_date))
+def mark_keep_until(keep_days, full_cluster=True):
+    roles_to_use = _get_roles(full_cluster)
+
+    @roles(roles_to_use)
+    @parallel
+    def mark(keep_days):
+        until_date = (datetime.utcnow() + timedelta(days=keep_days)).strftime(DATE_FMT)
+        with cd(env.code_root):
+            sudo('touch {}{}'.format(KEEP_UNTIL_PREFIX, until_date))
+
+    mark(keep_days)
 
 
 @roles(ROLES_ALL_SRC)
@@ -484,3 +508,7 @@ def reverse_patch(filepath):
 
     current_dir = sudo('readlink -f {}'.format(env.code_current))
     sudo('git apply -R --unsafe-paths {} --directory={}'.format(destination, current_dir))
+
+
+def _get_roles(full_cluster):
+    return ROLES_ALL_SRC if full_cluster else ROLES_MANAGE


### PR DESCRIPTION
This time with better testing... i.e. `cchq staging fab deploy` works, as well as just `cchq staging fab setup_<limited_>releases`. sorry @biyeun 

Apparently I didn't account for how the decorators worked with execute and just running setup_releases and setup_limited_releases wasn't the best test. The last commit (edit: f2dc175) is the one that changes things. The others are cleaning

tagging everyone who commented on #1651 --> @snopoke @dannyroberts @esoergel @emord 
buddy: @gcapalbo 