### PR TITLE
Static arguments

### DIFF
--- a/docs/commcare-cloud/commands/index.md
+++ b/docs/commcare-cloud/commands/index.md
@@ -203,7 +203,7 @@ commcare-cloud <env> run-module all debug "msg={{ inventory_hostname }}"
 Run an arbitrary command via the Ansible shell module:
 
 ```
-commcare-cloud <env> run-shell-command <inventory_group> <shell_command>
+commcare-cloud <env> run-shell-command <inventory_group> <shell_command> [--silence-warnings]
 ```
 
 ##### `<inventory_group>`
@@ -215,6 +215,10 @@ See [`run-module`](#run-module).
 Command to run remotely.
 (Tip: put quotes around it, as it will likely contain spaces.)
 Cannot being with `sudo`; to do that use the ansible `--become` option.
+
+##### `[--silence-warnings]`
+
+Silence shell warnings (such as to use another module instead).
 
 ##### Example
 ```
@@ -427,18 +431,19 @@ Usage examples:
    cchq <env> service pillowtop restart --limit <host> --only <pillow-name>
 
 ```
-comcare-cloud <env> service <service_group> <action:status|start|stop|restart> [--only <subservices>]
+comcare-cloud <env> service <services> <action:status|start|stop|restart> [--only <process_pattern>]
 ```
 
 Services are grouped together to form conceptual service groups.
 Thus the `postgresql` service group applies to both the `postgresql`
-service and the `pgbouncer` service. These actual services are called
-"subservices" in this command.
+service and the `pgbouncer` service. We'll call the actual services
+"subservices" here.
 
-##### `<service_group>`
+##### `<services>`
 
-The name of the service group to apply the action to.
+The name of the service group(s) to apply the action to.
 There is a preset list of service groups that are supported.
+More than one service may be supplied as separate arguments in a row.
 
 
 ##### `<action>`
@@ -446,7 +451,7 @@ There is a preset list of service groups that are supported.
 Action can be `status`, `start`, `stop`, or `restart`.
 This action is applied to every matching service.
 
-##### `[--only <subservices>]`
+##### `[--only <process_pattern>]`
 
 Many service groups are made up of more than one actual service
 or "subservice" as we call them here.

--- a/src/commcare_cloud/commands/ansible/ansible_playbook.py
+++ b/src/commcare_cloud/commands/ansible/ansible_playbook.py
@@ -35,8 +35,7 @@ class AnsiblePlaybook(CommandBase):
         ))
     )
 
-    def make_parser(self):
-        super(AnsiblePlaybook, self).make_parser()
+    def modify_parser(self):
         add_to_help_text(self.parser, "\n{}\n{}".format(
             "The ansible-playbook options below are available as well",
             filtered_help_message(

--- a/src/commcare_cloud/commands/ansible/ansible_playbook.py
+++ b/src/commcare_cloud/commands/ansible/ansible_playbook.py
@@ -5,13 +5,12 @@ import subprocess
 from six.moves import shlex_quote
 from clint.textui import puts, colored
 from commcare_cloud.cli_utils import ask, has_arg, check_branch, print_command
+from commcare_cloud.commands import shared_args
 from commcare_cloud.commands.ansible.helpers import (
     AnsibleContext, DEPRECATED_ANSIBLE_ARGS,
     get_common_ssh_args,
     get_user_arg, run_action_with_check_mode)
-from commcare_cloud.commands.command_base import CommandBase
-from commcare_cloud.commands.shared_args import arg_inventory_group, arg_skip_check, arg_quiet, \
-    arg_branch, arg_stdout_callback, arg_limit
+from commcare_cloud.commands.command_base import CommandBase, Argument
 from commcare_cloud.environment.main import get_environment
 from commcare_cloud.parse_help import add_to_help_text, filtered_help_message
 from commcare_cloud.environment.paths import ANSIBLE_DIR
@@ -25,16 +24,19 @@ class AnsiblePlaybook(CommandBase):
         "By default, you will see --check output and then asked whether to apply. "
     )
     aliases = ('ap',)
-
-    def make_parser(self):
-        arg_skip_check(self.parser)
-        arg_quiet(self.parser)
-        arg_branch(self.parser)
-        arg_stdout_callback(self.parser)
-        arg_limit(self.parser)
-        self.parser.add_argument('playbook', help=(
+    arguments = (
+        shared_args.SKIP_CHECK_ARG,
+        shared_args.QUIET_ARG,
+        shared_args.BRANCH_ARG,
+        shared_args.STDOUT_CALLBACK_ARG,
+        shared_args.LIMIT_ARG,
+        Argument('playbook', help=(
             "The ansible playbook .yml file to run."
         ))
+    )
+
+    def make_parser(self):
+        super(AnsiblePlaybook, self).make_parser()
         add_to_help_text(self.parser, "\n{}\n{}".format(
             "The ansible-playbook options below are available as well",
             filtered_help_message(
@@ -119,12 +121,13 @@ class AnsiblePlaybook(CommandBase):
 
 
 class _AnsiblePlaybookAlias(CommandBase):
-    def make_parser(self):
-        arg_skip_check(self.parser)
-        arg_quiet(self.parser)
-        arg_branch(self.parser)
-        arg_stdout_callback(self.parser)
-        arg_limit(self.parser)
+    arguments = (
+        shared_args.SKIP_CHECK_ARG,
+        shared_args.QUIET_ARG,
+        shared_args.BRANCH_ARG,
+        shared_args.STDOUT_CALLBACK_ARG,
+        shared_args.LIMIT_ARG,
+    )
 
 
 class DeployStack(_AnsiblePlaybookAlias):
@@ -159,10 +162,9 @@ class AfterReboot(_AnsiblePlaybookAlias):
         "Bring a just-rebooted machine back into operation. "
         "Includes mounting the encrypted drive."
     )
-
-    def make_parser(self):
-        super(AfterReboot, self).make_parser()
-        arg_inventory_group(self.parser)
+    arguments = _AnsiblePlaybookAlias.arguments + (
+        shared_args.INVENTORY_GROUP_ARG,
+    )
 
     def run(self, args, unknown_args):
         args.playbook = 'deploy_stack.yml'

--- a/src/commcare_cloud/commands/ansible/downtime.py
+++ b/src/commcare_cloud/commands/ansible/downtime.py
@@ -23,7 +23,7 @@ class Downtime(CommandBase):
         'Manage downtime for the selected environment.'
     )
 
-    def make_parser(self):
+    def modify_parser(self):
         self.parser.add_argument('action', choices=('start', 'end'))
         self.parser.add_argument('-m', '--message', help='Optional message to set on Datadog')
 

--- a/src/commcare_cloud/commands/ansible/downtime.py
+++ b/src/commcare_cloud/commands/ansible/downtime.py
@@ -11,7 +11,7 @@ from memoized import memoized
 from commcare_cloud.cli_utils import ask, ask_option
 from commcare_cloud.commands.ansible.helpers import AnsibleContext
 from commcare_cloud.commands.ansible.run_module import run_ansible_module
-from commcare_cloud.commands.command_base import CommandBase
+from commcare_cloud.commands.command_base import CommandBase, Argument
 from commcare_cloud.environment.main import get_environment
 
 HQ_PROCESSES_SCOPE = 'webworkers,celery,pillowtop,touchforms,formplayer,proxy'
@@ -22,10 +22,10 @@ class Downtime(CommandBase):
     help = (
         'Manage downtime for the selected environment.'
     )
-
-    def modify_parser(self):
-        self.parser.add_argument('action', choices=('start', 'end'))
-        self.parser.add_argument('-m', '--message', help='Optional message to set on Datadog')
+    arguments = (
+        Argument('action', choices=('start', 'end')),
+        Argument('-m', '--message', help='Optional message to set on Datadog'),
+    )
 
     def run(self, args, unknown_args):
         environment = get_environment(args.env_name)

--- a/src/commcare_cloud/commands/ansible/run_module.py
+++ b/src/commcare_cloud/commands/ansible/run_module.py
@@ -18,10 +18,10 @@ from commcare_cloud.environment.paths import ANSIBLE_DIR
 NON_POSITIONAL_ARGUMENTS = (
     Argument('-b', '--become', action='store_true', help=(
         "run operations with become (implies vault password prompting if necessary)"
-    )),
+    ), include_in_docs=False),
     Argument('--become-user', help=(
         "run operations as this user (default=root)"
-    )),
+    ), include_in_docs=False),
     shared_args.SKIP_CHECK_ARG,
     shared_args.QUIET_ARG,
     shared_args.STDOUT_CALLBACK_ARG,

--- a/src/commcare_cloud/commands/ansible/run_module.py
+++ b/src/commcare_cloud/commands/ansible/run_module.py
@@ -4,17 +4,28 @@ import subprocess
 from six.moves import shlex_quote
 from clint.textui import puts, colored
 from commcare_cloud.cli_utils import ask, print_command
+from commcare_cloud.commands import shared_args
 from commcare_cloud.commands.ansible.helpers import (
     AnsibleContext,
     DEPRECATED_ANSIBLE_ARGS,
     get_common_ssh_args,
     get_user_arg, run_action_with_check_mode)
-from commcare_cloud.commands.command_base import CommandBase
-from commcare_cloud.commands.shared_args import arg_inventory_group, arg_skip_check, arg_quiet, \
-    arg_stdout_callback
+from commcare_cloud.commands.command_base import CommandBase, Argument
 from commcare_cloud.environment.main import get_environment
 from commcare_cloud.parse_help import add_to_help_text, filtered_help_message
 from commcare_cloud.environment.paths import ANSIBLE_DIR
+
+NON_POSITIONAL_ARGUMENTS = (
+    Argument('-b', '--become', action='store_true', help=(
+        "run operations with become (implies vault password prompting if necessary)"
+    )),
+    Argument('--become-user', help=(
+        "run operations as this user (default=root)"
+    )),
+    shared_args.SKIP_CHECK_ARG,
+    shared_args.QUIET_ARG,
+    shared_args.STDOUT_CALLBACK_ARG,
+)
 
 
 class RunAnsibleModule(CommandBase):
@@ -22,23 +33,17 @@ class RunAnsibleModule(CommandBase):
     help = (
         'Run an arbitrary Ansible module.'
     )
+    arguments = (
+        shared_args.INVENTORY_GROUP_ARG,
+        Argument('module', help="The module to run"),
+        Argument('module_args', help="The arguments to pass to the module"),
+    ) + NON_POSITIONAL_ARGUMENTS
 
     def make_parser(self):
-        arg_inventory_group(self.parser)
-        self.parser.add_argument('module', help="The module to run")
-        self.parser.add_argument('module_args', help="The arguments to pass to the module")
-        self.add_non_positional_arguments()
+        super(RunAnsibleModule, self).make_parser()
+        self.add_help_text()
 
-    def add_non_positional_arguments(self):
-        self.parser.add_argument('-b', '--become', action='store_true', help=(
-            "run operations with become (implies vault password prompting if necessary)"
-        ))
-        self.parser.add_argument('--become-user', help=(
-            "run operations as this user (default=root)"
-        ))
-        arg_skip_check(self.parser)
-        arg_quiet(self.parser)
-        arg_stdout_callback(self.parser)
+    def add_help_text(self):
         add_to_help_text(self.parser, "\n{}\n{}".format(
             "The ansible options below are available as well",
             filtered_help_message(
@@ -135,12 +140,16 @@ class RunShellCommand(CommandBase):
     command = 'run-shell-command'
     help = 'Run an arbitrary command via the Ansible shell module.'
 
+    arguments = (
+        shared_args.INVENTORY_GROUP_ARG,
+        Argument('shell_command', help="The shell command you want to run"),
+        Argument('--silence-warnings', action='store_true',
+                 help="Silence shell warnings (such as to use another module instead)"),
+    ) + NON_POSITIONAL_ARGUMENTS
+
     def make_parser(self):
-        arg_inventory_group(self.parser)
-        self.parser.add_argument('shell_command', help="The shell command you want to run")
-        self.parser.add_argument('--silence-warnings', action='store_true',
-                                 help="Silence shell warnings (such as to use another module instead)")
-        RunAnsibleModule(self.parser).add_non_positional_arguments()
+        super(RunShellCommand, self).make_parser()
+        RunAnsibleModule(self.parser).add_help_text()
 
     def run(self, args, unknown_args):
         if args.shell_command.strip().startswith('sudo '):

--- a/src/commcare_cloud/commands/ansible/run_module.py
+++ b/src/commcare_cloud/commands/ansible/run_module.py
@@ -40,9 +40,6 @@ class RunAnsibleModule(CommandBase):
     ) + NON_POSITIONAL_ARGUMENTS
 
     def modify_parser(self):
-        self.add_help_text()
-
-    def add_help_text(self):
         add_to_help_text(self.parser, "\n{}\n{}".format(
             "The ansible options below are available as well",
             filtered_help_message(
@@ -147,7 +144,7 @@ class RunShellCommand(CommandBase):
     ) + NON_POSITIONAL_ARGUMENTS
 
     def modify_parser(self):
-        RunAnsibleModule(self.parser).add_help_text()
+        RunAnsibleModule(self.parser).modify_parser()
 
     def run(self, args, unknown_args):
         if args.shell_command.strip().startswith('sudo '):

--- a/src/commcare_cloud/commands/ansible/run_module.py
+++ b/src/commcare_cloud/commands/ansible/run_module.py
@@ -39,8 +39,7 @@ class RunAnsibleModule(CommandBase):
         Argument('module_args', help="The arguments to pass to the module"),
     ) + NON_POSITIONAL_ARGUMENTS
 
-    def make_parser(self):
-        super(RunAnsibleModule, self).make_parser()
+    def modify_parser(self):
         self.add_help_text()
 
     def add_help_text(self):
@@ -147,8 +146,7 @@ class RunShellCommand(CommandBase):
                  help="Silence shell warnings (such as to use another module instead)"),
     ) + NON_POSITIONAL_ARGUMENTS
 
-    def make_parser(self):
-        super(RunShellCommand, self).make_parser()
+    def modify_parser(self):
         RunAnsibleModule(self.parser).add_help_text()
 
     def run(self, args, unknown_args):

--- a/src/commcare_cloud/commands/ansible/service.py
+++ b/src/commcare_cloud/commands/ansible/service.py
@@ -526,7 +526,7 @@ class Service(CommandBase):
         Argument('--limit', help=(
             "Restrict the hosts to run the command on."
             "\nUse 'help' action to list all options."
-        )),
+        ), include_in_docs=False),
         Argument('--only', type=validate_pattern, dest='process_pattern', help=(
             "Sub-service name to limit action to."
             "\nFormat as 'name' or 'name:number'."

--- a/src/commcare_cloud/commands/ansible/service.py
+++ b/src/commcare_cloud/commands/ansible/service.py
@@ -15,7 +15,7 @@ from commcare_cloud.commands.ansible.helpers import (
     get_pillowtop_processes
 )
 from commcare_cloud.commands.ansible.run_module import run_ansible_module
-from commcare_cloud.commands.command_base import CommandBase
+from commcare_cloud.commands.command_base import CommandBase, Argument
 from commcare_cloud.environment.main import get_environment
 from commcare_cloud.fab.exceptions import NoHostsMatch
 
@@ -512,26 +512,27 @@ class Service(CommandBase):
         "\n"
     )
 
-    def make_parser(self):
-        self.parser.add_argument(
+    arguments = (
+        Argument(
             'services',
             nargs="+",
             choices=SERVICE_NAMES,
             help="The services to run the command on"
-        )
-        self.parser.add_argument(
+        ),
+        Argument(
             'action', choices=ACTIONS,
             help="What action to take"
-        )
-        self.parser.add_argument('--limit', help=(
+        ),
+        Argument('--limit', help=(
             "Restrict the hosts to run the command on."
             "\nUse 'help' action to list all options."
-        ))
-        self.parser.add_argument('--only', type=validate_pattern, dest='process_pattern', help=(
+        )),
+        Argument('--only', type=validate_pattern, dest='process_pattern', help=(
             "Sub-service name to limit action to."
             "\nFormat as 'name' or 'name:number'."
             "\nUse 'help' action to list all options."
-        ))
+        )),
+    )
 
     def run(self, args, unknown_args):
         environment = get_environment(args.env_name)

--- a/src/commcare_cloud/commands/command_base.py
+++ b/src/commcare_cloud/commands/command_base.py
@@ -7,14 +7,24 @@ class CommandBase(object):
     command = None
     help = None
     aliases = ()
+    arguments = ()
 
     def __init__(self, parser):
         self.parser = parser
 
-    @abc.abstractmethod
     def make_parser(self):
-        pass
+        for argument in self.arguments:
+            argument.add_to_parser(self.parser)
 
     @abc.abstractmethod
     def run(self, args, unknown_args):
         pass
+
+
+class Argument(object):
+    def __init__(self, *args, **kwargs):
+        self._args = args
+        self._kwargs = kwargs
+
+    def add_to_parser(self, parser):
+        parser.add_argument(*self._args, **self._kwargs)

--- a/src/commcare_cloud/commands/command_base.py
+++ b/src/commcare_cloud/commands/command_base.py
@@ -15,6 +15,10 @@ class CommandBase(object):
     def make_parser(self):
         for argument in self.arguments:
             argument.add_to_parser(self.parser)
+        self.modify_parser()
+
+    def modify_parser(self):
+        pass
 
     @abc.abstractmethod
     def run(self, args, unknown_args):

--- a/src/commcare_cloud/commands/command_base.py
+++ b/src/commcare_cloud/commands/command_base.py
@@ -27,8 +27,44 @@ class CommandBase(object):
 
 class Argument(object):
     def __init__(self, *args, **kwargs):
+        self.include_in_docs = kwargs.pop('include_in_docs', True)
         self._args = args
         self._kwargs = kwargs
+
+    @property
+    def name_in_docs(self):
+        flag = None
+        if not self._args:
+            if 'dest' in self._kwargs:
+                dest = self._kwargs['dest']
+        elif not self._args[0].startswith('-'):
+            # positional arg
+            if 'dest' in self._kwargs:
+                dest = self._kwargs['dest']
+            else:
+                dest = self._args[0]
+        else:
+            # non-positional arg
+            if self._args[0].startswith('--'):
+                # first arg is the long form
+                flag = self._args[0]
+            elif len(self._args) > 1 and self._args[1].startswith('--'):
+                # second arg is the long form
+                flag = self._args[1]
+            else:
+                # use the short form then
+                flag = self._args[0]
+            if 'dest' in self._kwargs:
+                dest = self._kwargs['dest']
+            else:
+                dest = flag.lstrip('-')
+
+        if flag and self._kwargs.get('action') in ('store_true', 'store_false'):
+            return flag
+        if flag:
+            return '{} <{}>'.format(flag, dest.replace('-', '_'))
+        else:
+            return '<{}>'.format(dest.replace('-', '_'))
 
     def add_to_parser(self, parser):
         parser.add_argument(*self._args, **self._kwargs)

--- a/src/commcare_cloud/commands/fab.py
+++ b/src/commcare_cloud/commands/fab.py
@@ -1,6 +1,6 @@
 import os
 from commcare_cloud.cli_utils import print_command
-from .command_base import CommandBase
+from .command_base import CommandBase, Argument
 from ..environment.paths import FABFILE
 from six.moves import shlex_quote
 
@@ -11,8 +11,11 @@ class Fab(CommandBase):
         "Run a fab command as you would with fab"
     )
 
+    arguments = (
+        Argument(dest='fab_command', help="fab command", default=None, nargs="?")
+    )
+
     def modify_parser(self):
-        self.parser.add_argument(dest='fab_command', help="fab command", default=None, nargs="?")
         self.parser.print_help = lambda file=None: os.execvp('fab', ('fab', '-l'))
 
     def run(self, args, unknown_args):

--- a/src/commcare_cloud/commands/fab.py
+++ b/src/commcare_cloud/commands/fab.py
@@ -12,7 +12,7 @@ class Fab(CommandBase):
     )
 
     arguments = (
-        Argument(dest='fab_command', help="fab command", default=None, nargs="?")
+        Argument(dest='fab_command', help="fab command", default=None, nargs="?"),
     )
 
     def modify_parser(self):

--- a/src/commcare_cloud/commands/fab.py
+++ b/src/commcare_cloud/commands/fab.py
@@ -11,7 +11,7 @@ class Fab(CommandBase):
         "Run a fab command as you would with fab"
     )
 
-    def make_parser(self):
+    def modify_parser(self):
         self.parser.add_argument(dest='fab_command', help="fab command", default=None, nargs="?")
         self.parser.print_help = lambda file=None: os.execvp('fab', ('fab', '-l'))
 

--- a/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 from commcare_cloud.cli_utils import print_command
-from commcare_cloud.commands.command_base import CommandBase
+from commcare_cloud.commands.command_base import CommandBase, Argument
 from commcare_cloud.environment.main import get_environment
 from .getinventory import get_server_address, get_monolith_address
 from six.moves import shlex_quote
@@ -12,15 +12,15 @@ from six.moves import shlex_quote
 class Lookup(CommandBase):
     command = 'lookup'
     help = "Lookup remote hostname or IP address"
-
-    def modify_parser(self):
-        self.parser.add_argument("server", nargs="?",
-            help="Server name/group: postgresql, proxy, webworkers, ... The server "
-                 "name/group may be prefixed with 'username@' to login as a specific "
-                 "user and may be terminated with ':<n>' to choose one of "
-                 "multiple servers if there is more than one in the group. "
-                 "For example: webworkers:0 will pick the first webworker. May also"
-                 "be ommitted for environments with only a single server.")
+    arguments = (
+        Argument("server", nargs="?", help=(
+            "Server name/group: postgresql, proxy, webworkers, ... The server "
+             "name/group may be prefixed with 'username@' to login as a specific "
+             "user and may be terminated with ':<n>' to choose one of "
+             "multiple servers if there is more than one in the group. "
+             "For example: webworkers:0 will pick the first webworker. May also"
+             "be ommitted for environments with only a single server.")),
+    )
 
     def lookup_server_address(self, args):
         def exit(message):
@@ -80,13 +80,11 @@ class Mosh(_Ssh):
 class Tmux(_Ssh):
     command = 'tmux'
     help = "Connect to a remote host with ssh and open a tmux session"
-
-    def modify_parser(self):
-        self.parser.add_argument('server',
-                                 help="server to run tmux session on. "
-                                      "Use '-' to for default (webworkers:0)")
-        self.parser.add_argument('remote_command', nargs='?',
-                                 help="command to run in new tmux session")
+    arguments = (
+        Argument('server', help=(
+            "server to run tmux session on. Use '-' to for default (webworkers:0)")),
+        Argument('remote_command', nargs='?', help="command to run in new tmux session"),
+    )
 
     def run(self, args, ssh_args):
         environment = get_environment(args.env_name)
@@ -124,10 +122,12 @@ class DjangoManage(CommandBase):
             "runs `./manage.py ...` on the first webworker of <env>. "
             "Omit <command> to see a full list of possible commands.")
 
-    def modify_parser(self):
-        self.parser.add_argument('--tmux', action='store_true', default=False, help="Run this command in a tmux and stay connected")
-        self.parser.add_argument('--release', help=(
-            "Name of release to run under. E.g. '2018-04-13_18.16'"))
+    arguments = (
+        Argument('--tmux', action='store_true', default=False, help=(
+            "Run this command in a tmux and stay connected")),
+        Argument('--release', help=(
+            "Name of release to run under. E.g. '2018-04-13_18.16'")),
+    )
 
     def run(self, args, manage_args):
         environment = get_environment(args.env_name)

--- a/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -13,7 +13,7 @@ class Lookup(CommandBase):
     command = 'lookup'
     help = "Lookup remote hostname or IP address"
 
-    def make_parser(self):
+    def modify_parser(self):
         self.parser.add_argument("server", nargs="?",
             help="Server name/group: postgresql, proxy, webworkers, ... The server "
                  "name/group may be prefixed with 'username@' to login as a specific "
@@ -81,7 +81,7 @@ class Tmux(_Ssh):
     command = 'tmux'
     help = "Connect to a remote host with ssh and open a tmux session"
 
-    def make_parser(self):
+    def modify_parser(self):
         self.parser.add_argument('server',
                                  help="server to run tmux session on. "
                                       "Use '-' to for default (webworkers:0)")
@@ -124,7 +124,7 @@ class DjangoManage(CommandBase):
             "runs `./manage.py ...` on the first webworker of <env>. "
             "Omit <command> to see a full list of possible commands.")
 
-    def make_parser(self):
+    def modify_parser(self):
         self.parser.add_argument('--tmux', action='store_true', default=False, help="Run this command in a tmux and stay connected")
         self.parser.add_argument('--release', help=(
             "Name of release to run under. E.g. '2018-04-13_18.16'"))

--- a/src/commcare_cloud/commands/migrations/couchdb.py
+++ b/src/commcare_cloud/commands/migrations/couchdb.py
@@ -19,11 +19,11 @@ from couchdb_cluster_admin.utils import put_shard_allocation, get_shard_allocati
     get_membership
 
 from commcare_cloud.cli_utils import ask
+from commcare_cloud.commands import shared_args
 from commcare_cloud.commands.ansible.helpers import AnsibleContext, run_action_with_check_mode
 from commcare_cloud.commands.ansible.run_module import run_ansible_module
-from commcare_cloud.commands.command_base import CommandBase
+from commcare_cloud.commands.command_base import CommandBase, Argument
 from commcare_cloud.commands.migrations.config import CouchMigration
-from commcare_cloud.commands.shared_args import arg_skip_check
 from commcare_cloud.environment.main import get_environment
 
 RSYNC_FILE_LIST_NAME = 'couchdb_migration_rsync_file_list'
@@ -34,11 +34,12 @@ class MigrateCouchdb(CommandBase):
     aliases = ('migrate_couchdb',)  # deprecated
     help = 'Perform a CouchDB migration'
 
-    def make_parser(self):
-        self.parser.add_argument(dest='migration_plan', help="Path to migration plan file")
-        self.parser.add_argument(dest='action', choices=['describe', 'plan', 'migrate', 'commit'],
-                                 help="Action to perform")
-        arg_skip_check(self.parser)
+    arguments = (
+        Argument(dest='migration_plan', help="Path to migration plan file"),
+        Argument(dest='action', choices=['describe', 'plan', 'migrate', 'commit'],
+                 help="Action to perform"),
+        shared_args.SKIP_CHECK_ARG,
+    )
 
     def run(self, args, unknown_args):
         environment = get_environment(args.env_name)

--- a/src/commcare_cloud/commands/shared_args.py
+++ b/src/commcare_cloud/commands/shared_args.py
@@ -1,40 +1,54 @@
 import os
 
+from commcare_cloud.commands.command_base import Argument
+
+INVENTORY_GROUP_ARG = Argument('inventory_group', help=(
+    "The inventory group to run the command on. Use 'all' for all hosts."
+))
+
+SKIP_CHECK_ARG = Argument('--skip-check', action='store_true', default=False, help=(
+    "skip the default of viewing --check output first"
+))
+
+QUIET_ARG = Argument('--quiet', action='store_true', default=False, help=(
+    "skip all user prompts and proceed as if answered in the affirmative"
+))
+
+BRANCH_ARG = Argument('--branch', default='master', help=(
+    "the name of the commcare-cloud git branch to run against, if not master"
+))
+
+STDOUT_CALLBACK_ARG = Argument(
+    '--output', dest='stdout_callback', choices=['actionable', 'minimal'],
+    default=os.environ.get('ANSIBLE_STDOUT_CALLBACK') or 'default',
+    help=("The callback plugin to use for generating output. "
+          "See ansible-doc -t callback -l and ansible-doc -t callback [ansible|minimal]")
+)
+
+LIMIT_ARG = Argument('-l', '--limit', metavar="SUBSET", help=(
+    "further limit selected hosts to an additional pattern"
+))
+
 
 def arg_inventory_group(parser):
-    parser.add_argument('inventory_group', help=(
-        "The inventory group to run the command on. Use 'all' for all hosts."
-    ))
+    INVENTORY_GROUP_ARG.add_to_parser(parser)
 
 
 def arg_skip_check(parser):
-    parser.add_argument('--skip-check', action='store_true', default=False, help=(
-        "skip the default of viewing --check output first"
-    ))
+    SKIP_CHECK_ARG.add_to_parser(parser)
 
 
 def arg_quiet(parser):
-    parser.add_argument('--quiet', action='store_true', default=False, help=(
-        "skip all user prompts and proceed as if answered in the affirmative"
-    ))
+    QUIET_ARG.add_to_parser(parser)
 
 
 def arg_branch(parser):
-    parser.add_argument('--branch', default='master', help=(
-        "the name of the commcare-cloud git branch to run against, if not master"
-    ))
+    BRANCH_ARG.add_to_parser(parser)
 
 
 def arg_stdout_callback(parser):
-    default = os.environ.get('ANSIBLE_STDOUT_CALLBACK') or 'default'
-    parser.add_argument(
-        '--output', dest='stdout_callback', default=default, choices=['actionable', 'minimal'],
-        help=("The callback plugin to use for generating output. "
-              "See ansible-doc -t callback -l and ansible-doc -t callback [ansible|minimal]")
-    )
+    STDOUT_CALLBACK_ARG.add_to_parser(parser)
 
 
 def arg_limit(parser):
-    parser.add_argument('-l', '--limit', metavar="SUBSET", help=(
-        "further limit selected hosts to an additional pattern"
-    ))
+    LIMIT_ARG.add_to_parser(parser)

--- a/src/commcare_cloud/commands/shared_args.py
+++ b/src/commcare_cloud/commands/shared_args.py
@@ -22,9 +22,10 @@ STDOUT_CALLBACK_ARG = Argument(
     '--output', dest='stdout_callback', choices=['actionable', 'minimal'],
     default=os.environ.get('ANSIBLE_STDOUT_CALLBACK') or 'default',
     help=("The callback plugin to use for generating output. "
-          "See ansible-doc -t callback -l and ansible-doc -t callback [ansible|minimal]")
+          "See ansible-doc -t callback -l and ansible-doc -t callback [ansible|minimal]"),
+    include_in_docs=False,
 )
 
 LIMIT_ARG = Argument('-l', '--limit', metavar="SUBSET", help=(
     "further limit selected hosts to an additional pattern"
-))
+), include_in_docs=False)

--- a/src/commcare_cloud/commands/shared_args.py
+++ b/src/commcare_cloud/commands/shared_args.py
@@ -28,27 +28,3 @@ STDOUT_CALLBACK_ARG = Argument(
 LIMIT_ARG = Argument('-l', '--limit', metavar="SUBSET", help=(
     "further limit selected hosts to an additional pattern"
 ))
-
-
-def arg_inventory_group(parser):
-    INVENTORY_GROUP_ARG.add_to_parser(parser)
-
-
-def arg_skip_check(parser):
-    SKIP_CHECK_ARG.add_to_parser(parser)
-
-
-def arg_quiet(parser):
-    QUIET_ARG.add_to_parser(parser)
-
-
-def arg_branch(parser):
-    BRANCH_ARG.add_to_parser(parser)
-
-
-def arg_stdout_callback(parser):
-    STDOUT_CALLBACK_ARG.add_to_parser(parser)
-
-
-def arg_limit(parser):
-    LIMIT_ARG.add_to_parser(parser)

--- a/src/commcare_cloud/commands/validate_environment_settings.py
+++ b/src/commcare_cloud/commands/validate_environment_settings.py
@@ -11,9 +11,6 @@ class ValidateEnvironmentSettings(CommandBase):
         "Validate your environment's configuration files"
     )
 
-    def make_parser(self):
-        pass
-
     def run(self, args, unknown_args):
         environment = get_environment(args.env_name)
         try:

--- a/tests/test_command_docs.py
+++ b/tests/test_command_docs.py
@@ -18,7 +18,7 @@ def _get_commands_doc():
 
 
 def contains_whole_word(word, text):
-    return re.search(r'\b{}\b'.format(re.escape(word)), text)
+    return re.search(r'[\[`\b]{}[\]`\b]'.format(re.escape(word)), text)
 
 
 def fuzzy_contains(string, text):
@@ -55,14 +55,17 @@ def test_all_aliases_appear_in_docs():
     )
 
 
-def test_all_help_strings_appear_in_docs():
+def test_all_arg_names_appear_in_docs():
     doc_text = _get_commands_doc()
-    missing_help_strings = set()
+    missing_args = set()
     for command_type in COMMAND_TYPES:
-        if not fuzzy_contains(command_type.help, doc_text):
-            missing_help_strings.add(command_type.command)
+        for argument in command_type.arguments:
+            if argument.include_in_docs and \
+                    not contains_whole_word(argument.name_in_docs, doc_text):
+                missing_args.add((command_type.command, argument.name_in_docs))
 
-    assert not missing_help_strings, "Missing help strings in {}: {}".format(
+    assert not missing_args, "Missing arguments in {}:{}".format(
         COMMAND_DOC_PATH,
-        ', '.join(sorted(missing_help_strings))
+        ''.join(sorted('\n  {} (for {})'.format(argument, command)
+                       for command, argument in missing_args))
     )


### PR DESCRIPTION
Pull out arguments so that they're defined statically on the command class as a list, rather than being added within `make_parser`. Any functionality from `make_parser` that was more complicated than that has been moved to the new `modify_parser` method, which only a few command classes have.

This lets me add a test that all arguments appear (somewhere) in the command docs. Not quite the dream of auto-generating docs that @czue mentioned on my last PR, but a small step in the right direction I think.

Opening for tests and review on general direction, will test more thoroughly that I didn't break any of the commands tomorrow.