### PR TITLE
remove unnecessary ANSIBLE_ROLES_PATH env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ We also recommend that you put the following in your `~/.profile` which gives yo
 from anywhere:
 ```
 export PATH=$PATH:~/.commcare-cloud/bin
-export ANSIBLE_ROLES_PATH=~/.ansible/roles
 source ~/.commcare-cloud/repo/control/.bash_completion
 ```
 

--- a/control/init.sh
+++ b/control/init.sh
@@ -95,7 +95,6 @@ alias update-code='${COMMCARE_CLOUD_REPO}/control/update_code.sh && . ~/init-ans
 alias update_code='${COMMCARE_CLOUD_REPO}/control/update_code.sh && . ~/init-ansible'
 
 export PATH=$PATH:~/.commcare-cloud/bin
-export ANSIBLE_ROLES_PATH=~/.ansible/roles
 source ~/.commcare-cloud/repo/src/commcare_cloud/.bash_completion
 
 YELLOW='\033[0;33m'


### PR DESCRIPTION
clean up from https://github.com/dimagi/commcare-cloud/pull/1626#discussion_r184796942

My best guess is that @pr33thi and I were making changes around the same time, and there was an interim period where she added this to get things to work, but I think it shouldn't be necessary on the latest version.