### PR TITLE
Revert "revert change that broke set_celery_supervisorconf in fab"

### DIFF
--- a/src/commcare_cloud/fab/operations/supervisor.py
+++ b/src/commcare_cloud/fab/operations/supervisor.py
@@ -79,8 +79,8 @@ def set_celery_supervisorconf():
             )
             continue
 
-        pooling = params.get('pooling', 'prefork')
-        max_tasks_per_child = params.get('max_tasks_per_child', 50)
+        pooling = params['pooling']
+        max_tasks_per_child = params['max_tasks_per_child']
         num_workers = params.get('num_workers', 1)
 
         params.update({


### PR DESCRIPTION
Reverts dimagi/commcare-cloud#1652

Bringing this back now that CeleryOptions is _actually_ wrapping each `celery_processes[host][queue]`.