### PR TITLE
adding couch sql logfile to better place

### DIFF
--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -82,6 +82,7 @@ EXPORT_MIGRATION_LOG_FILE = os.path.join(LOG_HOME,"{{ localsettings.DEPLOY_MACHI
 UCR_TIMING_FILE = os.path.join(LOG_HOME,"{{ localsettings.DEPLOY_MACHINE_NAME }}-ucr_timing.log")
 UCR_DIFF_FILE = os.path.join(LOG_HOME,"{{ localsettings.DEPLOY_MACHINE_NAME }}-ucr_diff.log")
 UCR_EXCEPTION_FILE = os.path.join(LOG_HOME,"{{ localsettings.DEPLOY_MACHINE_NAME }}-ucr_exception.log")
+MAIN_COUCH_SQL_DATAMIGRATION = os.path.join(LOG_HOME,"{{ localsettings.DEPLOY_MACHINE_NAME }}-couch_sql_migration.log")
 
 # Shared Drive Setup
 {% if shared_drive_enabled|default(true) %}


### PR DESCRIPTION
I noticed the logging that i added in [1f3ef0dfc8](https://github.com/dimagi/commcare-hq/commit/1f3ef0dfc8833ada35cdb06263281dae6c6060b1) is not showing up in the file also created there. Looking at logfiles that are working, this pattern seemed like the successful one. 

Lemme know if there's something else that might be going on, since I don't know much about our logging scaffolding

@proteusvacuum 