### PR TITLE
assert exactly one redis host

### DIFF
--- a/src/commcare_cloud/environment/main.py
+++ b/src/commcare_cloud/environment/main.py
@@ -190,6 +190,8 @@ class Environment(object):
     def _run_last_minute_checks(self):
         assert len(self.groups.get('rabbitmq', [])) == 1, \
             "You must have exactly one host in the [rabbitmq] group"
+        assert len(self.groups.get('redis', [])) == 1, \
+            "You must have exactly one host in the [redis] group"
 
     def create_generated_yml(self):
         self._run_last_minute_checks()


### PR DESCRIPTION
Found this commit from an abandoned branch of mine that seems like a harmless check. Easy to remove later if we want to support external redis.