### PR TITLE
using ip for server whitelist

### DIFF
--- a/environments/pna/app-processes.yml
+++ b/environments/pna/app-processes.yml
@@ -23,7 +23,7 @@ celery_processes:
       concurrency: 1
     celery_periodic:
       concurrency: 1
-      server_whitelist: pnaserver1
+      server_whitelist: 196.207.230.171
     flower: {}
   None:
     # todo: create these queues?


### PR DESCRIPTION
@snopoke 
@dannyroberts is it intentional that inventory names do not work and only IPs do? Fine if thats the case, was just surprised this failed