### PR TITLE
use hostnames in celery worker names

### DIFF
--- a/environments/development/inventory.ini
+++ b/environments/development/inventory.ini
@@ -1,3 +1,21 @@
+[app1]
+192.168.33.15
+
+[app1:vars]
+hostname='app1'
+
+[db1]
+192.168.33.16
+
+[db1:vars]
+hostname='db1'
+
+[proxy1]
+192.168.33.17
+
+[proxy1:vars]
+hostname='proxy1'
+
 [squid]
 192.168.33.14
 
@@ -78,3 +96,6 @@ swap_size=100M
 
 [control]
 192.168.33.14
+
+[control:vars]
+hostname='control'

--- a/environments/icds-new/inventory.ini
+++ b/environments/icds-new/inventory.ini
@@ -765,8 +765,14 @@ hostname='formplayer0'
 [redis0]
 10.247.164.87
 
+[redis0:vars]
+hostname='redis0'
+
 [patch0]
 10.247.63.132
+
+[patch0:vars]
+hostname='patch0'
 
 [proxy:children]
 web0

--- a/environments/softlayer/inventory.ini
+++ b/environments/softlayer/inventory.ini
@@ -1,68 +1,96 @@
 [celery0]
-10.162.36.233
+10.162.36.233 hostname="celery0"
 
 [django0]
-10.162.36.250
+10.162.36.250 hostname="django0"
 
 [db0]
 10.162.36.205
 
 [db0:vars]
 datadog_integration_cloudant=true
+hostname="db0"
 
 [es2]
-10.162.36.221 elasticsearch_node_name=es2 encrypted_root=/opt/data/ecrypt
+10.162.36.221
+
+[es2:vars]
+hostname="es2"
+elasticsearch_node_name=es2
+encrypted_root=/opt/data/ecrypt
 
 [es3]
-10.162.36.200 elasticsearch_node_name=es3 datavol_device=/dev/xvdc encrypted_root=/opt/data/ecrypt
+10.162.36.200
+
+[es3:vars]
+hostname="es3"
+elasticsearch_node_name=es3
+datavol_device=/dev/xvdc
+encrypted_root=/opt/data/ecrypt
 
 [kafka0]
-10.162.36.207 hostaname=kafka0 datavol_device=/dev/xvdc encrypted_root=/opt/data/ecrypt
+10.162.36.207 hostname=kafka0 datavol_device=/dev/xvdc encrypted_root=/opt/data/ecrypt
 
 [pillow1]
-10.162.36.253
+10.162.36.253 hostname="pillow1"
 
 [proxy0]
-10.162.36.203
+10.162.36.203 hostname="proxy0"
 
 [formplayer0]
-10.162.36.248 encrypted_root=/opt/data/ecrypt
+10.162.36.248 hostname="formplayer0" encrypted_root=/opt/data/ecrypt
 
 [riak15]
-10.162.36.235 encrypted_root=/opt/data/ecrypt
+10.162.36.235 hostname="riak15" encrypted_root=/opt/data/ecrypt
 
 [riak16]
-10.162.36.225 encrypted_root=/opt/data/ecrypt
+10.162.36.225 hostname="riak16" encrypted_root=/opt/data/ecrypt
 
 [riak17]
-10.162.36.244 encrypted_root=/opt/data/ecrypt
+10.162.36.244 hostname="riak17" encrypted_root=/opt/data/ecrypt
 
 [riak18]
-10.162.36.211 encrypted_root=/opt/data/ecrypt
+10.162.36.211 hostname="riak18" encrypted_root=/opt/data/ecrypt
 
 [riak19]
-10.162.36.202 encrypted_root=/opt/data/ecrypt
+10.162.36.202 hostname="riak19" encrypted_root=/opt/data/ecrypt
 
 [touch0]
-10.162.36.215
+10.162.36.215 hostname="touch0"
 
 [couch1]
 10.162.36.218
 
 [couch1:vars]
+hostname="couch1"
 devices='["/dev/xvde","/dev/xvdc"]'
 partitions=["/dev/xvde1","/dev/xvdc1"]
 datavol_device='/dev/mapper/consolidated-data'
 encrypted_root=/opt/data/ecrypt
 
 [couch2]
-10.162.36.254 datavol_device=/dev/xvdc encrypted_root=/opt/data/ecrypt
+10.162.36.254
+
+[couch2:vars]
+hostname="couch2"
+datavol_device=/dev/xvdc
+encrypted_root=/opt/data/ecrypt
 
 [couch3]
-10.162.36.198 datavol_device=/dev/xvdc encrypted_root=/opt/data/ecrypt
+10.162.36.198
+
+[couch3:vars]
+hostname="couch3"
+datavol_device=/dev/xvdc
+encrypted_root=/opt/data/ecrypt
 
 [couch4]
-10.162.36.220 datavol_device=/dev/xvdc encrypted_root=/opt/data/ecrypt
+10.162.36.220
+
+[couch4:vars]
+hostname="couch4"
+datavol_device=/dev/xvdc
+encrypted_root=/opt/data/ecrypt
 
 [proxy:children]
 proxy0
@@ -130,7 +158,7 @@ couch1
 couch1
 
 [control]
-10.162.36.196
+10.162.36.196 hostname="control"
 
 [pg_standby]
 

--- a/environments/softlayer/public.yml
+++ b/environments/softlayer/public.yml
@@ -1,3 +1,4 @@
+internal_domain_name: "india.commcarehq.org"
 couchdb2:
   username: "{{ localsettings_private.COUCH_USERNAME }}"
   password: "{{ localsettings_private.COUCH_PASSWORD }}"

--- a/src/commcare_cloud/fab/operations/supervisor.py
+++ b/src/commcare_cloud/fab/operations/supervisor.py
@@ -237,7 +237,6 @@ def _format_env(current_env, extra=None):
         'code_current',
         'log_dir',
         'sudo_user',
-        'host_string',
         'project',
         'es_endpoint',
         'jython_home',
@@ -274,6 +273,7 @@ def _format_env(current_env, extra=None):
     for prop in important_props:
         ret[prop] = current_env.get(prop, '')
 
+    ret['host_string'] = env.ccc_environment.get_hostname(env.host_string)
     ret['environment'] = current_env.get('deploy_env', '')
 
     if extra:


### PR DESCRIPTION
For environments like ICDS where host_string is an IP this will translate the IP address into the hostname as defined in the inventory file.

This makes it easier to know which host a process is running on when looking at the celery metric data:

`celery@10.247.164.40_reminder_case_update_queue_1`
becomes
`celery@celery0.internal-icds-new.commcarehq.org_reminder_case_update_queue_1`