### PR TITLE
fix test_hostnames for softlayer

### DIFF
--- a/environments/softlayer/inventory.ini
+++ b/environments/softlayer/inventory.ini
@@ -7,12 +7,16 @@
 [db0]
 10.162.36.205
 
-[db1]
-10.162.36.238 datavol_device=/dev/xvdc
-
 [db0:vars]
 datadog_integration_cloudant=true
 hostname="db0"
+
+[db1]
+10.162.36.238
+
+[db1:vars]
+hostname="db1"
+datavol_device=/dev/xvdc
 
 [es2]
 10.162.36.221

--- a/tests/test_environments.py
+++ b/tests/test_environments.py
@@ -40,4 +40,4 @@ def test_hostnames(env):
                 hostname = environment.get_hostname(host)
                 if hostname == host:
                     missing_hostnames.add(host)
-    assert len(missing_hostnames) == 0, "Envornment hosts missing hostnames".format(list(missing_hostnames))
+    assert len(missing_hostnames) == 0, "Environment hosts missing hostnames {}".format(list(missing_hostnames))


### PR DESCRIPTION
introduced in https://github.com/dimagi/commcare-cloud/pull/1712. Not sure why it only started failing on the second commit