### PR TITLE
make nginx restart task support latest nginx init script

### DIFF
--- a/src/commcare_cloud/ansible/roles/nginx/tasks/restart.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/tasks/restart.yml
@@ -19,4 +19,5 @@
   shell: 'service nginx status'
   register: nginx_status
   changed_when: false
-  failed_when: nginx_status.rc != 0 or nginx_status.stdout.find('start/running') == -1
+  # new versions have `* nginx is running`, old have something containing `start/running`
+  failed_when: nginx_status.rc != 0 or nginx_status.stdout.find('running') == -1


### PR DESCRIPTION
This came up because nginx got upgraded by the nginx/install.yml script. In other news, I would have suggested pinning to a version like we do for other services:

https://github.com/dimagi/commcare-cloud/blob/2397ef3e5da72c0e71b484be8a06d5e6306ca8fb/src/commcare_cloud/ansible/roles/nginx/tasks/install.yml#L14