### PR TITLE
define var on hosts not groups

### DIFF
--- a/environments/softlayer/inventory.ini
+++ b/environments/softlayer/inventory.ini
@@ -19,21 +19,19 @@ hostname="db1"
 datavol_device=/dev/xvdc
 
 [es2]
-10.162.36.221
+10.162.36.221 encrypted_root=/opt/data/ecrypt
 
 [es2:vars]
 hostname="es2"
 elasticsearch_node_name=es2
-encrypted_root=/opt/data/ecrypt
 
 [es3]
-10.162.36.200
+10.162.36.200 encrypted_root=/opt/data/ecrypt
 
 [es3:vars]
 hostname="es3"
 elasticsearch_node_name=es3
 datavol_device=/dev/xvdc
-encrypted_root=/opt/data/ecrypt
 
 [kafka0]
 10.162.36.207 hostname=kafka0 datavol_device=/dev/xvdc encrypted_root=/opt/data/ecrypt
@@ -66,38 +64,34 @@ encrypted_root=/opt/data/ecrypt
 10.162.36.215 hostname="touch0"
 
 [couch1]
-10.162.36.218
+10.162.36.218 encrypted_root=/opt/data/ecrypt
 
 [couch1:vars]
 hostname="couch1"
 devices='["/dev/xvde","/dev/xvdc"]'
 partitions=["/dev/xvde1","/dev/xvdc1"]
 datavol_device='/dev/mapper/consolidated-data'
-encrypted_root=/opt/data/ecrypt
 
 [couch2]
-10.162.36.254
+10.162.36.254 encrypted_root=/opt/data/ecrypt
 
 [couch2:vars]
 hostname="couch2"
 datavol_device=/dev/xvdc
-encrypted_root=/opt/data/ecrypt
 
 [couch3]
-10.162.36.198
+10.162.36.198 encrypted_root=/opt/data/ecrypt
 
 [couch3:vars]
 hostname="couch3"
 datavol_device=/dev/xvdc
-encrypted_root=/opt/data/ecrypt
 
 [couch4]
-10.162.36.220
+10.162.36.220 encrypted_root=/opt/data/ecrypt
 
 [couch4:vars]
 hostname="couch4"
 datavol_device=/dev/xvdc
-encrypted_root=/opt/data/ecrypt
 
 [proxy:children]
 proxy0


### PR DESCRIPTION
According to order or precedence, group vars in
inventory file get overridden by group vars in group_vars/all

https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#id18