### PR TITLE
adding env tag to celery check

### DIFF
--- a/src/commcare_cloud/ansible/roles/datadog/templates/celery.yaml.j2
+++ b/src/commcare_cloud/ansible/roles/datadog/templates/celery.yaml.j2
@@ -3,3 +3,5 @@ init_config:
 instances:
   - flower_url: "{{ CELERY_FLOWER_URL }}"
     timeout: 10
+    tags:
+      - environment:{{ env_monitoring_id }}


### PR DESCRIPTION
@snopoke 
I think this should be enough. It seems to be how the other templates do it and it looks like we pull this info into the check already https://github.com/dimagi/datadog-checks/blob/master/celery/celery.py#L76