### PR TITLE
Add new ICDS aggregation queue

### DIFF
--- a/environments/icds-new/app-processes.yml
+++ b/environments/icds-new/app-processes.yml
@@ -33,6 +33,9 @@ celery_processes:
     background_queue:
       concurrency: 6
       max_tasks_per_child: 1
+    icds_aggregation_queue:
+      pooling: gevent
+      concurrency: 4
     case_rule_queue:
       concurrency: 2
       max_tasks_per_child: 1

--- a/environments/softlayer/app-processes.yml
+++ b/environments/softlayer/app-processes.yml
@@ -40,7 +40,7 @@ celery_processes:
       concurrency: 10
     async_restore_queue:
       concurrency: 8
-    background_queue,case_rule_queue,icds_dashboard_reports_queue:
+    background_queue,case_rule_queue,icds_dashboard_reports_queue,icds_aggregation_queue:
       concurrency: 2
       max_tasks_per_child: 1
     flower: {}

--- a/src/commcare_cloud/environment/schemas/app_processes.py
+++ b/src/commcare_cloud/environment/schemas/app_processes.py
@@ -71,6 +71,7 @@ CELERY_PROCESSES = [
     CeleryProcess("email_queue"),
     CeleryProcess("export_download_queue"),
     CeleryProcess("flower"),
+    CeleryProcess("icds_aggregation_queue", required=False),
     CeleryProcess("icds_dashboard_reports_queue", required=False),
     CeleryProcess("ils_gateway_sms_queue", required=False),
     CeleryProcess("logistics_background_queue", required=False),


### PR DESCRIPTION
New celery queue for the aggregation script as these tasks only kick off SQL commands so they do almost nothing and these tasks will be in parallel several tasks at a time after https://github.com/dimagi/commcare-hq/pull/20633.

Keeping it as the same queue as the background queue on softlayer because it's very low use