### PR TITLE
Push more queries to ucr standby

### DIFF
--- a/environments/icds-new/postgresql.yml
+++ b/environments/icds-new/postgresql.yml
@@ -5,8 +5,8 @@ REPORTING_DATABASES:
     WRITE: icds-ucr
     READ:
       - [icds-ucr, 1]
-      - [icds-ucr-standby1, 1]
-      - [icds-ucr-standby2, 1]
+      - [icds-ucr-standby1, 2]
+      - [icds-ucr-standby2, 2]
   icds-test-ucr: icds-ucr
 
 LOAD_BALANCED_APPS:


### PR DESCRIPTION
@dimagi/scale-team standbys should be able to handle more reads than the main DB and the main db has quite a bit higher load pretty consistently