### PR TITLE
More robust deploy last commit finder

### DIFF
--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -167,7 +167,7 @@ def _setup_env(env_name):
     _confirm_branch(env.default_branch)
     _confirm_environment_time(env_name)
     execute(env_common)
-    _confirm_deploying_same_code()
+    execute(_confirm_deploying_same_code)
 
 
 def _confirm_branch(default_branch='master'):

--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -208,11 +208,29 @@ def _confirm_deploying_same_code():
     if env.deploy_metadata.current_ref_is_different_than_last:
         return
 
+    if env.code_branch == 'master':
+        branch_specific_msg = "Perhaps you meant to merge a PR or specify a --set code_branch=<branch> ?"
+    elif env.code_branch == 'enterprise':
+        branch_specific_msg = (
+            "Have you tried rebuilding the enterprise branch (in HQ directory)? "
+            "./scripts/rebuildstaging --enterprise"
+        )
+    elif env.code_branch == 'autostaging':
+        branch_specific_msg = (
+            "Have you tried rebuilding the autostaging branch (in HQ directory)? "
+            "./scripts/rebuildstaging"
+        )
+    else:
+        branch_specific_msg = (
+            "Did you specify the correct branch using --set cod_branch=<branch> ?"
+        )
+
     message = (
-        "Whoa there bud! You're deploying the same code as was previously deployed.\n"
-        "Perhaps you meant to specify --set code_branch=<branch> or should merge some PRs\n"
+        "Whoa there bud! You're deploying {code_branch} which happens to be "
+        "the same code as was previously deployed to this environment.\n"
+        "{branch_specific_msg}\n"
         "Is this intentional?"
-    )
+    ).format(code_branch=env.code_branch, branch_specific_msg=branch_specific_msg)
     if not console.confirm(message, default=False):
         utils.abort('Action aborted.')
 


### PR DESCRIPTION
@gbova @esoergel sorry about the earlier error. 

The first commit adds a new method to find the latest commit. It defaults to using `last_tag`'s sha but otherwise it cd's into the current directory to find it there. I'm pretty sure this should never fail because we always assume that there's a current release (even on new servers ansible will create that symlink)

The second commit gives some more firm direction on what to do with the error. It tells you what branch you are deploying and how to rebuild the appropriate yaml files.

Let me know what you think and then I'll send a note to the dev team