### PR TITLE
infer shared_drive_enabled from is_monolith

### DIFF
--- a/.travis/environments/travis/public.yml
+++ b/.travis/environments/travis/public.yml
@@ -78,7 +78,6 @@ postgres_users:
 
 encrypted_root: '/opt/data'
 
-shared_drive_enabled: True
 backup_postgres: dump
 backup_blobdb: True
 postgresql_backup_master: True

--- a/commcare-cloud-bootstrap/environment/public.yml
+++ b/commcare-cloud-bootstrap/environment/public.yml
@@ -70,7 +70,6 @@ postgres_users:
 
 encrypted_root: '/opt/data'
 
-shared_drive_enabled: True
 backup_postgres: plain
 backup_blobdb: True
 postgresql_backup_master: True

--- a/environments/development/public.yml
+++ b/environments/development/public.yml
@@ -77,7 +77,6 @@ postgres_users:
 
 encrypted_root: '/opt/data'
 
-shared_drive_enabled: True
 backup_postgres: plain
 backup_blobdb: True
 postgresql_backup_master: True

--- a/environments/icds-new/public.yml
+++ b/environments/icds-new/public.yml
@@ -35,8 +35,6 @@ datadog_extra_host_checks:
 
 file_email: False
 
-shared_drive_enabled: true
-
 touchforms_enabled: false
 
 etc_hosts_lines:

--- a/environments/pna/public.yml
+++ b/environments/pna/public.yml
@@ -49,8 +49,6 @@ nameservers:
   - 8.8.8.8
   - 8.8.4.4
 
-shared_drive_enabled: false
-
 touchforms_enabled: false
 
 localsettings:

--- a/environments/softlayer/public.yml
+++ b/environments/softlayer/public.yml
@@ -45,9 +45,6 @@ control_machine_ip: 10.162.36.196
 etc_hosts_lines: []
 etc_hosts_lines_removed: []
 
-shared_drive_enabled: true
-
-
 couch_dbs:
   default:
     host: "{{ groups.couchdb2_proxy[0] }}"

--- a/environments/swiss/public.yml
+++ b/environments/swiss/public.yml
@@ -31,9 +31,6 @@ aws_versioning_enabled: false
 
 KSPLICE_ACTIVE: yes
 
-
-shared_drive_enabled: false
-
 couch_dbs:
   default:
     host: 185.12.7.167

--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -12,12 +12,12 @@ project: "commcare-hq"
 airflow_home: "{{ cchq_home }}/airflow"
 airflow_virtualenv: "{{ airflow_home }}/env"
 
-shared_drive_enabled: true
 shared_dir_gid: 1500  # This GID cannot already be allocated
 shared_dir_name: "shared{{ '_' ~ deploy_env if deploy_env != 'production' else '' }}"
 shared_data_dir: "/opt/{{ shared_dir_name }}"
 shared_mount_dir: "/mnt/{{ shared_dir_name }}"
 is_monolith: '{{ groups["all"]|length == 1 }}'
+shared_drive_enabled: '{{ not is_monolith }}'
 transfer_payload_dir_name: "transfer_payloads"
 restore_payload_dir_name: "restore_payloads"
 shared_temp_dir_name: "temp"

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -88,7 +88,7 @@ UCR_EXCEPTION_FILE = os.path.join(LOG_HOME,"{{ localsettings.DEPLOY_MACHINE_NAME
 MAIN_COUCH_SQL_DATAMIGRATION = os.path.join(LOG_HOME,"{{ localsettings.DEPLOY_MACHINE_NAME }}-couch_sql_migration.log")
 
 # Shared Drive Setup
-{% if shared_drive_enabled|default(true) %}
+{% if shared_drive_enabled %}
 SHARED_DRIVE_ROOT = '{{ shared_mount_dir }}'
 {% else %}
 SHARED_DRIVE_ROOT = '{{ shared_data_dir }}'


### PR DESCRIPTION
can always override in public.yml, but no need to make every env specify
when it is this predictable