### PR TITLE
start postgres after reboot

### DIFF
--- a/src/commcare_cloud/ansible/roles/postgresql/handlers/main.yml
+++ b/src/commcare_cloud/ansible/roles/postgresql/handlers/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: Start postgres
+  become: yes
+  action: service name=postgresql args="{{ postgresql_version }}" state=started
+
 - name: Restart postgres
   become: yes
   action: service name=postgresql args="{{ postgresql_version }}" state=restarted

--- a/src/commcare_cloud/ansible/roles/postgresql/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/postgresql/tasks/main.yml
@@ -160,7 +160,7 @@
 
 - name: Restart postgresql (after reboot)
   command: /bin/true
-  notify: Restart postgres
+  notify: Start postgres
   when: no_tags is not defined
   tags: after-reboot
 

--- a/src/commcare_cloud/ansible/roles/postgresql/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/postgresql/tasks/main.yml
@@ -153,6 +153,17 @@
 # restart / reload if necessary to make sure replication slot config updated
 - meta: flush_handlers
 
+# Allows to excecute task only when a tag is specified: https://serverfault.com/a/748864
+- shell: /bin/true
+  changed_when: false
+  register: no_tags
+
+- name: Restart postgresql (after reboot)
+  command: /bin/true
+  notify: Restart postgres
+  when: no_tags is not defined
+  tags: after-reboot
+
 - name: Create replication slots
   pg_replication_slot:
     name: "{{ item }}"
@@ -205,11 +216,6 @@
   notify: Restart pgbouncer
   tags:
     - pgbouncer
-
-# Allows to excecute task only when a tag is specified: https://serverfault.com/a/748864
-- shell: /bin/true
-  changed_when: false
-  register: no_tags
 
 - name: Restarts pgbouncer (affect max open files limit)
   command: /bin/true


### PR DESCRIPTION
Noticed that PG doesn't get started by `after-reboot`.

Was introduced here: https://github.com/dimagi/commcare-cloud/commit/cb131fcadbddceb282f01fb6e09acb7cf46033b0