### PR TITLE
Remove enterprise branch as a default

### DIFF
--- a/environments/icds-new/fab-settings.yml
+++ b/environments/icds-new/fab-settings.yml
@@ -3,4 +3,3 @@ acceptable_maintenance_window:
   hour_end: 7
   timezone: Asia/Kolkata
 email_enabled: False
-default_branch: enterprise

--- a/environments/pna/fab-settings.yml
+++ b/environments/pna/fab-settings.yml
@@ -1,2 +1,1 @@
 ignore_kafka_checkpoint_warning: True
-default_branch: enterprise

--- a/environments/swiss/fab-settings.yml
+++ b/environments/swiss/fab-settings.yml
@@ -1,2 +1,1 @@
 ignore_kafka_checkpoint_warning: True
-default_branch: enterprise


### PR DESCRIPTION
Realized today after I attempted to rebuild the enterprise branch that including pull requests is not going to be the best way forward. 

If the submitter of the pull request has pulled master since the last deploy, that pull request then includes all commits to master since then which basically undoes any use of this branch.

It may be possible to determine what commits are in each branch and then cherry-pick each commit instead of merging the pull request, but I'm open to any other suggestions.

from the original convo: @millerdev @snopoke 