### PR TITLE
Explicitly set formplayer database host

### DIFF
--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -211,5 +211,11 @@ hq_main_db_host: "{% for config in postgresql_dbs -%}
   {%- endif -%}
 {%- endfor %}"
 
+formplayer_db_host: "{% for config in postgresql_dbs -%}
+  {%- if config.name == formplayer_db_name  -%}
+    {{ config.host }}
+  {%- endif -%}
+{%- endfor %}"
+
 nofile_limit: 4096
 

--- a/src/commcare_cloud/ansible/roles/formplayer/templates/application.properties.j2
+++ b/src/commcare_cloud/ansible/roles/formplayer/templates/application.properties.j2
@@ -33,13 +33,13 @@ datasource.hq.username={{ postgres_users.commcare.username }}
 datasource.hq.password={{ postgres_users.commcare.password }}
 
 datasource.formplayer.driverClassName=org.postgresql.Driver
-datasource.formplayer.url=jdbc:postgresql://{{ groups.postgresql.0 }}:6432/{{ formplayer_db_name
+datasource.formplayer.url=jdbc:postgresql://{{ formplayer_db_host }}:6432/{{ formplayer_db_name
 }}?prepareThreshold=0
 datasource.formplayer.username={{ postgres_users.commcare.username }}
 datasource.formplayer.password={{ postgres_users.commcare.password }}
 
 // set flyway URL to Formplayer's own DB
-flyway.url=jdbc:postgresql://{{ groups.postgresql.0 }}:6432/{{ formplayer_db_name }}?prepareThreshold=0
+flyway.url=jdbc:postgresql://{{ formplayer_db_host }}:6432/{{ formplayer_db_name }}?prepareThreshold=0
 flyway.user={{ postgres_users.commcare.username }}
 flyway.password={{ postgres_users.commcare.password }}
 flyway.driverClassName=org.postgresql.Driver


### PR DESCRIPTION
Currently this is the UCR database on ICDS. not sure how intentional that was, but that's at least the current state.