### PR TITLE
refactor generated postgresql_dbs test

### DIFF
--- a/src/commcare_cloud/environment/schemas/postgresql.py
+++ b/src/commcare_cloud/environment/schemas/postgresql.py
@@ -84,7 +84,11 @@ class PostgresqlConfig(jsonobject.JsonObject):
         data = self.to_json()
         del data['dbs']
         del data['override']
-        data['postgresql_dbs'] = [db.to_json() for db in self.generate_postgresql_dbs()]
+
+        data['postgresql_dbs'] = sorted(
+            (db.to_json() for db in self.generate_postgresql_dbs()),
+            key=lambda db: db['name']
+        )
         data.update(self.override.to_json())
         return data
 

--- a/tests/postgresql_config/2018-04-04-development-snapshot/.generated.yml
+++ b/tests/postgresql_config/2018-04-04-development-snapshot/.generated.yml
@@ -1,19 +1,19 @@
 postgresql_dbs:
 - create: true
-  django_alias: ucr
-  django_migrate: false
+  django_alias: default
+  django_migrate: true
   host: 192.168.33.16
-  name: commcarehq_ucr
+  name: commcarehq
   options: {}
   password: commcarehq
   port: 6432
   query_stats: false
   user: commcarehq
 - create: true
-  django_alias: default
-  django_migrate: true
+  django_alias: ucr
+  django_migrate: false
   host: 192.168.33.16
-  name: commcarehq
+  name: commcarehq_ucr
   options: {}
   password: commcarehq
   port: 6432

--- a/tests/postgresql_config/2018-04-04-enikshay-snapshot/.generated.yml
+++ b/tests/postgresql_config/2018-04-04-enikshay-snapshot/.generated.yml
@@ -10,26 +10,6 @@ postgresql_dbs:
   query_stats: false
   user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
 - create: true
-  django_alias: proxy
-  django_migrate: true
-  host: 172.25.3.5
-  name: commcarehq_proxy
-  options: {}
-  password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
-  port: 6432
-  query_stats: false
-  user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
-- create: true
-  django_alias: synclogs
-  django_migrate: true
-  host: 172.25.3.5
-  name: commcarehq_synclogs
-  options: {}
-  password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
-  port: 6432
-  query_stats: false
-  user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
-- create: true
   django_alias: p1
   django_migrate: true
   host: 172.25.3.5
@@ -39,6 +19,17 @@ postgresql_dbs:
   port: 6432
   query_stats: false
   shards: [0, 103]
+  user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
+- create: true
+  django_alias: p10
+  django_migrate: true
+  host: 172.25.3.5
+  name: commcarehq_p10
+  options: {}
+  password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
+  port: 6432
+  query_stats: false
+  shards: [927, 1023]
   user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
 - create: true
   django_alias: p2
@@ -129,15 +120,24 @@ postgresql_dbs:
   shards: [824, 926]
   user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
 - create: true
-  django_alias: p10
+  django_alias: proxy
   django_migrate: true
   host: 172.25.3.5
-  name: commcarehq_p10
+  name: commcarehq_proxy
   options: {}
   password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
   port: 6432
   query_stats: false
-  shards: [927, 1023]
+  user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
+- create: true
+  django_alias: synclogs
+  django_migrate: true
+  host: 172.25.3.5
+  name: commcarehq_synclogs
+  options: {}
+  password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
+  port: 6432
+  query_stats: false
   user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
 - create: true
   django_alias: ucr

--- a/tests/postgresql_config/2018-04-04-icds-new-snapshot/.generated.yml
+++ b/tests/postgresql_config/2018-04-04-icds-new-snapshot/.generated.yml
@@ -10,20 +10,21 @@ postgresql_dbs:
   query_stats: false
   user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
 - create: true
-  django_alias: synclogs
+  django_alias: icds-ucr
   django_migrate: true
-  host: 10.247.164.70
-  name: commcarehq_synclogs
+  host: 10.247.164.25
+  name: commcarehq_icds_aggregatedata
   options: {}
   password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
   port: 6432
-  query_stats: false
+  query_stats: true
   user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
-- create: true
-  django_alias: proxy
-  django_migrate: true
-  host: 10.247.164.56
-  name: commcarehq_proxy
+- create: false
+  django_alias: icds-ucr-standby1
+  django_migrate: false
+  host: 10.247.164.24
+  hq_acceptable_standby_delay: 30
+  name: commcarehq_icds_aggregatedata
   options: {}
   password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
   port: 6432
@@ -39,6 +40,17 @@ postgresql_dbs:
   port: 6432
   query_stats: false
   shards: [0, 103]
+  user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
+- create: true
+  django_alias: p10
+  django_migrate: true
+  host: 10.247.164.64
+  name: commcarehq_p10
+  options: {}
+  password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
+  port: 6432
+  query_stats: false
+  shards: [927, 1023]
   user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
 - create: true
   django_alias: p2
@@ -129,15 +141,24 @@ postgresql_dbs:
   shards: [824, 926]
   user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
 - create: true
-  django_alias: p10
+  django_alias: proxy
   django_migrate: true
-  host: 10.247.164.64
-  name: commcarehq_p10
+  host: 10.247.164.56
+  name: commcarehq_proxy
   options: {}
   password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
   port: 6432
   query_stats: false
-  shards: [927, 1023]
+  user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
+- create: true
+  django_alias: synclogs
+  django_migrate: true
+  host: 10.247.164.70
+  name: commcarehq_synclogs
+  options: {}
+  password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
+  port: 6432
+  query_stats: false
   user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
 - create: true
   django_alias: ucr
@@ -150,16 +171,6 @@ postgresql_dbs:
   query_stats: false
   user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
 - create: true
-  django_alias: icds-ucr
-  django_migrate: true
-  host: 10.247.164.25
-  name: commcarehq_icds_aggregatedata
-  options: {}
-  password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
-  port: 6432
-  query_stats: true
-  user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
-- create: true
   django_alias: null
   django_migrate: true
   host: 10.247.164.25
@@ -169,14 +180,3 @@ postgresql_dbs:
   port: 6432
   query_stats: false
   user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
-- create: false
-  django_alias: icds-ucr-standby1
-  django_migrate: false
-  host: 10.247.164.24
-  name: commcarehq_icds_aggregatedata
-  options: {}
-  password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
-  port: 6432
-  query_stats: false
-  user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
-  hq_acceptable_standby_delay: 30

--- a/tests/postgresql_config/2018-04-04-l10k-snapshot/.generated.yml
+++ b/tests/postgresql_config/2018-04-04-l10k-snapshot/.generated.yml
@@ -1,15 +1,5 @@
 postgresql_dbs:
 - create: true
-  django_alias: ucr
-  django_migrate: true
-  host: 127.0.0.1
-  name: commcarehq_ucr
-  options: {}
-  password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
-  port: 6432
-  query_stats: false
-  user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
-- create: true
   django_alias: default
   django_migrate: true
   host: 127.0.0.1
@@ -20,20 +10,30 @@ postgresql_dbs:
   query_stats: false
   user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
 - create: true
-  django_alias: null
+  django_alias: synclogs
   django_migrate: true
   host: 127.0.0.1
-  name: formplayer
+  name: commcarehq_synclogs
   options: {}
   password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
   port: 6432
   query_stats: false
   user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
 - create: true
-  django_alias: synclogs
+  django_alias: ucr
   django_migrate: true
   host: 127.0.0.1
-  name: commcarehq_synclogs
+  name: commcarehq_ucr
+  options: {}
+  password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
+  port: 6432
+  query_stats: false
+  user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
+- create: true
+  django_alias: null
+  django_migrate: true
+  host: 127.0.0.1
+  name: formplayer
   options: {}
   password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
   port: 6432

--- a/tests/postgresql_config/2018-04-04-pna-snapshot/.generated.yml
+++ b/tests/postgresql_config/2018-04-04-pna-snapshot/.generated.yml
@@ -10,26 +10,6 @@ postgresql_dbs:
   query_stats: false
   user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
 - create: true
-  django_alias: synclogs
-  django_migrate: true
-  host: 196.207.230.171
-  name: commcarehq_synclogs
-  options: {}
-  password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
-  port: 6432
-  query_stats: false
-  user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
-- create: true
-  django_alias: proxy
-  django_migrate: true
-  host: 196.207.230.171
-  name: commcarehq_proxy
-  options: {}
-  password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
-  port: 6432
-  query_stats: false
-  user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
-- create: true
   django_alias: p1
   django_migrate: true
   host: 196.207.230.171
@@ -39,6 +19,17 @@ postgresql_dbs:
   port: 6432
   query_stats: false
   shards: [0, 103]
+  user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
+- create: true
+  django_alias: p10
+  django_migrate: true
+  host: 196.207.230.171
+  name: commcarehq_p10
+  options: {}
+  password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
+  port: 6432
+  query_stats: false
+  shards: [927, 1023]
   user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
 - create: true
   django_alias: p2
@@ -129,15 +120,24 @@ postgresql_dbs:
   shards: [824, 926]
   user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
 - create: true
-  django_alias: p10
+  django_alias: proxy
   django_migrate: true
   host: 196.207.230.171
-  name: commcarehq_p10
+  name: commcarehq_proxy
   options: {}
   password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
   port: 6432
   query_stats: false
-  shards: [927, 1023]
+  user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
+- create: true
+  django_alias: synclogs
+  django_migrate: true
+  host: 196.207.230.171
+  name: commcarehq_synclogs
+  options: {}
+  password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
+  port: 6432
+  query_stats: false
   user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
 - create: true
   django_alias: ucr

--- a/tests/postgresql_config/2018-04-04-production-snapshot/.generated.yml
+++ b/tests/postgresql_config/2018-04-04-production-snapshot/.generated.yml
@@ -10,26 +10,6 @@ postgresql_dbs:
   query_stats: false
   user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
 - create: true
-  django_alias: proxy
-  django_migrate: true
-  host: hqdb1.internal-va.commcarehq.org
-  name: commcarehq_proxy
-  options: {}
-  password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
-  port: 6432
-  query_stats: false
-  user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
-- create: true
-  django_alias: synclogs
-  django_migrate: true
-  host: pgsynclog.internal-va.commcarehq.org
-  name: commcarehq_synclogs
-  options: {}
-  password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
-  port: 6432
-  query_stats: false
-  user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
-- create: true
   django_alias: p1
   django_migrate: true
   host: hqdb1.internal-va.commcarehq.org
@@ -83,6 +63,26 @@ postgresql_dbs:
   port: 6432
   query_stats: false
   shards: [820, 1023]
+  user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
+- create: true
+  django_alias: proxy
+  django_migrate: true
+  host: hqdb1.internal-va.commcarehq.org
+  name: commcarehq_proxy
+  options: {}
+  password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
+  port: 6432
+  query_stats: false
+  user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
+- create: true
+  django_alias: synclogs
+  django_migrate: true
+  host: pgsynclog.internal-va.commcarehq.org
+  name: commcarehq_synclogs
+  options: {}
+  password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
+  port: 6432
+  query_stats: false
   user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
 - create: true
   django_alias: ucr

--- a/tests/postgresql_config/2018-04-04-softlayer-snapshot/.generated.yml
+++ b/tests/postgresql_config/2018-04-04-softlayer-snapshot/.generated.yml
@@ -10,26 +10,6 @@ postgresql_dbs:
   query_stats: false
   user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
 - create: true
-  django_alias: proxy
-  django_migrate: true
-  host: 10.162.36.205
-  name: commcarehq_proxy
-  options: {}
-  password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
-  port: 6432
-  query_stats: false
-  user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
-- create: true
-  django_alias: synclogs
-  django_migrate: true
-  host: 10.162.36.205
-  name: commcarehq_synclogs
-  options: {}
-  password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
-  port: 6432
-  query_stats: false
-  user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
-- create: true
   django_alias: p1
   django_migrate: true
   host: 10.162.36.205
@@ -85,6 +65,26 @@ postgresql_dbs:
   shards: [820, 1023]
   user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
 - create: true
+  django_alias: proxy
+  django_migrate: true
+  host: 10.162.36.205
+  name: commcarehq_proxy
+  options: {}
+  password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
+  port: 6432
+  query_stats: false
+  user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
+- create: true
+  django_alias: synclogs
+  django_migrate: true
+  host: 10.162.36.205
+  name: commcarehq_synclogs
+  options: {}
+  password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
+  port: 6432
+  query_stats: false
+  user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
+- create: true
   django_alias: ucr
   django_migrate: true
   host: 10.162.36.205
@@ -95,20 +95,20 @@ postgresql_dbs:
   query_stats: false
   user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
 - create: true
-  django_alias: icds-ucr
+  django_alias: null
   django_migrate: true
   host: 10.162.36.205
-  name: icds-ucr
+  name: formplayer
   options: {}
   password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
   port: 6432
   query_stats: false
   user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
 - create: true
-  django_alias: null
+  django_alias: icds-ucr
   django_migrate: true
   host: 10.162.36.205
-  name: formplayer
+  name: icds-ucr
   options: {}
   password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
   port: 6432

--- a/tests/postgresql_config/2018-04-04-staging-snapshot/.generated.yml
+++ b/tests/postgresql_config/2018-04-04-staging-snapshot/.generated.yml
@@ -10,26 +10,6 @@ postgresql_dbs:
   query_stats: true
   user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
 - create: true
-  django_alias: proxy
-  django_migrate: true
-  host: hqdb1-staging.internal-va.commcarehq.org
-  name: commcarehq_proxy
-  options: {}
-  password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
-  port: 6432
-  query_stats: false
-  user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
-- create: true
-  django_alias: synclogs
-  django_migrate: true
-  host: hqdb1-staging.internal-va.commcarehq.org
-  name: commcarehq_synclogs
-  options: {}
-  password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
-  port: 6432
-  query_stats: false
-  user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
-- create: true
   django_alias: p1
   django_migrate: true
   host: hqdb1-staging.internal-va.commcarehq.org
@@ -83,6 +63,26 @@ postgresql_dbs:
   port: 6432
   query_stats: true
   shards: [400, 511]
+  user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
+- create: true
+  django_alias: proxy
+  django_migrate: true
+  host: hqdb1-staging.internal-va.commcarehq.org
+  name: commcarehq_proxy
+  options: {}
+  password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
+  port: 6432
+  query_stats: false
+  user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
+- create: true
+  django_alias: synclogs
+  django_migrate: true
+  host: hqdb1-staging.internal-va.commcarehq.org
+  name: commcarehq_synclogs
+  options: {}
+  password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
+  port: 6432
+  query_stats: false
   user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
 - create: true
   django_alias: ucr

--- a/tests/postgresql_config/2018-04-04-swiss-snapshot/.generated.yml
+++ b/tests/postgresql_config/2018-04-04-swiss-snapshot/.generated.yml
@@ -1,15 +1,5 @@
 postgresql_dbs:
 - create: true
-  django_alias: ucr
-  django_migrate: false
-  host: 127.0.0.1
-  name: commcarehq_ucr
-  options: {}
-  password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
-  port: 6432
-  query_stats: true
-  user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
-- create: true
   django_alias: default
   django_migrate: true
   host: 127.0.0.1
@@ -20,20 +10,30 @@ postgresql_dbs:
   query_stats: false
   user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
 - create: true
-  django_alias: null
+  django_alias: synclogs
   django_migrate: true
   host: 127.0.0.1
-  name: formplayer
+  name: commcarehq_synclogs
   options: {}
   password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
   port: 6432
   query_stats: false
   user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
 - create: true
-  django_alias: synclogs
+  django_alias: ucr
+  django_migrate: false
+  host: 127.0.0.1
+  name: commcarehq_ucr
+  options: {}
+  password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
+  port: 6432
+  query_stats: true
+  user: '{{ secrets.POSTGRES_USERS.commcare.username }}'
+- create: true
+  django_alias: null
   django_migrate: true
   host: 127.0.0.1
-  name: commcarehq_synclogs
+  name: formplayer
   options: {}
   password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
   port: 6432

--- a/tests/test_postgresql_config.py
+++ b/tests/test_postgresql_config.py
@@ -14,20 +14,14 @@ TEST_ENVIRONMENTS = os.listdir(TEST_ENVIRONMENTS_DIR)
 
 @parameterized(TEST_ENVIRONMENTS)
 def test_postgresql_config(env_name):
-    def map_json(db_list):
-        return [db.to_json() for db in db_list]
-
-    def get_normalized(db_json_list):
-        return sorted(db_json_list, key=lambda db: db['name'])
-
     env = Environment(DefaultPaths(env_name, environments_dir=TEST_ENVIRONMENTS_DIR))
 
     with open(env.paths.generated_yml) as f:
         generated = yaml.load(f)
         assert generated.keys() == ['postgresql_dbs']
 
-    expected_json = get_normalized(generated['postgresql_dbs'])
+    expected_json = generated['postgresql_dbs']
 
-    actual_json = get_normalized(env.postgresql_config.to_generated_variables()['postgresql_dbs'])
+    actual_json = env.postgresql_config.to_generated_variables()['postgresql_dbs']
 
     assert actual_json == expected_json, "{} != {}".format(actual_json, expected_json)

--- a/tests/test_postgresql_config.py
+++ b/tests/test_postgresql_config.py
@@ -28,6 +28,6 @@ def test_postgresql_config(env_name):
 
     expected_json = get_normalized(generated['postgresql_dbs'])
 
-    actual_json = get_normalized(map_json(env.postgresql_config.generate_postgresql_dbs()))
+    actual_json = get_normalized(env.postgresql_config.to_generated_variables()['postgresql_dbs'])
 
     assert actual_json == expected_json, "{} != {}".format(actual_json, expected_json)


### PR DESCRIPTION
Aside from tests, the only change in functionality is that the generated `postgresql_dbs` variable comes sorted by db `name`. The other changes
- sort dbs in `tests/postgresql_config/*/.generated.yml` files to match this output and
- make the test work off the actual output rather than an internal/intermediate data structure
- simplify the test now that the variable comes pre-sorted

This is a prefactor to make changes to `postgresql_dbs` and updates to the test easier to eyeball for correctness