### PR TITLE
Revert "Revert "Added web10 and web11""

### DIFF
--- a/environments/icds-new/app-processes.yml
+++ b/environments/icds-new/app-processes.yml
@@ -147,6 +147,12 @@ celery_processes:
   'web9':
     ucr_indicator_queue:
       concurrency: 4
+  'web10':
+    ucr_indicator_queue:
+      concurrency: 4
+  'web11':
+    ucr_indicator_queue:
+      concurrency: 4
 pillows:
   'pillow0':
     kafka-ucr-static-cases:

--- a/environments/icds-new/inventory.ini
+++ b/environments/icds-new/inventory.ini
@@ -463,6 +463,18 @@ hostname='web8'
 [web9:vars]
 hostname='web9'
 
+[web10]
+10.247.164.27
+
+[web10:vars]
+hostname='web10'
+
+[web11]
+10.247.164.26
+
+[web11:vars]
+hostname='web11'
+
 [es0]
 10.247.164.15
 
@@ -791,6 +803,8 @@ web6
 web7
 web8
 web9
+web10
+web11
 
 [postgresql_lvm:children]
 pgucr
@@ -841,6 +855,8 @@ web6
 web7
 web8
 web9
+web10
+web11
 
 [pillowtop:children]
 pillow0


### PR DESCRIPTION
Reverts dimagi/commcare-cloud#1817

This is breaking the deploy due to what I believe is an upgrade to pip. These two servers have pip 10.0.1 installed and the other ones have 9.x. When running pip install you get hte following issues:

```
(python_env) cchq@web10:~/www/icds/releases/2018-06-04_17.47$ pip install --timeout 60 --quiet --requirement /home/cchq/www/icds/releases/2018-06-04_17.47/requirements/prod-requirements.txt --requirement /home/cchq/www/icds/releases/2018-06-04_17.47/requirements/requirements.txt --proxy 10.247.63.132:3128
flower 0.8.4 has requirement pytz==2015.7, but you'll have pytz 2017.2 which is incompatible.
django-two-factor-auth 1.6.2 has requirement qrcode<4.99,>=4.0.0, but you'll have qrcode 5.3 which is incompatible.
kombu 3.0.37 has requirement amqp<2.0,>=1.4.9, but you'll have amqp 1.4.7 which is incompatible.
```

It looks like travis is also on pip 9.0.1 so that could by why this isn't caught. I will take a look at requirements to upgrade, but another option is to pin pip to 9.0.1 when installing new servers

@snopoke @NitigyaS 