### PR TITLE
fix letsencrypt_cert.yml

### DIFF
--- a/src/commcare_cloud/ansible/letsencrypt_cert.yml
+++ b/src/commcare_cloud/ansible/letsencrypt_cert.yml
@@ -4,7 +4,7 @@
   become: yes
   tasks:
     - name: Add certbot apt repo
-      apt_repository: repo='ppa:certbot/certbo' state=present
+      apt_repository: repo='ppa:certbot/certbot' state=present
       register: add_cert_repo
 
     - name: Update package list
@@ -25,11 +25,13 @@
         path: '/var/www/letsencrypt/.well-known/acme-challenge'
         owner: www-data
         group: www-data
+        state: directory
         recurse: yes
 
     - name: Create a test file
-      file:
-        path: '/var/www/letsencrypt/.well-known/acme-challenge/test.txt'
+      copy:
+        content: ""
+        dest: '/var/www/letsencrypt/.well-known/acme-challenge/test.txt'
         owner: www-data
         group: www-data
       ignore_errors: '{{ ansible_check_mode }}'
@@ -41,7 +43,20 @@
         regexp: "}$"
         line: " # For Letsencrypt \n location ^~ /.well-known/acme-challenge/ { root /var/www/letsencrypt; } \n}"
         backup: yes
-        validate: 'nginx -t'
+        # thanks to https://github.com/ansible/ansible/issues/9112#issuecomment-256483099
+        validate: >
+          bash -c 'nginx -t -c /dev/stdin <<< "
+            events {
+              worker_connections 1;
+            }
+
+            http {
+              # fake the log_format declarations that the modified site we're testing references
+              log_format rt_cache 'x';
+              log_format timing 'x';
+              include %s;
+            }
+          "'
 
     - name: Reload Nginx
       service:
@@ -51,9 +66,8 @@
 
     - name: Check that a test page returns a status 200
       uri:
-        url: 'https://{{SITE_HOST}}.well-known/acme-challenge/test.txt'
-        return_content: yes
-        register: webpage
+        url: 'https://{{SITE_HOST}}/.well-known/acme-challenge/test.txt'
+        validate_certs: no
 
     - name: 'Verify that there exists a certbot Directory /etc/letsencrypt/live/{{ SITE_HOST }}'
       stat:
@@ -65,12 +79,12 @@
       when: certdir.stat.exists
 
     - name: Run Certbot command when there is a www host
-      command: 'sudo certbot certonly --webroot -w /var/www/letsencrypt/ -d {{SITE_HOST}} -d {{ NO_WWW_SITE_HOST }}'
-      when: NO_WWW_SITE_HOST is defined
+      command: 'certbot certonly --webroot -w /var/www/letsencrypt/ -m {{ root_email }} --agree-tos -d {{SITE_HOST}} -d {{ NO_WWW_SITE_HOST }}'
+      when: NO_WWW_SITE_HOST
 
     - name: Run Certbot command when there is no www host
-      command: 'sudo certbot certonly --webroot -w /var/www/letsencrypt/ -d {{SITE_HOST}}'
-      when: NO_WWW_SITE_HOST is not defined
+      command: 'certbot certonly --webroot -w /var/www/letsencrypt/ -m {{ root_email }} --agree-tos -d {{SITE_HOST}}'
+      when: not NO_WWW_SITE_HOST
 
     - name: 'Copy Certificate /etc/letsencrypt/live/{{SITE_HOST}}/fullchain.pem to /etc/pki/tls/certs/{{ deploy_env }}_nginx_combined.crt'
       copy:
@@ -98,3 +112,15 @@
       service:
         name: nginx
         state: reloaded
+
+    - name: Final instructions
+      pause:
+        prompt: |
+
+          Hello person who ran letsencrypt_cert.yml.
+
+          Now you just have to finalize things by
+            - making sure `fake_ssl_cert` is set to `no` (or is absent) in `proxy.yml`
+            - running `commcare-cloud <env> ansible-playbook deploy_proxy.yml`
+            - optionally, copying the important files from `proxy` `/etc/pki/tls/`
+              to an encrypted file in the environment settings.

--- a/src/commcare_cloud/ansible/letsencrypt_cert.yml
+++ b/src/commcare_cloud/ansible/letsencrypt_cert.yml
@@ -51,7 +51,7 @@
             }
 
             http {
-              # fake the log_format declarations that the modified site we're testing references
+              # fake the log_format declarations that the modified site references
               log_format rt_cache 'x';
               log_format timing 'x';
               include %s;

--- a/src/commcare_cloud/ansible/roles/nginx/tasks/install.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/tasks/install.yml
@@ -77,7 +77,7 @@
     mode: 0400
     owner: root
     group: root
-  when: not fake_ssl_cert and nginx_combined_cert_value is defined
+  when: not fake_ssl_cert and nginx_combined_cert_value
   tags:
     - update-cert
 
@@ -90,7 +90,7 @@
     owner: root
     group: root
   no_log: true
-  when: not fake_ssl_cert and nginx_key_value is defined
+  when: not fake_ssl_cert and nginx_key_value
   tags:
     - update-cert
 


### PR DESCRIPTION
After making these changes I was able to run
```
commcare-cloud 64-test ansible-playbook letsencrypt_cert.yml --skip-check
# delete `fake_ssl_cert: yes` from `proxy.yml`
commcare-cloud 64-test ansible-playbook deploy_proxy.yml --skip-check
```
to set up HTTPS on a test server. Even though there were a few things I had to update to make it work, @NitigyaS what you had done was a huge help and got me most of the way there, which was great!