### PR TITLE
test to validate jinja template syntax

### DIFF
--- a/tests/test_jinja_templates.py
+++ b/tests/test_jinja_templates.py
@@ -1,0 +1,16 @@
+import fnmatch
+import os
+
+from jinja2 import Environment as JEnvironment
+
+
+def test_jinja_templates():
+    templates = []
+    for root, dirnames, filenames in os.walk('.'):
+        for filename in fnmatch.filter(filenames, '*.j2'):
+            templates.append(os.path.join(root, filename))
+
+    jinja_env = JEnvironment()
+    for path in templates:
+        with open(path) as template:
+            jinja_env.parse(template.read(), filename=path)


### PR DESCRIPTION
Example failure:
```
ERROR: tests.test_jinja_templates.test_jinja_templates
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/skelly/.virtualenvs/ansible/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/skelly/src/hqansible/tests/test_jinja_templates.py", line 16, in test_jinja_templates
    jinja_env.parse(template.read(), filename=path)
  File "/home/skelly/.virtualenvs/ansible/local/lib/python2.7/site-packages/jinja2/environment.py", line 493, in parse
    self.handle_exception(exc_info, source_hint=source)
  File "/home/skelly/.virtualenvs/ansible/local/lib/python2.7/site-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "./src/commcare_cloud/ansible/roles/postgresql/templates/pg_hba.conf.j2", line 7, in template
    {% if len(groups[; %}
TemplateSyntaxError: unexpected ';'
```