### PR TITLE
quote env vars

### DIFF
--- a/src/commcare_cloud/ansible/roles/http_proxy/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/http_proxy/tasks/main.yml
@@ -30,7 +30,7 @@
 - name: No proxy for local IPs
   lineinfile:
     dest: "/etc/environment"
-    line: "{{ item.0 }}={{ item.1|regex_replace('\\s','') }}"
+    line: "{{ item.0 }}=\"{{ item.1|regex_replace('\\s','') }}\""
     regexp: "{{item.0 }}="
     create: yes
     state: present


### PR DESCRIPTION
I discovered that on ICDS without the quotes the env vars
were getting cut off