### PR TITLE
Pin idna to 2.6 temporarily

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,9 @@ setup(
         'dimagi-memoized>=1.1.0',
         'dnspython',
         'Fabric==1.10.2',
+        # can remove once requests bumps its version requirement
+        # https://github.com/requests/requests/issues/4681
+        'idna==2.6',
         'jsonobject>=0.9.0',
         'netaddr',
         'passlib',


### PR DESCRIPTION
until requests bumps its version requirement (https://github.com/requests/requests/issues/4681)
This fixes the error:

```
pkg_resources.ContextualVersionConflict: (idna 2.7 (/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages), Requirement.parse('idna<2.7,>=2.5'), set(['requests']))
```