### PR TITLE
combine swiss queues

### DIFF
--- a/environments/swiss/app-processes.yml
+++ b/environments/swiss/app-processes.yml
@@ -38,8 +38,6 @@ celery_processes:
       max_tasks_per_child: 1
     sms_queue:
       concurrency: 1
-    async_restore_queue:
-      concurrency: 1
     flower: {}
 pillows:
   'swiss.commcarehq.org':

--- a/environments/swiss/app-processes.yml
+++ b/environments/swiss/app-processes.yml
@@ -12,32 +12,23 @@ celery_processes:
     background_queue,case_rule_queue:
       concurrency: 1
       max_tasks_per_child: 1
-    celery_periodic:
+    celery_periodic,email_queue:
       concurrency: 1
       server_whitelist: swiss.commcarehq.org
     repeat_record_queue:
       pooling: gevent
       concurrency: 1
-    email_queue:
+    email_queue,sms_queue:
       concurrency: 1
     saved_exports_queue:
       concurrency: 1
       max_tasks_per_child: 1
       optimize: True
-    submission_reprocessing_queue:
-      concurrency: 1
-    ucr_queue:
-      concurrency: 1
-      max_tasks_per_child: 5
-    reminder_case_update_queue:
-      concurrency: 1
-    reminder_queue:
+    submission_reprocessing_queue,reminder_case_update_queue,reminder_queue:
       concurrency: 1
     reminder_rule_queue:
       concurrency: 1
       max_tasks_per_child: 1
-    sms_queue:
-      concurrency: 1
     flower: {}
 pillows:
   'swiss.commcarehq.org':

--- a/src/commcare_cloud/environment/schemas/app_processes.py
+++ b/src/commcare_cloud/environment/schemas/app_processes.py
@@ -64,7 +64,7 @@ class CeleryProcess(namedtuple('CeleryProcess', ['name', 'required'])):
 
 
 CELERY_PROCESSES = [
-    CeleryProcess("async_restore_queue"),
+    CeleryProcess("async_restore_queue", required=False),
     CeleryProcess("background_queue"),
     CeleryProcess("case_rule_queue"),
     CeleryProcess("celery"),
@@ -87,7 +87,7 @@ CELERY_PROCESSES = [
     CeleryProcess("sms_queue"),
     CeleryProcess("submission_reprocessing_queue", required=False),
     CeleryProcess("ucr_indicator_queue", required=False),
-    CeleryProcess("ucr_queue"),
+    CeleryProcess("ucr_queue", required=False),
 ]
 
 


### PR DESCRIPTION
the swiss server always has high memory usage, so figured we should combine these queues so kafka stops dying during deploy