### PR TITLE
mounting encrypted tmp_storage on /tmp

### DIFF
--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -7,6 +7,7 @@ legacy_service_home: "{{ code_home }}/services"
 service_home: "{{ www_home }}/services"
 virtualenv_home: "{{ code_home }}/python_env"
 encrypted_root: "/opt/data"
+encrypted_tmp: "/opt/tmp"
 project: "commcare-hq"
 
 airflow_home: "{{ cchq_home }}/airflow"

--- a/src/commcare_cloud/ansible/roles/ecryptfs/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/ecryptfs/tasks/main.yml
@@ -147,5 +147,5 @@
     special_time: daily
     job: "/usr/sbin/tmpreaper {{ encrypted_tmp }} 2d"
     user: root
-    cron_file: purge_formplayer_files
+    cron_file: purge_tmp_files
   tags: cron

--- a/src/commcare_cloud/ansible/roles/ecryptfs/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/ecryptfs/tasks/main.yml
@@ -129,9 +129,13 @@
 - name: Drop unencrypted readme in directory
   become: yes
   lineinfile:
-    dest: '{{ encrypted_root }}/README'
+    dest: "{{ item }}"
     line: 'If you can read this file the directory is unencrypted'
     create: yes
     owner: root
     group: root
     mode: 0770
+  with_items:
+    - "'{{ encrypted_root }}/README"
+    - "'{{ encrypted_tmp }}/README"
+  tags: test45

--- a/src/commcare_cloud/ansible/roles/ecryptfs/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/ecryptfs/tasks/main.yml
@@ -139,3 +139,13 @@
     - "'{{ encrypted_root }}/README"
     - "'{{ encrypted_tmp }}/README"
   tags: test45
+
+- name: Create purging cron jobs
+  become: yes
+  cron:
+    name: "Purge files in {{ encrypted_tmp }}"
+    special_time: daily
+    job: "/usr/sbin/tmpreaper {{ encrypted_tmp }} 2d"
+    user: root
+    cron_file: purge_formplayer_files
+  tags: cron

--- a/src/commcare_cloud/ansible/roles/ecryptfs/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/ecryptfs/tasks/main.yml
@@ -68,7 +68,7 @@
   become: yes
   shell: 'printf "%s" "{{ ECRYPTFS_PASSWORD }}" | ecryptfs-add-passphrase | grep -o "\[.*\]" | sed "s/\[//g;s/\]//g"'
   register: password_hash
-  when: encrypted_root  not in mtab_contents.stdout
+  when: encrypted_root  not in mtab_contents.stdout or encrypted_tmp not in mtab_contents.stdout
   tags:
     - mount-ecryptfs
     - after-reboot
@@ -88,29 +88,24 @@
   tags:
     - ecryptfs-blobdb
 
-- name: Create {{ encrypted_root }}/tmp_storage to use for /tmp data.
+- name: Create {{encrypted_tmp}} to use for as tmp directory.
   become: yes
   file:
-    path: "{{ encrypted_root }}/tmp_storage"
-    mode: "u=rwx,g=rwx,o=rwx"
+    path: "{{ encrypted_tmp }}"
+    mode: "u=rwx,g=rwx,o=rx"
     state: directory
   tags:
     - mount-ecryptfs
     - after-reboot
     - tmp-encrypt
 
-- name: mount {{ encrypted_root }}/tmp_storage directory on /tmp
+- name: Mount tmp drive
   become: yes
-  mount:
-    path: /tmp/
-    src: "{{ encrypted_root }}/tmp_storage"
-    opts: bind
-    fstype: none
-    state: mounted
+  shell: "mount -t ecryptfs -o key=passphrase:passphrase_passwd={{ ECRYPTFS_PASSWORD }},user,noauto,ecryptfs_cipher=aes,ecryptfs_key_bytes=32,ecryptfs_unlink_sigs,ecryptfs_enable_filename_crypto=y,ecryptfs_fnek_sig={{ password_hash.stdout }},verbosity=0 {{ encrypted_tmp }}/ {{ encrypted_tmp }}/"
+  when: (password_hash.stdout is defined) and ( encrypted_tmp not in mtab_contents.stdout )
   tags:
     - mount-ecryptfs
     - after-reboot
-    - tmp-encrypt
 
 - name: Create shared data dir
   become: yes

--- a/src/commcare_cloud/ansible/roles/ecryptfs/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/ecryptfs/tasks/main.yml
@@ -138,7 +138,7 @@
   with_items:
     - "'{{ encrypted_root }}/README"
     - "'{{ encrypted_tmp }}/README"
-  tags: test45
+  tags: mount-ecryptfs
 
 - name: Create purging cron jobs
   become: yes

--- a/src/commcare_cloud/ansible/roles/ecryptfs/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/ecryptfs/tasks/main.yml
@@ -17,7 +17,7 @@
   # n - new partition
   # p - primary partition
   # 1 - partition number 1
-  #   - default - start at beginning of disk 
+  #   - default - start at beginning of disk
   #   - default - use entire disk
   # w - write the partition table
   when: datavol_device is defined and partition_check.rc == 0 and ansible_hostname not in groups['lvm']
@@ -87,6 +87,30 @@
   file: path="{{ encrypted_root }}/blobdb" owner=nobody group="{{ shared_dir_gid }}" mode=0775 state=directory
   tags:
     - ecryptfs-blobdb
+
+- name: Create {{ encrypted_root }}/tmp_storage to use for /tmp data.
+  become: yes
+  file:
+    path: "{{ encrypted_root }}/tmp_storage"
+    mode: "u=rwx,g=rwx,o=rwx"
+    state: directory
+  tags:
+    - mount-ecryptfs
+    - after-reboot
+    - tmp-encrypt
+
+- name: mount {{ encrypted_root }}/tmp_storage directory on /tmp
+  become: yes
+  mount:
+    path: /tmp/
+    src: "{{ encrypted_root }}/tmp_storage"
+    opts: bind
+    fstype: none
+    state: mounted
+  tags:
+    - mount-ecryptfs
+    - after-reboot
+    - tmp-encrypt
 
 - name: Create shared data dir
   become: yes

--- a/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
@@ -15,6 +15,7 @@
     cron_file: purge_formplayer_files
   with_items:
     - {name: 'Purge temp files', dir: '/tmp', time_spec: '2d'}
+    - {name: 'Purge encrypted tmp files', dir: '{{ encrypted_tmp }}', time_spec: '2d'}
     - {name: 'Purge sqlite db files', dir: '{{ formplayer_data_dir }}', time_spec: '{{ formplayer_purge_time_spec }}'}
   tags:
     - cron

--- a/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
@@ -15,7 +15,6 @@
     cron_file: purge_formplayer_files
   with_items:
     - {name: 'Purge temp files', dir: '/tmp', time_spec: '2d'}
-    - {name: 'Purge encrypted tmp files', dir: '{{ encrypted_tmp }}', time_spec: '2d'}
     - {name: 'Purge sqlite db files', dir: '{{ formplayer_data_dir }}', time_spec: '{{ formplayer_purge_time_spec }}'}
   tags:
     - cron


### PR DESCRIPTION
Rolling it will require to 

- stop services 
- deploy after-reboot (or just use it's tag)
- start services

results in 
`/$ mount`
`opt/data/tmp_storage on /tmp type none (rw,bind)`