### PR TITLE
Add seconds to the dateformat

### DIFF
--- a/src/commcare_cloud/fab/const.py
+++ b/src/commcare_cloud/fab/const.py
@@ -41,7 +41,7 @@ ROLES_AIRFLOW = ['airflow']
 
 RELEASE_RECORD = 'RELEASES.txt'
 KEEP_UNTIL_PREFIX = 'KEEP_UNTIL__'
-DATE_FMT = '%Y-%m-%d_%H.%M_%S'
+DATE_FMT = '%Y-%m-%d_%H.%M.%S'
 
 RSYNC_EXCLUDE = (
     '.DS_Store',

--- a/src/commcare_cloud/fab/const.py
+++ b/src/commcare_cloud/fab/const.py
@@ -41,7 +41,7 @@ ROLES_AIRFLOW = ['airflow']
 
 RELEASE_RECORD = 'RELEASES.txt'
 KEEP_UNTIL_PREFIX = 'KEEP_UNTIL__'
-DATE_FMT = '%Y-%m-%d_%H.%M'
+DATE_FMT = '%Y-%m-%d_%H.%M_%S'
 
 RSYNC_EXCLUDE = (
     '.DS_Store',


### PR DESCRIPTION
This means deploys can be attempted within the same minute, which will make testing faster. It didn't look like it would break anything because it's used everywhere deploys are referenced.