### PR TITLE
Revert "Pin idna to 2.6 temporarily"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,9 +36,6 @@ setup(
         'dimagi-memoized>=1.1.0',
         'dnspython',
         'Fabric==1.10.2',
-        # can remove once requests bumps its version requirement
-        # https://github.com/requests/requests/issues/4681
-        'idna==2.6',
         'jsonobject>=0.9.0',
         'netaddr',
         'passlib',


### PR DESCRIPTION
Reverts dimagi/commcare-cloud#1835 now that https://github.com/requests/requests/issues/4681#issuecomment-396619205 is resolved for `requests==2.19.0`