### PR TITLE
Don't call supervisor ansible playbook

### DIFF
--- a/src/commcare_cloud/commands/ansible/ansible_playbook.py
+++ b/src/commcare_cloud/commands/ansible/ansible_playbook.py
@@ -287,7 +287,7 @@ class UpdateSupervisorConfs(_AnsiblePlaybookAlias):
 
     def run(self, args, unknown_args):
         args.playbook = 'deploy_stack.yml'
-        unknown_args += ('--tags=supervisor,services',)
+        unknown_args += ('--tags=services',)
         rc = AnsiblePlaybook(self.parser).run(args, unknown_args)
         if ask("Some celery configs are still updated through fab. "
                "Do you want to run that as well (recommended)?"):


### PR DESCRIPTION
This playbook really likes killing supervisor which can result in lots of zombie processes especially on celery servers. I think it's best to remove this for now until it can be tracked down. It's a bit harder because `--check` doesn't catch those restarts