### PR TITLE
Add .bash_completion to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-include src/commcare_cloud/ansible *
 include src/commcare_cloud/help_cache/*
 include src/commcare_cloud/environmental-defaults/*
+include src/commcare_cloud/.bash_completion


### PR DESCRIPTION
I noticed that a wheel install wasn't giving us a .bash_completion