### PR TITLE
increasing redis memory

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -46,6 +46,8 @@ couch_dbs:
 
 TWO_FACTOR_GATEWAY_ENABLED: True
 
+redis_maxmemory: 6gb
+
 localsettings:
   ALLOWED_HOSTS:
     - www.commcarehq.org


### PR DESCRIPTION
@emord cc: @snopoke 
After some investigation I believe the constant logouts on prod are caused by redis running out of allowed memory and evicting old sessions. This PR increases allowed memory for redis from 4 to 6gb on prod, where it currently resides on its own 8gb machine. I set the memory to this using runtime config changes on friday, but it was reset over the weekend. It did appear to max out before that so it is not clear this is high enough (perhaps 7 is better to try since nothing else is on the machine). Based on this, at some point, we will also probably need a new bigger redis machine (note for @dannyroberts while planning aws migration), but hopefully this will delay that.