### PR TITLE
Update public.yml and inventory.ini.j2

### DIFF
--- a/commcare-cloud-bootstrap/environment/inventory.ini.j2
+++ b/commcare-cloud-bootstrap/environment/inventory.ini.j2
@@ -11,4 +11,10 @@
 {%- endfor %}
 {% endfor %}
 
+{% for _, group in inventory.all_groups.items()|sort %}
+[{{ group.name }}:vars]
+hostname='{{ group.name }}'
+{{ host_name }}
+{%- endfor %}
+
 [control]

--- a/commcare-cloud-bootstrap/environment/public.yml
+++ b/commcare-cloud-bootstrap/environment/public.yml
@@ -1,4 +1,4 @@
-internal_domain_name: null
+internal_domain_name: 'fullstack-deploy.commcarehq.org'
 
 riak_backend: "bitcask"
 riak_ring_size: 64


### PR DESCRIPTION
1. Add to the inventory.ini.2 template and entry that will add to inventory.ini:
```
[<host>:vars]
hostname='<host>'
```
for each host

2. Add an internal domain name so that this task does not get skipped here: https://github.com/dimagi/commcare-cloud/blob/master/src/commcare_cloud/ansible/roles/common/tasks/main.yml#L74


Reason: In order for kafka to start up, the hostname needs to be in `/etc/hosts`, and this was getting skipped because `internal_domain_name` was set to `null` here: https://github.com/dimagi/commcare-cloud/commit/d46527f156e4837c59ede9c7a47eba86b093c842