### PR TITLE
Add a django_manage group which contains the webworker

### DIFF
--- a/.travis/spec.yml
+++ b/.travis/spec.yml
@@ -12,6 +12,9 @@ settings:
 
 allocations:
   proxy: 1
+  couchdb2_proxy:
+    count: 1
+    from: proxy
   webworkers: 1
   postgresql: 1
   rabbitmq: 1
@@ -30,7 +33,4 @@ allocations:
     count: 1
     from: riakcs
   couchdb2: 1
-  couchdb2_proxy:
-    count: 1
-    from: proxy
   pg_standby: 0

--- a/.travis/spec.yml
+++ b/.travis/spec.yml
@@ -16,6 +16,9 @@ allocations:
     count: 1
     from: proxy
   webworkers: 1
+  django_manage:
+    count: 1
+    from: webworkers
   postgresql: 1
   rabbitmq: 1
   kafka: 1

--- a/.travis/spec.yml
+++ b/.travis/spec.yml
@@ -13,6 +13,9 @@ settings:
 allocations:
   proxy: 1
   webworkers: 1
+  django_manage:
+    count: 1
+    from: webworkers
   postgresql: 1
   rabbitmq: 1
   kafka: 1

--- a/.travis/spec.yml
+++ b/.travis/spec.yml
@@ -13,9 +13,6 @@ settings:
 allocations:
   proxy: 1
   webworkers: 1
-  django_manage:
-    count: 1
-    from: webworkers
   postgresql: 1
   rabbitmq: 1
   kafka: 1

--- a/.travis/spec.yml
+++ b/.travis/spec.yml
@@ -32,5 +32,5 @@ allocations:
   couchdb2: 1
   couchdb2_proxy:
     count: 1
-    from: couchdb2
+    from: proxy
   pg_standby: 0

--- a/commcare-cloud-bootstrap/commcare_cloud_bootstrap.py
+++ b/commcare-cloud-bootstrap/commcare_cloud_bootstrap.py
@@ -205,9 +205,20 @@ def bootstrap_inventory(spec, env_name):
 def ask_aws_for_instances(env_name, aws_config, count):
     cache_file = '{env}-aws-new-instances.json'.format(env=env_name)
     if os.path.exists(cache_file):
-        with open(cache_file, 'r') as f:
-            aws_response = f.read()
-    else:
+        cache_file_response = raw_input("\n{} already exists. Enter: "
+                                        "\n(d) to delete the file and terminate the existing aws instances or "
+                                        "\n(anything) to continue using this file and these instances."
+                                        "\n Enter selection: ".format(cache_file))
+        if cache_file_response == 'd':
+            # Remove old cache file and terminate existing instances for this env
+            print("Terminating existing instances for {}".format(env_name))
+            subprocess.call(['commcare-cloud-bootstrap', 'terminate',  env_name])
+            print("Deleting file: {}".format(cache_file))
+            os.remove(cache_file)
+
+    if not os.path.exists(cache_file):
+        # Provision new instances for this env
+        print("Provisioning new instances.")
         cmd_parts = [
             'aws', 'ec2', 'run-instances',
             '--image-id', aws_config.ami,
@@ -227,6 +238,10 @@ def ask_aws_for_instances(env_name, aws_config, count):
         aws_response = subprocess.check_output(cmd_parts)
         with open(cache_file, 'w') as f:
             f.write(aws_response)
+    else:
+        # Use the existing instances
+        with open(cache_file, 'r') as f:
+            aws_response = f.read()
     aws_response = json.loads(aws_response)
     return {instance['InstanceId'] for instance in aws_response["Instances"]}
 

--- a/commcare-cloud-bootstrap/specs/example_spec.yml
+++ b/commcare-cloud-bootstrap/specs/example_spec.yml
@@ -10,6 +10,9 @@ aws_config:
 allocations:
   proxy: 1
   webworkers: 1
+  django_manage:
+    count: 1
+    from: webworkers
   postgresql: 1
   rabbitmq: 1
   kafka: 1

--- a/commcare-cloud-bootstrap/specs/example_spec.yml
+++ b/commcare-cloud-bootstrap/specs/example_spec.yml
@@ -29,5 +29,5 @@ allocations:
   couchdb2: 1
   couchdb2_proxy:
     count: 1
-    from: couchdb2
+    from: proxy
   pg_standby: 0

--- a/commcare-cloud-bootstrap/specs/example_spec.yml
+++ b/commcare-cloud-bootstrap/specs/example_spec.yml
@@ -13,6 +13,9 @@ allocations:
     count: 1
     from: proxy
   webworkers: 1
+  django_manage:
+    count: 1
+    from: webworkers
   postgresql: 1
   rabbitmq: 1
   kafka: 1

--- a/commcare-cloud-bootstrap/specs/example_spec.yml
+++ b/commcare-cloud-bootstrap/specs/example_spec.yml
@@ -9,6 +9,9 @@ aws_config:
 
 allocations:
   proxy: 1
+  couchdb2_proxy:
+    count: 1
+    from: proxy
   webworkers: 1
   postgresql: 1
   rabbitmq: 1
@@ -27,7 +30,4 @@ allocations:
     count: 1
     from: riakcs
   couchdb2: 1
-  couchdb2_proxy:
-    count: 1
-    from: proxy
   pg_standby: 0

--- a/commcare-cloud-bootstrap/specs/example_spec.yml
+++ b/commcare-cloud-bootstrap/specs/example_spec.yml
@@ -10,9 +10,6 @@ aws_config:
 allocations:
   proxy: 1
   webworkers: 1
-  django_manage:
-    count: 1
-    from: webworkers
   postgresql: 1
   rabbitmq: 1
   kafka: 1


### PR DESCRIPTION
This will make the `django_manage` group show up in the inventory.ini file, with the webworkers0 machine in the group when it is autogenerated during the fullstack deploy.

I also changed the couchdb proxy group to use the proxy machine, which already needs to have nginx running (so no longer 2 different machines running nginx). This might have made it easier to fix a bug @dannyroberts and I looked at earlier today.

Without this, we get an error when this ansible task is run: https://github.com/dimagi/commcare-cloud/blob/master/src/commcare_cloud/ansible/roles/shared_dir/tasks/setup_host.yml#L72