### PR TITLE
Add a django_manage group which contains the webworker

### DIFF
--- a/.travis/spec.yml
+++ b/.travis/spec.yml
@@ -12,7 +12,13 @@ settings:
 
 allocations:
   proxy: 1
+  couchdb2_proxy:
+    count: 1
+    from: proxy
   webworkers: 1
+  django_manage:
+    count: 1
+    from: webworkers
   postgresql: 1
   rabbitmq: 1
   kafka: 1
@@ -30,7 +36,4 @@ allocations:
     count: 1
     from: riakcs
   couchdb2: 1
-  couchdb2_proxy:
-    count: 1
-    from: couchdb2
   pg_standby: 0

--- a/commcare-cloud-bootstrap/specs/example_spec.yml
+++ b/commcare-cloud-bootstrap/specs/example_spec.yml
@@ -9,7 +9,13 @@ aws_config:
 
 allocations:
   proxy: 1
+  couchdb2_proxy:
+    count: 1
+    from: proxy
   webworkers: 1
+  django_manage:
+    count: 1
+    from: webworkers
   postgresql: 1
   rabbitmq: 1
   kafka: 1
@@ -27,7 +33,4 @@ allocations:
     count: 1
     from: riakcs
   couchdb2: 1
-  couchdb2_proxy:
-    count: 1
-    from: couchdb2
   pg_standby: 0


### PR DESCRIPTION
This is the same as this pr: https://github.com/dimagi/commcare-cloud/pull/1872, but I noticed that it had some reverts in the commit history that I don't want. This contains only the changes I wanted to make in 1 commit.
=======Description copy pasted from other ticket=======
This will make the django_manage group show up in the inventory.ini file, with the webworkers0 machine in the group when it is autogenerated during the fullstack deploy.

I also changed the couchdb proxy group to use the proxy machine, which already needs to have nginx running (so no longer 2 different machines running nginx). This might have made it easier to fix a bug @dannyroberts and I looked at earlier today.

Without this, we get an error when this ansible task is run: https://github.com/dimagi/commcare-cloud/blob/master/src/commcare_cloud/ansible/roles/shared_dir/tasks/setup_host.yml#L72