### PR TITLE
on == True in yaml

### DIFF
--- a/src/commcare_cloud/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/cas_ssl.yml
@@ -69,7 +69,7 @@ nginx_sites:
        proxy_next_upstream_tries: 1
        proxy_read_timeout: 900s
        proxy_cache: app_cache
-       proxy_cache_lock: on
+       proxy_cache_lock: "on"
        proxy_cache_lock_timeout: 30s
        client_body_buffer_size: 5m
        proxy_ignore_headers: Set-Cookie


### PR DESCRIPTION
Some days I think about how YAML is way nicer than JSON to use, and then this kind of thing happens and I have no idea why anyone would want this.

Also @snopoke it looks like deploy_proxy wants to change the app cache's owner:

```
 {
-    "owner": 33,
+    "owner": 1022,
     "path": "/home/cchq/www/icds/app_downloads/cache"
 }

```

I know you just worked on that. any ideas?

I hotfixed this on ICDS