### PR TITLE
fixing ecrypt grep

### DIFF
--- a/src/commcare_cloud/ansible/roles/ecryptfs/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/ecryptfs/tasks/main.yml
@@ -40,7 +40,7 @@
   when: datavol_device is defined
 
 - name: Check for already mounted encrypted drive
-  shell: grep '{{ encrypted_root }} \| {{ encrypted_tmp }} ecryptfs' /etc/mtab
+  shell: grep '{{ encrypted_root }} ecryptfs \| {{ encrypted_tmp }} ecryptfs' /etc/mtab
   register: mtab_contents
   failed_when: false
   changed_when: false


### PR DESCRIPTION
@jmtroth0 @NitigyaS 
The old grep matched the mount of the block storage device to `/opt/data`. This way properly matches only if ecryptfs is mounted to `encrypted_root`