### PR TITLE
Make ENVIRONMENT_HOSTS ordering consistent

### DIFF
--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -626,7 +626,11 @@ SUPERVISOR_USERNAME = '{{ supervisor_http_username }}'
 SUPERVISOR_PASSWORD = '{{ supervisor_http_password }}'
 {% endif %}
 
-ENVIRONMENT_HOSTS = {{ groups | to_json }}
+ENVIRONMENT_HOSTS = {
+{% for group, hosts in groups.items() | sort %}
+    {{ group | to_json }}: {{ hosts | to_json }},
+{% endfor %}
+}
 
 {% if HQ_PRIVATE_KEY %}
 HQ_PRIVATE_KEY = \


### PR DESCRIPTION
to get rid of "fake" localsettings changes

This also makes the output prettier (one line per group, rather than all on one line) but that's just a nice side effect.