### PR TITLE
Sk/env vars

### DIFF
--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/webworkers.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/webworkers.yml
@@ -19,6 +19,7 @@
         no_proxy: "{% if http_proxy_address is defined %}{{ groups['all'] | join(',') }},{{ app_processes_config.additional_no_proxy_hosts }}{% endif %}"
         NEW_RELIC_CONFIG_FILE: '{% if app_processes_config.newrelic_djangoagent %}{{ www_home }}/newrelic.ini{% endif %}'
         NEW_RELIC_ENVIRONMENT: '{% if app_processes_config.newrelic_djangoagent %}{{ env_monitoring_id }}{% endif %}'
+        TMPDIR: '{{ encrypted_tmp }}'
       gunicorn_workers: "{{ app_processes_config.gunicorn_workers_static_factor + (ansible_processor_vcpus * app_processes_config.gunicorn_workers_factor)|int }}"
   tags:
     - services

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/common_supervisor_management.conf.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/common_supervisor_management.conf.j2
@@ -1,5 +1,6 @@
 [program:{{ project }}-{{ deploy_env }}-{{ item.process_name }}]
 directory={{ code_home }}
+environment=TMPDIR="{{ encrypted_tmp }}"
 command={{ virtualenv_home }}/bin/python manage.py {{ item.management_command }}
 user={{ cchq_user }}
 numprocs=1

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_pillowtop.conf.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_pillowtop.conf.j2
@@ -2,6 +2,7 @@
 {% for num_process in range(params.get('start_process', 0), params.get('start_process', 0) + params.get('num_processes', 1)) %}
 
 [program:commcare-hq-{{ deploy_env }}-pillowtop-{{ pillow_name }}-{{ num_process }}]
+environment=TMPDIR="{{ encrypted_tmp }}"
 command={{ virtualenv_home }}/bin/python {{ code_home }}/manage.py run_ptop --pillow-name {{ pillow_name }} --num-processes={{ params.get('total_processes', params.get('num_processes', 1)) }} --process-number={{ num_process }}
 directory={{ code_home }}
 user=cchq

--- a/src/commcare_cloud/fab/operations/supervisor.py
+++ b/src/commcare_cloud/fab/operations/supervisor.py
@@ -246,13 +246,6 @@ def _format_env(current_env, extra=None):
 
     ret['supervisor_env_vars'] = {}
 
-    if env.newrelic_djangoagent:
-        host = current_env.get('host_string')
-        webworkers = env.ccc_environment.groups['webworkers']
-        if host in webworkers:
-            ret['supervisor_env_vars']['NEW_RELIC_CONFIG_FILE'] = '%(root)s/newrelic.ini' % env
-            ret['supervisor_env_vars']['NEW_RELIC_ENVIRONMENT'] = current_env.get('deploy_env', '')
-
     if env.http_proxy:
         ret['supervisor_env_vars']['http_proxy'] = 'http://{}'.format(env.http_proxy)
         ret['supervisor_env_vars']['https_proxy'] = 'https://{}'.format(env.http_proxy)

--- a/src/commcare_cloud/fab/operations/supervisor.py
+++ b/src/commcare_cloud/fab/operations/supervisor.py
@@ -244,7 +244,9 @@ def _format_env(current_env, extra=None):
 
     all_hosts = env.ccc_environment.sshable_hostnames_by_group['all']
 
-    ret['supervisor_env_vars'] = {}
+    ret['supervisor_env_vars'] = {
+        "TMPDIR": "/opt/tmp"
+    }
 
     if env.http_proxy:
         ret['supervisor_env_vars']['http_proxy'] = 'http://{}'.format(env.http_proxy)

--- a/src/commcare_cloud/fab/operations/supervisor.py
+++ b/src/commcare_cloud/fab/operations/supervisor.py
@@ -245,13 +245,11 @@ def _format_env(current_env, extra=None):
     all_hosts = env.ccc_environment.sshable_hostnames_by_group['all']
 
     ret['supervisor_env_vars'] = {}
-    ret['command_prefix'] = ''
 
     if env.newrelic_djangoagent:
         host = current_env.get('host_string')
         webworkers = env.ccc_environment.groups['webworkers']
         if host in webworkers:
-            ret['command_prefix'] = '%(virtualenv_root)s/bin/newrelic-admin run-program ' % env
             ret['supervisor_env_vars']['NEW_RELIC_CONFIG_FILE'] = '%(root)s/newrelic.ini' % env
             ret['supervisor_env_vars']['NEW_RELIC_ENVIRONMENT'] = current_env.get('deploy_env', '')
 


### PR DESCRIPTION
https://trello.com/c/x6v1Vlfr/112-add-encrypted-drive-to-all-vms-running-hq-for-use-as-temporary-storage

Follow on from https://github.com/dimagi/commcare-cloud/pull/1837

Set `TMPDIR` for all HQ processes that might create temp files. 

See https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir