### PR TITLE
Stop running touchforms

### DIFF
--- a/src/commcare_cloud/fab/operations/supervisor.py
+++ b/src/commcare_cloud/fab/operations/supervisor.py
@@ -9,7 +9,6 @@ import uuid
 
 from commcare_cloud.commands.ansible.helpers import (
     get_django_webworker_name,
-    get_formplayer_instance_name,
     get_formplayer_spring_instance_name,
     get_celery_worker_name)
 from fabric.api import roles, parallel, env, sudo, serial, execute
@@ -38,7 +37,6 @@ from six.moves import range
 def set_supervisor_config():
     """Upload and link Supervisor configuration from the template."""
     set_celery_supervisorconf()
-    set_formsplayer_supervisorconf()
     set_formplayer_spring_supervisorconf()
 
 
@@ -139,15 +137,6 @@ def show_periodic_server_whitelist_message_and_abort(env):
                 host=env.host,
                 env_name=env.env_name)
     )
-
-
-def set_formsplayer_supervisorconf():
-    if _check_in_roles(ROLES_TOUCHFORMS):
-        _rebuild_supervisor_conf_file('make_supervisor_conf',
-                                      'supervisor_formsplayer.conf',
-                                      {'formplayer_instance_name':
-                                           get_formplayer_instance_name(env.ccc_environment)}
-                                      )
 
 
 def set_formplayer_spring_supervisorconf():

--- a/src/commcare_cloud/fab/services/templates/supervisor_formsplayer.conf
+++ b/src/commcare_cloud/fab/services/templates/supervisor_formsplayer.conf
@@ -1,8 +1,0 @@
-[program:{{ formplayer_instance_name }}]
-command=java -Xmx{{ jython_memory }} -Xss1024k -classpath {{ jython_home }}/jython.jar: -Dpython.home={{ jython_home }} -Dpython.executable={{ jython_home }}/bin/jython org.python.util.jython {{ code_current }}/submodules/touchforms-src/touchforms/backend/xformserver.py
-user={{ sudo_user }}
-autostart=true
-autorestart=true
-stdout_logfile={{ log_dir }}/formsplayer.log
-redirect_stderr=true
-stderr_logfile={{ log_dir }}/formsplayer.error.log


### PR DESCRIPTION
This should make it so that touchforms no longer runs anywhere.

All that's left is to remove all references to touchforms in the commcare cloud code and then remove the submodule from the hq code base. That's a bit more than I have capacity for right now but tracking that [here](https://trello.com/c/jGzPtKKR/120-remove-references-to-touchforms).

@wpride @snopoke 