### PR TITLE
Sk/encrypted temp

### DIFF
--- a/src/commcare_cloud/ansible/deploy_commcarehq.yml
+++ b/src/commcare_cloud/ansible/deploy_commcarehq.yml
@@ -12,6 +12,8 @@
   become: true
   roles:
     - {role: commcarehq, tags: commcarehq}
+  tasks:
+    - import_tasks: roles/ecryptfs/tmp.yml
 
 - name: Celery cron jobs for HQ
   hosts:

--- a/src/commcare_cloud/ansible/deploy_commcarehq.yml
+++ b/src/commcare_cloud/ansible/deploy_commcarehq.yml
@@ -13,7 +13,8 @@
   roles:
     - {role: commcarehq, tags: commcarehq}
   tasks:
-    - import_tasks: roles/ecryptfs/tmp.yml tags=ecryptfs
+    - import_tasks: roles/ecryptfs/tmp.yml
+      tags: ecryptfs
 
 - name: Celery cron jobs for HQ
   hosts:

--- a/src/commcare_cloud/ansible/deploy_commcarehq.yml
+++ b/src/commcare_cloud/ansible/deploy_commcarehq.yml
@@ -13,7 +13,7 @@
   roles:
     - {role: commcarehq, tags: commcarehq}
   tasks:
-    - import_tasks: roles/ecryptfs/tmp.yml
+    - import_tasks: roles/ecryptfs/tasks/tmp.yml
       tags: ecryptfs
 
 - name: Celery cron jobs for HQ

--- a/src/commcare_cloud/ansible/deploy_commcarehq.yml
+++ b/src/commcare_cloud/ansible/deploy_commcarehq.yml
@@ -13,7 +13,7 @@
   roles:
     - {role: commcarehq, tags: commcarehq}
   tasks:
-    - import_tasks: roles/ecryptfs/tmp.yml
+    - import_tasks: roles/ecryptfs/tmp.yml tags=ecryptfs
 
 - name: Celery cron jobs for HQ
   hosts:

--- a/src/commcare_cloud/ansible/deploy_db.yml
+++ b/src/commcare_cloud/ansible/deploy_db.yml
@@ -15,6 +15,9 @@
   roles:
     - {role: ecryptfs, tags: 'ecryptfs'}
     - {role: backups, tags: 'backups'}
+  tasks:
+    - import_tasks: roles/ecryptfs/tasks/remove-tmp.yml
+      tags: ecryptfs-cleanup
 
 - name: PostgreSQL
   hosts: postgresql:pg_standby

--- a/src/commcare_cloud/ansible/deploy_riakcs.yml
+++ b/src/commcare_cloud/ansible/deploy_riakcs.yml
@@ -24,6 +24,9 @@
   become: true
   roles:
     - {role: ecryptfs}
+  tasks:
+    - import_tasks: roles/ecryptfs/tasks/remove-tmp.yml
+      tags: ecryptfs-cleanup
 
 - name: First host in riakcs group -> riakcs_control_host
   # riakcs_control_host group must contain at most one host

--- a/src/commcare_cloud/ansible/deploy_riakcs_new.yml
+++ b/src/commcare_cloud/ansible/deploy_riakcs_new.yml
@@ -28,6 +28,9 @@
   become: true
   roles:
     - {role: ecryptfs}
+  tasks:
+    - import_tasks: roles/ecryptfs/tasks/remove-tmp.yml
+      tags: ecryptfs-cleanup
 
 - name: First host in riakcs_new group -> riakcs_new_control_host
   # riakcs_new_control_host group must contain at most one host

--- a/src/commcare_cloud/ansible/roles/ecryptfs/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/ecryptfs/tasks/main.yml
@@ -40,7 +40,7 @@
   when: datavol_device is defined
 
 - name: Check for already mounted encrypted drive
-  shell: grep '{{ encrypted_root }} ecryptfs \| {{ encrypted_tmp }} ecryptfs' /etc/mtab
+  shell: grep '{{ encrypted_root }} ecryptfs' /etc/mtab
   register: mtab_contents
   failed_when: false
   changed_when: false
@@ -68,7 +68,7 @@
   become: yes
   shell: 'printf "%s" "{{ ECRYPTFS_PASSWORD }}" | ecryptfs-add-passphrase | grep -o "\[.*\]" | sed "s/\[//g;s/\]//g"'
   register: password_hash
-  when: encrypted_root  not in mtab_contents.stdout or encrypted_tmp not in mtab_contents.stdout
+  when: encrypted_root  not in mtab_contents.stdout
   tags:
     - mount-ecryptfs
     - after-reboot
@@ -87,25 +87,6 @@
   file: path="{{ encrypted_root }}/blobdb" owner=nobody group="{{ shared_dir_gid }}" mode=0775 state=directory
   tags:
     - ecryptfs-blobdb
-
-- name: Create {{encrypted_tmp}} to use for as tmp directory.
-  become: yes
-  file:
-    path: "{{ encrypted_tmp }}"
-    mode: "u=rwx,g=rwx,o=rx"
-    state: directory
-  tags:
-    - mount-ecryptfs
-    - after-reboot
-    - tmp-encrypt
-
-- name: Mount tmp drive
-  become: yes
-  shell: "mount -t ecryptfs -o key=passphrase:passphrase_passwd={{ ECRYPTFS_PASSWORD }},user,noauto,ecryptfs_cipher=aes,ecryptfs_key_bytes=32,ecryptfs_unlink_sigs,ecryptfs_enable_filename_crypto=y,ecryptfs_fnek_sig={{ password_hash.stdout }},verbosity=0 {{ encrypted_tmp }}/ {{ encrypted_tmp }}/"
-  when: (password_hash.stdout is defined) and ( encrypted_tmp not in mtab_contents.stdout )
-  tags:
-    - mount-ecryptfs
-    - after-reboot
 
 - name: Create shared data dir
   become: yes
@@ -129,23 +110,10 @@
 - name: Drop unencrypted readme in directory
   become: yes
   lineinfile:
-    dest: "{{ item }}"
+    dest: "{{ encrypted_root }}/README"
     line: 'If you can read this file the directory is unencrypted'
     create: yes
     owner: root
     group: root
     mode: 0770
-  with_items:
-    - "'{{ encrypted_root }}/README"
-    - "'{{ encrypted_tmp }}/README"
   tags: mount-ecryptfs
-
-- name: Create purging cron jobs
-  become: yes
-  cron:
-    name: "Purge files in {{ encrypted_tmp }}"
-    special_time: daily
-    job: "/usr/sbin/tmpreaper {{ encrypted_tmp }} 2d"
-    user: root
-    cron_file: purge_tmp_files
-  tags: cron

--- a/src/commcare_cloud/ansible/roles/ecryptfs/tasks/remove-tmp.yml
+++ b/src/commcare_cloud/ansible/roles/ecryptfs/tasks/remove-tmp.yml
@@ -1,0 +1,13 @@
+---
+- name: Unmount Mount tmp drive
+  become: yes
+  mount:
+    path: "{{ encrypted_tmp }}"
+    state: absent
+
+- name: Remove cron job
+  become: yes
+  cron:
+    name: "Purge files in {{ encrypted_tmp }}"
+    cron_file: purge_tmp_files
+    state: absent

--- a/src/commcare_cloud/ansible/roles/ecryptfs/tasks/remove-tmp.yml
+++ b/src/commcare_cloud/ansible/roles/ecryptfs/tasks/remove-tmp.yml
@@ -1,9 +1,15 @@
 ---
-- name: Unmount Mount tmp drive
+- name: Check for already mounted encrypted tmp drive
+  shell: grep '{{ encrypted_tmp }} ecryptfs' /etc/mtab
+  register: mtab_contents
+  failed_when: false
+  changed_when: false
+  check_mode: no
+
+- name: Unmount tmp drive
   become: yes
-  mount:
-    path: "{{ encrypted_tmp }}"
-    state: absent
+  shell: "umount {{ encrypted_tmp }}"
+  when: encrypted_tmp in mtab_contents.stdout
 
 - name: Remove cron job
   become: yes

--- a/src/commcare_cloud/ansible/roles/ecryptfs/tasks/tmp.yml
+++ b/src/commcare_cloud/ansible/roles/ecryptfs/tasks/tmp.yml
@@ -1,0 +1,67 @@
+---
+- name: Check for already mounted encrypted tmp drive
+  shell: grep '{{ encrypted_tmp }} ecryptfs' /etc/mtab
+  register: mtab_contents
+  failed_when: false
+  changed_when: false
+  check_mode: no
+  tags:
+    - mount-ecryptfs
+    - after-reboot
+
+- name: Install ecryptfs-utils
+  become: yes
+  apt: name=ecryptfs-utils state=present
+  # Do not install ecryptfs utils if already mounted. This should trigger alarm
+  # bells if something causes a false positive result on checking for encrypted
+  # volume is already mounted.
+  when: encrypted_root not in mtab_contents.stdout
+
+- name: Add encryption password to keyring
+  become: yes
+  shell: 'printf "%s" "{{ ECRYPTFS_PASSWORD }}" | ecryptfs-add-passphrase | grep -o "\[.*\]" | sed "s/\[//g;s/\]//g"'
+  register: password_hash
+  when: encrypted_tmp not in mtab_contents.stdout
+  tags:
+    - mount-ecryptfs
+    - after-reboot
+
+- name: Create {{encrypted_tmp}} to use for as tmp directory.
+  become: yes
+  file:
+    path: "{{ encrypted_tmp }}"
+    mode: "u=rwx,g=rwx,o=rx"
+    state: directory
+  tags:
+    - mount-ecryptfs
+    - after-reboot
+    - tmp-encrypt
+
+- name: Mount tmp drive
+  become: yes
+  shell: "mount -t ecryptfs -o key=passphrase:passphrase_passwd={{ ECRYPTFS_PASSWORD }},user,noauto,ecryptfs_cipher=aes,ecryptfs_key_bytes=32,ecryptfs_unlink_sigs,ecryptfs_enable_filename_crypto=y,ecryptfs_fnek_sig={{ password_hash.stdout }},verbosity=0 {{ encrypted_tmp }}/ {{ encrypted_tmp }}/"
+  when: (password_hash.stdout is defined) and ( encrypted_tmp not in mtab_contents.stdout )
+  tags:
+    - mount-ecryptfs
+    - after-reboot
+
+- name: Drop unencrypted readme in directory
+  become: yes
+  lineinfile:
+    dest: "{{ encrypted_tmp }}/README"
+    line: 'If you can read this file the directory is unencrypted'
+    create: yes
+    owner: root
+    group: root
+    mode: 0770
+  tags: mount-ecryptfs
+
+- name: Create purging cron jobs
+  become: yes
+  cron:
+    name: "Purge files in {{ encrypted_tmp }}"
+    special_time: daily
+    job: "/usr/sbin/tmpreaper {{ encrypted_tmp }} 2d"
+    user: root
+    cron_file: purge_tmp_files
+  tags: cron


### PR DESCRIPTION
@NitigyaS in the process of rolling out https://github.com/dimagi/commcare-cloud/pull/1906 I realized that we'd created the encrypted tmp folders only on 'DB' machines instead of on the machines running HQ processes.

This PR addresses that and also cleans up the tmp folders on the DB machines. Rollout process:
```
cchq <env> aps --tags=ecryptfs-cleanup
cchq <env> ap deploy_commcarehq.yml --tags=ecryptfs
```

I've already rolled this out to staging and prod.

buddy @jmtroth0 