### PR TITLE
Remove duplicate repeat_record_queue from swiss

### DIFF
--- a/environments/swiss/app-processes.yml
+++ b/environments/swiss/app-processes.yml
@@ -15,9 +15,6 @@ celery_processes:
     celery_periodic,email_queue:
       concurrency: 1
       server_whitelist: swiss.commcarehq.org
-    repeat_record_queue:
-      pooling: gevent
-      concurrency: 1
     email_queue,sms_queue:
       concurrency: 1
     saved_exports_queue:


### PR DESCRIPTION
Looks like we've been running an extra queue since february https://github.com/dimagi/commcare-cloud/commit/ef6c0eaa4bcbc9926013120e3d30c656dfb47614#diff-02338665690f88220a8d96f9c210ea2d

@dannyroberts fyi, not sure if we want to add something that checks running the same queue twice on one server