### PR TITLE
Comment out aws staging hosts

### DIFF
--- a/environments/staging/inventory.ini
+++ b/environments/staging/inventory.ini
@@ -2,7 +2,7 @@
 proxy0-staging.internal-va.commcarehq.org swap_size=1G
 
 [proxy1]
-10.200.10.85 hostname=proxy1-staging
+# 10.200.10.85 hostname=proxy1-staging
 
 [proxy:children]
 proxy0
@@ -16,10 +16,10 @@ hqdjango0-staging.internal-va.commcarehq.org swap_size=1G
 hqdjango1-staging.internal-va.commcarehq.org swap_size=1G
 
 [web0]
-10.200.10.178 swap_size=1G hostname=web0-staging
+# 10.200.10.178 swap_size=1G hostname=web0-staging
 
 [web1]
-10.200.11.219 swap_size=1G hostname=web1-staging
+# 10.200.11.219 swap_size=1G hostname=web1-staging
 
 [webworkers:children]
 hqdjango0
@@ -37,7 +37,7 @@ hqdb1
 # staging.cibdtdv2q1vz.us-east-1.rds.amazonaws.com
 
 [rabbit0]
-10.200.10.107 hostname=rabbit0-staging
+# 10.200.10.107 hostname=rabbit0-staging
 
 
 [rabbitmq:children]
@@ -53,7 +53,7 @@ swap_size=1G
 kafka_broker_id=0
 
 [kafka0]
-10.200.10.199 kafka_broker_id=0 hostname=kafka0-staging
+# 10.200.10.199 kafka_broker_id=0 hostname=kafka0-staging
 
 [zookeeper:children]
 hqkafka0
@@ -66,7 +66,7 @@ hqkafka0
 # kafka0
 
 [celery0]
-10.200.11.168 hostname=celery0-staging
+# 10.200.11.168 hostname=celery0-staging
 
 [celery:children]
 hqdb1
@@ -77,7 +77,7 @@ hqdb1
 hqpillow0-staging.internal-va.commcarehq.org
 
 [pillow0]
-10.200.12.203 hostname=pillow0-staging
+# 10.200.12.203 hostname=pillow0-staging
 
 [pillowtop:children]
 hqpillow0
@@ -88,7 +88,7 @@ hqpillow0
 hqtouch0-staging.internal-va.commcarehq.org swap_size=1G
 
 [formplayer0]
-10.200.10.63 hostname=formplayer0-staging
+# 10.200.10.63 hostname=formplayer0-staging
 
 [touchforms:children]
 hqtouch0
@@ -109,7 +109,7 @@ hqdb1
 hqes0-staging.internal-va.commcarehq.org elasticsearch_node_name=hqes0-staging
 
 [es0]
-10.200.10.223 elasticsearch_node_name=hqes0-staging hostname=es0-staging
+# 10.200.10.223 elasticsearch_node_name=hqes0-staging hostname=es0-staging
 
 [elasticsearch:children]
 hqes0
@@ -138,7 +138,7 @@ hqriak01
 hqairflow0-staging.internal-va.commcarehq.org
 
 [airflow0]
-10.200.10.110 hostname=airflow0-staging
+# 10.200.10.110 hostname=airflow0-staging
 
 [airflow:children]
 hqairflow0


### PR DESCRIPTION
Their presence as actual host meant they matched `all`
so e.g. updating users applied to them. Will uncomment
once VPN is more accessible and there is a better defined process
for deploying to old and new machines at once.