### PR TITLE
Use supervisor 3.3.4 instead of 3.0b

### DIFF
--- a/src/commcare_cloud/ansible/roles/supervisor/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/supervisor/tasks/main.yml
@@ -1,5 +1,9 @@
 ---
 
+- name: remove supervisor 3.0b
+  apt: name=supervisor state=absent
+  become: yes
+
 - name: find supervisord path
   shell: 'which supervisord'
   register: which_supervisord
@@ -7,10 +11,19 @@
   failed_when: which_supervisord.rc != 0 and which_supervisord.rc != 1
   check_mode: no
 
-- name: install supervisor
-  apt: name=supervisor state=present
+- name: install supervisor 3.3.4
+  pip: name=supervisor state=present version=3.3.4
   become: yes
   when: not which_supervisord.stdout
+
+- name: link supervisor
+  file:
+    path: /usr/bin/{{ item }}
+    state: link
+    src: /usr/local/bin/{{ item }}
+  with_items:
+    - supervisord
+    - supervisorctl
 
 - name: retry finding supervisord path
   shell: 'which supervisord'


### PR DESCRIPTION
which on ubuntu 14.04 requires installing from pip

Curious what you all think about this. We've been on 3.0b forever, but it seems like with the occasional issues we have with supervisor not properly killing this, it'd be nice to rule out just being on an old version [May 2013](https://pypi.org/project/supervisor/3.0b2/).

The immediate ticket that prompted this was https://manage.dimagi.com/default.asp?276826. Not sure if we've seen that before (celerybeat process not getting killed on restart, resulting two celerybeat processes, resulting in duplicate period tasks), but it seems to be happening regularly now.