### PR TITLE
Add list-dbs command

### DIFF
--- a/docs/commcare-cloud/commands/index.md
+++ b/docs/commcare-cloud/commands/index.md
@@ -10,7 +10,7 @@ All `commcare-cloud` commands take the following form:
 ```
 commcare-cloud [--control]
                <env>
-               {bootstrap-users,ansible-playbook,django-manage,aps,tmux,ap,validate-environment-settings,restart-elasticsearch,deploy-stack,service,update-supervisor-confs,update-users,ping,migrate_couchdb,lookup,run-module,update-config,copy-files,mosh,after-reboot,ssh,downtime,fab,update-local-known-hosts,migrate-couchdb,run-shell-command}
+               {bootstrap-users,ansible-playbook,django-manage,aps,tmux,ap,validate-environment-settings,restart-elasticsearch,deploy-stack,service,update-supervisor-confs,update-users,ping,migrate_couchdb,lookup,run-module,update-config,copy-files,mosh,after-reboot,ssh,downtime,fab,update-local-known-hosts,list-dbs,migrate-couchdb,run-shell-command}
                ...
 ```
 
@@ -1004,3 +1004,12 @@ Action to perform
 
 - prepare: generate the scripts and push them to the target servers
 - migrate: execute the scripts
+
+
+#### `list-dbs`
+
+List out databases by host
+
+```
+commcare-cloud <env> list-dbs
+```

--- a/src/commcare_cloud/commands/dbs.py
+++ b/src/commcare_cloud/commands/dbs.py
@@ -1,0 +1,36 @@
+from __future__ import print_function
+
+import collections
+
+from commcare_cloud.commands.command_base import CommandBase
+from commcare_cloud.environment.main import get_environment
+
+
+class ListDbs(CommandBase):
+    command = 'list-dbs'
+    help = """
+        List out databases by host
+    """
+
+    def run(self, args, unknown_args):
+        environment = get_environment(args.env_name)
+        dbs = environment.postgresql_config.to_generated_variables()['postgresql_dbs']['all']
+        dbs_by_host = collections.defaultdict(list)
+        for db in dbs:
+            dbs_by_host[db['host']].append(db['name'])
+
+        db_standby_by_host = collections.defaultdict(list)
+        for standby in environment.groups['pg_standby']:
+            if 'hot_standby_master' in environment.get_host_vars(standby):
+                db_standby_by_host[environment.get_host_vars(standby)['hot_standby_master']].append(standby)
+
+        for host, db_names in sorted(dbs_by_host.items()):
+            standby_hostnames = sorted(environment.get_hostname(standby).split('.')[0]
+                                 for standby in db_standby_by_host[host])
+            hostname = environment.get_hostname(host).split('.')[0]
+            if not standby_hostnames:
+                print(hostname)
+            else:
+                print('{} ({})'.format(hostname, ', '.join(standby_hostnames)))
+            for db_name in sorted(db_names):
+                print(' ', db_name)

--- a/src/commcare_cloud/commcare_cloud.py
+++ b/src/commcare_cloud/commcare_cloud.py
@@ -15,6 +15,7 @@ from commcare_cloud.commands.ansible.downtime import Downtime
 from commcare_cloud.commands.migrations.couchdb import MigrateCouchdb
 from commcare_cloud.commands.migrations.copy_files import CopyFiles
 from commcare_cloud.commands.validate_environment_settings import ValidateEnvironmentSettings
+from commcare_cloud.commands.dbs import ListDbs
 from .argparse14 import ArgumentParser, RawTextHelpFormatter
 
 from .commands.ansible.ansible_playbook import (
@@ -62,6 +63,7 @@ COMMAND_GROUPS = OrderedDict([
         MigrateCouchdb,
         Downtime,
         CopyFiles,
+        ListDbs,
     ])
 ])
 

--- a/src/commcare_cloud/environment/main.py
+++ b/src/commcare_cloud/environment/main.py
@@ -178,6 +178,10 @@ class Environment(object):
     def _ansible_inventory_variable_manager(self):
         return get_variable_manager(self._ansible_inventory_data_loader, self.inventory_manager)
 
+    def get_host_vars(self, host):
+        host_object, = [h for h in self.inventory_manager.get_hosts() if h.name == host]
+        return self._ansible_inventory_variable_manager.get_vars(host=host_object)
+
     @memoized_property
     def groups(self):
         """


### PR DESCRIPTION
G2 kept asking to verify which dbs on which machines should be copied, and I noticed we didn't really have a source of truth that showed the information in a decisive format. (`postgresql.yml` for instance doesn't show the actual names of the dbs, which are inferred; `.generated.yml` is an embarrassing place to ask someone to look, and kind of a mess to pull this out from.)
