### PR TITLE
Reduce workers and concurrency for softlayer celery

### DIFF
--- a/environments/softlayer/app-processes.yml
+++ b/environments/softlayer/app-processes.yml
@@ -26,10 +26,10 @@ celery_processes:
       optimize: True
     reminder_case_update_queue:
       pooling: gevent
-      concurrency: 1
+      concurrency: 5
     reminder_queue:
       pooling: gevent
-      concurrency: 2
+      concurrency: 5
     reminder_rule_queue:
       concurrency: 1
       max_tasks_per_child: 1

--- a/environments/softlayer/app-processes.yml
+++ b/environments/softlayer/app-processes.yml
@@ -18,7 +18,7 @@ celery_processes:
     ucr_indicator_queue:
       concurrency: 1
     celery,export_download_queue:
-      concurrency: 4
+      concurrency: 2
       max_tasks_per_child: 5
     saved_exports_queue:
       concurrency: 2
@@ -26,12 +26,10 @@ celery_processes:
       optimize: True
     reminder_case_update_queue:
       pooling: gevent
-      concurrency: 5
-      num_workers: 2
+      concurrency: 1
     reminder_queue:
       pooling: gevent
-      concurrency: 5
-      num_workers: 2
+      concurrency: 2
     reminder_rule_queue:
       concurrency: 1
       max_tasks_per_child: 1
@@ -39,7 +37,7 @@ celery_processes:
       pooling: gevent
       concurrency: 10
     async_restore_queue:
-      concurrency: 8
+      concurrency: 4
     background_queue,case_rule_queue,icds_dashboard_reports_queue,icds_aggregation_queue:
       concurrency: 2
       max_tasks_per_child: 1

--- a/environments/softlayer/app-processes.yml
+++ b/environments/softlayer/app-processes.yml
@@ -37,7 +37,7 @@ celery_processes:
       pooling: gevent
       concurrency: 10
     async_restore_queue:
-      concurrency: 4
+      concurrency: 1
     background_queue,case_rule_queue,icds_dashboard_reports_queue,icds_aggregation_queue:
       concurrency: 2
       max_tasks_per_child: 1


### PR DESCRIPTION
Celery machine of softlayer is running full on memory.
Since there is not much activity on softlayer it should be fine to have less processes running since we wont need high number of tasks to be run in parallel.
i think its mainly the "number of workers" which is going to reduce the load by reducing the number of processes running.
Reduced concurrency at places to avoid memory spikes, just in case they are multiple tasks required of a worker.