### PR TITLE
Standardize help cache generation across environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,18 @@
 all : src/commcare_cloud/help_cache/ansible.txt src/commcare_cloud/help_cache/ansible-playbook.txt docs/commcare-cloud/commands/index.md
 
+
+# The length of the home directory affects
+# how help text gets wrapped in ansible/ansible-playbook -h output.
+# Pick a standard (but arbitrary) value for $HOME to be used across all environments.
+# Make it short but unlikely to occur otherwise, so that we can safely find/replace it with ~.
+# (Directly using escaped '~' does not work.)
+STANDARD_HOME=/!
+
 src/commcare_cloud/help_cache/ansible.txt:
-	ansible -h | sed "s|${HOME}|~|g" > src/commcare_cloud/help_cache/ansible.txt
+	COLUMNS=80 HOME="${STANDARD_HOME}" ansible -h | sed "s|${STANDARD_HOME}|~|g" > src/commcare_cloud/help_cache/ansible.txt
 
 src/commcare_cloud/help_cache/ansible-playbook.txt:
-	ansible-playbook -h | sed "s|${HOME}|~|g" > src/commcare_cloud/help_cache/ansible-playbook.txt
+	COLUMNS=80 HOME="${STANDARD_HOME}" ansible-playbook -h | sed "s|${STANDARD_HOME}|~|g" > src/commcare_cloud/help_cache/ansible-playbook.txt
 
 docs/commcare-cloud/commands/index.md : src/commcare_cloud/* src/commcare_cloud/*/* src/commcare_cloud/*/*/*
 	manage-commcare-cloud make-docs > docs/commcare-cloud/commands/index.md


### PR DESCRIPTION
long home directory paths (i.e. long usernames) otherwise cause
different text wrap behavior

Thanks @pr33thi for your long name!