### PR TITLE
Fix disconnects in fullstack deploy

### DIFF
--- a/commcare-cloud-bootstrap/bootstrap.sh
+++ b/commcare-cloud-bootstrap/bootstrap.sh
@@ -14,4 +14,4 @@ done
 commcare-cloud $ENV bootstrap-users --quiet --branch=$BRANCH
 commcare-cloud $ENV deploy-stack --skip-check --quiet -e 'CCHQ_IS_FRESH_INSTALL=1' --branch=$BRANCH
 
-commcare-cloud $ENV fab deploy:confirm=no --show=debug --set ignore_kafka_checkpoint_warning=true
+commcare-cloud $ENV fab deploy:confirm=no,skip_record=yes --show=debug --set ignore_kafka_checkpoint_warning=true

--- a/commcare-cloud-bootstrap/environment/app-processes.yml.j2
+++ b/commcare-cloud-bootstrap/environment/app-processes.yml.j2
@@ -9,7 +9,7 @@ celery_processes:
       concurrency: 1
     sms_queue, export_download_queue:
       concurrency: 1
-#    reminder_queue,submission_reprocessing_queue,ucr_indicator_queue,ucr_queue:
+#    reminder_queue,submission_reprocessing_queue,ucr_indicator_queue,ucr_queue, celery_periodic:
 #      concurrency: 1
     flower: {}
 pillows:

--- a/commcare-cloud-bootstrap/environment/app-processes.yml.j2
+++ b/commcare-cloud-bootstrap/environment/app-processes.yml.j2
@@ -1,16 +1,14 @@
 celery_processes:
   {{ celery_host.name }}:
     beat: {}
-    celery_periodic:
-      concurrency: 4
-#    async_restore_queue,background_queue,case_rule_queue,celery,export_download_queue:
-#      concurrency: 1
-#    email_queue,reminder_case_update_queue:
-#      concurrency: 1
-#    reminder_rule_queue,reminder_queue,repeat_record_queue,saved_exports_queue:
-#      concurrency: 1
-#    sms_queue,submission_reprocessing_queue,ucr_indicator_queue,ucr_queue:
-#      concurrency: 1
+    background_queue,case_rule_queue,celery,export_download_queue:
+      concurrency: 1
+    email_queue,reminder_case_update_queue:
+      concurrency: 1
+    reminder_rule_queue,repeat_record_queue,saved_exports_queue:
+      concurrency: 1
+    sms_queue:
+      concurrency: 1
     flower: {}
 pillows:
   {{ pillowtop_host.name }}:

--- a/commcare-cloud-bootstrap/environment/app-processes.yml.j2
+++ b/commcare-cloud-bootstrap/environment/app-processes.yml.j2
@@ -3,14 +3,14 @@ celery_processes:
     beat: {}
     celery_periodic:
       concurrency: 4
-    async_restore_queue,background_queue,case_rule_queue,celery,export_download_queue:
-      concurrency: 1
-    email_queue,reminder_case_update_queue:
-      concurrency: 1
-    reminder_rule_queue,reminder_queue,repeat_record_queue,saved_exports_queue:
-      concurrency: 1
-    sms_queue,submission_reprocessing_queue,ucr_indicator_queue,ucr_queue:
-      concurrency: 1
+#    async_restore_queue,background_queue,case_rule_queue,celery,export_download_queue:
+#      concurrency: 1
+#    email_queue,reminder_case_update_queue:
+#      concurrency: 1
+#    reminder_rule_queue,reminder_queue,repeat_record_queue,saved_exports_queue:
+#      concurrency: 1
+#    sms_queue,submission_reprocessing_queue,ucr_indicator_queue,ucr_queue:
+#      concurrency: 1
     flower: {}
 pillows:
   {{ pillowtop_host.name }}:

--- a/commcare-cloud-bootstrap/environment/app-processes.yml.j2
+++ b/commcare-cloud-bootstrap/environment/app-processes.yml.j2
@@ -1,14 +1,16 @@
 celery_processes:
   {{ celery_host.name }}:
     beat: {}
-    background_queue,case_rule_queue,celery,export_download_queue:
+    background_queue,case_rule_queue,celery:
       concurrency: 1
     email_queue,reminder_case_update_queue:
       concurrency: 1
     reminder_rule_queue,repeat_record_queue,saved_exports_queue:
       concurrency: 1
-    sms_queue:
+    sms_queue, export_download_queue:
       concurrency: 1
+#    reminder_queue,submission_reprocessing_queue,ucr_indicator_queue,ucr_queue:
+#      concurrency: 1
     flower: {}
 pillows:
   {{ pillowtop_host.name }}:

--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -549,7 +549,7 @@ def announce_formplayer_deploy_start():
     )
 
 
-def _deploy_without_asking():
+def _deploy_without_asking(skip_record):
     if env.offline:
         commands = OFFLINE_DEPLOY_COMMANDS
     else:
@@ -579,8 +579,9 @@ def _deploy_without_asking():
         execute(check_servers.perform_system_checks)
         execute_with_timing(release.update_current)
         silent_services_restart()
-        execute_with_timing(release.record_successful_release)
-        execute_with_timing(release.record_successful_deploy)
+        if skip_record == 'no':
+            execute_with_timing(release.record_successful_release)
+            execute_with_timing(release.record_successful_deploy)
         clear_cached_deploy()
 
 
@@ -699,11 +700,12 @@ def manage(cmd):
 
 
 @task(alias='deploy')
-def awesome_deploy(confirm="yes", resume='no', offline='no'):
+def awesome_deploy(confirm="yes", resume='no', offline='no', skip_record='no'):
     """Preindex and deploy if it completes quickly enough, otherwise abort
     fab <env> deploy:confirm=no  # do not confirm
     fab <env> deploy:resume=yes  # resume from previous deploy
     fab <env> deploy:offline=yes  # offline deploy
+    fab <env> deploy:skip_record=yes  # skip record_successful_release
     """
     _require_target()
     if strtobool(confirm) and (
@@ -760,7 +762,7 @@ def awesome_deploy(confirm="yes", resume='no', offline='no'):
         print('┃┃┃┃┃┃')
         print('┻┻┻┻┻┻')
 
-    _deploy_without_asking()
+    _deploy_without_asking(skip_record)
 
 
 @task


### PR DESCRIPTION
1. Make an option to not run the `record_successful_release` task (which often errors during fullstack deploy and isn't actually necessary)
2. Remove non-required celery processes which seemed to be taking up too much memory.