### PR TITLE
Username in settings should be a list

### DIFF
--- a/commcare-cloud-bootstrap/commcare_cloud_bootstrap.py
+++ b/commcare-cloud-bootstrap/commcare_cloud_bootstrap.py
@@ -67,7 +67,7 @@ class AwsConfig(StrictJsonObject):
 
 
 class Settings(StrictJsonObject):
-    users = jsonobject.ListProperty(unicode, default='dimagi', required=True)
+    users = jsonobject.ListProperty(unicode, required=True)
 
 
 class Allocation(StrictJsonObject):

--- a/commcare-cloud-bootstrap/commcare_cloud_bootstrap.py
+++ b/commcare-cloud-bootstrap/commcare_cloud_bootstrap.py
@@ -67,7 +67,7 @@ class AwsConfig(StrictJsonObject):
 
 
 class Settings(StrictJsonObject):
-    users = jsonobject.StringProperty(default='dimagi')
+    users = jsonobject.ListProperty(unicode, default='dimagi', required=True)
 
 
 class Allocation(StrictJsonObject):


### PR DESCRIPTION
Must have missed this one for this pr: 
https://github.com/dimagi/commcare-cloud/pull/1815

Noticed it because it gets hit when running fullstack deploy from travis.