### PR TITLE
Add allow_dump_from_pgstandby to switch on ability to pg_dump from standby

### DIFF
--- a/environments/production/postgresql.yml
+++ b/environments/production/postgresql.yml
@@ -1,6 +1,7 @@
 DEFAULT_POSTGRESQL_HOST: hqdb0
 
 override:
+  allow_dump_from_pgstandby: yes
   pgbouncer_default_pool: 290
   pgbouncer_max_connections: 800
   pgbouncer_pool_mode: transaction

--- a/src/commcare_cloud/ansible/roles/postgresql/defaults/main.yml
+++ b/src/commcare_cloud/ansible/roles/postgresql/defaults/main.yml
@@ -15,6 +15,7 @@ postgresql_num_logs_to_keep: 20
 pgstandby_wal_keep_segments: 8
 postgresql_wal_keep_segments: 8
 
+allow_dump_from_pgstandby: "{{ postgres_users.get('netvault') != None }}"
 
 pgbouncer_port: 6432
 pgbouncer_pid_file: "/var/run/postgresql/pgbouncer.pid"

--- a/src/commcare_cloud/ansible/roles/postgresql/templates/postgresql.conf.j2
+++ b/src/commcare_cloud/ansible/roles/postgresql/templates/postgresql.conf.j2
@@ -64,7 +64,7 @@ wal_keep_segments = {{ postgresql_wal_keep_segments }}
 # REPLICATION
 
 hot_standby = on    # ignored on masters
-{% if postgres_users.get('netvault') %}
+{% if allow_dump_from_pgstandby %}
 hot_standby_feedback = on
 {% endif %}
 max_replication_slots = 8

--- a/src/commcare_cloud/environment/schemas/postgresql.py
+++ b/src/commcare_cloud/environment/schemas/postgresql.py
@@ -6,7 +6,10 @@ import six
 from commcare_cloud.environment.constants import constants
 from commcare_cloud.environment.schemas.role_defaults import get_defaults_jsonobject
 
-PostgresqlOverride = get_defaults_jsonobject('postgresql')
+PostgresqlOverride = get_defaults_jsonobject(
+    'postgresql',
+    allow_dump_from_pgstandby=jsonobject.BooleanProperty,
+)
 
 
 def alphanum_key(key):


### PR DESCRIPTION
Falls back to the current logic which is to allow if there is a netvault user defined

The change here (affecting only production) has already been deployed