### PR TITLE
Autogenerate `keystore_file` var

### DIFF
--- a/.travis/environments/travis/public.yml
+++ b/.travis/environments/travis/public.yml
@@ -43,10 +43,6 @@ DATADOG_ENABLED: False
 
 CLOUDANT_CLUSTER_NAME: null
 
-
-# This dumps the dummy keystore, but allows the ansible script to continue, should be overriden for real deploys
-#keystore_file: 'DimagiKeyStore'
-
 backup_es: False
 backup_postgres: dump
 backup_blobdb: True

--- a/commcare-cloud-bootstrap/environment/public.yml
+++ b/commcare-cloud-bootstrap/environment/public.yml
@@ -24,10 +24,6 @@ DATADOG_ENABLED: False
 
 CLOUDANT_CLUSTER_NAME: null
 
-
-# This dumps the dummy keystore, but allows the ansible script to continue, should be overridden for real deploys
-#keystore_file: 'DimagiKeyStore'
-
 backup_es: False
 backup_postgres: plain
 backup_blobdb: True

--- a/environments/64-test/public.yml
+++ b/environments/64-test/public.yml
@@ -29,10 +29,6 @@ DATADOG_ENABLED: True
 
 CLOUDANT_CLUSTER_NAME: null
 
-
-# This dumps the dummy keystore, but allows the ansible script to continue, should be overridden for real deploys
-#keystore_file: 'DimagiKeyStore'
-
 backup_es: False
 backup_postgres: plain
 backup_blobdb: True

--- a/environments/development/public.yml
+++ b/environments/development/public.yml
@@ -30,10 +30,6 @@ DATADOG_ENABLED: False
 
 CLOUDANT_CLUSTER_NAME: null
 
-
-# This dumps the dummy keystore, but allows the ansible script to continue, should be overriden for real deploys
-#keystore_file: 'DimagiKeyStore'
-
 backup_es: False
 backup_postgres: plain
 backup_blobdb: True

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -17,8 +17,6 @@ nofile_limit: 65536
 
 supervisor_http_enabled: True
 
-keystore_file: '../environments/{{ deploy_env }}/DimagiKeyStore.vault'
-
 backup_blobdb: False
 backup_postgres: plain
 backup_es: True

--- a/environments/softlayer/public.yml
+++ b/environments/softlayer/public.yml
@@ -16,8 +16,6 @@ elasticsearch_download_sha256: 78affc30353730ec245dad1f17de242a4ad12cf808eaa87dd
 
 supervisor_http_enabled: True
 
-keystore_file: '../environments/{{ deploy_env }}/DimagiKeyStore.vault'
-
 backup_blobdb: False
 backup_postgres: plain
 backup_es: True

--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -9,8 +9,6 @@ elasticsearch_download_sha256: 78affc30353730ec245dad1f17de242a4ad12cf808eaa87dd
 
 supervisor_http_enabled: True
 
-keystore_file: '../environments/{{ deploy_env }}/DimagiKeyStore.vault'
-
 backup_blobdb: False
 backup_postgres: plain
 backup_es: False

--- a/src/commcare_cloud/environment/main.py
+++ b/src/commcare_cloud/environment/main.py
@@ -1,4 +1,5 @@
 import getpass
+import os
 
 import yaml
 from ansible.parsing.vault import AnsibleVaultError
@@ -277,6 +278,9 @@ class Environment(object):
         generated_variables.update(self.postgresql_config.to_generated_variables())
         generated_variables.update(self.proxy_config.to_generated_variables())
         generated_variables.update(constants.to_json())
+
+        if os.path.exists(self.paths.dimagi_key_store_vault):
+            generated_variables.update({'keystore_file': self.paths.dimagi_key_store_vault})
 
         with open(self.paths.generated_yml, 'w') as f:
             f.write(yaml.safe_dump(generated_variables))

--- a/src/commcare_cloud/environment/paths.py
+++ b/src/commcare_cloud/environment/paths.py
@@ -83,6 +83,10 @@ class DefaultPaths(object):
         return os.path.join(PACKAGE_BASE, 'environmental-defaults', 'fab-settings.yml')
 
     @lazy_immutable_property
+    def dimagi_key_store_vault(self):
+        return self.get_env_file_path('DimagiKeyStore.vault')
+
+    @lazy_immutable_property
     def generated_yml(self):
         return self.get_env_file_path('.generated.yml')
 


### PR DESCRIPTION
based on the presence or absence of a `DimagiKeyStore.vault` file in the env

(this variable is only needed for j2me == old nokia phones we no longer actively support)