### PR TITLE
Define the riak secrets

### DIFF
--- a/commcare-cloud-bootstrap/environment/private.yml
+++ b/commcare-cloud-bootstrap/environment/private.yml
@@ -23,6 +23,8 @@ secrets:
         username: 'hqrepl'
         password: 'hqrepl'
         role_attr_flags: 'LOGIN,REPLICATION'
+  S3_BLOB_DB_ACCESS_KEY: klJUt0LPbSuC+EOPz0Fxx53q
+  S3_BLOB_DB_SECRET_KEY: Qg8qO3kBFnB2jzMpZRwco0cP
 
 localsettings_private:
   COUCH_PASSWORD: p9RzGNx7wZr3BqLhNc7UtjQv

--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -54,8 +54,8 @@ old_s3_blob_db_s3_bucket: 'blobdb'
 
 # To use these vars without deploying the riak control machine
 # add riakcs_s3_access_key and riakcs_s3_secret_key to the ansible secret config directory
-s3_blob_db_access_key: "{{ riakcs_s3_access_key if riakcs_s3_access_key else (hostvars[riakcs_control]['riak_key'] if s3_blob_db_enabled else '') }}"
-s3_blob_db_secret_key:  "{{ riakcs_s3_secret_key if riakcs_s3_secret_key else (hostvars[riakcs_control]['riak_secret'] if s3_blob_db_enabled else '') }}"
+s3_blob_db_access_key: "{{ secrets.S3_BLOB_DB_ACCESS_KEY | default(None) }}"
+s3_blob_db_secret_key:  "{{ secrets.S3_BLOB_DB_SECRET_KEY | default(None) }}"
 
 couchdb_mirror: https://archive.apache.org/dist/couchdb/source
 


### PR DESCRIPTION
Set a riak password rather than waiting for them to be generated by riak. Reason: I want the variable to persist over multiple ansible-playbook command calls because I'm currently working on parallelizing a bunch of this.