### PR TITLE
Fix run-shell-command with --become-user cchq

### DIFF
--- a/src/commcare_cloud/commands/ansible/run_module.py
+++ b/src/commcare_cloud/commands/ansible/run_module.py
@@ -118,11 +118,7 @@ def run_ansible_module(environment, ansible_context, inventory_group, module, mo
     include_vars = False
     if become:
         cmd_parts += ('--become',)
-        if become_user not in ('cchq',):
-            # ansible user can do things as cchq without a password,
-            # but needs the ansible user password in order to do things as other users.
-            # In that case, we need to pull in the vault variable containing this password
-            include_vars = True
+        include_vars = True
         if become_user:
             cmd_parts += ('--become-user', become_user)
 


### PR DESCRIPTION
it no longer appears to be the case that the ansible can run cchq commands without a password
so changing logic that assumes that. (Thanks, comment!)