### PR TITLE
Increase client_body_buffer_size to 128k for prod

### DIFF
--- a/src/commcare_cloud/ansible/roles/nginx/vars/cchq_ssl.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/cchq_ssl.yml
@@ -28,6 +28,7 @@ nginx_sites:
       proxy_read_timeout: 900s
       proxy_buffers: 8 64k
       proxy_buffer_size: 64k
+      client_body_buffer_size: "128k"
     - name: "/static"
       alias: "{{ nginx_static_home }}"
       add_header: "Access-Control-Allow-Origin *"


### PR DESCRIPTION
We have a lot of warnings about buffering to disk on prod. This is what we use for riak. we use 512k for icds & PNA. 