### PR TITLE
Add request length to nginx logs

### DIFF
--- a/src/commcare_cloud/ansible/roles/nginx/templates/nginx.conf.j2
+++ b/src/commcare_cloud/ansible/roles/nginx/templates/nginx.conf.j2
@@ -20,7 +20,7 @@ http {
 
         log_format timing '[$time_local] $upstream_cache_status $request $status $request_time';
         log_format rt_cache '$remote_addr - $remote_user - $upstream_cache_status - [$time_local] '
-                    '"$request" $status $body_bytes_sent '
+                    '"$request" $status $request_length $body_bytes_sent '
                     '"$http_referer" "$http_user_agent"';
 
 {% for k,v in nginx_http_params.iteritems() %}


### PR DESCRIPTION
@dimagi/devops Looking for some feedback

> $request_length - request length (including request line, header, and request body)

https://nginx.org/en/docs/http/ngx_http_log_module.html

This could be useful for current interrupt ticket to see how large of a request a mobile worker is trying to send. It seems like it could be useful in the future, but not sure if we have a preferred way to add these, or a reason to not add it.