### PR TITLE
Don't implicitly tag setup release

### DIFF
--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -456,6 +456,7 @@ def _setup_release(keep_days=0, full_cluster=True):
     :param full_cluster: If False, only setup on webworkers[0] where the command will be run
     """
     deploy_ref = env.deploy_metadata.deploy_ref  # Make sure we have a valid commit
+    env.deploy_metadata.tag_setup_release()
     execute_with_timing(release.create_code_dir(full_cluster))
     execute_with_timing(release.update_code(full_cluster), deploy_ref)
     execute_with_timing(release.update_virtualenv(full_cluster))

--- a/src/commcare_cloud/fab/utils.py
+++ b/src/commcare_cloud/fab/utils.py
@@ -139,21 +139,22 @@ class DeployMetadata(object):
 
         # turn whatever `code_branch` is into a commit hash
         branch = self.repo.get_branch(self._code_branch)
-        deploy_ref = branch.commit.sha
+        return branch.commit.sha
 
+    def tag_setup_release(self):
         if _github_auth_provided():
             try:
                 self.repo.create_git_ref(
                     ref='refs/tags/' + '{}-{}-setup_release'.format(self.timestamp, self._environment),
-                    sha=deploy_ref,
+                    sha=self.deploy_ref,
                 )
             except UnknownObjectException:
                 raise Exception(
                     'Github API key does not have the right settings. '
                     'Please create an API key with the public_repo scope enabled.'
                 )
-
-        return deploy_ref
+            return True
+        return False
 
     @property
     def current_ref_is_different_than_last(self):


### PR DESCRIPTION
We've been generating a lot of extra tags because this ends up adding a tag even if you're trying to resume a failed deploy