### PR TITLE
restart airflow on service restart

### DIFF
--- a/src/commcare_cloud/fab/const.py
+++ b/src/commcare_cloud/fab/const.py
@@ -24,7 +24,8 @@ ROLES_ALL_SERVICES = [
     'django_pillowtop',
     'formsplayer',
     'formplayer',
-    'staticfiles'
+    'staticfiles',
+    'airflow'
 ]
 ROLES_CELERY = ['django_monolith', 'django_celery']
 ROLES_PILLOWTOP = ['django_monolith', 'django_pillowtop']


### PR DESCRIPTION
as new code directories were deployed airflow was not being restarted so it pointed to old releases. this should fix that

@snopoke @emord @nickpell 