### PR TITLE
drop supervisor logs kept to 5

### DIFF
--- a/src/commcare_cloud/ansible/roles/supervisor/templates/supervisord.conf.j2
+++ b/src/commcare_cloud/ansible/roles/supervisor/templates/supervisord.conf.j2
@@ -21,7 +21,7 @@ password={{ supervisor_http_password }}               ; (default is no password 
 [supervisord]
 logfile=/tmp/supervisord.log ; (main log file;default $CWD/supervisord.log)
 logfile_maxbytes=20MB        ; (max main logfile bytes b4 rotation;default 50MB)
-logfile_backups=10           ; (num of main logfile rotation backups;default 10)
+logfile_backups=5            ; (num of main logfile rotation backups;default 10)
 loglevel=info                ; (log level;default info; others: debug,warn,trace)
 pidfile=/tmp/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
 nodaemon=false               ; (start in foreground if true;default false)


### PR DESCRIPTION
Should help swiss disks which have 14.7GB of logs. Also don't think we use these much.