### PR TITLE
Upgrade to couchdb 1.7.2

### DIFF
--- a/src/commcare_cloud/ansible/roles/couchdb/defaults/main.yml
+++ b/src/commcare_cloud/ansible/roles/couchdb/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # /roles/couchdb/defaults/main.yml
 couchdb_source_mirror: http://mirrors.ibiblio.org/apache/couchdb/source
-couchdb_version: 1.6.1
+couchdb_version: 1.7.2
 couchdb_distro_filename: "apache-couchdb-{{ couchdb_version }}.tar.gz"
 couchdb_install_path: /usr/local/bin/couchdb
 couch_data_dir: '{{ encrypted_root }}/couchdb'


### PR DESCRIPTION
Add this to the list of things shouldn't be done in a production instance. Will send out a more full retro for why I did it.

@dimagi/devops This is necessary because the package for 1.6.1 is no longer around. 