### PR TITLE
Add a superuser so the postgres service check passes

### DIFF
--- a/commcare-cloud-bootstrap/bootstrap.sh
+++ b/commcare-cloud-bootstrap/bootstrap.sh
@@ -18,5 +18,7 @@ commcare-cloud $ENV fab deploy:confirm=no,skip_record=yes --show=debug --set ign
 
 commcare-cloud $ENV django-manage check_services
 
+# Make the test superuser test_superuser@test.com, so the postgres service check passes
+echo -e "123\n123" | cchq $ENV django-manage make_superuser test_superuser@test.com
 proxy=$(grep -A1 "\[$ENV-proxy-0\]" environments/$ENV/inventory.ini | tail -n 1| awk '{print $2}' | awk -F'=' '{print $2}')
 curl https://${proxy}/serverup.txt --insecure


### PR DESCRIPTION
Before, the service check would return this for the postgres check, because no superuser existed in the new env:
```
FAILURE (Took   0.02s) postgres       : default:commcarehq:OK ucr:commcarehq_ucr:OK No users found in postgres
```