### PR TITLE
enable password obfuscation on NIC

### DIFF
--- a/environments/icds-new/public.yml
+++ b/environments/icds-new/public.yml
@@ -250,3 +250,5 @@ localsettings:
   UCR_COMPARISONS:
     'static-icds-cas-static-mpr_2a_person_cases': 'static-icds-cas-static-custom_sql_mpr_2a_person_cases'
   USER_REPORTING_METADATA_UPDATE_FREQUENCY_HOURS: 6
+  OBFUSCATE_PASSWORD_FOR_NIC_COMPLIANCE: True
+


### PR DESCRIPTION
For AKS audit,
enable password obfuscation on NIC.

Functionality enabled: https://github.com/dimagi/commcare-hq/pull/15490

fyi @snopoke 