### PR TITLE
enable password obfuscation on softlayer

### DIFF
--- a/environments/softlayer/public.yml
+++ b/environments/softlayer/public.yml
@@ -109,6 +109,7 @@ localsettings:
   TRANSFER_SERVER: 'nginx'
   WS4REDIS_CONNECTION_HOST: "{{ groups.redis.0 }}"
   XFORMS_PLAYER_URL: "http://{{ groups.touchforms.0 }}:4444/"
+  OBFUSCATE_PASSWORD_FOR_NIC_COMPLIANCE: True
 
 site_locations:
   - name: /data_dumps/export/enikshay/public


### PR DESCRIPTION
Enabling password obfuscation on india server as well since ICDS master app is on softlayer for which [we have enabled obfuscation](https://github.com/dimagi/commcare-cloud/pull/2051) and is blocking using of app on india server.