### PR TITLE
Add env name to logs

### DIFF
--- a/src/commcare_cloud/commands/ansible/service.py
+++ b/src/commcare_cloud/commands/ansible/service.py
@@ -64,7 +64,7 @@ class ServiceBase(six.with_metaclass(ABCMeta)):
             self.print_help()
             return 0
         elif action == 'logs':
-            print("Logs can be found at:\n{}".format(self.log_location.format(env_name)))
+            print("Logs can be found at:\n{}".format(self.log_location.format(env=env_name)))
             return 0
         try:
             return self.execute_action(action, host_pattern, process_pattern)
@@ -281,8 +281,8 @@ class MultiAnsibleService(SubServicesMixin, AnsibleService):
 class Nginx(AnsibleService):
     name = 'nginx'
     inventory_groups = ['proxy']
-    log_location = '/home/cchq/www/{0}/log/{0}_commcare-nginx_error.log\n' \
-                   '/home/cchq/www/{0}/log/{0}_commcare-nginx_access.log'
+    log_location = '/home/cchq/www/{env}/log/{env}_commcare-nginx_error.log\n' \
+                   '/home/cchq/www/{env}/log/{env}_commcare-nginx_access.log'
 
 
 class ElasticsearchClassic(AnsibleService):
@@ -420,7 +420,7 @@ class SingleSupervisorService(SupervisorService):
 class CommCare(SingleSupervisorService):
     name = 'commcare'
     inventory_groups = ['webworkers', 'celery', 'pillowtop', 'formplayer', 'proxy']
-    log_location = '/home/cchq/www/{0}/log/django.log'
+    log_location = '/home/cchq/www/{env}/log/django.log'
 
     @property
     def supervisor_process_name(self):
@@ -430,8 +430,8 @@ class CommCare(SingleSupervisorService):
 class Webworker(SingleSupervisorService):
     name = 'webworker'
     inventory_groups = ['webworkers']
-    log_location = 'Regular logger: /home/cchq/www/{0}/log/<host>-commcarehq.django.log\n' \
-                   'Accounting logger: /home/cchq/www/{0}/log/<host>-commcarehq.accounting.log'
+    log_location = 'Regular logger: /home/cchq/www/{env}/log/<host>-commcarehq.django.log\n' \
+                   'Accounting logger: /home/cchq/www/{env}/log/<host>-commcarehq.accounting.log'
 
     @property
     def supervisor_process_name(self):
@@ -441,7 +441,7 @@ class Webworker(SingleSupervisorService):
 class Formplayer(SingleSupervisorService):
     name = 'formplayer'
     inventory_groups = ['formplayer']
-    log_location = '/home/cchq/www/{0}/log/formplayer-spring.log'
+    log_location = '/home/cchq/www/{env}/log/formplayer-spring.log'
 
     @property
     def supervisor_process_name(self):
@@ -451,7 +451,7 @@ class Formplayer(SingleSupervisorService):
 class Celery(SupervisorService):
     name = 'celery'
     inventory_groups = ['celery']
-    log_location = '/home/cchq/www/{0}/log/celery_*.log'
+    log_location = '/home/cchq/www/{env}/log/celery_*.log'
 
     def _get_processes_by_host(self, process_pattern=None):
         return get_processes_by_host(
@@ -468,7 +468,7 @@ class Celery(SupervisorService):
 class Pillowtop(SupervisorService):
     name = 'pillowtop'
     inventory_groups = ['pillowtop']
-    log_location = '/home/cchq/www/{0}/log/pillowtop-<pillow_name>-<num_process>.log'
+    log_location = '/home/cchq/www/{env}/log/pillowtop-<pillow_name>-<num_process>.log'
 
     @property
     def managed_services(self):

--- a/src/commcare_cloud/commands/ansible/service.py
+++ b/src/commcare_cloud/commands/ansible/service.py
@@ -59,12 +59,12 @@ class ServiceBase(six.with_metaclass(ABCMeta)):
         self.environment = environment
         self.ansible_context = ansible_context
 
-    def run(self, action, env_name, host_pattern=None, process_pattern=None):
+    def run(self, action, host_pattern=None, process_pattern=None):
         if action == 'help':
             self.print_help()
             return 0
         elif action == 'logs':
-            print("Logs can be found at:\n{}".format(self.log_location.format(env=env_name)))
+            print("Logs can be found at:\n{}".format(self.log_location.format(env=self.environment.paths.env_name)))
             return 0
         try:
             return self.execute_action(action, host_pattern, process_pattern)
@@ -636,7 +636,7 @@ class Service(CommandBase):
         non_zero_exits = []
         for service_cls in services:
             service = service_cls(environment, ansible_context)
-            exit_code = service.run(args.action, args.env_name, args.limit, args.process_pattern)
+            exit_code = service.run(args.action, args.limit, args.process_pattern)
             if exit_code != 0:
                 non_zero_exits.append(exit_code)
         return non_zero_exits[0] if non_zero_exits else 0

--- a/src/commcare_cloud/commands/ansible/service.py
+++ b/src/commcare_cloud/commands/ansible/service.py
@@ -289,14 +289,14 @@ class ElasticsearchClassic(AnsibleService):
     name = 'elasticsearch-classic'
     service_name = 'elasticsearch'
     inventory_groups = ['elasticsearch']
-    log_location = '/opt/data/<ecrypt>/elasticsearch-<version>/logs'
+    log_location = '/opt/data/(ecrypt)/elasticsearch-<version>/logs'
 
 
 class Elasticsearch(ServiceBase):
     name = 'elasticsearch'
     service_name = 'elasticsearch'
     inventory_groups = ['elasticsearch']
-    log_location = '/opt/data/<ecrypt>/elasticsearch-<version>/logs'
+    log_location = '/opt/data/(ecrypt)/elasticsearch-<version>/logs'
 
     def execute_action(self, action, host_pattern=None, process_pattern=None):
         if action == 'status':

--- a/src/commcare_cloud/commands/ansible/service.py
+++ b/src/commcare_cloud/commands/ansible/service.py
@@ -59,12 +59,12 @@ class ServiceBase(six.with_metaclass(ABCMeta)):
         self.environment = environment
         self.ansible_context = ansible_context
 
-    def run(self, action, host_pattern=None, process_pattern=None):
+    def run(self, action, env_name, host_pattern=None, process_pattern=None):
         if action == 'help':
             self.print_help()
             return 0
         elif action == 'logs':
-            print("Logs can be found at:\n{}".format(self.log_location))
+            print("Logs can be found at:\n{}".format(self.log_location.format(env_name)))
             return 0
         try:
             return self.execute_action(action, host_pattern, process_pattern)
@@ -281,22 +281,22 @@ class MultiAnsibleService(SubServicesMixin, AnsibleService):
 class Nginx(AnsibleService):
     name = 'nginx'
     inventory_groups = ['proxy']
-    log_location = '/home/cchq/www/{env}/log/{env}_commcare-nginx_error.log\n' \
-                   '/home/cchq/www/{env}/log/{env}_commcare-nginx_access.log'
+    log_location = '/home/cchq/www/{0}/log/{0}_commcare-nginx_error.log\n' \
+                   '/home/cchq/www/{0}/log/{0}_commcare-nginx_access.log'
 
 
 class ElasticsearchClassic(AnsibleService):
     name = 'elasticsearch-classic'
     service_name = 'elasticsearch'
     inventory_groups = ['elasticsearch']
-    log_location = '/opt/data/{ecrypt}/elasticsearch-1.7.3/logs'
+    log_location = '/opt/data/<ecrypt>/elasticsearch-<version>/logs'
 
 
 class Elasticsearch(ServiceBase):
     name = 'elasticsearch'
     service_name = 'elasticsearch'
     inventory_groups = ['elasticsearch']
-    log_location = '/opt/data/{ecrypt}/elasticsearch-{version}/logs'
+    log_location = '/opt/data/<ecrypt>/elasticsearch-<version>/logs'
 
     def execute_action(self, action, host_pattern=None, process_pattern=None):
         if action == 'status':
@@ -360,7 +360,7 @@ class RabbitMq(AnsibleService):
     name = 'rabbitmq'
     inventory_groups = ['rabbitmq']
     service_name = 'rabbitmq-server'
-    log_location = '/var/log/rabbitmq/rabbit@{rabbitmq machine}.log'
+    log_location = '/var/log/rabbitmq/rabbit@<rabbitmq machine>.log'
 
 
 class Redis(AnsibleService):
@@ -395,7 +395,7 @@ class Postgresql(MultiAnsibleService):
         'postgresql': ('postgresql', 'postgresql,pg_standby'),
         'pgbouncer': ('pgbouncer', 'postgresql,pg_standby')
     }
-    log_location = 'Postgres: /opt/data/postgresql/{version}/main/pg_log\n' \
+    log_location = 'Postgres: /opt/data/postgresql/<version>/main/pg_log\n' \
                    'Pgbouncer: /var/log/postgresql/pgbouncer.log'
 
 
@@ -420,7 +420,7 @@ class SingleSupervisorService(SupervisorService):
 class CommCare(SingleSupervisorService):
     name = 'commcare'
     inventory_groups = ['webworkers', 'celery', 'pillowtop', 'formplayer', 'proxy']
-    log_location = '/home/cchq/www/{env}/log/django.log'
+    log_location = '/home/cchq/www/{0}/log/django.log'
 
     @property
     def supervisor_process_name(self):
@@ -430,8 +430,8 @@ class CommCare(SingleSupervisorService):
 class Webworker(SingleSupervisorService):
     name = 'webworker'
     inventory_groups = ['webworkers']
-    log_location = 'Regular logger: /home/cchq/www/{env}/log/{host}-commcarehq.django.log\n' \
-                   'Accounting logger: /home/cchq/www/{env}/log/{host}-commcarehq.accounting.log'
+    log_location = 'Regular logger: /home/cchq/www/{0}/log/<host>-commcarehq.django.log\n' \
+                   'Accounting logger: /home/cchq/www/{0}/log/<host>-commcarehq.accounting.log'
 
     @property
     def supervisor_process_name(self):
@@ -441,7 +441,7 @@ class Webworker(SingleSupervisorService):
 class Formplayer(SingleSupervisorService):
     name = 'formplayer'
     inventory_groups = ['formplayer']
-    log_location = '/home/cchq/www/{env}/log/formplayer-spring.log'
+    log_location = '/home/cchq/www/{0}/log/formplayer-spring.log'
 
     @property
     def supervisor_process_name(self):
@@ -451,7 +451,7 @@ class Formplayer(SingleSupervisorService):
 class Celery(SupervisorService):
     name = 'celery'
     inventory_groups = ['celery']
-    log_location = '/home/cchq/www/{env}/log/celery_*.log'
+    log_location = '/home/cchq/www/{0}/log/celery_*.log'
 
     def _get_processes_by_host(self, process_pattern=None):
         return get_processes_by_host(
@@ -468,7 +468,7 @@ class Celery(SupervisorService):
 class Pillowtop(SupervisorService):
     name = 'pillowtop'
     inventory_groups = ['pillowtop']
-    log_location = '/home/cchq/www/{env}/log/pillowtop-{pillow_name}-{num_process}.log'
+    log_location = '/home/cchq/www/{0}/log/pillowtop-<pillow_name>-<num_process>.log'
 
     @property
     def managed_services(self):
@@ -636,7 +636,7 @@ class Service(CommandBase):
         non_zero_exits = []
         for service_cls in services:
             service = service_cls(environment, ansible_context)
-            exit_code = service.run(args.action, args.limit, args.process_pattern)
+            exit_code = service.run(args.action, args.env_name, args.limit, args.process_pattern)
             if exit_code != 0:
                 non_zero_exits.append(exit_code)
         return non_zero_exits[0] if non_zero_exits else 0


### PR DESCRIPTION
- Env name gets added to the log locations
- Replaced `{}` with `<>` so that `.format()` doesn't get confused

In reference to this: https://github.com/dimagi/commcare-cloud/pull/2033#issuecomment-414816646