### PR TITLE
limit toc levels to 4

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,3 +1,6 @@
 title: <a href="/commcare-cloud/"><img src="https://www.commcarehq.org/static/hqstyle/images/commcare-flower-lg.png" width="40"/></a> CommCare Cloud
 description: Official toolkit for deploying and maintaining CommCare server environment
 author: Dimagi
+
+kramdown:
+  toc_levels: "1..4"


### PR DESCRIPTION
This was particularly for the 'commands' page which has a very long TOC