### PR TITLE
icds-cas pillow & celery configurations

### DIFF
--- a/environments/icds-cas/app-processes.yml
+++ b/environments/icds-cas/app-processes.yml
@@ -191,6 +191,39 @@ celery_processes:
       concurrency: 4
 pillows:
   'pillow0':
+    # Catch all server for low volume pillows
+    AppDbChangeFeedPillow:
+      num_processes: 1
+    ApplicationToElasticsearchPillow:
+      num_processes: 1
+    CacheInvalidatePillow:
+      num_processes: 1
+    DefaultChangeFeedPillow:
+      num_processes: 1
+    DomainDbKafkaPillow:
+      num_processes: 1
+    GroupPillow:
+      num_processes: 1
+    GroupToUserPillow:
+      num_processes: 1
+    KafkaDomainPillow:
+      num_processes: 1
+    LedgerToElasticsearchPillow:
+      num_processes: 1
+    SqlSMSPillow:
+      num_processes: 1
+    UserCacheInvalidatePillow:
+      num_processes: 1
+    UserGroupsDbKafkaPillow:
+      num_processes: 1
+    UserPillow:
+      num_processes: 1
+    UpdateUserSyncHistoryPillow:
+      num_processes: 1
+    kafka-ucr-main:
+      num_processes: 1
+    kafka-ucr-static-awc-location:
+      num_processes: 1
   'pillow1':
     kafka-ucr-static-cases:
       start_process: 0
@@ -256,14 +289,6 @@ pillows:
       num_processes: 6
       total_processes: 36
   'pillow7':
-    kafka-ucr-main:
-      num_processes: 1
-    KafkaDomainPillow:
-      num_processes: 1
-    LedgerToElasticsearchPillow:
-      num_processes: 1
-    SqlSMSPillow:
-      num_processes: 1
     XFormToElasticsearchPillow:
       num_processes: 4
     kafka-ucr-static-forms:
@@ -283,29 +308,5 @@ pillows:
       num_processes: 8
       total_processes: 16
   'pillow10':
-    AppDbChangeFeedPillow:
-      num_processes: 1
-    ApplicationToElasticsearchPillow:
-      num_processes: 1
-    CacheInvalidatePillow:
-      num_processes: 1
-    UserGroupsDbKafkaPillow:
-      num_processes: 1
-    UserPillow:
-      num_processes: 1
-    DefaultChangeFeedPillow:
-      num_processes: 1
-    DomainDbKafkaPillow:
-      num_processes: 1
-    GroupPillow:
-      num_processes: 1
-    GroupToUserPillow:
-      num_processes: 1
-    kafka-ucr-static-awc-location:
-      num_processes: 1
-    UpdateUserSyncHistoryPillow:
-      num_processes: 1
-    UserCacheInvalidatePillow:
-      num_processes: 1
   'pillow13':
   'pillow14':

--- a/environments/icds-cas/app-processes.yml
+++ b/environments/icds-cas/app-processes.yml
@@ -191,6 +191,7 @@ celery_processes:
       concurrency: 4
 pillows:
   'pillow0':
+  'pillow1':
     kafka-ucr-static-cases:
       start_process: 0
       num_processes: 6
@@ -199,7 +200,7 @@ pillows:
       start_process: 0
       num_processes: 4
       total_processes: 36
-  'pillow1':
+  'pillow2':
     kafka-ucr-static-cases:
       start_process: 6
       num_processes: 6
@@ -208,7 +209,7 @@ pillows:
       start_process: 4
       num_processes: 4
       total_processes: 36
-  'pillow2':
+  'pillow3':
     kafka-ucr-static-cases:
       start_process: 12
       num_processes: 6
@@ -217,7 +218,7 @@ pillows:
       start_process: 8
       num_processes: 4
       total_processes: 36
-  'pillow3':
+  'pillow4':
     kafka-ucr-static-cases:
       start_process: 18
       num_processes: 6
@@ -226,7 +227,7 @@ pillows:
       start_process: 12
       num_processes: 4
       total_processes: 36
-  'pillow4':
+  'pillow5':
     kafka-ucr-static-cases:
       start_process: 24
       num_processes: 6
@@ -235,7 +236,7 @@ pillows:
       start_process: 16
       num_processes: 4
       total_processes: 36
-  'pillow5':
+  'pillow6':
     kafka-ucr-static-cases:
       start_process: 30
       num_processes: 6
@@ -244,17 +245,17 @@ pillows:
       start_process: 20
       num_processes: 4
       total_processes: 36
-  'pillow10':
+  'pillow11':
     CaseToElasticsearchPillow:
       start_process: 24
       num_processes: 6
       total_processes: 36
-  'pillow11':
+  'pillow12':
     CaseToElasticsearchPillow:
       start_process: 30
       num_processes: 6
       total_processes: 36
-  'pillow6':
+  'pillow7':
     kafka-ucr-main:
       num_processes: 1
     KafkaDomainPillow:
@@ -269,19 +270,19 @@ pillows:
       start_process: 8
       num_processes: 4
       total_processes: 16
-  'pillow7':
+  'pillow8':
     FormSubmissionMetadataTrackerPillow:
       num_processes: 8
     kafka-ucr-static-forms:
       start_process: 12
       num_processes: 4
       total_processes: 16
-  'pillow8':
+  'pillow9':
     kafka-ucr-static-forms:
       start_process: 0
       num_processes: 8
       total_processes: 16
-  'pillow9':
+  'pillow10':
     AppDbChangeFeedPillow:
       num_processes: 1
     ApplicationToElasticsearchPillow:
@@ -306,8 +307,5 @@ pillows:
       num_processes: 1
     UserCacheInvalidatePillow:
       num_processes: 1
-  'pillow10':
-  'pillow11':
-  'pillow12':
   'pillow13':
   'pillow14':

--- a/environments/icds-cas/app-processes.yml
+++ b/environments/icds-cas/app-processes.yml
@@ -119,8 +119,32 @@ celery_processes:
     icds_dashboard_reports_queue:
       concurrency: 2
   'celery8':
+    ucr_indicator_queue:
+      concurrency: 4
+    reminder_case_update_queue:
+      pooling: gevent
+      concurrency: 5
+      num_workers: 6
+    icds_dashboard_reports_queue:
+      concurrency: 2
   'celery9':
+    ucr_indicator_queue:
+      concurrency: 4
+    reminder_case_update_queue:
+      pooling: gevent
+      concurrency: 5
+      num_workers: 6
+    icds_dashboard_reports_queue:
+      concurrency: 2
   'celery10':
+    ucr_indicator_queue:
+      concurrency: 4
+    reminder_case_update_queue:
+      pooling: gevent
+      concurrency: 5
+      num_workers: 6
+    icds_dashboard_reports_queue:
+      concurrency: 2
   'web0':
     ucr_indicator_queue:
       concurrency: 3

--- a/environments/icds-cas/app-processes.yml
+++ b/environments/icds-cas/app-processes.yml
@@ -248,65 +248,89 @@ pillows:
     kafka-ucr-static-cases:
       start_process: 0
       num_processes: 6
-      total_processes: 36
+      total_processes: 60
     CaseToElasticsearchPillow:
       start_process: 0
-      num_processes: 4
-      total_processes: 36
+      num_processes: 6
+      total_processes: 60
   'pillow6':
     kafka-ucr-static-cases:
       start_process: 6
       num_processes: 6
-      total_processes: 36
+      total_processes: 60
     CaseToElasticsearchPillow:
-      start_process: 4
-      num_processes: 4
-      total_processes: 36
+      start_process: 6
+      num_processes: 6
+      total_processes: 60
   'pillow7':
     kafka-ucr-static-cases:
       start_process: 12
       num_processes: 6
-      total_processes: 36
+      total_processes: 60
     CaseToElasticsearchPillow:
-      start_process: 8
-      num_processes: 4
-      total_processes: 36
+      start_process: 12
+      num_processes: 6
+      total_processes: 60
   'pillow8':
     kafka-ucr-static-cases:
       start_process: 18
       num_processes: 6
-      total_processes: 36
+      total_processes: 60
     CaseToElasticsearchPillow:
-      start_process: 12
-      num_processes: 4
-      total_processes: 36
+      start_process: 18
+      num_processes: 6
+      total_processes: 60
   'pillow9':
     kafka-ucr-static-cases:
       start_process: 24
       num_processes: 6
-      total_processes: 36
+      total_processes: 60
     CaseToElasticsearchPillow:
-      start_process: 16
-      num_processes: 4
-      total_processes: 36
+      start_process: 24
+      num_processes: 6
+      total_processes: 60
   'pillow10':
     kafka-ucr-static-cases:
       start_process: 30
       num_processes: 6
-      total_processes: 36
-    CaseToElasticsearchPillow:
-      start_process: 20
-      num_processes: 4
-      total_processes: 36
-  'pillow11':
-    CaseToElasticsearchPillow:
-      start_process: 24
-      num_processes: 6
-      total_processes: 36
-  'pillow12':
+      total_processes: 60
     CaseToElasticsearchPillow:
       start_process: 30
       num_processes: 6
-      total_processes: 36
+      total_processes: 60
+  'pillow11':
+    kafka-ucr-static-cases:
+      start_process: 36
+      num_processes: 6
+      total_processes: 60
+    CaseToElasticsearchPillow:
+      start_process: 36
+      num_processes: 6
+      total_processes: 60
+  'pillow12':
+    kafka-ucr-static-cases:
+      start_process: 42
+      num_processes: 6
+      total_processes: 60
+    CaseToElasticsearchPillow:
+      start_process: 42
+      num_processes: 6
+      total_processes: 60
   'pillow13':
+    kafka-ucr-static-cases:
+      start_process: 48
+      num_processes: 6
+      total_processes: 60
+    CaseToElasticsearchPillow:
+      start_process: 48
+      num_processes: 6
+      total_processes: 60
   'pillow14':
+    kafka-ucr-static-cases:
+      start_process: 54
+      num_processes: 6
+      total_processes: 60
+    CaseToElasticsearchPillow:
+      start_process: 54
+      num_processes: 6
+      total_processes: 60

--- a/environments/icds-cas/app-processes.yml
+++ b/environments/icds-cas/app-processes.yml
@@ -225,6 +225,26 @@ pillows:
     kafka-ucr-static-awc-location:
       num_processes: 1
   'pillow1':
+    FormSubmissionMetadataTrackerPillow:
+      num_processes: 8
+    XFormToElasticsearchPillow:
+      num_processes: 8
+  'pillow2':
+    kafka-ucr-static-forms:
+      start_process: 0
+      num_processes: 8
+      total_processes: 24
+  'pillow3':
+    kafka-ucr-static-forms:
+      start_process: 8
+      num_processes: 8
+      total_processes: 24
+  'pillow4':
+    kafka-ucr-static-forms:
+      start_process: 16
+      num_processes: 8
+      total_processes: 24
+  'pillow5':
     kafka-ucr-static-cases:
       start_process: 0
       num_processes: 6
@@ -233,7 +253,7 @@ pillows:
       start_process: 0
       num_processes: 4
       total_processes: 36
-  'pillow2':
+  'pillow6':
     kafka-ucr-static-cases:
       start_process: 6
       num_processes: 6
@@ -242,7 +262,7 @@ pillows:
       start_process: 4
       num_processes: 4
       total_processes: 36
-  'pillow3':
+  'pillow7':
     kafka-ucr-static-cases:
       start_process: 12
       num_processes: 6
@@ -251,7 +271,7 @@ pillows:
       start_process: 8
       num_processes: 4
       total_processes: 36
-  'pillow4':
+  'pillow8':
     kafka-ucr-static-cases:
       start_process: 18
       num_processes: 6
@@ -260,7 +280,7 @@ pillows:
       start_process: 12
       num_processes: 4
       total_processes: 36
-  'pillow5':
+  'pillow9':
     kafka-ucr-static-cases:
       start_process: 24
       num_processes: 6
@@ -269,7 +289,7 @@ pillows:
       start_process: 16
       num_processes: 4
       total_processes: 36
-  'pillow6':
+  'pillow10':
     kafka-ucr-static-cases:
       start_process: 30
       num_processes: 6
@@ -288,25 +308,5 @@ pillows:
       start_process: 30
       num_processes: 6
       total_processes: 36
-  'pillow7':
-    XFormToElasticsearchPillow:
-      num_processes: 4
-    kafka-ucr-static-forms:
-      start_process: 8
-      num_processes: 4
-      total_processes: 16
-  'pillow8':
-    FormSubmissionMetadataTrackerPillow:
-      num_processes: 8
-    kafka-ucr-static-forms:
-      start_process: 12
-      num_processes: 4
-      total_processes: 16
-  'pillow9':
-    kafka-ucr-static-forms:
-      start_process: 0
-      num_processes: 8
-      total_processes: 16
-  'pillow10':
   'pillow13':
   'pillow14':

--- a/environments/icds-cas/app-processes.yml
+++ b/environments/icds-cas/app-processes.yml
@@ -44,7 +44,7 @@ celery_processes:
   'celery1':
     ucr_queue:
       concurrency: 4
-      max_tasks_per_child: 5
+      max_tasks_per_child: 1
     reminder_case_update_queue:
       pooling: gevent
       concurrency: 5


### PR DESCRIPTION
@dimagi/scale-team 

Being fairly conservative here. We should still have plenty of RAM and CPU after this. main changes are form partitions 16 -> 24 and case partitions 36 -> 60. 

Going to start a doc about how I think scaling to 250k works with some current code changes that are being worked on.