### PR TITLE
Make test_autogen.docs.sh fail loudly if any part of it fails

### DIFF
--- a/tests/test_autogen_docs.sh
+++ b/tests/test_autogen_docs.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-
+set -e
 
 make clean
 make


### PR DESCRIPTION
currently if running `make` fails, it will only fail later incidentally
because the previous `make clean` created a diff. Now any failing command in this script
will bubble up directly