### PR TITLE
temporarily remove project

### DIFF
--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -800,7 +800,7 @@ DAILY_DEPLOY_EMAIL = '{{ daily_deploy_email }}'
 TRANSIFEX_DETAILS = {
     'organization': 'dimagi',
     'project': {
-        'icds-cas': ['icds-cas-english', 'test-project-211'],
+        'icds-cas': ['test-project-211'],
     },
     'teams': {
         'icds-cas': {


### PR DESCRIPTION
Currently we are migrating from 'icds-cas-english' to 'icds-cas-app' on transifex.
So removing it from here for now to avoid any updates to it during migration.