### PR TITLE
update galaxy requirements

### DIFF
--- a/src/commcare_cloud/ansible/requirements.yml
+++ b/src/commcare_cloud/ansible/requirements.yml
@@ -1,10 +1,6 @@
 ---
-- src: git+https://github.com/andrewrothstein/ansible-couchdb-cluster.git
-  version: 1d1558722c30e03cedb641e8bb2abf9ad5bc1fcd
-  name: andrewrothstein.ansible-couchdb-cluster
-- src: git+https://github.com/andrewrothstein/ansible-couchdb.git
-  version: f0e026e73b8bf6f4ee5cc710f8fdbcdeb7418b2b
-  name: andrewrothstein.couchdb
+- name: andrewrothstein.ansible-couchdb-cluster
+- version: 1.1.3
 - src: git+https://github.com/debops-contrib/ansible-etckeeper.git
   version: 29c721de3df965ff355cbed242db813f70b811a2
   name: debops-contrib.etckeeper


### PR DESCRIPTION
1.1.3 got released a few days ago with some changes we've made. I've removed the couchdb role since I think that should get pulled in automatically.