### PR TITLE
Upgrade ansible to >=2.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ PIP_COMPILE = pip-compile --output-file requirements.txt setup.py requirements*.
 # Pick a standard (but arbitrary) value for $HOME to be used across all environments.
 # Make it short but unlikely to occur otherwise, so that we can safely find/replace it with ~.
 # (Directly using escaped '~' does not work.)
-STANDARD_HOME=/!
+STANDARD_HOME=/tmp
 # ANSIBLE_LIBRARY cannot be set to a relative path,
 # because it gets expanded to an absolute path.
 # Instead we prefix it with a fake absolute prefix we can replace later in ansible -h output.

--- a/docs/commcare-cloud/commands/index.md
+++ b/docs/commcare-cloud/commands/index.md
@@ -286,6 +286,11 @@ authenticate using the pem file (or prompt for root password if there is no pem 
                         prepend colon-separated path(s) to module library
                         (default=[u'./src/commcare_cloud/ansible/library'])
   -o, --one-line        condense output
+  --playbook-dir=BASEDIR
+                        Since this tool does not use playbooks, use this as a
+                        subsitute playbook directory.This sets the relative
+                        path for many features including roles/ group_vars/
+                        etc.
   -P POLL_INTERVAL, --poll=POLL_INTERVAL
                         set the poll interval if using -B (default=15)
   --syntax-check        perform a syntax check on the playbook, but do not
@@ -330,7 +335,7 @@ authenticate using the pem file (or prompt for root password if there is no pem 
     --become-method=BECOME_METHOD
                         privilege escalation method to use (default=sudo),
                         valid choices: [ sudo | su | pbrun | pfexec | doas |
-                        dzdo | ksu | runas | pmrun ]
+                        dzdo | ksu | runas | pmrun | enable | machinectl ]
     -K, --ask-become-pass
                         ask for privilege escalation password
 ```
@@ -400,6 +405,11 @@ authenticate using the pem file (or prompt for root password if there is no pem 
                         prepend colon-separated path(s) to module library
                         (default=[u'./src/commcare_cloud/ansible/library'])
   -o, --one-line        condense output
+  --playbook-dir=BASEDIR
+                        Since this tool does not use playbooks, use this as a
+                        subsitute playbook directory.This sets the relative
+                        path for many features including roles/ group_vars/
+                        etc.
   -P POLL_INTERVAL, --poll=POLL_INTERVAL
                         set the poll interval if using -B (default=15)
   --syntax-check        perform a syntax check on the playbook, but do not
@@ -444,7 +454,7 @@ authenticate using the pem file (or prompt for root password if there is no pem 
     --become-method=BECOME_METHOD
                         privilege escalation method to use (default=sudo),
                         valid choices: [ sudo | su | pbrun | pfexec | doas |
-                        dzdo | ksu | runas | pmrun ]
+                        dzdo | ksu | runas | pmrun | enable | machinectl ]
     -K, --ask-become-pass
                         ask for privilege escalation password
 ```
@@ -588,7 +598,7 @@ authenticate using the pem file (or prompt for root password if there is no pem 
   -e EXTRA_VARS, --extra-vars=EXTRA_VARS
                         set additional variables as key=value or YAML/JSON, if
                         filename prepend with @
-  --flush-cache         clear the fact cache
+  --flush-cache         clear the fact cache for every host in inventory
   --force-handlers      run handlers even if a task fails
   -f FORKS, --forks=FORKS
                         specify number of parallel processes to use
@@ -650,7 +660,7 @@ authenticate using the pem file (or prompt for root password if there is no pem 
     --become-method=BECOME_METHOD
                         privilege escalation method to use (default=sudo),
                         valid choices: [ sudo | su | pbrun | pfexec | doas |
-                        dzdo | ksu | runas | pmrun ]
+                        dzdo | ksu | runas | pmrun | enable | machinectl ]
     --become-user=BECOME_USER
                         run operations as this user (default=root)
     -K, --ask-become-pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 #    pip-compile --output-file requirements.txt setup.py requirements-python-lt-2.7.9-ssl-issue.in
 #
 ansible-vault==1.1.1
-ansible==2.4.3
+ansible==2.6.2
 argparse==1.4.0
 args==0.1.0               # via clint
 asn1crypto==0.24.0        # via cryptography

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     },
     install_requires=(
         'ansible-vault==1.1.1',
-        'ansible==2.4.3',
+        'ansible>=2.6',
         'argparse>=1.4',
         'attrs>=18.1.0',
         'clint',

--- a/src/commcare_cloud/help_cache/ansible-playbook.txt
+++ b/src/commcare_cloud/help_cache/ansible-playbook.txt
@@ -11,7 +11,7 @@ Options:
   -e EXTRA_VARS, --extra-vars=EXTRA_VARS
                         set additional variables as key=value or YAML/JSON, if
                         filename prepend with @
-  --flush-cache         clear the fact cache
+  --flush-cache         clear the fact cache for every host in inventory
   --force-handlers      run handlers even if a task fails
   -f FORKS, --forks=FORKS
                         specify number of parallel processes to use
@@ -86,7 +86,7 @@ Options:
     --become-method=BECOME_METHOD
                         privilege escalation method to use (default=sudo),
                         valid choices: [ sudo | su | pbrun | pfexec | doas |
-                        dzdo | ksu | runas | pmrun ]
+                        dzdo | ksu | runas | pmrun | enable | machinectl ]
     --become-user=BECOME_USER
                         run operations as this user (default=root)
     --ask-sudo-pass     ask for sudo password (deprecated, use become)

--- a/src/commcare_cloud/help_cache/ansible.txt
+++ b/src/commcare_cloud/help_cache/ansible.txt
@@ -33,6 +33,11 @@ Options:
                         prepend colon-separated path(s) to module library
                         (default=[u'./src/commcare_cloud/ansible/library'])
   -o, --one-line        condense output
+  --playbook-dir=BASEDIR
+                        Since this tool does not use playbooks, use this as a
+                        subsitute playbook directory.This sets the relative
+                        path for many features including roles/ group_vars/
+                        etc.
   -P POLL_INTERVAL, --poll=POLL_INTERVAL
                         set the poll interval if using -B (default=15)
   --syntax-check        perform a syntax check on the playbook, but do not
@@ -86,7 +91,7 @@ Options:
     --become-method=BECOME_METHOD
                         privilege escalation method to use (default=sudo),
                         valid choices: [ sudo | su | pbrun | pfexec | doas |
-                        dzdo | ksu | runas | pmrun ]
+                        dzdo | ksu | runas | pmrun | enable | machinectl ]
     --become-user=BECOME_USER
                         run operations as this user (default=root)
     --ask-sudo-pass     ask for sudo password (deprecated, use become)


### PR DESCRIPTION
This came up during some changes I need to make for AWS because of the plan to use RDS to present a postgresql service. Some errors I was seeing when using the `postgresql_user` ansible module the way I was doing with RDS went away when I upgraded to ansible 2.6. (I wish I'd kept a better of my research trail, but I think it was related to one of these two issues: https://github.com/ansible/ansible/issues/24928, https://github.com/ansible/ansible/issues/32358.)