### PR TITLE
set forks in config

### DIFF
--- a/src/commcare_cloud/ansible/ansible.cfg
+++ b/src/commcare_cloud/ansible/ansible.cfg
@@ -12,6 +12,8 @@ timeout = 30
 inventory_plugins = ./plugins/inventory
 library = ./library
 
+forks = 50
+
 [ssh_connection]
 pipelining = True
 

--- a/src/commcare_cloud/commands/ansible/ansible_playbook.py
+++ b/src/commcare_cloud/commands/ansible/ansible_playbook.py
@@ -115,9 +115,6 @@ def run_ansible_playbook(
         public_vars = environment.public_vars
         cmd_parts += get_user_arg(public_vars, unknown_args)
 
-        if not has_arg(unknown_args, '-f', '--forks'):
-            cmd_parts += ('--forks', '15')
-
         if has_arg(unknown_args, '-D', '--diff') or has_arg(unknown_args, '-C', '--check'):
             puts(colored.red("Options --diff and --check not allowed. Please remove -D, --diff, -C, --check."))
             puts("These ansible-playbook options are managed automatically by commcare-cloud and cannot be set manually.")


### PR DESCRIPTION
Rather than setting this programatically just set in config.
This also has the effect of applying to runs of the 'ansible' command
and not just 'ansible_playbook'.

Increased count from 15 to 50.