### PR TITLE
Simplify supervisord installation

### DIFF
--- a/src/commcare_cloud/ansible/roles/supervisor/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/supervisor/tasks/main.yml
@@ -4,17 +4,9 @@
   apt: name=supervisor state=absent
   become: yes
 
-- name: find supervisord path
-  shell: 'which supervisord'
-  register: which_supervisord
-  changed_when: false
-  failed_when: which_supervisord.rc != 0 and which_supervisord.rc != 1
-  check_mode: no
-
 - name: install supervisor 3.3.4
   pip: name=supervisor state=present version=3.3.4 executable=pip2
   become: yes
-  when: not which_supervisord.stdout
 
 - name: link supervisor
   file:
@@ -25,16 +17,12 @@
     - supervisord
     - supervisorctl
 
-- name: retry finding supervisord path
+- name: find supervisord path
   shell: 'which supervisord'
-  register: which_supervisord_retry
+  register: which_supervisord
   changed_when: false
   failed_when: which_supervisord.rc != 0 and which_supervisord.rc != 1
   check_mode: no
-  when: not which_supervisord.stdout
-
-- set_fact: which_supervisord = which_supervisord_retry
-  when: not which_supervisord.stdout
 
 - name: check for sysvinit conf
   stat: path=/etc/init.d/supervisor


### PR DESCRIPTION
potentially fixes bug that caused supervisor executable path to be
missing from the conf, which made it impossible to start supervisord
(using upstart at least) until upgrade-users had been run a second time