### PR TITLE
Changed domain to correct domain name to avoid being spammed.

### DIFF
--- a/environments/pna/public.yml
+++ b/environments/pna/public.yml
@@ -39,8 +39,8 @@ couch_dbs:
     password: "{{ localsettings_private.COUCH_PASSWORD }}"
     is_https: False
 
-server_email: commcare@pna.sn
-default_from_email: commcare@pna.sn
+server_email: commcare@commcare.pna.sn
+default_from_email: commcare@commcare.pna.sn
 
 KSPLICE_ACTIVE: yes
 


### PR DESCRIPTION
Since the `pna.sn` and `commcare.pna.sn` are two different IP and `pna.sn` has not SPF records
sending mail from `pna.sn` will cause the mail to marked as spoofed mails. 
Should resolve the mail being delivered to spam. 