### PR TITLE
Add encrypted dir to django_manage VM

### DIFF
--- a/src/commcare_cloud/ansible/deploy_db.yml
+++ b/src/commcare_cloud/ansible/deploy_db.yml
@@ -11,6 +11,7 @@
     - riakcs
     - formplayer
     - pg_standby
+    - django_manage
   become: true
   roles:
     - {role: ecryptfs, tags: 'ecryptfs'}


### PR DESCRIPTION
Ran this on production, but nowhere else.

@dannyroberts 