### PR TITLE
adding more ucr static processors to see what happens

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -89,12 +89,18 @@ pillows:
       num_processes: 8
     CaseSearchToElasticsearchPillow:
       num_processes: 4
+    kafka-ucr-static:
+      start_process: 0
+      num_processes: 2
+      total_processes: 4
   hqpillowtop2.internal-va.commcarehq.org:
     kafka-ucr-main:
       num_processes: 4
-  hqpillowtop0.internal-va.commcarehq.org:
     kafka-ucr-static:
-      num_processes: 1
+      start_process: 2
+      num_processes: 2
+      total_processes: 4
+  hqpillowtop0.internal-va.commcarehq.org:
     AppDbChangeFeedPillow:
       num_processes: 1
     ApplicationToElasticsearchPillow:

--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -86,20 +86,14 @@ celery_processes:
 pillows:
   hqpillowtop3.internal-va.commcarehq.org:
     CaseToElasticsearchPillow:
-      num_processes: 8
-    CaseSearchToElasticsearchPillow:
-      num_processes: 4
-    kafka-ucr-static:
-      start_process: 0
       num_processes: 2
-      total_processes: 4
+    CaseSearchToElasticsearchPillow:
+      num_processes: 2
+    kafka-ucr-static:
+      num_processes: 4
   hqpillowtop2.internal-va.commcarehq.org:
     kafka-ucr-main:
       num_processes: 4
-    kafka-ucr-static:
-      start_process: 2
-      num_processes: 2
-      total_processes: 4
   hqpillowtop0.internal-va.commcarehq.org:
     AppDbChangeFeedPillow:
       num_processes: 1


### PR DESCRIPTION
this might be a bit overboard in terms of numbers, but it seemed like hqpillowtop{2,3} had plenty of space to spare and I was curious to see how this would affect the (for now daily) [hills](https://app.datadoghq.com/dash/256236/change-feeds-pillows?live=true&page=0&is_auto=false&from_ts=1536090657826&to_ts=1536695457826&tile_size=m) kafka-ucr-static is crawling up

https://manage.dimagi.com/default.asp?282671#edit_1_282671

@emord @czue 