### PR TITLE
Use spawnvp instead of execvp

### DIFF
--- a/src/commcare_cloud/commands/fab.py
+++ b/src/commcare_cloud/commands/fab.py
@@ -70,4 +70,4 @@ def exec_fab_command(env_name, *extra_args):
     ) + tuple(extra_args)
     cmd = ' '.join(shlex_quote(arg) for arg in cmd_parts)
     print_command(cmd)
-    os.execvp('fab', cmd_parts)
+    os.spawnvp(os.P_WAIT, 'fab', cmd_parts)

--- a/src/commcare_cloud/commands/fab.py
+++ b/src/commcare_cloud/commands/fab.py
@@ -70,4 +70,4 @@ def exec_fab_command(env_name, *extra_args):
     ) + tuple(extra_args)
     cmd = ' '.join(shlex_quote(arg) for arg in cmd_parts)
     print_command(cmd)
-    subprocess.call(cmd_parts)
+    return subprocess.call(cmd_parts)

--- a/src/commcare_cloud/commands/fab.py
+++ b/src/commcare_cloud/commands/fab.py
@@ -70,4 +70,4 @@ def exec_fab_command(env_name, *extra_args):
     ) + tuple(extra_args)
     cmd = ' '.join(shlex_quote(arg) for arg in cmd_parts)
     print_command(cmd)
-    os.spawnvp(os.P_WAIT, 'fab', cmd_parts)
+    subprocess.call(cmd_parts)


### PR DESCRIPTION
This allows calling two fab commands in a row.

https://docs.python.org/2/library/os.html

execvp:

> These functions all execute a new program, replacing the current process; they do not return

spawnvp waits until it returns

@dannyroberts any reason that we were using execvp originally? I haven't tested this out with other commands, but this is what I would have expected behavior to be. 

Also note that the python docs suggest using `subprocess` here. I tried that for a second, but got an error about not being able to find `fab`. I didn't look deeply into it, but that would probably be even better