### PR TITLE
add extra config with auth_cache_size

### DIFF
--- a/src/commcare_cloud/ansible/roles/couchdb2/defaults/main.yml
+++ b/src/commcare_cloud/ansible/roles/couchdb2/defaults/main.yml
@@ -9,3 +9,4 @@ couchdb_user: couchdb
 couchdb_group: couchdb
 couchdb_backup_days: 2
 couchdb_backup_weeks: 2
+couchdb_auth_cache_size: 200

--- a/src/commcare_cloud/ansible/roles/couchdb2/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/couchdb2/tasks/main.yml
@@ -6,7 +6,7 @@
     dest: "{{ couchdb_etc_local_dir }}/extras.ini"
     owner: '{{ couchdb_user }}'
     group: '{{ couchdb_group }}'
-    mode: '{{ default("0644") }}'
+    mode: 0644
   notify: restart couchdb2
 
 - meta: flush_handlers

--- a/src/commcare_cloud/ansible/roles/couchdb2/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/couchdb2/tasks/main.yml
@@ -1,4 +1,14 @@
 ---
+- name: Copy extra config
+  become: yes
+  template:
+    src: extras.ini.j2
+    dest: "{{ couchdb_etc_local_dir }}/extras.ini"
+    owner: '{{ couchdb_user }}'
+    group: '{{ couchdb_group }}'
+    mode: '{{ default("0644") }}'
+  notify: restart couchdb2
+
 - meta: flush_handlers
 
 - name: Add nodes

--- a/src/commcare_cloud/ansible/roles/couchdb2/templates/extras.ini.j2
+++ b/src/commcare_cloud/ansible/roles/couchdb2/templates/extras.ini.j2
@@ -1,0 +1,2 @@
+[couch_httpd_auth]
+auth_cache_size = {{ couchdb_auth_cache_size }}


### PR DESCRIPTION
Seems like the default isn't big enough: 
![image](https://user-images.githubusercontent.com/249606/45572984-06b56d00-b839-11e8-9e40-200f51713948.png)


http://docs.couchdb.org/en/stable/config/auth.html#couch_httpd_auth/auth_cache_size