### PR TITLE
Mk pillows conclude

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -86,7 +86,7 @@ celery_processes:
 pillows:
   hqpillowtop3.internal-va.commcarehq.org:
     CaseToElasticsearchPillow:
-      num_processes: 3
+      num_processes: 4
     CaseSearchToElasticsearchPillow:
       num_processes: 2
     kafka-ucr-static:

--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -94,9 +94,7 @@ pillows:
     XFormToElasticsearchPillow:
       num_processes: 2
     FormSubmissionMetadataTrackerPillow:
-      start_process: 0
-      num_processes: 3
-      total_processes: 6
+      num_processes: 2
   hqpillowtop2.internal-va.commcarehq.org:
     kafka-ucr-main:
       num_processes: 4
@@ -113,10 +111,6 @@ pillows:
       num_processes: 1
     FarmerRecordFluffPillow:
       num_processes: 1
-    FormSubmissionMetadataTrackerPillow:
-      start_processes: 3
-      num_processes: 3
-      total_processes: 6
     GeographyFluffPillow:
       num_processes: 1
     GroupPillow:

--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -86,7 +86,7 @@ celery_processes:
 pillows:
   hqpillowtop3.internal-va.commcarehq.org:
     CaseToElasticsearchPillow:
-      num_processes: 2
+      num_processes: 3
     CaseSearchToElasticsearchPillow:
       num_processes: 2
     kafka-ucr-static:
@@ -124,7 +124,7 @@ pillows:
     M4ChangeFormFluffPillow:
       num_processes: 1
     ReportCaseToElasticsearchPillow:
-      num_processes: 1
+      num_processes: 2
     ReportXFormToElasticsearchPillow:
       num_processes: 1
     SqlSMSPillow:


### PR DESCRIPTION
Looking for this to conclude all pillows changes during firefighting last week.

Before this was in [this](https://github.com/dimagi/commcare-cloud/blob/8aa90c026ad181fa51e5931043c4760fe9701b79/environments/production/app-processes.yml) state

So now effectively to address increase in [number of form submissions](https://app.datadoghq.com/dash/256236/change-feeds-pillows?live=true&page=0&is_auto=false&from_ts=1537781826772&to_ts=1537785426772&tile_size=m&fullscreen=211359693) , we have
1. Double `CaseToElasticsearchPillow`, from 2 -> 4
2. Double `ReportCaseToElasticsearchPillow`, from 1 -> 2
3. Double `XFormToElasticsearchPillow`, from 1 -> 2 and move it to pillow3 from pillow0
4. Double `FormSubmissionMetadataTrackerPillow` from 1 -> 2 and move it to pillow3 from pillow0. This should be increased once we have figured out https://manage.dimagi.com/default.asp?283232#BugEvent.1531623

Older PRs, in order of creation:
1. https://github.com/dimagi/commcare-cloud/pull/2162/files
2. https://github.com/dimagi/commcare-cloud/pull/2163
3. https://github.com/dimagi/commcare-cloud/pull/2166
4. https://github.com/dimagi/commcare-cloud/pull/2168
