### PR TITLE
Mk increase capacity

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -94,7 +94,7 @@ pillows:
     XFormToElasticsearchPillow:
       num_processes: 2
     FormSubmissionMetadataTrackerPillow:
-      num_processes: 2
+      num_processes: 4
   hqpillowtop2.internal-va.commcarehq.org:
     kafka-ucr-main:
       num_processes: 4

--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -97,8 +97,14 @@ pillows:
       num_processes: 4
   hqpillowtop2.internal-va.commcarehq.org:
     kafka-ucr-main:
+      start_processes: 0
       num_processes: 4
+      total_processes: 6
   hqpillowtop0.internal-va.commcarehq.org:
+    kafka-ucr-main:
+      start_processes: 4
+      num_processes: 2
+      total_processes: 6
     AppDbChangeFeedPillow:
       num_processes: 1
     ApplicationToElasticsearchPillow:


### PR DESCRIPTION
Did some dig in for this from https://github.com/dimagi/commcare-cloud/pull/2170. 
```
Double FormSubmissionMetadataTrackerPillow from 1 -> 2 and move it to pillow3 from pillow0. This should be increased once we have figured out https://manage.dimagi.com/default.asp?283232#BugEvent.1531623
```
Does not look like concurrency would cause the Conflict updates considering how the [pillows are divided](https://github.com/dimagi/commcare-hq/blob/b52861c85ee76621135138e9ee9cac630fef9dc0/corehq/apps/change_feed/consumer/feed.py#L144) for different queues
So increasing processes for FormSubmission meta data now

Also added 2 more for `ucr-main` to address the delay and would keep that long term.