### PR TITLE
remove django5 temporarily

### DIFF
--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -22,16 +22,12 @@ hqdjango3.internal-va.commcarehq.org
 [hqdjango4]
 hqdjango4.internal-va.commcarehq.org
 
-[hqdjango5]
-hqdjango5.internal-va.commcarehq.org
-
 [webworkers:children]
 hqdjango0
 hqdjango1
 hqdjango2
 hqdjango3
 hqdjango4
-hqdjango5
 
 [hqdb2]
 hqdb2.internal-va.commcarehq.org


### PR DESCRIPTION
Django5 was unresponsive and had to be hard rebooted twice in last few hours

Reached out to rackspace for help [here](https://portal.rackspace.com/tickets/details/180926-ord-0000189)

Removing django5 off the webworkers. This can be reverted once the above is resolved.