### PR TITLE
move and increase export_download_queue

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -76,12 +76,15 @@ celery_processes:
       concurrency: 6
       max_tasks_per_child: 1
       optimize: True
+    export_download_queue:
+      concurrency: 4
+      max_tasks_per_child: 5
   hqcelery4.internal-va.commcarehq.org:
     celery:
       concurrency: 6
       max_tasks_per_child: 5
     export_download_queue:
-      concurrency: 8
+      concurrency: 6
       max_tasks_per_child: 5
 pillows:
   hqpillowtop3.internal-va.commcarehq.org:


### PR DESCRIPTION
follow up from https://github.com/dimagi/commcare-cloud/pull/2177

Looks like increasing concurrency on the same server didn't go well. The queue restarted multiple times and then stopped accepting tasks as well.
So moving this to a different server instead and adding two more processes since the tasks get long running and tend to block new exports.