### PR TITLE
Add a variable to public.yml

### DIFF
--- a/commcare-cloud-bootstrap/environment/public.yml
+++ b/commcare-cloud-bootstrap/environment/public.yml
@@ -41,6 +41,8 @@ couchdb2:
   username: "{{ localsettings_private.COUCH_USERNAME }}"
   password: "{{ localsettings_private.COUCH_PASSWORD }}"
 
+couchdb_admins: "{'{{ localsettings_private.COUCH_USERNAME }}': '{{ localsettings_private.COUCH_PASSWORD }}',}"
+
 couchdb_bind:
   ty: static
   host: '{{ internal_ipv4.address }}'


### PR DESCRIPTION
Add in a couchdb_admins line so admins.ini.j2 from the ansible-couchdb-cluster repo is correctly populated.
This line is looking for it: https://github.com/andrewrothstein/ansible-couchdb-cluster/blob/master/templates/admins.ini.j2#L7