### PR TITLE
Set icds log retention for 60 days

### DIFF
--- a/environments/icds-cas/public.yml
+++ b/environments/icds-cas/public.yml
@@ -25,6 +25,7 @@ nofile_limit: 65536
 redis_appendonly: 'yes'
 
 kafka_log_dir: '{{ encrypted_root }}/kafka'
+kafka_log_retention: 1440 # 60 days
 
 KSPLICE_ACTIVE: no
 

--- a/src/commcare_cloud/ansible/roles/kafka/defaults/main.yml
+++ b/src/commcare_cloud/ansible/roles/kafka/defaults/main.yml
@@ -6,3 +6,4 @@ kafka_group: kafka
 kafka_data_dir: "{{ encrypted_root }}/kafka/data"
 kafka_conf_dir: /etc/kafka/config
 kafka_log_dir: /var/log/kafka
+kafka_log_retention: 672 # 28 days

--- a/src/commcare_cloud/ansible/roles/kafka/templates/server.properties.j2
+++ b/src/commcare_cloud/ansible/roles/kafka/templates/server.properties.j2
@@ -88,7 +88,7 @@ num.partitions=1
 # from the end of the log.
 
 # The minimum age of a log file to be eligible for deletion
-log.retention.hours=672
+log.retention.hours={{ kafka_log_retention }}
 
 # A size-based retention policy for logs. Segments are pruned from the log as long as the remaining
 # segments don't drop below log.retention.bytes.


### PR DESCRIPTION
@dimagi/scale-team we're still super far behind on forms from the really slow object storage. Increasing this to 60 days for now so that we don't run into a situation where we don't have the changes in kafka