### PR TITLE
Add command to fill inventory from AWS

### DIFF
--- a/docs/commcare-cloud/commands/index.md
+++ b/docs/commcare-cloud/commands/index.md
@@ -11,7 +11,7 @@ All `commcare-cloud` commands take the following form:
 ```
 commcare-cloud [--control]
                <env>
-               {bootstrap-users,ansible-playbook,django-manage,aps,tmux,ap,validate-environment-settings,deploy-stack,service,update-supervisor-confs,update-users,ping,migrate_couchdb,lookup,run-module,update-config,copy-files,mosh,list-postgresql-dbs,after-reboot,ssh,downtime,fab,update-local-known-hosts,aws-list,migrate-couchdb,terraform,run-shell-command}
+               {bootstrap-users,ansible-playbook,django-manage,aps,tmux,ap,validate-environment-settings,deploy-stack,service,update-supervisor-confs,update-users,ping,migrate_couchdb,lookup,run-module,update-config,copy-files,mosh,list-postgresql-dbs,after-reboot,ssh,downtime,fab,update-local-known-hosts,aws-list,aws-fill-inventory,migrate-couchdb,terraform,run-shell-command}
                ...
 ```
 
@@ -1074,6 +1074,16 @@ List endpoints (ec2, rds, etc.) on AWS
 
 ```
 commcare-cloud <env> aws-list
+```
+
+---
+
+#### `aws-fill-inventory`
+
+Fill inventory.ini.j2 using existing AWS resources
+
+```
+commcare-cloud <env> aws-fill-inventory
 ```
 
 ---

--- a/environments/staging-aws-test/inventory.ini.j2
+++ b/environments/staging-aws-test/inventory.ini.j2
@@ -30,7 +30,7 @@ kafka0
 kafka0
 
 [celery0]
-{{ celery0-staging }} hostname=celery0-staging
+{{ celery0-staging }} hostname=celery0-staging swap_size=8G
 
 [celery:children]
 celery0
@@ -86,7 +86,7 @@ remote_postgresql
 
 [redis]
 # ElastiCache
-{{ staging-redis }}:6379
+{{ redis-staging-test }}:6379
 
 [ansible_skip:children]
 rds_pg0

--- a/environments/staging-aws-test/make-inventory.sh
+++ b/environments/staging-aws-test/make-inventory.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
-cchq staging-aws-test aws-list | xargs -n2 echo \
-    | awk 'BEGIN { printf "sed " } { printf "-e '\''s/{{ "$2" }}/"$1"/'\'' " } END { printf "environments/staging-aws-test/inventory.ini.j2" }' \
-    | bash > environments/staging-aws-test/inventory.ini
+ENV=$1
+cchq ${ENV} aws-list | xargs -n2 echo \
+    | awk 'BEGIN { printf "sed " } { printf "-e '\''s/{{ "$2" }}/"$1"/'\'' " } END { printf "environments/'${ENV}'/inventory.ini.j2" }' \
+    | bash > environments/${ENV}/inventory.ini

--- a/environments/staging-aws-test/make-inventory.sh
+++ b/environments/staging-aws-test/make-inventory.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-ENV=$1
-cchq ${ENV} aws-list | xargs -n2 echo \
-    | awk 'BEGIN { printf "sed " } { printf "-e '\''s/{{ "$2" }}/"$1"/'\'' " } END { printf "environments/'${ENV}'/inventory.ini.j2" }' \
-    | bash > environments/${ENV}/inventory.ini

--- a/environments/staging-aws-test/make-inventory.sh
+++ b/environments/staging-aws-test/make-inventory.sh
@@ -1,23 +1,4 @@
 #!/usr/bin/env bash
-cat <(
-    AWS_PROFILE=dimagi aws ec2 describe-instances \
-        --filter \
-            "Name=tag-key,Values=Name" "Name=tag-value,Values=*$name_tag*" \
-            "Name=instance-state-name,Values=running" \
-            "Name=tag-key,Values=Environment" "Name=tag-value,Values=staging-test" \
-        --query "Reservations[*].Instances[*][Tags[?Key=='Name'].Value[],NetworkInterfaces[0].PrivateIpAddresses[0].PrivateIpAddress]" \
-        --output text --region us-east-1
-    ) <(
-    AWS_PROFILE=dimagi aws ec2 describe-instances \
-        --filter \
-            "Name=tag-key,Values=Name" "Name=tag-value,Values=proxy1-staging" \
-            "Name=instance-state-name,Values=running" \
-        --query "Reservations[*].Instances[*][Tags[?Key=='Name'].Value[],NetworkInterfaces[0].Association.PublicIp]" \
-        --output text --region us-east-1 | sed '$s/$/.public_ip/' \
-    ) <(
-    AWS_PROFILE=dimagi aws elasticache describe-cache-clusters --show-cache-node-info \
-        --query 'CacheClusters[0].CacheNodes[0].Endpoint.Address' \
-        --output text --region us-east-1; echo staging-redis
-    ) | xargs -n2 echo \
+cchq staging-aws-test aws-list | xargs -n2 echo \
     | awk 'BEGIN { printf "sed " } { printf "-e '\''s/{{ "$2" }}/"$1"/'\'' " } END { printf "environments/staging-aws-test/inventory.ini.j2" }' \
     | bash > environments/staging-aws-test/inventory.ini

--- a/environments/staging/inventory.ini
+++ b/environments/staging/inventory.ini
@@ -1,8 +1,13 @@
+# This file currently contains a lot of commented-out hosts
+# that refer to presumed eventual hosts that will live on AWS but don't yet exit
+# As they get added, we'll uncomment them and the IPs will get populated from live AWS resources
+# using the aws-fill-inventory command.
+
 [proxy0]
 proxy0-staging.internal-va.commcarehq.org swap_size=1G
 
 [proxy1]
-# 10.200.10.85 hostname=proxy1-staging ec2=yes
+# {{ proxy1-staging }} hostname=proxy1-staging ec2=yes
 
 [proxy:children]
 proxy0
@@ -37,7 +42,7 @@ hqdb1
 # staging.cibdtdv2q1vz.us-east-1.rds.amazonaws.com
 
 [rabbit0]
-# 10.200.10.107 hostname=rabbit0-staging ec2=yes
+# {{ rabbit0-staging }} hostname=rabbit0-staging ec2=yes
 
 
 [rabbitmq:children]
@@ -53,7 +58,7 @@ swap_size=1G
 kafka_broker_id=0
 
 [kafka0]
-# 10.200.10.199 kafka_broker_id=0 hostname=kafka0-staging ec2=yes
+# {{ kafka0-staging }} kafka_broker_id=0 hostname=kafka0-staging ec2=yes
 
 [zookeeper:children]
 hqkafka0
@@ -66,7 +71,7 @@ hqkafka0
 # kafka0
 
 [celery0]
-# 10.200.11.168 hostname=celery0-staging ec2=yes
+# {{ celery0-staging }} hostname=celery0-staging ec2=yes
 
 [celery:children]
 hqdb1
@@ -77,7 +82,7 @@ hqdb1
 hqpillow0-staging.internal-va.commcarehq.org
 
 [pillow0]
-# 10.200.12.203 hostname=pillow0-staging ec2=yes
+# {{ pillow0-staging }} hostname=pillow0-staging ec2=yes
 
 [pillowtop:children]
 hqpillow0
@@ -88,7 +93,7 @@ hqpillow0
 hqtouch0-staging.internal-va.commcarehq.org swap_size=1G
 
 [formplayer0]
-# 10.200.10.63 hostname=formplayer0-staging ec2=yes
+# {{ formplayer0-staging }} hostname=formplayer0-staging ec2=yes
 
 [formplayer:children]
 hqtouch0
@@ -97,14 +102,14 @@ hqtouch0
 
 [redis:children]
 hqdb1
-# Amazon ElastiCache (staging-redis)
-# staging-redis.ck3xwy.0001.use1.cache.amazonaws.com:6379
+# Amazon ElastiCache
+# {{ redis-staging }}:6379
 
 [hqes0]
 hqes0-staging.internal-va.commcarehq.org elasticsearch_node_name=hqes0-staging
 
 [es0]
-# 10.200.10.223 elasticsearch_node_name=hqes0-staging hostname=es0-staging ec2=yes
+# {{ hqes0-staging }} elasticsearch_node_name=hqes0-staging hostname=es0-staging ec2=yes
 
 [elasticsearch:children]
 hqes0
@@ -133,7 +138,7 @@ hqriak01
 hqairflow0-staging.internal-va.commcarehq.org
 
 [airflow0]
-# 10.200.10.110 hostname=airflow0-staging ec2=yes
+# {{ airflow0-staging }} hostname=airflow0-staging ec2=yes
 
 [airflow:children]
 hqairflow0

--- a/environments/staging/inventory.ini.j2
+++ b/environments/staging/inventory.ini.j2
@@ -1,8 +1,13 @@
+# This file currently contains a lot of commented-out hosts
+# that refer to presumed eventual hosts that will live on AWS but don't yet exist
+# As they get added, we'll uncomment them and the IPs will get populated from live AWS resources
+# using the aws-fill-inventory command.
+
 [proxy0]
 proxy0-staging.internal-va.commcarehq.org swap_size=1G
 
 [proxy1]
-# 10.200.10.85 hostname=proxy1-staging ec2=yes
+# {{ proxy1-staging }} hostname=proxy1-staging ec2=yes
 
 [proxy:children]
 proxy0
@@ -37,7 +42,7 @@ hqdb1
 # staging.cibdtdv2q1vz.us-east-1.rds.amazonaws.com
 
 [rabbit0]
-# 10.200.10.107 hostname=rabbit0-staging ec2=yes
+# {{ rabbit0-staging }} hostname=rabbit0-staging ec2=yes
 
 
 [rabbitmq:children]
@@ -53,7 +58,7 @@ swap_size=1G
 kafka_broker_id=0
 
 [kafka0]
-# 10.200.10.199 kafka_broker_id=0 hostname=kafka0-staging ec2=yes
+# {{ kafka0-staging }} kafka_broker_id=0 hostname=kafka0-staging ec2=yes
 
 [zookeeper:children]
 hqkafka0
@@ -66,7 +71,7 @@ hqkafka0
 # kafka0
 
 [celery0]
-# 10.200.11.168 hostname=celery0-staging ec2=yes
+# {{ celery0-staging }} hostname=celery0-staging ec2=yes
 
 [celery:children]
 hqdb1
@@ -77,7 +82,7 @@ hqdb1
 hqpillow0-staging.internal-va.commcarehq.org
 
 [pillow0]
-# 10.200.12.203 hostname=pillow0-staging ec2=yes
+# {{ pillow0-staging }} hostname=pillow0-staging ec2=yes
 
 [pillowtop:children]
 hqpillow0
@@ -88,7 +93,7 @@ hqpillow0
 hqtouch0-staging.internal-va.commcarehq.org swap_size=1G
 
 [formplayer0]
-# 10.200.10.63 hostname=formplayer0-staging ec2=yes
+# {{ formplayer0-staging }} hostname=formplayer0-staging ec2=yes
 
 [formplayer:children]
 hqtouch0
@@ -97,14 +102,14 @@ hqtouch0
 
 [redis:children]
 hqdb1
-# Amazon ElastiCache (staging-redis)
-# staging-redis.ck3xwy.0001.use1.cache.amazonaws.com:6379
+# Amazon ElastiCache
+# {{ redis-staging }}:6379
 
 [hqes0]
 hqes0-staging.internal-va.commcarehq.org elasticsearch_node_name=hqes0-staging
 
 [es0]
-# 10.200.10.223 elasticsearch_node_name=hqes0-staging hostname=es0-staging ec2=yes
+# {{ hqes0-staging }} elasticsearch_node_name=hqes0-staging hostname=es0-staging ec2=yes
 
 [elasticsearch:children]
 hqes0
@@ -133,7 +138,7 @@ hqriak01
 hqairflow0-staging.internal-va.commcarehq.org
 
 [airflow0]
-# 10.200.10.110 hostname=airflow0-staging ec2=yes
+# {{ airflow0-staging }} hostname=airflow0-staging ec2=yes
 
 [airflow:children]
 hqairflow0
@@ -142,7 +147,7 @@ hqairflow0
 
 [control]
 # Amazon EC2
-10.201.10.187 hostname=control-staging ec2=yes
+{{ control-staging }} hostname=control-staging ec2=yes
 
 [pg_standby]
 

--- a/environments/staging/inventory.ini.j2
+++ b/environments/staging/inventory.ini.j2
@@ -1,0 +1,160 @@
+[proxy0]
+proxy0-staging.internal-va.commcarehq.org swap_size=1G
+
+[proxy1]
+# 10.200.10.85 hostname=proxy1-staging ec2=yes
+
+[proxy:children]
+proxy0
+# Amazon EC2
+# proxy1
+
+[hqdjango0]
+hqdjango0-staging.internal-va.commcarehq.org swap_size=1G
+
+[hqdjango1]
+hqdjango1-staging.internal-va.commcarehq.org swap_size=1G
+
+[web0]
+{{ web0-staging }} swap_size=1G hostname=web0-staging ec2=yes
+
+[web1]
+{{ web1-staging }} swap_size=1G hostname=web1-staging ec2=yes
+
+[webworkers:children]
+hqdjango0
+hqdjango1
+# Amazon EC2
+web0
+web1
+
+[hqdb1]
+hqdb1-staging.internal-va.commcarehq.org swap_size=1G
+
+[postgresql:children]
+hqdb1
+# Amazon RDS Instance
+# staging.cibdtdv2q1vz.us-east-1.rds.amazonaws.com
+
+[rabbit0]
+# 10.200.10.107 hostname=rabbit0-staging ec2=yes
+
+
+[rabbitmq:children]
+hqdb1
+# Amazon EC2
+# rabbit0
+
+[hqkafka0]
+hqkafka0-staging.internal-va.commcarehq.org
+
+[hqkafka0:vars]
+swap_size=1G
+kafka_broker_id=0
+
+[kafka0]
+# 10.200.10.199 kafka_broker_id=0 hostname=kafka0-staging ec2=yes
+
+[zookeeper:children]
+hqkafka0
+# Amazon EC2
+# kafka0
+
+[kafka:children]
+hqkafka0
+# Amazon EC2
+# kafka0
+
+[celery0]
+# 10.200.11.168 hostname=celery0-staging ec2=yes
+
+[celery:children]
+hqdb1
+# Amazon EC2
+# celery0
+
+[hqpillow0]
+hqpillow0-staging.internal-va.commcarehq.org
+
+[pillow0]
+# 10.200.12.203 hostname=pillow0-staging ec2=yes
+
+[pillowtop:children]
+hqpillow0
+# Amazon EC2
+# pillow0
+
+[hqtouch0]
+hqtouch0-staging.internal-va.commcarehq.org swap_size=1G
+
+[formplayer0]
+# 10.200.10.63 hostname=formplayer0-staging ec2=yes
+
+[formplayer:children]
+hqtouch0
+# Amazon EC2
+# formplayer0
+
+[redis:children]
+hqdb1
+# Amazon ElastiCache (staging-redis)
+# staging-redis.ck3xwy.0001.use1.cache.amazonaws.com:6379
+
+[hqes0]
+hqes0-staging.internal-va.commcarehq.org elasticsearch_node_name=hqes0-staging
+
+[es0]
+# 10.200.10.223 elasticsearch_node_name=hqes0-staging hostname=es0-staging ec2=yes
+
+[elasticsearch:children]
+hqes0
+# Amazon EC2
+# es0
+
+[shared_dir_host:children]
+hqdb1
+# Amazon EC2
+# rabbit0
+
+[stanchion:children]
+hqkafka0
+
+[hqriak00]
+hqriak00-staging.internal-va.commcarehq.org
+
+[hqriak01]
+hqriak01-staging.internal-va.commcarehq.org
+
+[riakcs:children]
+hqriak00
+hqriak01
+
+[hqairflow0]
+hqairflow0-staging.internal-va.commcarehq.org
+
+[airflow0]
+# 10.200.10.110 hostname=airflow0-staging ec2=yes
+
+[airflow:children]
+hqairflow0
+# Amazon EC2
+# airflow0
+
+[control]
+# Amazon EC2
+10.201.10.187 hostname=control-staging ec2=yes
+
+[pg_standby]
+
+[ansible_skip:children]
+
+[django_manage:children]
+hqdjango0
+# Amazon EC2
+# web0
+
+[pg_barman:children]
+hqriak00
+
+[pg_barman_source:children]
+postgresql

--- a/src/commcare_cloud/commands/terraform/aws.py
+++ b/src/commcare_cloud/commands/terraform/aws.py
@@ -28,54 +28,81 @@ def aws_cli(environment, cmd_parts):
         check_output(cmd_parts, env={'AWS_PROFILE': environment.terraform_config.aws_profile}))
 
 
+def get_aws_resources(environment):
+    config = environment.terraform_config
+
+    # Private IP addresses
+    private_ip_query = aws_cli(environment, [
+        'aws', 'ec2', 'describe-instances',
+        '--filter', "Name=tag-key,Values=Name", "Name=tag-value,Values=*",
+        "Name=instance-state-name,Values=running",
+        "Name=tag-key,Values=Environment",
+        "Name=tag-value,Values={}".format(config.environment),
+        "--query",
+        "Reservations[*].Instances[*][Tags[?Key=='Name'].Value, NetworkInterfaces[0].PrivateIpAddresses[0].PrivateIpAddress]",
+        "--output", "json",
+        "--region", config.region,
+    ])
+    name_private_ip_pairs = [(item[0][0][0], item[0][1]) for item in private_ip_query]
+
+    # Public IP addresses
+    public_ip_query = aws_cli(environment, [
+        'aws', 'ec2', 'describe-instances',
+        '--filter', "Name=tag-key,Values=Name", "Name=tag-value,Values=*",
+        "Name=instance-state-name,Values=running",
+        "Name=tag-key,Values=Environment",
+        "Name=tag-value,Values={}".format(config.environment),
+        "--query",
+        "Reservations[*].Instances[*][Tags[?Key=='Name'].Value[],NetworkInterfaces[0].Association.PublicIp]",
+        "--output", "json",
+        "--region", config.region,
+    ])
+    name_public_ip_pairs = [(item[0][0][0], item[0][1]) for item in public_ip_query
+                            if item[0][1] is not None]
+
+    elasticache_address = aws_cli(environment, [
+        'aws', 'elasticache', 'describe-cache-clusters', '--show-cache-node-info',
+        '--query', 'CacheClusters[0].CacheNodes[0].Endpoint.Address',
+        '--output', 'json', '--region', config.region,
+    ])
+
+    resources = {}
+    for name, ip in name_private_ip_pairs:
+        resources[name] = ip
+
+    for name, ip in name_public_ip_pairs:
+        resources['{}.public_ip'.format(name)] = ip
+
+    if elasticache_address:
+        resources['redis-{}'.format(config.environment)] = elasticache_address
+
+    return resources
+
+
 class AwsList(CommandBase):
     command = 'aws-list'
     help = "List endpoints (ec2, rds, etc.) on AWS"
 
     def run(self, args, unknown_args):
         environment = get_environment(args.env_name)
-        config = environment.terraform_config
-
-        # Private IP addresses
-        private_ip_query = aws_cli(environment, [
-            'aws', 'ec2', 'describe-instances',
-            '--filter', "Name=tag-key,Values=Name", "Name=tag-value,Values=*",
-            "Name=instance-state-name,Values=running",
-            "Name=tag-key,Values=Environment",
-            "Name=tag-value,Values={}".format(config.environment),
-            "--query", "Reservations[*].Instances[*][Tags[?Key=='Name'].Value, NetworkInterfaces[0].PrivateIpAddresses[0].PrivateIpAddress]",
-            "--output", "json",
-            "--region", config.region,
-        ])
-        name_private_ip_pairs = [(item[0][0][0], item[0][1]) for item in private_ip_query]
-
-        # Public IP addresses
-        public_ip_query = aws_cli(environment, [
-            'aws', 'ec2', 'describe-instances',
-            '--filter', "Name=tag-key,Values=Name", "Name=tag-value,Values=*",
-            "Name=instance-state-name,Values=running",
-            "Name=tag-key,Values=Environment",
-            "Name=tag-value,Values={}".format(config.environment),
-            "--query",
-            "Reservations[*].Instances[*][Tags[?Key=='Name'].Value[],NetworkInterfaces[0].Association.PublicIp]",
-            "--output", "json",
-            "--region", config.region,
-        ])
-        name_public_ip_pairs = [(item[0][0][0], item[0][1]) for item in public_ip_query
-                                if item[0][1] is not None]
-
-        elasticache_query = aws_cli(environment, [
-            'aws', 'elasticache', 'describe-cache-clusters', '--show-cache-node-info',
-            '--query', 'CacheClusters[0].CacheNodes[0].Endpoint.Address',
-            '--output', 'json', '--region', config.region,
-        ])
-
-        for name, ip in name_private_ip_pairs:
-            print('{}\t{}'.format(ip, name))
-
-        for name, ip in name_public_ip_pairs:
-            print('{}\t{}.public_ip'.format(ip, name))
-
-        if elasticache_query:
-            print('{}\tredis-{}'.format(elasticache_query, config.environment))
+        resources = get_aws_resources(environment)
+        for name, address in sorted(resources.items()):
+            print('{}\t{}'.format(address, name))
         return 0
+
+
+class AwsFillInventory(CommandBase):
+    command = 'aws-fill-inventory'
+    help = "Fill inventory.ini.j2 using existing AWS resources"
+
+    def run(self, args, unknown_args):
+        environment = get_environment(args.env_name)
+        resources = get_aws_resources(environment)
+        with open(environment.paths.inventory_ini_j2) as f:
+            template_string = f.read()
+
+        for name, address in resources.items():
+            template_string = template_string.replace('{{ ' + name + ' }}', address)
+
+        with open(environment.paths.inventory_ini, 'w') as f:
+            f.write(template_string)

--- a/src/commcare_cloud/commands/terraform/aws.py
+++ b/src/commcare_cloud/commands/terraform/aws.py
@@ -64,9 +64,18 @@ class AwsList(CommandBase):
         name_public_ip_pairs = [(item[0][0][0], item[0][1]) for item in public_ip_query
                                 if item[0][1] is not None]
 
+        elasticache_query = aws_cli(environment, [
+            'aws', 'elasticache', 'describe-cache-clusters', '--show-cache-node-info',
+            '--query', 'CacheClusters[0].CacheNodes[0].Endpoint.Address',
+            '--output', 'json', '--region', config.region,
+        ])
+
         for name, ip in name_private_ip_pairs:
             print('{}\t{}'.format(ip, name))
 
         for name, ip in name_public_ip_pairs:
             print('{}\t{}.public_ip'.format(ip, name))
+
+        if elasticache_query:
+            print('{}\tredis-{}'.format(elasticache_query, config.environment))
         return 0

--- a/src/commcare_cloud/commcare_cloud.py
+++ b/src/commcare_cloud/commcare_cloud.py
@@ -14,7 +14,7 @@ from commcare_cloud.cli_utils import print_command
 from commcare_cloud.commands.ansible.downtime import Downtime
 from commcare_cloud.commands.migrations.couchdb import MigrateCouchdb
 from commcare_cloud.commands.migrations.copy_files import CopyFiles
-from commcare_cloud.commands.terraform.aws import AwsList
+from commcare_cloud.commands.terraform.aws import AwsList, AwsFillInventory
 from commcare_cloud.commands.terraform.terraform import Terraform
 from commcare_cloud.commands.validate_environment_settings import ValidateEnvironmentSettings
 from .argparse14 import ArgumentParser, RawTextHelpFormatter
@@ -67,6 +67,7 @@ COMMAND_GROUPS = OrderedDict([
         ListDatabases,
         Terraform,
         AwsList,
+        AwsFillInventory,
     ])
 ])
 

--- a/src/commcare_cloud/environment/paths.py
+++ b/src/commcare_cloud/environment/paths.py
@@ -58,6 +58,10 @@ class DefaultPaths(object):
         return self.get_env_file_path('inventory.ini')
 
     @lazy_immutable_property
+    def inventory_ini_j2(self):
+        return self.get_env_file_path('inventory.ini.j2')
+
+    @lazy_immutable_property
     def inventory_csv(self):
         return self.get_env_file_path('inventory.csv')
 

--- a/src/commcare_cloud/terraform/modules/commcarehq/main.tf
+++ b/src/commcare_cloud/terraform/modules/commcarehq/main.tf
@@ -78,7 +78,7 @@ resource "aws_eip" "proxy" {
 module "Redis" {
   source               = "../elasticache"
   create               = "${lookup(local.redis, "create", true)}"
-  cluster_id           = "${var.environment}-redis"
+  cluster_id           = "redis-${var.environment}"
   engine               = "redis"
   engine_version       = "${local.redis["engine_version"]}"
   node_type            = "${local.redis["node_type"]}"


### PR DESCRIPTION
Very rudimentary pattern here to allow templating an inventory and filling in IP addresses from what's on AWS. Helpful to be able to use the machine's name and have it fill in the address, and for when you need to rebuild a machine and have it change the IP for you.