### PR TITLE
Riak fix

### DIFF
--- a/src/commcare_cloud/ansible/deploy_riakcs.yml
+++ b/src/commcare_cloud/ansible/deploy_riakcs.yml
@@ -117,15 +117,16 @@
     - role: riakcs/configure
       vars:
         name: riak
-        drop_conf: "{{ backend_vars.drop_conf }}"
-        advanced_conf: "{{ backend_vars.advanced_conf }}"
-        data_dirs:
-          - "{{ riak_data_dir }}"
-          - "{{ riak_ring_dir }}"
-          - "{{ riak_data_root_leveldb }}"
-          - "{{ riak_data_root_bitcask if _riak_backend == 'bitcask' else '' }}"
-          - "{{ riak_data_root_blocks if _riak_backend == 'leveldb' else '' }}"
-        when: _force_riak_config | bool
+      drop_conf: "{{ backend_vars.drop_conf }}"
+      advanced_conf: "{{ backend_vars.advanced_conf }}"
+      data_dirs:
+        - "{{ riak_data_dir }}"
+        - "{{ riak_ring_dir }}"
+        - "{{ riak_data_root_leveldb }}"
+        - "{{ riak_data_root_bitcask if _riak_backend == 'bitcask' else '' }}"
+        - "{{ riak_data_root_blocks if _riak_backend == 'leveldb' else '' }}"
+      when: _force_riak_config | bool
+
 
 - name: Start Riak
   become: true


### PR DESCRIPTION
Only keep the 'name' variable under 'vars' (for ansible 2.5 compatibility), it doesn't properly pass in the other variables when nested under 'vars'

@calellowitz 
code buddy @jmtroth0 

Note: Closing this PR which didn't address the root cause: https://github.com/dimagi/commcare-cloud/pull/2219