### PR TITLE
Update the list of queues that cannot share a process

### DIFF
--- a/.travis/environments/travis/app-processes.yml
+++ b/.travis/environments/travis/app-processes.yml
@@ -3,9 +3,13 @@ celery_processes:
     celery_periodic:
     async_restore_queue,background_queue,case_rule_queue,celery,export_download_queue:
     email_queue,reminder_case_update_queue,analytics_queue:
-    reminder_rule_queue,reminder_queue,repeat_record_queue,saved_exports_queue:
-    sms_queue,submission_reprocessing_queue,ucr_indicator_queue,ucr_queue:
+    reminder_rule_queue,repeat_record_queue,saved_exports_queue:
+    ucr_indicator_queue,ucr_queue:
     flower:
+    submission_reprocessing_queue:
+    sms_queue:
+    reminder_queue:
+
   celery:
 pillows:
   pillowtop:

--- a/commcare-cloud-bootstrap/environment/app-processes.yml.j2
+++ b/commcare-cloud-bootstrap/environment/app-processes.yml.j2
@@ -1,17 +1,16 @@
 celery_processes:
   {{ celery_host.name }}:
     beat: {}
+    sms_queue: {}
+    flower: {}
     background_queue,case_rule_queue,celery,analytics_queue:
       concurrency: 1
-    email_queue,reminder_case_update_queue:
+    email_queue,reminder_case_update_queue,export_download_queue:
       concurrency: 1
     reminder_rule_queue,repeat_record_queue,saved_exports_queue:
       concurrency: 1
-    sms_queue,export_download_queue:
-      concurrency: 1
 #    reminder_queue,submission_reprocessing_queue,ucr_indicator_queue,ucr_queue,celery_periodic:
 #      concurrency: 1
-    flower: {}
 pillows:
   {{ pillowtop_host.name }}:
     kafka-ucr-main:

--- a/commcare-cloud-bootstrap/environment/app-processes.yml.j2
+++ b/commcare-cloud-bootstrap/environment/app-processes.yml.j2
@@ -9,8 +9,12 @@ celery_processes:
       concurrency: 1
     reminder_rule_queue,repeat_record_queue,saved_exports_queue:
       concurrency: 1
-#    reminder_queue,submission_reprocessing_queue,ucr_indicator_queue,ucr_queue,celery_periodic:
-#      concurrency: 1
+#	reminder_queue:
+#	  concurrency: 1
+#	submission_reprocessing_queue
+#	  concurrency: 1
+#	ucr_indicator_queue,ucr_queue,celery_periodic:
+#	  concurrency: 1
 pillows:
   {{ pillowtop_host.name }}:
     kafka-ucr-main:

--- a/environments/64-test/app-processes.yml
+++ b/environments/64-test/app-processes.yml
@@ -7,9 +7,9 @@ celery_processes:
       concurrency: 1
     email_queue,reminder_case_update_queue:
       concurrency: 5
-    reminder_rule_queue,reminder_queue,repeat_record_queue,saved_exports_queue:
+    reminder_rule_queue,repeat_record_queue,saved_exports_queue:
       concurrency: 1
-    sms_queue,submission_reprocessing_queue,ucr_indicator_queue,ucr_queue:
+    ucr_indicator_queue,ucr_queue:
       concurrency: 1
     flower: {}
 pillows:

--- a/environments/development/app-processes.yml
+++ b/environments/development/app-processes.yml
@@ -7,9 +7,9 @@ celery_processes:
       concurrency: 1
     email_queue,reminder_case_update_queue:
       concurrency: 1
-    reminder_rule_queue,reminder_queue,repeat_record_queue,saved_exports_queue:
+    reminder_rule_queue,repeat_record_queue,saved_exports_queue:
       concurrency: 1
-    sms_queue,submission_reprocessing_queue,ucr_indicator_queue,ucr_queue:
+    ucr_indicator_queue,ucr_queue:
       concurrency: 1
     flower: {}
 pillows:

--- a/environments/enikshay-reference/app-processes.yml
+++ b/environments/enikshay-reference/app-processes.yml
@@ -7,9 +7,9 @@ celery_processes:
       concurrency: 1
     email_queue,reminder_case_update_queue:
       concurrency: 1
-    reminder_rule_queue,reminder_queue,repeat_record_queue,saved_exports_queue:
+    reminder_rule_queue,repeat_record_queue,saved_exports_queue:
       concurrency: 1
-    sms_queue,submission_reprocessing_queue,ucr_indicator_queue,ucr_queue:
+    ucr_indicator_queue,ucr_queue:
       concurrency: 1
     flower: {}
 pillows:

--- a/environments/pna/app-processes.yml
+++ b/environments/pna/app-processes.yml
@@ -17,7 +17,7 @@ celery_processes:
       max_tasks_per_child: 1
 # wait until background_queue,export_download_queue have been verified to work with optimize
 #      optimize: True
-    submission_reprocessing_queue,ucr_queue,async_restore_queue,email_queue,case_rule_queue:
+    ucr_queue,async_restore_queue,email_queue,case_rule_queue:
       concurrency: 1
       max_tasks_per_child: 1
     beat: {}

--- a/environments/swiss/app-processes.yml
+++ b/environments/swiss/app-processes.yml
@@ -15,13 +15,13 @@ celery_processes:
     beat: {}
     celery_periodic,email_queue:
       concurrency: 1
-    email_queue,sms_queue:
+    email_queue:
       concurrency: 1
     saved_exports_queue:
       concurrency: 1
       max_tasks_per_child: 1
       optimize: True
-    submission_reprocessing_queue,reminder_case_update_queue,reminder_queue:
+    reminder_case_update_queue:
       concurrency: 1
     reminder_rule_queue:
       concurrency: 1

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/celery.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/celery.yml
@@ -1,3 +1,6 @@
+# Note: Make sure to add queues with associated tasks to the solo_queues list in
+# validate_app_processes_config(), in app_processes.py, so they don't share a process with another queue.
+
 - name: define reminder queue services
   become: cchq
   template:


### PR DESCRIPTION
I'll describe how I found this error which I think will explain what the error is.
[This task](https://github.com/dimagi/commcare-cloud/blob/master/src/commcare_cloud/ansible/roles/commcarehq/tasks/celery.yml#L39) kept getting skipped on this `when` clause

So I added in this debug statement right before that task: `- debug: msg="{{ app_processes_config.celery_processes.get(inventory_hostname) }}"`, and the output was:
```
ok: [10.0.0.23] => {
    "msg": {
        "background_queue,case_rule_queue,celery,analytics_queue": {
            "concurrency": 1,
            "max_tasks_per_child": 50,
            "num_workers": 1,
            "optimize": false,
            "pooling": "prefork"
        },
        "beat": {
            "concurrency": 1,
            "max_tasks_per_child": 50,
            "num_workers": 1,
            "optimize": false,
            "pooling": "prefork"
        },
        "email_queue,reminder_case_update_queue": {
            "concurrency": 1,
            "max_tasks_per_child": 50,
            "num_workers": 1,
            "optimize": false,
            "pooling": "prefork"
        },
        "flower": {
            "concurrency": 1,
            "max_tasks_per_child": 50,
            "num_workers": 1,
            "optimize": false,
            "pooling": "prefork"
        },
        "reminder_rule_queue,repeat_record_queue,saved_exports_queue": {
            "concurrency": 1,
            "max_tasks_per_child": 50,
            "num_workers": 1,
            "optimize": false,
            "pooling": "prefork"
        },
        "sms_queue,export_download_queue": {
            "concurrency": 1,
            "max_tasks_per_child": 50,
            "num_workers": 1,
            "optimize": false,
            "pooling": "prefork"
        }
    }
}
```

What I got from that is that all the queues that have their own tasks in celery.yml cannot be grouped with other queues.

This fix breaks a bunch of tests, because this is currently being violated in every env specified in danny's comment!


@dannyroberts 
code buddy @jmtroth0 