### PR TITLE
Check_services should come after the postgres user was created

### DIFF
--- a/commcare-cloud-bootstrap/bootstrap.sh
+++ b/commcare-cloud-bootstrap/bootstrap.sh
@@ -16,9 +16,10 @@ commcare-cloud $ENV deploy-stack --skip-check --quiet -e 'CCHQ_IS_FRESH_INSTALL=
 
 commcare-cloud $ENV fab deploy:confirm=no,skip_record=yes --show=debug --set ignore_kafka_checkpoint_warning=true --branch=$BRANCH
 
-commcare-cloud $ENV django-manage check_services
-
 # Make the test superuser test_superuser@test.com, so the postgres service check passes
 echo -e "123\n123" | cchq $ENV django-manage make_superuser test_superuser@test.com
 proxy=$(grep -A1 "\[$ENV-proxy-0\]" environments/$ENV/inventory.ini | tail -n 1| awk '{print $2}' | awk -F'=' '{print $2}')
+
+commcare-cloud $ENV django-manage check_services
+
 curl https://${proxy}/serverup.txt --insecure


### PR DESCRIPTION
Otherwise check services has this line: `FAILURE (Took   0.01s) postgres       : default:commcarehq:OK ucr:commcarehq_ucr:OK No users found in postgres`

@dannyroberts 
code buddy @jmtroth0 