### PR TITLE
Use cleaner ansible calls

### DIFF
--- a/src/commcare_cloud/ansible/echo_vault_password.sh
+++ b/src/commcare_cloud/ansible/echo_vault_password.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "${ANSIBLE_VAULT_PASSWORD}"

--- a/src/commcare_cloud/commands/ansible/run_module.py
+++ b/src/commcare_cloud/commands/ansible/run_module.py
@@ -102,7 +102,6 @@ class RunAnsibleModule(CommandBase):
 def run_ansible_module(environment, ansible_context, inventory_group, module, module_args,
                        become, become_user, factory_auth, *extra_args):
     cmd_parts = (
-        'ANSIBLE_CONFIG={}'.format(os.path.join(ANSIBLE_DIR, 'ansible.cfg')),
         'ansible', inventory_group,
         '-m', module,
         '-i', environment.paths.inventory_source,
@@ -131,17 +130,15 @@ def run_ansible_module(environment, ansible_context, inventory_group, module, mo
 
     ask_vault_pass = include_vars and public_vars.get('commcare_cloud_use_vault', True)
     if ask_vault_pass:
-        cmd_parts += ('--vault-password-file=/bin/cat',)
+        cmd_parts += ('--vault-password-file={}/echo_vault_password.sh'.format(ANSIBLE_DIR),)
     cmd_parts_with_common_ssh_args = get_common_ssh_args(environment, use_factory_auth=factory_auth)
     cmd_parts += cmd_parts_with_common_ssh_args
     cmd = ' '.join(shlex_quote(arg) for arg in cmd_parts)
     print_command(cmd)
-    p = subprocess.Popen(cmd, stdin=subprocess.PIPE, shell=True, env=ansible_context.env_vars)
+    env_vars = ansible_context.env_vars
     if ask_vault_pass:
-        p.communicate(input='{}\n'.format(environment.get_ansible_vault_password()))
-    else:
-        p.communicate()
-    return p.returncode
+        env_vars['ANSIBLE_VAULT_PASSWORD'] = environment.get_ansible_vault_password()
+    return subprocess.call(cmd_parts, env=env_vars)
 
 
 class RunShellCommand(CommandBase):


### PR DESCRIPTION
This makes run-module and ansible-playbook commands use cleaner shell calls that allow those commands to act interactively. This allows us for example to put prompts in ansible playbooks. It's also just a more straightforward subprocess call.

We previously "had" to pass in the vault password via stdin because I couldn't think of a way to pass it in as an environment variable. This uses the same idea of passing in an executable to `--ansible-password-file`, but not the executable prints out the value of `ANSIBLE_VAULT_PASSWORD` rather than the output of stdin (which is what we were using `/bin/cat` to do).