### PR TITLE
[pv-deploy] Call provable deploy running for 45 minutes a success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ env:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - env: TEST=prove-deploy
 
 before_install:
   # The next line exits out of the prove-deploy test if the last commit that was merged in doesn't contain [pv-test]

--- a/.travis/tests.sh
+++ b/.travis/tests.sh
@@ -39,7 +39,17 @@ then
     bootstrap() {
         ssh-keygen -f ~/.ssh/id_rsa -N "" -q
         cp ~/.ssh/id_rsa.pub .travis/environments/_authorized_keys/travis.pub
-        COMMCARE_CLOUD_ENVIRONMENTS=.travis/environments bash commcare-cloud-bootstrap/bootstrap.sh hq-${TRAVIS_COMMIT} FETCH_HEAD .travis/spec.yml
+        (COMMCARE_CLOUD_ENVIRONMENTS=.travis/environments \
+            timeout 45m \
+            bash commcare-cloud-bootstrap/bootstrap.sh hq-${TRAVIS_COMMIT} FETCH_HEAD .travis/spec.yml)
+        rc=$?
+        if [[ "${rc}" = 124 ]]
+        then
+            echo "The bootstrapping process ran successfully for 45 minutes before being killed."
+            echo "For now, for the purposes of this test, we're calling that a success"
+        else
+            exit ${rc}
+        fi
     }
     bootstrap
 fi


### PR DESCRIPTION
I think this nice built-in `timeout` should do what we were discussing earlier, about killing provable deploy after 45 minutes without failing the build, but still failing if it exits earlier with a non-zero status code.