### PR TITLE
Use cheaper and better AWS t3 instance class

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -27,7 +27,7 @@ external_routes:
 
 servers:
   - server_name: "control-production"
-    server_instance_type: "t2.medium"
+    server_instance_type: "t3.medium"
     network_tier: "app-private"
     az: "a"
     volume_size: 8
@@ -39,7 +39,7 @@ rds_instances:
   # See: https://github.com/hashicorp/terraform/issues/9858#issuecomment-263654145
   - create: no
     identifier: "pg0"
-    instance_type: "db.t2.medium"
+    instance_type: "db.t3.medium"
     storage: 300
 
 redis:

--- a/environments/staging/terraform.yml
+++ b/environments/staging/terraform.yml
@@ -27,17 +27,17 @@ external_routes:
 
 servers:
   - server_name: "control-staging"
-    server_instance_type: "t2.medium"
+    server_instance_type: "t3.medium"
     network_tier: "app-private"
     az: "a"
     volume_size: 8
   - server_name: "web0-staging"
-    server_instance_type: "t2.medium"
+    server_instance_type: "t3.medium"
     network_tier: "app-private"
     az: "a"
     volume_size: 80
   - server_name: "web1-staging"
-    server_instance_type: "t2.medium"
+    server_instance_type: "t3.medium"
     network_tier: "app-private"
     az: "b"
     volume_size: 80
@@ -49,7 +49,7 @@ rds_instances:
   # See: https://github.com/hashicorp/terraform/issues/9858#issuecomment-263654145
   - create: no
     identifier: "staging0"
-    instance_type: "db.t2.medium"
+    instance_type: "db.t3.medium"
     storage: 300
 
 redis:

--- a/src/commcare_cloud/terraform/modules/commcarehq/variables.tf
+++ b/src/commcare_cloud/terraform/modules/commcarehq/variables.tf
@@ -67,7 +67,7 @@ variable "proxy_servers" {
 
 locals {
   default_redis = {
-    node_type             = "cache.t2.small"
+    node_type             = "cache.t3.small"
     num_cache_nodes       = 1
     engine_version        = "4.0.10"
     parameter_group_name  = "default.redis4.0"
@@ -76,7 +76,7 @@ locals {
 
   default_rds = {
     storage = ""
-    instance_type = "db.t2.medium"
+    instance_type = "db.t3.medium"
     identifier = ""
     username = "root"
     storage_type = "gp2"

--- a/src/commcare_cloud/terraform/modules/servers/main.tf
+++ b/src/commcare_cloud/terraform/modules/servers/main.tf
@@ -8,6 +8,9 @@ resource aws_instance "server" {
   key_name                = "${var.key_name}"
   vpc_security_group_ids  = ["${var.security_group_options[lookup(var.servers[count.index], "network_tier")]}"]
   source_dest_check       = false
+  credit_specification {
+    cpu_credits = "unlimited"
+  }
   root_block_device {
     volume_size           = "${lookup(var.servers[count.index], "volume_size")}"
     volume_type           = "gp2"


### PR DESCRIPTION
and always use cpu_credits = "unlimited"

This lets us elastically pay for more CPU usage when it's needed with no cap. If things are well calibrated this shouldn't cost very much but will save us from bursty performance issues; and if it's expensive one month we can upgrade the machine type for more provisioned CPU. (The change to t3 is just upgrading to the new generation which is both better and cheaper.)