### PR TITLE
Key iam users by name in terraform

### DIFF
--- a/src/commcare_cloud/commands/terraform/entrypoint.tf.j2
+++ b/src/commcare_cloud/commands/terraform/entrypoint.tf.j2
@@ -108,10 +108,12 @@ module "commcarehq" {
   }
 
   account_alias = {{ (account_alias or "")|tojson }}
-
-  users = [
-  {%- for user in (users if manage_users else []) %}
-    {username = {{ user.username|tojson }}},
-  {%- endfor %}
-  ]
 }
+
+{%- for user in (users if manage_users else []) %}
+module "iam_user__{{ user.username }}" {
+  source = "../modules/iam/user"
+  username = {{ user.username|tojson }}
+  administrators_iam_group = "${module.commcarehq.administrators_iam_group}"
+}
+{%- endfor %}

--- a/src/commcare_cloud/commands/terraform/entrypoint.tf.j2
+++ b/src/commcare_cloud/commands/terraform/entrypoint.tf.j2
@@ -64,7 +64,6 @@ module "commcarehq" {
   ]
 
   key_name = {{ key_name|tojson }}
-  public_key = {{ public_key|tojson }}
 
   servers = [
   {%- for server in servers %}
@@ -111,6 +110,11 @@ module "commcarehq" {
 }
 
 {%- for user in (users if manage_users else []) %}
+resource "aws_key_pair" {{ user.username|tojson }} {
+  key_name = {{ user.username|tojson }}
+  public_key = {{ user.public_key|tojson }}
+}
+
 module "iam_user__{{ user.username }}" {
   source = "../modules/iam/user"
   username = {{ user.username|tojson }}

--- a/src/commcare_cloud/commands/terraform/terraform.py
+++ b/src/commcare_cloud/commands/terraform/terraform.py
@@ -91,9 +91,10 @@ def generate_terraform_entrypoint(environment, key_name):
         raise UnauthorizedUser(key_name)
 
     context.update({
-        'users': [{'username': username}
-                  for username in environment.users_config.dev_users.present],
-        'public_key': environment.get_authorized_key(key_name),
+        'users': [{
+            'username': username,
+            'public_key': environment.get_authorized_key(username)
+        } for username in environment.users_config.dev_users.present],
         'key_name': key_name,
     })
     return render_template('entrypoint.tf.j2', context, os.path.dirname(__file__))

--- a/src/commcare_cloud/terraform/modules/commcarehq/main.tf
+++ b/src/commcare_cloud/terraform/modules/commcarehq/main.tf
@@ -106,6 +106,5 @@ module "openvpn" {
 
 module "Users" {
   source = "../iam"
-  users = "${var.users}"
   account_alias = "${var.account_alias}"
 }

--- a/src/commcare_cloud/terraform/modules/commcarehq/main.tf
+++ b/src/commcare_cloud/terraform/modules/commcarehq/main.tf
@@ -41,11 +41,6 @@ locals {
   }
 }
 
-resource "aws_key_pair" "main" {
-  key_name = "${var.key_name}"
-  public_key = "${var.public_key}"
-}
-
 module "servers" {
   source = "../servers"
   servers = "${var.servers}"

--- a/src/commcare_cloud/terraform/modules/commcarehq/outputs.tf
+++ b/src/commcare_cloud/terraform/modules/commcarehq/outputs.tf
@@ -1,0 +1,3 @@
+output "administrators_iam_group" {
+  value = "${module.Users.administrators_iam_group}"
+}

--- a/src/commcare_cloud/terraform/modules/commcarehq/variables.tf
+++ b/src/commcare_cloud/terraform/modules/commcarehq/variables.tf
@@ -49,7 +49,6 @@ variable "rds_instances" {
 variable "account_alias" {}
 
 variable "key_name" {}
-variable "public_key" {}
 variable "servers" {
   type = "list"
   default = []

--- a/src/commcare_cloud/terraform/modules/commcarehq/variables.tf
+++ b/src/commcare_cloud/terraform/modules/commcarehq/variables.tf
@@ -46,10 +46,6 @@ variable "rds_instances" {
   default = []
 }
 
-variable "users" {
-  type = "list"
-}
-
 variable "account_alias" {}
 
 variable "key_name" {}

--- a/src/commcare_cloud/terraform/modules/iam/main.tf
+++ b/src/commcare_cloud/terraform/modules/iam/main.tf
@@ -3,27 +3,12 @@ resource "aws_iam_account_alias" "alias" {
   account_alias = "${var.account_alias}"
 }
 
-resource "aws_iam_user" "users" {
-  count = "${length(var.users)}"
-  name = "${lookup(var.users[count.index], "username")}"
-  force_destroy = true
-}
-
-resource "aws_iam_user_group_membership" "group_memberships" {
-  count = "${length(var.users)}"
-  user = "${aws_iam_user.users.*.name[count.index]}"
-
-  groups = ["${aws_iam_group.administrators.name}"]
-}
 
 resource "aws_iam_group" "administrators" {
-  count = "${length(var.users) == 0 ? 0 : 1}"
   name = "Administrators"
-
 }
 
 resource "aws_iam_group_policy_attachment" "administrators" {
-  count = "${length(var.users) == 0 ? 0 : 1}"
   group = "${aws_iam_group.administrators.name}"
   policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }

--- a/src/commcare_cloud/terraform/modules/iam/outputs.tf
+++ b/src/commcare_cloud/terraform/modules/iam/outputs.tf
@@ -1,0 +1,3 @@
+output "administrators_iam_group" {
+  value = "${aws_iam_group.administrators.id}"
+}

--- a/src/commcare_cloud/terraform/modules/iam/user/main.tf
+++ b/src/commcare_cloud/terraform/modules/iam/user/main.tf
@@ -1,0 +1,10 @@
+resource "aws_iam_user" "user" {
+  name = "${var.username}"
+  force_destroy = true
+}
+
+resource "aws_iam_user_group_membership" "group_memberships" {
+  user = "${aws_iam_user.user.name}"
+
+  groups = ["${var.administrators_iam_group}"]
+}

--- a/src/commcare_cloud/terraform/modules/iam/user/variables.tf
+++ b/src/commcare_cloud/terraform/modules/iam/user/variables.tf
@@ -1,0 +1,2 @@
+variable "username" {}
+variable "administrators_iam_group" {}

--- a/src/commcare_cloud/terraform/modules/iam/variables.tf
+++ b/src/commcare_cloud/terraform/modules/iam/variables.tf
@@ -1,5 +1,1 @@
-variable "users" {
-  type = "list"
-}
-
 variable "account_alias" {}


### PR DESCRIPTION
and add an AWS key pair for each user.

This change has already been applied to staging and production. It'll make it so that deleting or adding a user doesn't shift everything off by one (common terraform problem when you build things from a list, incredibly!)