### PR TITLE
Print `cchq <env> lookup <group>` output to stdout, not stderr

### DIFF
--- a/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -37,7 +37,7 @@ class Lookup(CommandBase):
             sys.stderr.write(
                 "Ignoring extra argument(s): {}\n".format(unknown_args)
             )
-        print_command(self.lookup_server_address(args))
+        print(self.lookup_server_address(args))
 
 
 class _Ssh(Lookup):


### PR DESCRIPTION
This is just a minor nuisance I stumbled upon. It's nice to be able to run e.g.

```
PROXY_IP=$(cchq ${ENV} lookup proxy:0)
```
or something like that to use it programmatically in a script, but you can't do that if lookup prints to stderr.