### PR TITLE
Make host_group_aliases.yml result in ok, not changed

### DIFF
--- a/src/commcare_cloud/ansible/host_group_aliases.yml
+++ b/src/commcare_cloud/ansible/host_group_aliases.yml
@@ -7,6 +7,7 @@
         groups: all_commcarehq
       with_items: "{{ groups['all'] }}"
       when: "item not in groups['openvpn']|default([])"
+      changed_when: no
     - name: Create commcarehq group alias
       add_host:
         hostname: "{{ item }}"
@@ -20,5 +21,6 @@
         - "{{ groups['couchdb2_proxy']|default([]) }}"
         - "{{ groups['airflow']|default([]) }}"
         - "{{ groups['django_manage']|default([]) }}"
+      changed_when: no
   tags:
     - always


### PR DESCRIPTION
Another small thing I noticed that was annoying me. I recently added these tasks to dynamically create the `all_commcarehq` and `commcarehq` host groups so that playbooks can reference these and avoid copy-and-paste, but these in-memory tasks were always showing up as "changed". This will make them show up as "ok" instead.