### PR TITLE
Fix --branch issue on travis cron build

### DIFF
--- a/.travis/tests.sh
+++ b/.travis/tests.sh
@@ -2,17 +2,21 @@
 
 set -ve
 
+# pull branch from git status the exact same way that commcare-cloud does
+# so that --branch=${BRANCH} will always match
+BRANCH=$(git status | head -n1 | xargs -n1 echo | tail -n1)
+
 if [[ ${TEST} = 'main' ]]
 then
 
     cp .travis/environments/travis/private.yml .travis/environments/travis/vault.yml
 
     test_syntax() {
-        COMMCARE_CLOUD_ENVIRONMENTS=.travis/environments commcare-cloud travis deploy-stack --branch=FETCH_HEAD  --skip-check --quiet --syntax-check
+        COMMCARE_CLOUD_ENVIRONMENTS=.travis/environments commcare-cloud travis deploy-stack --branch=${BRANCH}  --skip-check --quiet --syntax-check
     }
 
     test_localsettings() {
-        COMMCARE_CLOUD_ENVIRONMENTS=.travis/environments commcare-cloud travis deploy-stack --branch=FETCH_HEAD  --skip-check --quiet --tags=commcarehq
+        COMMCARE_CLOUD_ENVIRONMENTS=.travis/environments commcare-cloud travis deploy-stack --branch=${BRANCH}  --skip-check --quiet --tags=commcarehq
         sudo python -m py_compile /home/cchq/www/travis/current/localsettings.py
     }
 
@@ -41,7 +45,7 @@ then
         cp ~/.ssh/id_rsa.pub .travis/environments/_authorized_keys/travis.pub
         (COMMCARE_CLOUD_ENVIRONMENTS=.travis/environments \
             timeout 45m \
-            bash commcare-cloud-bootstrap/bootstrap.sh hq-${TRAVIS_COMMIT} FETCH_HEAD .travis/spec.yml)
+            bash commcare-cloud-bootstrap/bootstrap.sh hq-${TRAVIS_COMMIT} ${BRANCH} .travis/spec.yml)
         rc=$?
         if [[ "${rc}" = 124 ]]
         then


### PR DESCRIPTION
see https://travis-ci.org/dimagi/commcare-cloud/jobs/439120219

> You are not currently on the branch specified with the --branch tag. To deploy on this branch, use --branch=7809a83, otherwise, change branches

(Also responsible for today's cron build failure: https://travis-ci.org/dimagi/commcare-cloud/jobs/439623872)