### PR TITLE
Include proxy.public_ip in ALLOWED_HOSTS

### DIFF
--- a/environments/icds-cas/public.yml
+++ b/environments/icds-cas/public.yml
@@ -130,7 +130,6 @@ s3_blob_db_s3_bucket: 'blobdb'
 localsettings:
   ALLOWED_HOSTS:
     - '{{ CAS_SITE_HOST }}'
-    - '{{ hostvars[groups.proxy.0].public_ip }}'
   ASYNC_INDICATORS_TO_QUEUE: 60000
   ASYNC_INDICATOR_QUEUE_TIMES:
     '*':

--- a/environments/icds-new/public.yml
+++ b/environments/icds-new/public.yml
@@ -125,7 +125,6 @@ TWO_FACTOR_GATEWAY_ENABLED: True
 localsettings:
   ALLOWED_HOSTS:
     - '{{ CAS_SITE_HOST }}'
-    - '{{ hostvars[groups.proxy.0].public_ip }}'
   ASYNC_INDICATORS_TO_QUEUE: 60000
   ASYNC_INDICATOR_QUEUE_TIMES:
     '*':

--- a/environments/staging-aws-test/public.yml
+++ b/environments/staging-aws-test/public.yml
@@ -40,10 +40,8 @@ s3_blob_db_s3_bucket: 'dimagi-commcare-staging-test-blobdb'
 
 localsettings:
   ALLOWED_HOSTS:
-    - staging.commcarehq.org
     - j2mestaging.commcarehq.org
     - testserver
-    - '{{ hostvars[groups.proxy.0].public_ip }}'
   ANALYTICS_DEBUG: True
   ANALYTICS_LOG_LEVEL: "debug"
   BANK_ADDRESS: { 'first_line': "1 Citizens Drive", 'city': "Riverside", 'region': "RI", 'postal_code': "02915" }

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -17,7 +17,7 @@ from celery.schedules import crontab
 
 _ROOT_DIR  = os.path.dirname(os.path.abspath(__file__))
 
-ALLOWED_HOSTS = {{ (localsettings.ALLOWED_HOSTS|default([]) + [SITE_HOST, 'localhost', '127.0.0.1'] + groups.proxy + groups.proxy | map('extract', hostvars, 'ansible_host') | map('default', 'localhost') | list) | unique | to_json }}
+ALLOWED_HOSTS = {{ (localsettings.ALLOWED_HOSTS|default([]) + [SITE_HOST, 'localhost', '127.0.0.1'] + groups.proxy + groups.proxy | map('extract', hostvars, 'ansible_host') | map('default', 'localhost') | list + groups.proxy | map('extract', hostvars, 'public_ip') | map('default', 'localhost') | list) | unique | to_json }}
 
 {% if SEPARATE_SYNCLOGS_DB %}
 SYNCLOGS_SQL_DB_ALIAS = "synclogs"


### PR DESCRIPTION
This comes up every time we're switching proxies, since you'll want to test on the public IP before flipping the DNS