### PR TITLE
Fix rolling restart

### DIFF
--- a/src/commcare_cloud/commands/ansible/service.py
+++ b/src/commcare_cloud/commands/ansible/service.py
@@ -325,12 +325,15 @@ class Elasticsearch(ServiceBase):
                     "\nStart will start pillows and start elasticsearch "
                     "\nRestart is a stop followed by a start.\n Continue?", strict=False):
                 return 0  # exit code
-            if action == 'stop' or action == 'restart':
+            if action == 'stop':
                 self._act_on_pillows(action='stop')
                 self._run_rolling_restart_yml(tags='action_stop')
-
-            if action == 'start' or action == 'restart':
+            elif action == 'start':
                 self._run_rolling_restart_yml(tags='action_start')
+                self._act_on_pillows(action='start')
+            elif action == 'restart':
+                self._act_on_pillows(action='stop')
+                self._run_rolling_restart_yml(tags='action_stop,action_start')
                 self._act_on_pillows(action='start')
 
     def _act_on_pillows(self, action):

--- a/src/commcare_cloud/commands/ansible/service.py
+++ b/src/commcare_cloud/commands/ansible/service.py
@@ -327,13 +327,13 @@ class Elasticsearch(ServiceBase):
                 return 0  # exit code
             if action == 'stop':
                 self._act_on_pillows(action='stop')
-                self._run_rolling_restart_yml(tags='action_stop')
+                self._run_rolling_restart_yml(tags='action_stop', limit=host_pattern)
             elif action == 'start':
-                self._run_rolling_restart_yml(tags='action_start')
+                self._run_rolling_restart_yml(tags='action_start', limit=host_pattern)
                 self._act_on_pillows(action='start')
             elif action == 'restart':
                 self._act_on_pillows(action='stop')
-                self._run_rolling_restart_yml(tags='action_stop,action_start')
+                self._run_rolling_restart_yml(tags='action_stop,action_start', limit=host_pattern)
                 self._act_on_pillows(action='start')
 
     def _act_on_pillows(self, action):
@@ -344,13 +344,14 @@ class Elasticsearch(ServiceBase):
             print("ERROR while trying to {} pillows. Exiting.".format(action))
             sys.exit(1)
 
-    def _run_rolling_restart_yml(self, tags):
+    def _run_rolling_restart_yml(self, tags, limit):
         from commcare_cloud.commands.ansible.ansible_playbook import run_ansible_playbook
         run_ansible_playbook(environment=self.environment,
                              playbook='es_rolling_restart.yml',
                              ansible_context=AnsibleContext(args=None),
-                             unknown_args=['--tags={}'.format(tags)],
-                             skip_check=True)
+                             unknown_args=['--tags={}'.format(tags),
+                                           '--limit={}'.format(limit)],
+                             skip_check=True, quiet=True)
 
 
 class Couchdb(AnsibleService):


### PR DESCRIPTION
@pr33thi there were a number of problems with the implementation as it was:

- A restart would stop _all_ the nodes, and then start _all_ the nodes, in that order, causing lots of downtime, instead of stopping and starting each node in sequence, which wouldn't cause downtime
- it didn't respect `--limit` (but didn't complain either) making it so there's no way to restart only a subset of nodes
- (minor) it was a bit chatty and asked for too many `y`s to keep going at different points