### PR TITLE
create separate process for icds_aggregation_queue on softlayer

### DIFF
--- a/environments/softlayer/app-processes.yml
+++ b/environments/softlayer/app-processes.yml
@@ -42,7 +42,8 @@ celery_processes:
       concurrency: 2
       max_tasks_per_child: 1
     icds_aggregation_queue:
-      concurrency: 1
+      pooling: gevent
+      concurrency: 2
     flower: {}
 pillows:
   'pillow1':

--- a/environments/softlayer/app-processes.yml
+++ b/environments/softlayer/app-processes.yml
@@ -38,9 +38,11 @@ celery_processes:
       concurrency: 10
     async_restore_queue:
       concurrency: 1
-    background_queue,case_rule_queue,icds_dashboard_reports_queue,icds_aggregation_queue,analytics_queue:
+    background_queue,case_rule_queue,icds_dashboard_reports_queue,analytics_queue:
       concurrency: 2
       max_tasks_per_child: 1
+    icds_aggregation_queue:
+      concurrency: 1
     flower: {}
 pillows:
   'pillow1':


### PR DESCRIPTION
ICDS aggregation tasks are causing a celery backup on softlayer:

https://app.datadoghq.com/dash/141098/celery-overview?live=true&page=0&is_auto=false&from_ts=1539208017772&to_ts=1539294417772&tile_size=m&fullscreen=false&tpl_var_environment=softlayer