### PR TITLE
Add easy way to call other commcare-cloud commands

### DIFF
--- a/docs/commcare-cloud/commands/index.md
+++ b/docs/commcare-cloud/commands/index.md
@@ -702,16 +702,10 @@ but skipping check mode.
 Run the ansible playbook for updating app config.
 
 ```
-commcare-cloud <env> update-config [--use-factory-auth]
+commcare-cloud <env> update-config
 ```
 
 This includes django `localsettings.py` and formplayer `application.properties`.
-
-##### Optional Arguments
-
-###### `--use-factory-auth`
-
-authenticate using the pem file (or prompt for root password if there is no pem file)
 
 ---
 

--- a/src/commcare_cloud/alias.py
+++ b/src/commcare_cloud/alias.py
@@ -23,6 +23,8 @@ def _encode_args(*args, **kwargs):
 
 
 def commcare_cloud(*args, **kwargs):
+    from .cli_utils import print_command
     from .commcare_cloud import call_commcare_cloud
     argv = _encode_args('commcare-cloud', *args, **kwargs)
+    print_command(argv)
     return call_commcare_cloud(argv)

--- a/src/commcare_cloud/alias.py
+++ b/src/commcare_cloud/alias.py
@@ -13,7 +13,7 @@ def _encode_args(*args, **kwargs):
     for arg in args:
         argv.append(unicode(arg).encode('utf-8'))
     for key, value in kwargs.items():
-        if value is False:
+        if value is False or value is None:
             continue
         elif value is True:
             argv.append('--{}'.format(key))

--- a/src/commcare_cloud/alias.py
+++ b/src/commcare_cloud/alias.py
@@ -23,6 +23,6 @@ def _encode_args(*args, **kwargs):
 
 
 def commcare_cloud(*args, **kwargs):
-    from .commcare_cloud import main
+    from .commcare_cloud import call_commcare_cloud
     argv = _encode_args('commcare-cloud', *args, **kwargs)
-    main(argv)
+    return call_commcare_cloud(argv)

--- a/src/commcare_cloud/alias.py
+++ b/src/commcare_cloud/alias.py
@@ -1,0 +1,28 @@
+import six
+
+
+def _encode_args(*args, **kwargs):
+    argv = []
+
+    def encode_string(value):
+        if isinstance(value, six.string_types + six.integer_types):
+            return unicode(value).encode('utf-8')
+        else:
+            TypeError("Do not know how to interpret type {} as a command-line argument: {}"
+                      .format(type(value), value))
+    for arg in args:
+        argv.append(unicode(arg).encode('utf-8'))
+    for key, value in kwargs.items():
+        if value is False:
+            continue
+        elif value is True:
+            argv.append('--{}'.format(key))
+        else:
+            argv.extend(['--{}'.format(key), encode_string(value)])
+    return argv
+
+
+def commcare_cloud(*args, **kwargs):
+    from .commcare_cloud import main
+    argv = _encode_args('commcare-cloud', *args, **kwargs)
+    main(argv)

--- a/src/commcare_cloud/cli_utils.py
+++ b/src/commcare_cloud/cli_utils.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 from clint.textui import puts, colored
 from .environment.paths import ANSIBLE_DIR
-from six.moves import input
+from six.moves import input, shlex_quote
 
 
 def ask(message, strict=False, quiet=False):
@@ -82,4 +82,6 @@ def print_command(command):
 
     Use this function to do so
     """
+    if isinstance(command, (list, tuple)):
+        command = ' '.join(shlex_quote(arg) for arg in command)
     print(colored.cyan(command), file=sys.stderr)

--- a/src/commcare_cloud/commands/ansible/ansible_playbook.py
+++ b/src/commcare_cloud/commands/ansible/ansible_playbook.py
@@ -200,8 +200,11 @@ class UpdateConfig(CommandBase):
     This includes django `localsettings.py` and formplayer `application.properties`.
     """
 
+    arguments = (shared_args.BRANCH_ARG,)
+
     def run(self, args, unknown_args):
-        return commcare_cloud(args.environment, 'ansible-playbook', 'deploy_localsettings.yml', tags='localsettings', *unknown_args)
+        return commcare_cloud(args.environment, 'ansible-playbook', 'deploy_localsettings.yml',
+                              tags='localsettings', branch=args.branch, *unknown_args)
 
 
 class AfterReboot(_AnsiblePlaybookAlias):

--- a/src/commcare_cloud/commands/ansible/ansible_playbook.py
+++ b/src/commcare_cloud/commands/ansible/ansible_playbook.py
@@ -203,7 +203,7 @@ class UpdateConfig(CommandBase):
     arguments = (shared_args.BRANCH_ARG,)
 
     def run(self, args, unknown_args):
-        return commcare_cloud(args.environment, 'ansible-playbook', 'deploy_localsettings.yml',
+        return commcare_cloud(args.env_name, 'ansible-playbook', 'deploy_localsettings.yml',
                               tags='localsettings', branch=args.branch, *unknown_args)
 
 

--- a/src/commcare_cloud/commands/ansible/ansible_playbook.py
+++ b/src/commcare_cloud/commands/ansible/ansible_playbook.py
@@ -5,6 +5,8 @@ from copy import deepcopy
 
 from six.moves import shlex_quote
 from clint.textui import puts, colored
+
+from commcare_cloud.alias import commcare_cloud
 from commcare_cloud.cli_utils import ask, has_arg, check_branch, print_command
 from commcare_cloud.commands import shared_args
 from commcare_cloud.commands.ansible.helpers import (
@@ -190,7 +192,7 @@ class DeployStack(_AnsiblePlaybookAlias):
             args, unknown_args, always_skip_check=always_skip_check)
 
 
-class UpdateConfig(_AnsiblePlaybookAlias):
+class UpdateConfig(CommandBase):
     command = 'update-config'
     help = """
     Run the ansible playbook for updating app config.
@@ -199,9 +201,7 @@ class UpdateConfig(_AnsiblePlaybookAlias):
     """
 
     def run(self, args, unknown_args):
-        args.playbook = 'deploy_localsettings.yml'
-        unknown_args += ('--tags=localsettings',)
-        return AnsiblePlaybook(self.parser).run(args, unknown_args)
+        return commcare_cloud(args.environment, 'ansible-playbook', 'deploy_localsettings.yml', tags='localsettings', *unknown_args)
 
 
 class AfterReboot(_AnsiblePlaybookAlias):

--- a/src/commcare_cloud/commcare_cloud.py
+++ b/src/commcare_cloud/commcare_cloud.py
@@ -158,8 +158,7 @@ def make_command_parser(available_envs, formatter_class=RawTextHelpFormatter,
     return parser, subparsers, commands
 
 
-def main(input_argv=sys.argv):
-    print(input_argv)
+def call_commcare_cloud(input_argv=sys.argv):
     put_virtualenv_bin_on_the_path()
     parser, subparsers, commands = make_command_parser(available_envs=get_available_envs())
     args, unknown_args = parser.parse_known_args(input_argv)
@@ -172,8 +171,13 @@ def main(input_argv=sys.argv):
         exit_code = commands[args.command].run(args, unknown_args)
     except CommandError as e:
         puts(colored.red(str(e), bold=True))
-        exit(1)
+        return 1
 
+    return exit_code
+
+
+def main():
+    exit_code = call_commcare_cloud()
     if exit_code is not 0:
         exit(exit_code)
 

--- a/src/commcare_cloud/commcare_cloud.py
+++ b/src/commcare_cloud/commcare_cloud.py
@@ -8,7 +8,6 @@ import sys
 import warnings
 from collections import OrderedDict
 
-import six
 from clint.textui import puts, colored
 
 from commcare_cloud.cli_utils import print_command
@@ -157,32 +156,6 @@ def make_command_parser(available_envs, formatter_class=RawTextHelpFormatter,
         for alias in cmd.aliases:
             commands[alias] = cmd
     return parser, subparsers, commands
-
-
-def _encode_args(*args, **kwargs):
-    argv = []
-
-    def encode_string(value):
-        if isinstance(value, six.string_types + six.integer_types):
-            return unicode(value).encode('utf-8')
-        else:
-            TypeError("Do not know how to interpret type {} as a command-line argument: {}"
-                      .format(type(value), value))
-    for arg in args:
-        argv.append(unicode(arg).encode('utf-8'))
-    for key, value in kwargs.items():
-        if value is False:
-            continue
-        elif value is True:
-            argv.append('--{}'.format(key))
-        else:
-            argv.extend(['--{}'.format(key), encode_string(value)])
-    return argv
-
-
-def commcare_cloud(*args, **kwargs):
-    argv = _encode_args('commcare-cloud', *args, **kwargs)
-    main(argv)
 
 
 def main(input_argv=sys.argv):

--- a/src/commcare_cloud/commcare_cloud.py
+++ b/src/commcare_cloud/commcare_cloud.py
@@ -161,7 +161,7 @@ def make_command_parser(available_envs, formatter_class=RawTextHelpFormatter,
 def call_commcare_cloud(input_argv=sys.argv):
     put_virtualenv_bin_on_the_path()
     parser, subparsers, commands = make_command_parser(available_envs=get_available_envs())
-    args, unknown_args = parser.parse_known_args(input_argv)
+    args, unknown_args = parser.parse_known_args(input_argv[1:])
 
     add_backwards_compatibility_to_args(args)
 


### PR DESCRIPTION
`commcare_cloud('staging', 'fab', 'deploy')` is equivalent to `suprocess.call(['commcare-cloud', 'staging', 'fab', 'deploy'])`, except that it doesn't require forking a new process (which is in the case of python, _very_ expensive in terms of time).

Will test further but I think the general concept works.

I converted one usage just as an example, but if we like the pattern, I'll convert others as well. There's also some cleanup I can do with the way  `print_command` gets called in other places.