### PR TITLE
Soft delete es5-production by replacing with a tiny machine

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -31,14 +31,13 @@ servers:
     network_tier: "app-private"
     az: "a"
     volume_size: 40
-  # These ES Machines apparently have to be in zone b:
-  #   Your requested instance type (h1.2xlarge) is not supported in your requested Availability Zone (us-east-1a).
-  #   Please retry your request by not specifying an Availability Zone or choosing us-east-1b, us-east-1f.
+  # this is a placeholder for a machine that's been deleted.
+  # Working in another branch to make deleting machines from this list less painful
   - server_name: "es5-production"
-    server_instance_type: i3.xlarge
+    server_instance_type: t3.nano
     network_tier: "db-private"
     az: "b"
-    volume_size: 40
+    volume_size: 1
   - server_name: "es6-production"
     server_instance_type: i3.xlarge
     network_tier: "db-private"


### PR DESCRIPTION
I manually terminated this machine when it acted up, and deleting machines from this config is surprisingly annoying. Working on a better way to do this that's more sustainable.