### PR TITLE
Fixed Ansible not noticing new line after condition

### DIFF
--- a/src/commcare_cloud/ansible/roles/ssh/templates/sshd_config.j2
+++ b/src/commcare_cloud/ansible/roles/ssh/templates/sshd_config.j2
@@ -88,6 +88,7 @@ Subsystem sftp /usr/lib/openssh/sftp-server
 UsePAM yes
 
 {%- for user in ssh_allow_password_users %}
+
 Match User {{ user }}
     PasswordAuthentication yes
 {%- endfor %}


### PR DESCRIPTION
It messed up the SSH config and resulted in SSH server failed and not reachable. 

```
-UsePAM yes
-
-Match User unixadmin
+UsePAM yesMatch User unixadmin

```