### PR TITLE
Hardcode 8 gunicorn workers for production

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -2,7 +2,8 @@ newrelic_djangoagent: False
 newrelic_javaagent: True
 datadog_pythonagent: True
 django_command_prefix: '{{ virtualenv_home }}/bin/ddtrace-run '
-
+gunicorn_workers_static_factor: 8
+gunicorn_workers_factor: 0
 celery_processes:
   hqcelery0.internal-va.commcarehq.org:
     beat: {}


### PR DESCRIPTION
The AWS ones are currently running at 2 even because of the default CPU calculation. They're on t3.large machines which have "burstable" CPU, but present to the OS as having two CPUs. I'm honestly not sure what that translates to, but I think it's worth upping it to 8 workers and seeing the effect.