### PR TITLE
[pv-deploy] Fix couchdb_use_haproxy undefined

### DIFF
--- a/.travis/tests.sh
+++ b/.travis/tests.sh
@@ -45,15 +45,16 @@ then
         cp ~/.ssh/id_rsa.pub .travis/environments/_authorized_keys/travis.pub
         (COMMCARE_CLOUD_ENVIRONMENTS=.travis/environments \
             timeout 45m \
-            bash commcare-cloud-bootstrap/bootstrap.sh hq-${TRAVIS_COMMIT} ${BRANCH} .travis/spec.yml)
-        rc=$?
-        if [[ "${rc}" = 124 ]]
-        then
-            echo "The bootstrapping process ran successfully for 45 minutes before being killed."
-            echo "For now, for the purposes of this test, we're calling that a success"
-        else
-            exit ${rc}
-        fi
+            bash commcare-cloud-bootstrap/bootstrap.sh hq-${TRAVIS_COMMIT} ${BRANCH} .travis/spec.yml) || {
+                rc=$?
+                if [[ "${rc}" = 124 ]]
+                then
+                    echo "The bootstrapping process ran successfully for 45 minutes before being killed."
+                    echo "For now, for the purposes of this test, we're calling that a success"
+                else
+                    exit ${rc}
+                fi
+            }
     }
     bootstrap
 fi

--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -188,6 +188,7 @@ es_local_repo: false
 blobdb_snapshot_bucket: dimagi-{{ deploy_env }}-blobdb-backups
 couchdb_snapshot_bucket: dimagi-{{ deploy_env }}-couch-backups
 postgres_snapshot_bucket: dimagi-{{ deploy_env }}-postgres-backups
+backup_es_s3: False
 es_snapshot_bucket: "dimagi-{{ deploy_env }}-es-snapshots"
 aws_region: None
 # this reads "'s3.{{ aws_region }}.amazonaws.com' if aws_region else None"

--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -44,6 +44,7 @@ riakcs_control: "{{ groups.get('riakcs')[0] | default('riakcs-is-disabled') }}"
 zookeeper_client_port: 2181
 formplayer_port: 8181
 couchdb2_port: 15984
+couchdb_use_haproxy: False
 couchdb2_proxy_port: "{{ 35984 if couchdb_use_haproxy else 25984 }}"
 couchdb_admins: "{
   '{{ localsettings_private.COUCH_USERNAME }}': '{{ localsettings_private.COUCH_PASSWORD }}',

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/main.yml
@@ -8,6 +8,8 @@
 #    path: "{{ code_home }}"
 #    state: absent
 
+- import_tasks: www_log_dir.yml
+
 - name: create required directories
   become: yes
   file:
@@ -17,9 +19,6 @@
     mode: 0755
     state: directory
   with_items:
-    - "{{ www_dir }}"
-    - "{{ www_home }}"
-    - "{{ log_home }}"
     - "{{ code_releases }}"
 
 - name: create required directories

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/www_log_dir.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/www_log_dir.yml
@@ -1,0 +1,16 @@
+# nginx proxy also relies on log home and calls this tasks file directly
+# including couchdb2_proxy, which doesn't run the commcarehq role
+- name: Create www directory and log home
+  become: yes
+  file:
+    path: "{{ item }}"
+    owner: "{{ cchq_user }}"
+    group: "{{ cchq_user }}"
+    mode: 0755
+    state: directory
+    # sometimes the log directory is a symlink to a dir on an encrypted drive
+    follow: yes
+  with_items:
+    - "{{ www_dir }}"
+    - "{{ www_home }}"
+    - "{{ log_home }}"

--- a/src/commcare_cloud/ansible/roles/nginx/tasks/install.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/tasks/install.yml
@@ -153,4 +153,7 @@
   tags:
     - link_pna_cas
 
+- name: Make sure the log directory exists
+  import_tasks: roles/commcarehq/tasks/www_log_dir.yml
+
 - set_fact: nginx_installed=True


### PR DESCRIPTION
this issue appears in prove-deploy test: https://api.travis-ci.org/v3/job/442292654/log.txt

I think this full stack deploy bug was introduced in this PR https://github.com/dimagi/commcare-cloud/pull/2209, and I think this fixes it without breaking the positive use case. Running a prove-deploy build to confirm the former.

I'm pretty sure that `public.yml` will win if it's defined there (https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable) and that the other interpolations in this file that use `couchdb_use_haproxy` will use the overridden value from `public.yml` and not the default value just because it's defined in the same file, but would appreciate someone if you could double check my logic @snopoke so I don't by mistake cause issues where it _is_ used (like ICDS).