### PR TITLE
[pv-deploy] Set couch_ver rather than pin to old galaxy requirement version

### DIFF
--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -48,6 +48,7 @@ couchdb2_proxy_port: "{{ 35984 if couchdb_use_haproxy else 25984 }}"
 couchdb_admins: "{
   '{{ localsettings_private.COUCH_USERNAME }}': '{{ localsettings_private.COUCH_PASSWORD }}',
 }"
+couchdb_ver: '2.1.1'
 
 # commcare-hq connects to an S3-compatible service, which is Riak CS
 s3_blob_db_enabled: "{{ True if groups.get('riakcs') else False }}"

--- a/src/commcare_cloud/ansible/requirements.yml
+++ b/src/commcare_cloud/ansible/requirements.yml
@@ -1,9 +1,6 @@
 ---
 - version: v1.1.4
   name: andrewrothstein.couchdb-cluster
-- src: git+https://github.com/andrewrothstein/ansible-couchdb.git
-  version: f0e026e73b8bf6f4ee5cc710f8fdbcdeb7418b2b
-  name: andrewrothstein.couchdb
 - src: git+https://github.com/debops-contrib/ansible-etckeeper.git
   version: 29c721de3df965ff355cbed242db813f70b811a2
   name: debops-contrib.etckeeper


### PR DESCRIPTION
Followup to suggestion on https://github.com/dimagi/commcare-cloud/pull/2278