### PR TITLE
Change production AWS webworkers instance type to c5.xlarge

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -69,32 +69,32 @@ servers:
     az: "b"
     volume_size: 40
   - server_name: "web0-production"
-    server_instance_type: t3.large
+    server_instance_type: c5.xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 40
   - server_name: "web1-production"
-    server_instance_type: t3.large
+    server_instance_type: c5.xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 40
   - server_name: "web2-production"
-    server_instance_type: t3.large
+    server_instance_type: c5.xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 40
   - server_name: "web3-production"
-    server_instance_type: t3.large
+    server_instance_type: c5.xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 40
   - server_name: "web4-production"
-    server_instance_type: t3.large
+    server_instance_type: c5.xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 40
   - server_name: "web5-production"
-    server_instance_type: t3.large
+    server_instance_type: c5.xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 40


### PR DESCRIPTION
t3.large is 2 vCPU (pay for prolonged above-30% usage) 8GB RAM
c5.xlarge is 4 vCPU (dedicated) 8GB RAM