### PR TITLE
Set reduce couch limit to False for Softlayer

### DIFF
--- a/environments/softlayer/public.yml
+++ b/environments/softlayer/public.yml
@@ -49,7 +49,7 @@ couch_dbs:
     password: "{{ localsettings_private.COUCH_PASSWORD }}"
     is_https: False
 
-
+couchdb_reduce_limit: False
 couchdb_cluster_settings:
   q: 8
   r: 1


### PR DESCRIPTION
setting `couchdb_reduce_limit` to false will avoid the data reduce limit from couch. 

https://manage.dimagi.com/default.asp?284632#1538918