### PR TITLE
redis cluster var

### DIFF
--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -50,7 +50,7 @@ couchdb_admins: "{
   '{{ localsettings_private.COUCH_USERNAME }}': '{{ localsettings_private.COUCH_PASSWORD }}',
 }"
 couchdb_ver: '2.1.1'
-is_redis_cluster: '{{ "redis_cluster_master" in group_names and groups["redis_cluster_master"]|length > 1 }}'
+is_redis_cluster: '{{ "redis_cluster_master" in groups and groups["redis_cluster_master"]|length > 1 }}'
 
 # commcare-hq connects to an S3-compatible service, which is Riak CS
 s3_blob_db_enabled: "{{ True if groups.get('riakcs') else False }}"

--- a/src/commcare_cloud/ansible/roles/formplayer/templates/application.properties.j2
+++ b/src/commcare_cloud/ansible/roles/formplayer/templates/application.properties.j2
@@ -61,7 +61,7 @@ smtp.to.address=commcarehq-ops+formplayer@dimagi.com
 
 // Redis for locking
 {% if is_redis_cluster %}
-redis.clusterString={{ groups.redis_cluster_master | join(":6379,") }}:6379
+redis.clusterString={{ groups.redis_cluster_master | join(":" + localsettings.REDIS_PORT + ",") }}:{{ localsettings.REDIS_PORT }}
 {% else %}
 redis.hostname={{ localsettings.REDIS_HOST }}
 {% endif %}


### PR DESCRIPTION
the first commit fixes the `is_redis_cluster` var when just running `update-config`, when `redis_cluster_master` doesn't seem to be included in `group_names` even though it is in `groups`. it should fix staging

the second commit is cleanup from a comment on a previous pr

@sravfeyn buddy: @Rohit25negi 