### PR TITLE
Increase RAM (and CPU threads) on production AWS webworkers

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -69,32 +69,32 @@ servers:
     az: "b"
     volume_size: 40
   - server_name: "web0-production"
-    server_instance_type: c5.xlarge
+    server_instance_type: t3.2xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 40
   - server_name: "web1-production"
-    server_instance_type: c5.xlarge
+    server_instance_type: t3.2xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 40
   - server_name: "web2-production"
-    server_instance_type: c5.xlarge
+    server_instance_type: t3.2xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 40
   - server_name: "web3-production"
-    server_instance_type: c5.xlarge
+    server_instance_type: t3.2xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 40
   - server_name: "web4-production"
-    server_instance_type: c5.xlarge
+    server_instance_type: t3.2xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 40
   - server_name: "web5-production"
-    server_instance_type: c5.xlarge
+    server_instance_type: t3.2xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 40


### PR DESCRIPTION
From 4 vCPU (provisioned), 8GB RAM (c5.xlarge @ $0.17/hr)
To 8 vCPU (burstable), 32GB RAM (t3.2xlarge @ $0.3328/hr)