### PR TITLE
Revert "attempt to speed up"

### DIFF
--- a/src/commcare_cloud/ansible/host_group_aliases.yml
+++ b/src/commcare_cloud/ansible/host_group_aliases.yml
@@ -2,21 +2,25 @@
   hosts: all
   tasks:
     - name: Create all_commcarehq group alias
-      group_by: key=all_commcarehq
-      when: "'openvpn' not in group_names"
+      add_host:
+        hostname: "{{ item }}"
+        groups: all_commcarehq
+      with_items: "{{ groups['all'] }}"
+      when: "item not in groups['openvpn']|default([])"
       changed_when: no
     - name: Create commcarehq group alias
-      group_by: key=commcarehq
-      when: |
-        ('webworkers' in group_names) or
-        ('formplayer' in group_names) or
-        ('celery' in group_names) or
-        ('proxy' in group_names) or
-        ('pillowtop' in group_names) or
-        ('couchdb2_proxy' in group_names) or
-        ('airflow' in group_names) or
-        ('django_manage' in group_names)
+      add_host:
+        hostname: "{{ item }}"
+        groups: commcarehq
+      with_items:
+        - "{{ groups['webworkers']|default([]) }}"
+        - "{{ groups['formplayer']|default([]) }}"
+        - "{{ groups['celery']|default([]) }}"
+        - "{{ groups['proxy']|default([]) }}"
+        - "{{ groups['pillowtop']|default([]) }}"
+        - "{{ groups['couchdb2_proxy']|default([]) }}"
+        - "{{ groups['airflow']|default([]) }}"
+        - "{{ groups['django_manage']|default([]) }}"
       changed_when: no
   tags:
     - always
-


### PR DESCRIPTION
Reverts dimagi/commcare-cloud#2288

Turns out this has the side effect of leaving the group with different membership when you use --limit, and in particular the group not existing at all if none of the --limit hosts are members. Since you seemed lukewarm about the change anyway, I'll suggest just reverting.