### PR TITLE
Send submissions to a separate group of webworkers

### DIFF
--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -49,10 +49,10 @@ web0
 web1
 web2
 web3
-web4
-web5
 
 [mobile_webworkers:children]
+web4
+web5
 web6
 web7
 web8

--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -44,19 +44,25 @@ mount_points="[{'partition':'/dev/xvdb1', 'dest':'/mnt/storage', 'fstype':'ext4'
 10.202.11.153 hostname=web11-production ec2=yes
 
 
-[webworkers:children]
+[hq_webworkers:children]
 web0
 web1
 web2
 web3
 web4
 web5
+
+[mobile_webworkers:children]
 web6
 web7
 web8
 web9
 web10
 web11
+
+[webworkers:children]
+hq_webworkers
+mobile_webworkers
 
 [hqdb0]
 hqdb0.internal-va.commcarehq.org

--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -49,10 +49,10 @@ web0
 web1
 web2
 web3
-
-[mobile_webworkers:children]
 web4
 web5
+
+[mobile_webworkers:children]
 web6
 web7
 web8

--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -51,18 +51,8 @@ web2
 web3
 web4
 web5
-web6
-web7
-web8
-web9
-web10
 
 [mobile_webworkers:children]
-web1
-web2
-web3
-web4
-web5
 web6
 web7
 web8

--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -51,8 +51,18 @@ web2
 web3
 web4
 web5
+web6
+web7
+web8
+web9
+web10
 
 [mobile_webworkers:children]
+web1
+web2
+web3
+web4
+web5
 web6
 web7
 web8

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -49,10 +49,10 @@ web0
 web1
 web2
 web3
-web4
-web5
 
 [mobile_webworkers:children]
+web4
+web5
 web6
 web7
 web8

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -44,19 +44,25 @@ mount_points="[{'partition':'/dev/xvdb1', 'dest':'/mnt/storage', 'fstype':'ext4'
 {{ web11-production }} hostname=web11-production ec2=yes
 
 
-[webworkers:children]
+[hq_webworkers:children]
 web0
 web1
 web2
 web3
 web4
 web5
+
+[mobile_webworkers:children]
 web6
 web7
 web8
 web9
 web10
 web11
+
+[webworkers:children]
+hq_webworkers
+mobile_webworkers
 
 [hqdb0]
 hqdb0.internal-va.commcarehq.org

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -49,10 +49,10 @@ web0
 web1
 web2
 web3
-
-[mobile_webworkers:children]
 web4
 web5
+
+[mobile_webworkers:children]
 web6
 web7
 web8

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -51,18 +51,8 @@ web2
 web3
 web4
 web5
-web6
-web7
-web8
-web9
-web10
 
 [mobile_webworkers:children]
-web1
-web2
-web3
-web4
-web5
 web6
 web7
 web8

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -51,8 +51,18 @@ web2
 web3
 web4
 web5
+web6
+web7
+web8
+web9
+web10
 
 [mobile_webworkers:children]
+web1
+web2
+web3
+web4
+web5
 web6
 web7
 web8

--- a/src/commcare_cloud/ansible/roles/datadog/defaults/main.yml
+++ b/src/commcare_cloud/ansible/roles/datadog/defaults/main.yml
@@ -13,6 +13,8 @@ datadog_shell_sha256sum: ff6933fedded6c169a7dbfc4d962595250ec9b6586752648f8df848
 
 monitoring_groups:
   - webworkers
+  - hq_webworkers
+  - mobile_webworkers
   - proxy
   - elasticsearch
   - postgresql

--- a/src/commcare_cloud/ansible/roles/nginx/templates/site.j2
+++ b/src/commcare_cloud/ansible/roles/nginx/templates/site.j2
@@ -12,7 +12,7 @@ upstream {{ balancer.name }} {
   least_conn;
   {% endif %}
 
-{% for host in groups[balancer.hosts] %}
+{% for host in groups[balancer.hosts] | default(balancer.hosts) %}
   server {{ host }}:{{ balancer.port }};
 {% endfor %}
 }

--- a/src/commcare_cloud/ansible/roles/nginx/vars/cchq_ssl.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/cchq_ssl.yml
@@ -3,7 +3,10 @@ nginx_sites:
 - server:
    balancers:
     - name: "{{ deploy_env }}_commcare"
-      hosts: webworkers
+      hosts: "{{ groups['hq_webworkers'] | default('webworkers') }}"
+      port: "{{ django_port }}"
+    - name: "{{ deploy_env }}_commcare_submissions"
+      hosts: "{{ groups['mobile_webworkers'] | default('webworkers') }}"
       port: "{{ django_port }}"
     - name: "{{ deploy_env }}_formplayer"
       hosts: formplayer
@@ -31,6 +34,13 @@ nginx_sites:
       proxy_redirect: "http://{{ SITE_HOST }} https://{{ SITE_HOST }}"
       proxy_next_upstream_tries: 1
       proxy_read_timeout: 1200s # 900s temporarily increase timeout for UCR data exports for ICDS
+      proxy_buffers: 8 64k
+      proxy_buffer_size: 64k
+      client_body_buffer_size: 512k
+    - name: '~ /a/[^/]+/receiver'
+      balancer: "{{ deploy_env }}_commcare_submissions"
+      proxy_redirect: "http://{{ SITE_HOST }} https://{{ SITE_HOST }}"
+      proxy_next_upstream_tries: 1
       proxy_buffers: 8 64k
       proxy_buffer_size: 64k
       client_body_buffer_size: 512k


### PR DESCRIPTION
Okay, this is deployed now. Settled on splitting it 50/50, because even though `receiver/` gets less than a third of requests, it's responsible for more than half of the requests that take longer than 2 minutes. So I figured giving allotting half the webworkers for just submissions seemed like a reasonable place to start.