### PR TITLE
Get rid of references to the rackspace pillow machine now that the AWS pillow machine is up

### DIFF
--- a/environments/staging/app-processes.yml
+++ b/environments/staging/app-processes.yml
@@ -27,7 +27,6 @@ celery_processes:
       concurrency: 4
     flower: {}
 pillows:
-  'hqpillow0-staging.internal-va.commcarehq.org': {}
   'pillow0':
     AppDbChangeFeedPillow:
       num_processes: 1

--- a/environments/staging/app-processes.yml
+++ b/environments/staging/app-processes.yml
@@ -27,6 +27,7 @@ celery_processes:
       concurrency: 4
     flower: {}
 pillows:
+  'hqpillow0-staging.internal-va.commcarehq.org': {}
   'pillow0':
     AppDbChangeFeedPillow:
       num_processes: 1

--- a/environments/staging/app-processes.yml
+++ b/environments/staging/app-processes.yml
@@ -27,7 +27,7 @@ celery_processes:
       concurrency: 4
     flower: {}
 pillows:
-  'hqpillow0-staging.internal-va.commcarehq.org':
+  'pillow0':
     AppDbChangeFeedPillow:
       num_processes: 1
     ApplicationToElasticsearchPillow:

--- a/environments/staging/inventory.ini
+++ b/environments/staging/inventory.ini
@@ -70,15 +70,15 @@ hqdb1
 # Amazon EC2
 # celery0
 
-# [hqpillow0]
-# hqpillow0-staging.internal-va.commcarehq.org
+[hqpillow0]
+hqpillow0-staging.internal-va.commcarehq.org
 
 [pillow0]
 10.201.10.41 hostname=pillow0-staging ec2=yes
 
 [pillowtop:children]
 pillow0
-# hqpillow0
+hqpillow0
 # Amazon EC2
 
 

--- a/environments/staging/inventory.ini
+++ b/environments/staging/inventory.ini
@@ -70,17 +70,12 @@ hqdb1
 # Amazon EC2
 # celery0
 
-[hqpillow0]
-hqpillow0-staging.internal-va.commcarehq.org
-
 [pillow0]
 10.201.10.41 hostname=pillow0-staging ec2=yes
 
 [pillowtop:children]
-pillow0
-hqpillow0
 # Amazon EC2
-
+pillow0
 
 [hqtouch0]
 hqtouch0-staging.internal-va.commcarehq.org swap_size=1G

--- a/environments/staging/inventory.ini
+++ b/environments/staging/inventory.ini
@@ -70,17 +70,17 @@ hqdb1
 # Amazon EC2
 # celery0
 
-[hqpillow0]
-hqpillow0-staging.internal-va.commcarehq.org
+# [hqpillow0]
+# hqpillow0-staging.internal-va.commcarehq.org
 
 [pillow0]
-# 10.201.10.41 hostname=pillow0-staging ec2=yes
+10.201.10.41 hostname=pillow0-staging ec2=yes
 
 [pillowtop:children]
 pillow0
-hqpillow0
+# hqpillow0
 # Amazon EC2
-# pillow0
+
 
 [hqtouch0]
 hqtouch0-staging.internal-va.commcarehq.org swap_size=1G

--- a/environments/staging/inventory.ini.j2
+++ b/environments/staging/inventory.ini.j2
@@ -74,9 +74,8 @@ hqdb1
 {{ pillow0-staging }} hostname=pillow0-staging ec2=yes
 
 [pillowtop:children]
-hqpillow0
 # Amazon EC2
-# pillow0
+pillow0
 
 [hqtouch0]
 hqtouch0-staging.internal-va.commcarehq.org swap_size=1G


### PR DESCRIPTION
I followed the steps I outlined [here](https://confluence.dimagi.com/pages/editpage.action?pageId=45615094) to migrate the pillow machines to AWS. Staging is currently working, and `cchq staging service pillowtop` gives me this, which makes me think the migration worked:

```
10.201.10.41 | SUCCESS | rc=0 >>
commcare-hq-staging-pillowtop-CaseToElasticsearchPillow-0             RUNNING   pid 9561, uptime 1:33:53
commcare-hq-staging-pillowtop-GroupToUserPillow-0                     RUNNING   pid 9747, uptime 1:33:42
commcare-hq-staging-pillowtop-CaseSearchToElasticsearchPillow-0       RUNNING   pid 9933, uptime 1:33:31
commcare-hq-staging-pillowtop-LedgerToElasticsearchPillow-0           RUNNING   pid 10119, uptime 1:33:20
commcare-hq-staging-pillowtop-ReportCaseToElasticsearchPillow-0       RUNNING   pid 10305, uptime 1:33:10
commcare-hq-staging-pillowtop-UserPillow-0                            RUNNING   pid 10491, uptime 1:32:59
commcare-hq-staging-pillowtop-SqlSMSPillow-0                          RUNNING   pid 10677, uptime 1:32:48
commcare-hq-staging-pillowtop-XFormToElasticsearchPillow-0            RUNNING   pid 10863, uptime 1:32:38
commcare-hq-staging-pillowtop-GroupPillow-0                           RUNNING   pid 11049, uptime 1:32:28
commcare-hq-staging-pillowtop-DefaultChangeFeedPillow-0               RUNNING   pid 11235, uptime 1:32:17
commcare-hq-staging-pillowtop-UnknownUsersPillow-0                    RUNNING   pid 11421, uptime 1:32:07
commcare-hq-staging-pillowtop-DomainDbKafkaPillow-0                   RUNNING   pid 11607, uptime 1:31:57
commcare-hq-staging-pillowtop-kafka-ucr-main-0                        RUNNING   pid 11793, uptime 1:31:46
commcare-hq-staging-pillowtop-CacheInvalidatePillow-0                 RUNNING   pid 14289, uptime 0:24:20
commcare-hq-staging-pillowtop-ReportXFormToElasticsearchPillow-0      RUNNING   pid 12165, uptime 1:31:26
commcare-hq-staging-pillowtop-KafkaDomainPillow-0                     RUNNING   pid 12351, uptime 1:31:16
commcare-hq-staging-pillowtop-AppDbChangeFeedPillow-0                 RUNNING   pid 12537, uptime 1:31:06
commcare-hq-staging-pillowtop-ApplicationToElasticsearchPillow-0      RUNNING   pid 12723, uptime 1:30:55
commcare-hq-staging-pillowtop-UpdateUserSyncHistoryPillow-0           RUNNING   pid 12910, uptime 1:30:45
commcare-hq-staging-pillowtop-UserGroupsDbKafkaPillow-0               RUNNING   pid 13096, uptime 1:30:34
commcare-hq-staging-pillowtop-UserCacheInvalidatePillow-0             RUNNING   pid 13282, uptime 1:30:24
commcare-hq-staging-pillowtop-FormSubmissionMetadataTrackerPillow-0   RUNNING   pid 13468, uptime 1:30:13
commcare-hq-staging-pillowtop-kafka-ucr-static-0                      RUNNING   pid 13654, uptime 1:30:03
```

So I plan to merge this PR and then destroy the old machines.

@dannyroberts 
code buddy @sravfeyn 