### PR TITLE
 Move all production webworkers to m5.2xlarge

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -2,8 +2,8 @@ newrelic_djangoagent: False
 newrelic_javaagent: True
 datadog_pythonagent: True
 django_command_prefix: '{{ virtualenv_home }}/bin/ddtrace-run '
-gunicorn_workers_static_factor: 8
-gunicorn_workers_factor: 0
+gunicorn_workers_static_factor: 0
+gunicorn_workers_factor: 2
 celery_processes:
   hqcelery0.internal-va.commcarehq.org:
     beat: {}

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -36,22 +36,22 @@ servers:
     network_tier: "db-private"
     az: "a"
   - server_name: "web6-production"
-    server_instance_type: t3.xlarge
+    server_instance_type: m5.2xlarge
     network_tier: "app-private"
     az: "b"
     volume_size: 40
   - server_name: "web7-production"
-    server_instance_type: t3.xlarge
+    server_instance_type: m5.2xlarge
     network_tier: "app-private"
     az: "b"
     volume_size: 40
   - server_name: "web8-production"
-    server_instance_type: t3.xlarge
+    server_instance_type: m5.2xlarge
     network_tier: "app-private"
     az: "b"
     volume_size: 40
   - server_name: "web9-production"
-    server_instance_type: t3.xlarge
+    server_instance_type: m5.2xlarge
     network_tier: "app-private"
     az: "b"
     volume_size: 40
@@ -66,32 +66,32 @@ servers:
     az: "b"
     volume_size: 40
   - server_name: "web0-production"
-    server_instance_type: t3.xlarge
+    server_instance_type: m5.2xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 40
   - server_name: "web1-production"
-    server_instance_type: t3.xlarge
+    server_instance_type: m5.2xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 40
   - server_name: "web2-production"
-    server_instance_type: t3.xlarge
+    server_instance_type: m5.2xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 40
   - server_name: "web3-production"
-    server_instance_type: t3.xlarge
+    server_instance_type: m5.2xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 40
   - server_name: "web4-production"
-    server_instance_type: t3.xlarge
+    server_instance_type: m5.2xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 40
   - server_name: "web5-production"
-    server_instance_type: t3.xlarge
+    server_instance_type: m5.2xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 40
@@ -121,12 +121,12 @@ servers:
     az: "a"
     volume_size: 600
   - server_name: "web10-production"
-    server_instance_type: t3.xlarge
+    server_instance_type: m5.2xlarge
     network_tier: "app-private"
     az: "b"
     volume_size: 40
   - server_name: "web11-production"
-    server_instance_type: t3.xlarge
+    server_instance_type: m5.2xlarge
     network_tier: "app-private"
     az: "b"
     volume_size: 40


### PR DESCRIPTION
doubling to 32GB RAM and 8 vCPU

(I chose m5.2xlarge for the time being because there's a shortage of the similar-but-cheaper t3.2xlarge in us-east-1a.)

Already deployed, around 9:45-10AM ET