### PR TITLE
Staging- Migrate celery from rackspace to AWS

### DIFF
--- a/environments/staging/app-processes.yml
+++ b/environments/staging/app-processes.yml
@@ -4,7 +4,6 @@ celery_processes:
     # so that no SMSes, etc. ever come from staging.
     celery_periodic: {}
     beat: {}
-  'hqdb1-staging.internal-va.commcarehq.org': {}
   'celery0':
     repeat_record_queue,reminder_case_update_queue,reminder_rule_queue,celery,export_download_queue:
       concurrency: 4

--- a/environments/staging/app-processes.yml
+++ b/environments/staging/app-processes.yml
@@ -4,7 +4,8 @@ celery_processes:
     # so that no SMSes, etc. ever come from staging.
     celery_periodic: {}
     beat: {}
-  'hqdb1-staging.internal-va.commcarehq.org':
+  'hqdb1-staging.internal-va.commcarehq.org': {}
+  'celery0':
     repeat_record_queue,reminder_case_update_queue,reminder_rule_queue,celery,export_download_queue:
       concurrency: 4
       max_tasks_per_child: 5

--- a/environments/staging/inventory.ini
+++ b/environments/staging/inventory.ini
@@ -63,24 +63,20 @@ hqkafka0
 # kafka0
 
 [celery0]
-# {{ celery0-staging }} hostname=celery0-staging ec2=yes
+10.201.40.125 hostname=celery0-staging ec2=yes
 
 [celery:children]
 hqdb1
 # Amazon EC2
-# celery0
-
-[hqpillow0]
-hqpillow0-staging.internal-va.commcarehq.org
+celery0
 
 [pillow0]
-# 10.201.10.41 hostname=pillow0-staging ec2=yes
+10.201.10.41 hostname=pillow0-staging ec2=yes
 
 [pillowtop:children]
-pillow0
 hqpillow0
 # Amazon EC2
-# pillow0
+pillow0
 
 [hqtouch0]
 hqtouch0-staging.internal-va.commcarehq.org swap_size=1G

--- a/environments/staging/inventory.ini
+++ b/environments/staging/inventory.ini
@@ -70,6 +70,9 @@ hqdb1
 # Amazon EC2
 celery0
 
+[hqpillow0]
+hqpillow0-staging.internal-va.commcarehq.org
+
 [pillow0]
 10.201.10.41 hostname=pillow0-staging ec2=yes
 

--- a/environments/staging/inventory.ini
+++ b/environments/staging/inventory.ini
@@ -66,12 +66,8 @@ hqkafka0
 10.201.40.125 hostname=celery0-staging ec2=yes
 
 [celery:children]
-hqdb1
 # Amazon EC2
 celery0
-
-[hqpillow0]
-hqpillow0-staging.internal-va.commcarehq.org
 
 [pillow0]
 10.201.10.41 hostname=pillow0-staging ec2=yes

--- a/environments/staging/inventory.ini.j2
+++ b/environments/staging/inventory.ini.j2
@@ -63,12 +63,12 @@ hqkafka0
 # kafka0
 
 [celery0]
-# {{ celery0-staging }} hostname=celery0-staging ec2=yes
+{{ celery0-staging }} hostname=celery0-staging ec2=yes
 
 [celery:children]
 hqdb1
 # Amazon EC2
-# celery0
+celery0
 
 [pillow0]
 {{ pillow0-staging }} hostname=pillow0-staging ec2=yes
@@ -76,7 +76,7 @@ hqdb1
 [pillowtop:children]
 hqpillow0
 # Amazon EC2
-# pillow0
+pillow0
 
 [hqtouch0]
 hqtouch0-staging.internal-va.commcarehq.org swap_size=1G

--- a/environments/staging/inventory.ini.j2
+++ b/environments/staging/inventory.ini.j2
@@ -66,7 +66,6 @@ hqkafka0
 {{ celery0-staging }} hostname=celery0-staging ec2=yes
 
 [celery:children]
-hqdb1
 # Amazon EC2
 celery0
 

--- a/environments/staging/terraform.yml
+++ b/environments/staging/terraform.yml
@@ -51,6 +51,11 @@ servers:
     network_tier: "app-private"
     az: "a"
     volume_size: 80
+  - server_name: "celery0-staging"
+    server_instance_type: "t3.large"
+    network_tier: "db-private"
+    az: "a"
+    volume_size: 80
 
 proxy_servers:
   - server_name: "proxy1-staging"


### PR DESCRIPTION
Builds off of [this PR](https://github.com/dimagi/commcare-cloud/pull/2326) (so this one can be merged and that one can be closed: closes #2328). Migrated staging celery from rackspace to AWS

@dannyroberts 
code buddy @sravfeyn 