### PR TITLE
set redis client timeout to 5 mins

### DIFF
--- a/src/commcare_cloud/ansible/group_vars/redis.yml
+++ b/src/commcare_cloud/ansible/group_vars/redis.yml
@@ -10,6 +10,7 @@ redis_maxmemory: 4gb
 redis_maxmemory_policy: volatile-lru
 redis_save: []
 redis_appendonly: "yes"
+redis_timeout: 300  # 5 minutes
 cluster_config:
   cluster-enabled: "yes"
   cluster-config-file: "nodes.conf" # Redis internal filename, never change this


### PR DESCRIPTION
This will make redis kill client connections that are idle for 5 mins. This will prevent the buildup of redis connections we've been seeing (though won't fix the root cause).