### PR TITLE
Revert "Use local aws couchdb2 for production users and domains dbs"

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -50,20 +50,6 @@ couch_dbs:
     username: "{{ localsettings_private.COUCH_USERNAME }}"
     password: "{{ localsettings_private.COUCH_PASSWORD }}"
     is_https: True
-  domains:
-    host: "{{ groups.couchdb2_proxy.0 }}"
-    port: "{{ couchdb2_proxy_port }}"
-    name: commcarehq__domains
-    username: "{{ localsettings_private.COUCH_USERNAME }}"
-    password: "{{ localsettings_private.COUCH_PASSWORD }}"
-    is_https: False
-  users:
-    host: "{{ groups.couchdb2_proxy.0 }}"
-    port: "{{ couchdb2_proxy_port }}"
-    name: commcarehq__users
-    username: "{{ localsettings_private.COUCH_USERNAME }}"
-    password: "{{ localsettings_private.COUCH_PASSWORD }}"
-    is_https: False
 
 couchdb2:
   username: "{{ localsettings_private.COUCH_USERNAME }}"


### PR DESCRIPTION
This reverts commit 6f0dbcf00088ca81dfea2ef478d320d80b412589.

Realized I merged in https://github.com/dimagi/commcare-cloud/pull/2330 with this, but that we're not quite ready for this yet. Will add back when we are.