### PR TITLE
Migrate production celery and rabbitmq

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -5,11 +5,11 @@ django_command_prefix: '{{ virtualenv_home }}/bin/ddtrace-run '
 gunicorn_workers_static_factor: 0
 gunicorn_workers_factor: 2
 celery_processes:
-  celery0: {}
-  hqcelery0.internal-va.commcarehq.org:
+  celery0:
     beat: {}
     celery_periodic:
       concurrency: 4
+  hqcelery0.internal-va.commcarehq.org:
     submission_reprocessing_queue:
       concurrency: 1
     email_queue:

--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -26,7 +26,8 @@ celery_processes:
     async_restore_queue:
       concurrency: 2
       max_tasks_per_child: 5
-  celery1: {}
+  celery1:
+    flower: {}
   hqcelery1.internal-va.commcarehq.org:
     case_rule_queue:
       concurrency: 4
@@ -58,7 +59,6 @@ celery_processes:
     logistics_background_queue:
       concurrency: 2
       max_tasks_per_child: 5
-    flower: {}
   celery2: {}
   hqcelery2.internal-va.commcarehq.org:
     background_queue:

--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -9,9 +9,9 @@ celery_processes:
     beat: {}
     celery_periodic:
       concurrency: 4
-  hqcelery0.internal-va.commcarehq.org:
     submission_reprocessing_queue:
       concurrency: 1
+  hqcelery0.internal-va.commcarehq.org:
     email_queue:
       concurrency: 2
     repeat_record_queue,sumologic_logs_queue:
@@ -28,6 +28,14 @@ celery_processes:
       max_tasks_per_child: 5
   celery1:
     flower: {}
+    reminder_queue:
+      pooling: gevent
+      concurrency: 10
+      num_workers: 3
+    sms_queue:
+      pooling: gevent
+      concurrency: 10
+      num_workers: 3
   hqcelery1.internal-va.commcarehq.org:
     case_rule_queue:
       concurrency: 4
@@ -36,17 +44,9 @@ celery_processes:
       pooling: gevent
       concurrency: 5
       num_workers: 2
-    reminder_queue:
-      pooling: gevent
-      concurrency: 10
-      num_workers: 3
     reminder_rule_queue:
       concurrency: 3
       max_tasks_per_child: 1
-    sms_queue:
-      pooling: gevent
-      concurrency: 10
-      num_workers: 3
     ils_gateway_sms_queue:
       # Use 1 worker with concurrency 8 in order to enforce the
       # restriction of having 8 max simultaneous connections with

--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -73,6 +73,14 @@ celery_processes:
       concurrency: 2
       max_tasks_per_child: 5
   hqcelery1.internal-va.commcarehq.org:
+    reminder_queue:
+      pooling: gevent
+      concurrency: 10
+      num_workers: 3
+    sms_queue:
+      pooling: gevent
+      concurrency: 10
+      num_workers: 3
     case_rule_queue:
       concurrency: 4
       max_tasks_per_child: 1

--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -11,6 +11,20 @@ celery_processes:
       concurrency: 4
     submission_reprocessing_queue:
       concurrency: 1
+    email_queue:
+      concurrency: 2
+    repeat_record_queue,sumologic_logs_queue:
+      pooling: gevent
+      concurrency: 50
+      num_workers: 4
+    ucr_queue:
+      concurrency: 4
+      max_tasks_per_child: 5
+    ucr_indicator_queue:
+      concurrency: 2
+    async_restore_queue:
+      concurrency: 2
+      max_tasks_per_child: 5
   hqcelery0.internal-va.commcarehq.org:
     email_queue:
       concurrency: 2
@@ -36,6 +50,28 @@ celery_processes:
       pooling: gevent
       concurrency: 10
       num_workers: 3
+    case_rule_queue:
+      concurrency: 4
+      max_tasks_per_child: 1
+    reminder_case_update_queue:
+      pooling: gevent
+      concurrency: 5
+      num_workers: 2
+    reminder_rule_queue:
+      concurrency: 3
+      max_tasks_per_child: 1
+    ils_gateway_sms_queue:
+      # Use 1 worker with concurrency 8 in order to enforce the
+      # restriction of having 8 max simultaneous connections with
+      # the push sms gateway
+      pooling: gevent
+      concurrency: 8
+    logistics_reminder_queue:
+      concurrency: 2
+      max_tasks_per_child: 5
+    logistics_background_queue:
+      concurrency: 2
+      max_tasks_per_child: 5
   hqcelery1.internal-va.commcarehq.org:
     case_rule_queue:
       concurrency: 4
@@ -59,7 +95,19 @@ celery_processes:
     logistics_background_queue:
       concurrency: 2
       max_tasks_per_child: 5
-  celery2: {}
+  celery2:
+    background_queue:
+      concurrency: 8
+      max_tasks_per_child: 1
+    send_report_throttled:
+      concurrency: 2
+      max_tasks_per_child: 1
+    async_restore_queue:
+      concurrency: 2
+      max_tasks_per_child: 5
+    analytics_queue:
+      pooling: gevent
+      concurrency: 10
   hqcelery2.internal-va.commcarehq.org:
     background_queue:
       concurrency: 8
@@ -73,7 +121,17 @@ celery_processes:
     analytics_queue:
       pooling: gevent
       concurrency: 10
-  celery3: {}
+  celery3:
+    async_restore_queue:
+      concurrency: 8
+      max_tasks_per_child: 5
+    saved_exports_queue:
+      concurrency: 6
+      max_tasks_per_child: 1
+      optimize: True
+    export_download_queue:
+      concurrency: 4
+      max_tasks_per_child: 5
   hqcelery3.internal-va.commcarehq.org:
     async_restore_queue:
       concurrency: 8
@@ -85,7 +143,13 @@ celery_processes:
     export_download_queue:
       concurrency: 4
       max_tasks_per_child: 5
-  celery4: {}
+  celery4:
+    celery:
+      concurrency: 6
+      max_tasks_per_child: 5
+    export_download_queue:
+      concurrency: 6
+      max_tasks_per_child: 5
   hqcelery4.internal-va.commcarehq.org:
     celery:
       concurrency: 6

--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -136,8 +136,8 @@ hqtouch0.internal-va.commcarehq.org
 10.202.42.98 hostname=rabbit0-production ec2=yes
 
 [rabbitmq:children]
-hqtouch0
 rabbit0
+hqtouch0
 
 [rabbitmq:vars]
 swap_size=2G

--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -158,7 +158,7 @@ kafka_broker_id=1
 hqcelery0.internal-va.commcarehq.org
 
 [hqcelery1]
-hqcelery1.internal-va.commcarehq.org datadog_integrations=celery
+hqcelery1.internal-va.commcarehq.org
 
 [hqcelery2]
 hqcelery2.internal-va.commcarehq.org
@@ -174,7 +174,7 @@ hqcelery4.internal-va.commcarehq.org
 10.202.12.202 hostname=celery0-production ec2=yes
 
 [celery1]
-10.202.12.214 hostname=celery1-production ec2=yes #datadog_integrations=celery
+10.202.12.214 hostname=celery1-production ec2=yes
 
 [celery2]
 10.202.12.26 hostname=celery2-production ec2=yes
@@ -187,16 +187,16 @@ hqcelery4.internal-va.commcarehq.org
 
 
 [celery:children]
-hqcelery1
-hqcelery0
-hqcelery2
-hqcelery3
-hqcelery4
 celery1
 celery0
 celery2
 celery3
 celery4
+hqcelery1
+hqcelery0
+hqcelery2
+hqcelery3
+hqcelery4
 
 [celery:vars]
 swap_size=8G
@@ -276,13 +276,13 @@ es_data
 
 
 [couch0]
-10.202.10.19 hostname=couch0-production ec2=yes
+10.202.40.211 hostname=couch0-production ec2=yes
 
 [couch1]
-10.202.11.235 hostname=couch1-production ec2=yes
+10.202.41.83 hostname=couch1-production ec2=yes
 
 [couch2]
-10.202.12.181 hostname=couch2-production ec2=yes
+10.202.42.85 hostname=couch2-production ec2=yes
 
 [couchdb2:children]
 couch0

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -158,7 +158,7 @@ kafka_broker_id=1
 hqcelery0.internal-va.commcarehq.org
 
 [hqcelery1]
-hqcelery1.internal-va.commcarehq.org datadog_integrations=celery
+hqcelery1.internal-va.commcarehq.org
 
 [hqcelery2]
 hqcelery2.internal-va.commcarehq.org
@@ -174,7 +174,7 @@ hqcelery4.internal-va.commcarehq.org
 {{ celery0-production }} hostname=celery0-production ec2=yes
 
 [celery1]
-{{ celery1-production }} hostname=celery1-production ec2=yes #datadog_integrations=celery
+{{ celery1-production }} hostname=celery1-production ec2=yes
 
 [celery2]
 {{ celery2-production }} hostname=celery2-production ec2=yes
@@ -187,16 +187,16 @@ hqcelery4.internal-va.commcarehq.org
 
 
 [celery:children]
-hqcelery1
-hqcelery0
-hqcelery2
-hqcelery3
-hqcelery4
 celery1
 celery0
 celery2
 celery3
 celery4
+hqcelery1
+hqcelery0
+hqcelery2
+hqcelery3
+hqcelery4
 
 [celery:vars]
 swap_size=8G

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -136,8 +136,8 @@ hqtouch0.internal-va.commcarehq.org
 {{ rabbit0-production }} hostname=rabbit0-production ec2=yes
 
 [rabbitmq:children]
-hqtouch0
 rabbit0
+hqtouch0
 
 [rabbitmq:vars]
 swap_size=2G


### PR DESCRIPTION
This PR follows up on #2332.

This has all been deployed: all new tasks are going to the new RabbitMQ (rabbit0) and picked up by the new celery workers (celery[0-4]). The old ones are still up to go through the backlog, and I'm leaving up a bit in case some process continued sending there before it died. I'll check and remove the old rabbit & celery machines tomorrow.