### PR TITLE
Update concurrency for softlayer icds aggregation queue

### DIFF
--- a/environments/softlayer/app-processes.yml
+++ b/environments/softlayer/app-processes.yml
@@ -43,7 +43,7 @@ celery_processes:
       max_tasks_per_child: 1
     icds_aggregation_queue:
       pooling: gevent
-      concurrency: 2
+      concurrency: 10
     flower: {}
 pillows:
   'pillow1':


### PR DESCRIPTION
This is needed after adding more parallel tasks for child health monthly @calellowitz 