### PR TITLE
Split case imports queue off of 'celery'

### DIFF
--- a/.travis/environments/travis/app-processes.yml
+++ b/.travis/environments/travis/app-processes.yml
@@ -1,7 +1,7 @@
 celery_processes:
   None:
     celery_periodic:
-    async_restore_queue,background_queue,case_rule_queue,celery,export_download_queue:
+    async_restore_queue,background_queue,case_rule_queue,celery,export_download_queue,case_import_queue:
     email_queue,reminder_case_update_queue,analytics_queue:
     reminder_rule_queue,repeat_record_queue,saved_exports_queue:
     ucr_indicator_queue,ucr_queue:

--- a/commcare-cloud-bootstrap/environment/app-processes.yml.j2
+++ b/commcare-cloud-bootstrap/environment/app-processes.yml.j2
@@ -3,7 +3,7 @@ celery_processes:
     beat: {}
     sms_queue: {}
     flower: {}
-    background_queue,case_rule_queue,celery,analytics_queue:
+    background_queue,case_rule_queue,celery,analytics_queue,case_import_queue:
       concurrency: 1
     email_queue,reminder_case_update_queue,export_download_queue:
       concurrency: 1

--- a/environments/64-test/app-processes.yml
+++ b/environments/64-test/app-processes.yml
@@ -3,7 +3,7 @@ celery_processes:
     beat: {}
     celery_periodic:
       concurrency: 4
-    async_restore_queue,background_queue,case_rule_queue,celery,export_download_queue,analytics_queue:
+    async_restore_queue,background_queue,case_rule_queue,celery,export_download_queue,analytics_queue,case_import_queue:
       concurrency: 1
     email_queue,reminder_case_update_queue:
       concurrency: 5

--- a/environments/development/app-processes.yml
+++ b/environments/development/app-processes.yml
@@ -3,7 +3,7 @@ celery_processes:
     beat: {}
     celery_periodic:
       concurrency: 4
-    async_restore_queue,background_queue,case_rule_queue,celery,export_download_queue,analytics_queue:
+    async_restore_queue,background_queue,case_rule_queue,celery,export_download_queue,analytics_queue,case_import_queue:
       concurrency: 1
     email_queue,reminder_case_update_queue:
       concurrency: 1

--- a/environments/echis/app-processes.yml
+++ b/environments/echis/app-processes.yml
@@ -13,7 +13,7 @@ celery_processes:
     async_restore_queue:
     ucr_queue:
   echis_server0:
-    celery,export_download_queue,email_queue:
+    celery,export_download_queue,email_queue,case_import_queue:
       concurrency: 1
       max_tasks_per_child: 5
     background_queue,case_rule_queue,analytics_queue:

--- a/environments/enikshay-reference/app-processes.yml
+++ b/environments/enikshay-reference/app-processes.yml
@@ -3,7 +3,7 @@ celery_processes:
     beat: {}
     celery_periodic:
       concurrency: 4
-    async_restore_queue,background_queue,case_rule_queue,celery,export_download_queue,analytics_queue:
+    async_restore_queue,background_queue,case_rule_queue,celery,export_download_queue,analytics_queue,case_import_queue:
       concurrency: 1
     email_queue,reminder_case_update_queue:
       concurrency: 1

--- a/environments/icds-cas/app-processes.yml
+++ b/environments/icds-cas/app-processes.yml
@@ -11,7 +11,7 @@ celery_processes:
     # on this machine have the cpu they need to perform their tasks.
     flower: {}
     beat: {}
-    celery,export_download_queue:
+    celery,export_download_queue,case_import_queue:
       concurrency: 8
       max_tasks_per_child: 5
     celery_periodic:

--- a/environments/icds-new/app-processes.yml
+++ b/environments/icds-new/app-processes.yml
@@ -12,7 +12,7 @@ celery_processes:
     # workers here so that the workers
     # on this machine have the cpu they need to perform their tasks.
     flower: {}
-    celery,export_download_queue:
+    celery,export_download_queue,case_import_queue:
       concurrency: 8
       max_tasks_per_child: 5
     beat: {}

--- a/environments/pna/app-processes.yml
+++ b/environments/pna/app-processes.yml
@@ -9,7 +9,7 @@ celery_processes:
     repeat_record_queue:
       concurrency: 2
       max_tasks_per_child: 1
-    celery:
+    celery,case_import_queue:
       concurrency: 2
       max_tasks_per_child: 1
     background_queue,export_download_queue,saved_exports_queue,analytics_queue:

--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -83,7 +83,7 @@ celery_processes:
       concurrency: 4
       max_tasks_per_child: 5
   celery4:
-    celery:
+    celery,case_import_queue:
       concurrency: 6
       max_tasks_per_child: 5
     export_download_queue:

--- a/environments/softlayer/app-processes.yml
+++ b/environments/softlayer/app-processes.yml
@@ -20,7 +20,7 @@ celery_processes:
     ucr_queue,ucr_indicator_queue:
       concurrency: 1
       max_tasks_per_child: 5
-    celery,export_download_queue,reminder_rule_queue:
+    celery,export_download_queue,reminder_rule_queue,case_import_queue:
       concurrency: 2
       max_tasks_per_child: 5
     saved_exports_queue:

--- a/environments/staging-aws-test/app-processes.yml
+++ b/environments/staging-aws-test/app-processes.yml
@@ -5,7 +5,7 @@ celery_processes:
     celery_periodic: {}
     beat: {}
   celery0:
-    repeat_record_queue,reminder_case_update_queue,reminder_rule_queue,celery,export_download_queue:
+    repeat_record_queue,reminder_case_update_queue,reminder_rule_queue,celery,export_download_queue,case_import_queue:
       concurrency: 4
       max_tasks_per_child: 5
     background_queue,case_rule_queue,analytics_queue:

--- a/environments/staging/app-processes.yml
+++ b/environments/staging/app-processes.yml
@@ -5,7 +5,7 @@ celery_processes:
     celery_periodic: {}
     beat: {}
   'celery0':
-    repeat_record_queue,reminder_case_update_queue,reminder_rule_queue,celery,export_download_queue:
+    repeat_record_queue,reminder_case_update_queue,reminder_rule_queue,celery,export_download_queue,case_import_queue:
       concurrency: 4
       max_tasks_per_child: 5
     background_queue,case_rule_queue,analytics_queue:

--- a/environments/swiss/app-processes.yml
+++ b/environments/swiss/app-processes.yml
@@ -6,7 +6,7 @@ service_blacklist:
 
 celery_processes:
   'swiss.commcarehq.org':
-    repeat_record_queue,celery,export_download_queue:
+    repeat_record_queue,celery,export_download_queue,case_import_queue:
       concurrency: 1
       max_tasks_per_child: 5
     background_queue,case_rule_queue,analytics_queue:

--- a/src/commcare_cloud/environment/schemas/app_processes.py
+++ b/src/commcare_cloud/environment/schemas/app_processes.py
@@ -69,6 +69,7 @@ CELERY_PROCESSES = [
     CeleryProcess("background_queue"),
     CeleryProcess("beat", required=False),
     CeleryProcess("case_rule_queue"),
+    CeleryProcess("case_import_queue"),
     CeleryProcess("celery"),
     CeleryProcess("celery_periodic", required=False),
     CeleryProcess("email_queue"),


### PR DESCRIPTION
Case imports are currently in the catchall queue.  As I understand it, this PR won't actually change anything, but it'll allow us to track the queues separately and split this off elsewhere if it looks necessary.

In conjunction with https://github.com/dimagi/commcare-hq/pull/22246

Full disclosure, I have a fairly rudimentary understanding of the implications of this change - it's largely mirrored off of https://github.com/dimagi/commcare-cloud/pull/1500