### PR TITLE
Increase size of pillow0 machine

### DIFF
--- a/environments/staging/terraform.yml
+++ b/environments/staging/terraform.yml
@@ -51,7 +51,7 @@ servers:
     az: "a"
     volume_size: 80
   - server_name: "pillow0-staging"
-    server_instance_type: "t3.large"
+    server_instance_type: "t3.xlarge"
     network_tier: "app-private"
     az: "a"
     volume_size: 80


### PR DESCRIPTION
Reason: the deploy was timing out because the pillowtop processes were using up basically all the ram on the 8GB machine, so this increase it to 16GB.
@dannyroberts 
code buddy @sravfeyn 
