### PR TITLE
Update the celery ip address

### DIFF
--- a/environments/staging/inventory.ini
+++ b/environments/staging/inventory.ini
@@ -63,7 +63,7 @@ hqkafka0
 # kafka0
 
 [celery0]
-10.201.40.193 hostname=celery0-staging ec2=yes
+10.201.10.150 hostname=celery0-staging ec2=yes
 
 [celery:children]
 # Amazon EC2


### PR DESCRIPTION
This is part of changing the celery machine from db-private to app-private. Going to go ahead and merge this in.
@dannyroberts 