### PR TITLE
Remove old celery and rabbit from prod inventory

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -25,7 +25,6 @@ celery_processes:
     async_restore_queue:
       concurrency: 2
       max_tasks_per_child: 5
-  hqcelery0.internal-va.commcarehq.org: {}
   celery1:
     flower: {}
     reminder_queue:
@@ -58,7 +57,6 @@ celery_processes:
     logistics_background_queue:
       concurrency: 2
       max_tasks_per_child: 5
-  hqcelery1.internal-va.commcarehq.org: {}
   celery2:
     background_queue:
       concurrency: 8
@@ -72,7 +70,6 @@ celery_processes:
     analytics_queue:
       pooling: gevent
       concurrency: 10
-  hqcelery2.internal-va.commcarehq.org: {}
   celery3:
     async_restore_queue:
       concurrency: 8
@@ -84,7 +81,6 @@ celery_processes:
     export_download_queue:
       concurrency: 4
       max_tasks_per_child: 5
-  hqcelery3.internal-va.commcarehq.org: {}
   celery4:
     celery:
       concurrency: 6
@@ -92,7 +88,6 @@ celery_processes:
     export_download_queue:
       concurrency: 6
       max_tasks_per_child: 5
-  hqcelery4.internal-va.commcarehq.org: {}
 pillows:
   hqpillowtop3.internal-va.commcarehq.org:
     CaseToElasticsearchPillow:

--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -129,15 +129,11 @@ pgsynclog1
 postgresql_30gb
 postgresql_15gb
 
-[hqtouch0]
-hqtouch0.internal-va.commcarehq.org
-
 [rabbit0]
 10.202.42.98 hostname=rabbit0-production ec2=yes
 
 [rabbitmq:children]
 rabbit0
-hqtouch0
 
 [rabbitmq:vars]
 swap_size=2G
@@ -153,22 +149,6 @@ hqes1
 
 [kafka:vars]
 kafka_broker_id=1
-
-[hqcelery0]
-hqcelery0.internal-va.commcarehq.org
-
-[hqcelery1]
-hqcelery1.internal-va.commcarehq.org
-
-[hqcelery2]
-hqcelery2.internal-va.commcarehq.org
-
-[hqcelery3]
-hqcelery3.internal-va.commcarehq.org
-
-[hqcelery4]
-hqcelery4.internal-va.commcarehq.org
-
 
 [celery0]
 10.202.12.202 hostname=celery0-production ec2=yes
@@ -192,11 +172,6 @@ celery0
 celery2
 celery3
 celery4
-hqcelery1
-hqcelery0
-hqcelery2
-hqcelery3
-hqcelery4
 
 [celery:vars]
 swap_size=8G

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -129,15 +129,11 @@ pgsynclog1
 postgresql_30gb
 postgresql_15gb
 
-[hqtouch0]
-hqtouch0.internal-va.commcarehq.org
-
 [rabbit0]
 {{ rabbit0-production }} hostname=rabbit0-production ec2=yes
 
 [rabbitmq:children]
 rabbit0
-hqtouch0
 
 [rabbitmq:vars]
 swap_size=2G
@@ -153,22 +149,6 @@ hqes1
 
 [kafka:vars]
 kafka_broker_id=1
-
-[hqcelery0]
-hqcelery0.internal-va.commcarehq.org
-
-[hqcelery1]
-hqcelery1.internal-va.commcarehq.org
-
-[hqcelery2]
-hqcelery2.internal-va.commcarehq.org
-
-[hqcelery3]
-hqcelery3.internal-va.commcarehq.org
-
-[hqcelery4]
-hqcelery4.internal-va.commcarehq.org
-
 
 [celery0]
 {{ celery0-production }} hostname=celery0-production ec2=yes
@@ -192,11 +172,6 @@ celery0
 celery2
 celery3
 celery4
-hqcelery1
-hqcelery0
-hqcelery2
-hqcelery3
-hqcelery4
 
 [celery:vars]
 swap_size=8G


### PR DESCRIPTION
We've been on the new setup for a day+ now, and the old queues have been stopped for a while.