### PR TITLE
Mk minimize softlayer

### DIFF
--- a/environments/softlayer/app-processes.yml
+++ b/environments/softlayer/app-processes.yml
@@ -3,10 +3,17 @@ newrelic_javaagent: True
 celery_processes:
   'celery0':
     beat: {}
-    celery_periodic:
-      concurrency: 2
+    flower: {}
+    reminder_queue:
+      pooling: gevent
+      concurrency: 5
     submission_reprocessing_queue:
       concurrency: 1
+    sms_queue:
+      pooling: gevent
+      concurrency: 10
+    celery_periodic:
+      concurrency: 2
     email_queue:
       concurrency: 2
     repeat_record_queue,sumologic_logs_queue:
@@ -27,15 +34,9 @@ celery_processes:
     reminder_case_update_queue:
       pooling: gevent
       concurrency: 5
-    reminder_queue:
-      pooling: gevent
-      concurrency: 5
     reminder_rule_queue:
       concurrency: 1
       max_tasks_per_child: 1
-    sms_queue:
-      pooling: gevent
-      concurrency: 10
     async_restore_queue:
       concurrency: 1
     background_queue,case_rule_queue,icds_dashboard_reports_queue,analytics_queue:
@@ -44,7 +45,6 @@ celery_processes:
     icds_aggregation_queue:
       pooling: gevent
       concurrency: 10
-    flower: {}
 pillows:
   'pillow1':
     AppDbChangeFeedPillow:

--- a/environments/softlayer/app-processes.yml
+++ b/environments/softlayer/app-processes.yml
@@ -12,39 +12,29 @@ celery_processes:
     sms_queue:
       pooling: gevent
       concurrency: 10
-    celery_periodic:
-      concurrency: 2
-    email_queue:
+    celery_periodic,email_queue:
       concurrency: 2
     repeat_record_queue,sumologic_logs_queue:
       pooling: gevent
       concurrency: 200
-    ucr_queue:
-      concurrency: 2
-      max_tasks_per_child: 5
-    ucr_indicator_queue:
+    ucr_queue,ucr_indicator_queue:
       concurrency: 1
-    celery,export_download_queue:
+      max_tasks_per_child: 5
+    celery,export_download_queue,reminder_rule_queue:
       concurrency: 2
       max_tasks_per_child: 5
     saved_exports_queue:
       concurrency: 2
       max_tasks_per_child: 1
       optimize: True
-    reminder_case_update_queue:
+    reminder_case_update_queue,icds_aggregation_queue:
       pooling: gevent
       concurrency: 5
-    reminder_rule_queue:
-      concurrency: 1
-      max_tasks_per_child: 1
     async_restore_queue:
       concurrency: 1
     background_queue,case_rule_queue,icds_dashboard_reports_queue,analytics_queue:
       concurrency: 2
       max_tasks_per_child: 1
-    icds_aggregation_queue:
-      pooling: gevent
-      concurrency: 10
 pillows:
   'pillow1':
     AppDbChangeFeedPillow:


### PR DESCRIPTION
[Source ticket](https://manage.dimagi.com/default.asp?285065)

Celery machine on softlayer has no memory to even do a location upload,
so this is to reduce the memory usage till we move it to AWS

My understanding is that activity on softlayer is minimal hence combining the queues and reducing the concurrency should be the right to do anyway

best review commit by commit