### PR TITLE
Rate-limit sauti-1

### DIFF
--- a/environments/icds-cas/proxy.yml
+++ b/environments/icds-cas/proxy.yml
@@ -12,3 +12,49 @@ special_sites:
 
 letsencrypt_cchq_ssl: True
 letsencrypt_cas_ssl: True
+
+site_locations:
+  - name: /files
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: '/etc/nginx/.htpasswd'
+  - name: /bihar_ls_files
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_bihar"
+  - name: /maharashtra_icds-cas_files
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_maharashtra"
+  - name: /mp_ls_files
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_mp"
+  - name: /ls_hindi
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_ls_hindi"
+  - name: /ls_marathi
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_ls_marathi"
+  - name: /ls_telugu
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_ls_telugu"
+  - name: /hindi_files
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_hindi_files"
+  - name: /marathi_files
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_marathi_files"
+  - name: /telugu_files
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_telugu_files"
+  - name: /adhaar_id_scanner_apk
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_adhaar_id_scanner_apk"

--- a/environments/icds-cas/public.yml
+++ b/environments/icds-cas/public.yml
@@ -52,51 +52,6 @@ server_email: commcarehq-noreply@icds-cas.gov.in
 cchq_bug_report_email: commcarehq-bug-reports@icds-cas.gov.in
 
 commcare_errors_branch: "master-icds"
-site_locations:
-  - name: /files
-    try_files: "$uri $uri/index.html $uri/ =404"
-    auth_basic: '"Restricted Content"'
-    auth_basic_user_file: '/etc/nginx/.htpasswd'
-  - name: /bihar_ls_files 
-    try_files: "$uri $uri/index.html $uri/ =404"
-    auth_basic: '"Restricted Content"'
-    auth_basic_user_file: "/etc/nginx/.htpasswd_bihar"
-  - name: /maharashtra_icds-cas_files 
-    try_files: "$uri $uri/index.html $uri/ =404"
-    auth_basic: '"Restricted Content"'
-    auth_basic_user_file: "/etc/nginx/.htpasswd_maharashtra"
-  - name: /mp_ls_files
-    try_files: "$uri $uri/index.html $uri/ =404"
-    auth_basic: '"Restricted Content"'
-    auth_basic_user_file: "/etc/nginx/.htpasswd_mp"
-  - name: /ls_hindi 
-    try_files: "$uri $uri/index.html $uri/ =404"
-    auth_basic: '"Restricted Content"'
-    auth_basic_user_file: "/etc/nginx/.htpasswd_ls_hindi"
-  - name: /ls_marathi 
-    try_files: "$uri $uri/index.html $uri/ =404"
-    auth_basic: '"Restricted Content"'
-    auth_basic_user_file: "/etc/nginx/.htpasswd_ls_marathi"
-  - name: /ls_telugu 
-    try_files: "$uri $uri/index.html $uri/ =404"
-    auth_basic: '"Restricted Content"'
-    auth_basic_user_file: "/etc/nginx/.htpasswd_ls_telugu"
-  - name: /hindi_files 
-    try_files: "$uri $uri/index.html $uri/ =404"
-    auth_basic: '"Restricted Content"'
-    auth_basic_user_file: "/etc/nginx/.htpasswd_hindi_files"
-  - name: /marathi_files 
-    try_files: "$uri $uri/index.html $uri/ =404"
-    auth_basic: '"Restricted Content"'
-    auth_basic_user_file: "/etc/nginx/.htpasswd_marathi_files"
-  - name: /telugu_files 
-    try_files: "$uri $uri/index.html $uri/ =404"
-    auth_basic: '"Restricted Content"'
-    auth_basic_user_file: "/etc/nginx/.htpasswd_telugu_files"
-  - name: /adhaar_id_scanner_apk
-    try_files: "$uri $uri/index.html $uri/ =404"
-    auth_basic: '"Restricted Content"'
-    auth_basic_user_file: "/etc/nginx/.htpasswd_adhaar_id_scanner_apk"
 
 couchdb_use_haproxy: True
 couchdb_reduce_limit: False

--- a/environments/icds-new/proxy.yml
+++ b/environments/icds-new/proxy.yml
@@ -17,3 +17,49 @@ special_sites:
 letsencrypt_cchq_ssl: True
 # CAS configurations are also present on softlayer
 letsencrypt_cas_ssl: True
+
+site_locations:
+  - name: /files
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: '/etc/nginx/.htpasswd'
+  - name: /bihar_ls_files
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_bihar"
+  - name: /maharashtra_icds-cas_files
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_maharashtra"
+  - name: /mp_ls_files
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_mp"
+  - name: /ls_hindi
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_ls_hindi"
+  - name: /ls_marathi
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_ls_marathi"
+  - name: /ls_telugu
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_ls_telugu"
+  - name: /hindi_files
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_hindi_files"
+  - name: /marathi_files
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_marathi_files"
+  - name: /telugu_files
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_telugu_files"
+  - name: /adhaar_id_scanner_apk
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_adhaar_id_scanner_apk"

--- a/environments/icds-new/public.yml
+++ b/environments/icds-new/public.yml
@@ -53,51 +53,6 @@ no_proxy_hosts:
   - smsgw.sms.gov.in
 
 commcare_errors_branch: "master-icds"
-site_locations:
-  - name: /files
-    try_files: "$uri $uri/index.html $uri/ =404"
-    auth_basic: '"Restricted Content"'
-    auth_basic_user_file: '/etc/nginx/.htpasswd'
-  - name: /bihar_ls_files
-    try_files: "$uri $uri/index.html $uri/ =404"
-    auth_basic: '"Restricted Content"'
-    auth_basic_user_file: "/etc/nginx/.htpasswd_bihar"
-  - name: /maharashtra_icds-cas_files
-    try_files: "$uri $uri/index.html $uri/ =404"
-    auth_basic: '"Restricted Content"'
-    auth_basic_user_file: "/etc/nginx/.htpasswd_maharashtra"
-  - name: /mp_ls_files
-    try_files: "$uri $uri/index.html $uri/ =404"
-    auth_basic: '"Restricted Content"'
-    auth_basic_user_file: "/etc/nginx/.htpasswd_mp"
-  - name: /ls_hindi
-    try_files: "$uri $uri/index.html $uri/ =404"
-    auth_basic: '"Restricted Content"'
-    auth_basic_user_file: "/etc/nginx/.htpasswd_ls_hindi"
-  - name: /ls_marathi
-    try_files: "$uri $uri/index.html $uri/ =404"
-    auth_basic: '"Restricted Content"'
-    auth_basic_user_file: "/etc/nginx/.htpasswd_ls_marathi"
-  - name: /ls_telugu
-    try_files: "$uri $uri/index.html $uri/ =404"
-    auth_basic: '"Restricted Content"'
-    auth_basic_user_file: "/etc/nginx/.htpasswd_ls_telugu"
-  - name: /hindi_files
-    try_files: "$uri $uri/index.html $uri/ =404"
-    auth_basic: '"Restricted Content"'
-    auth_basic_user_file: "/etc/nginx/.htpasswd_hindi_files"
-  - name: /marathi_files
-    try_files: "$uri $uri/index.html $uri/ =404"
-    auth_basic: '"Restricted Content"'
-    auth_basic_user_file: "/etc/nginx/.htpasswd_marathi_files"
-  - name: /telugu_files
-    try_files: "$uri $uri/index.html $uri/ =404"
-    auth_basic: '"Restricted Content"'
-    auth_basic_user_file: "/etc/nginx/.htpasswd_telugu_files"
-  - name: /adhaar_id_scanner_apk
-    try_files: "$uri $uri/index.html $uri/ =404"
-    auth_basic: '"Restricted Content"'
-    auth_basic_user_file: "/etc/nginx/.htpasswd_adhaar_id_scanner_apk"
 
 couchdb_cluster_settings:
   q: 8

--- a/environments/production/proxy.yml
+++ b/environments/production/proxy.yml
@@ -23,3 +23,35 @@ special_sites:
   - wiki_http
   - motech
   - motech2
+
+limit_req_zones:
+  - name: "restore"
+    zone: "$digest_submission"
+    size: "10m"
+    rate: "1r/s"
+  - name: "submissions"
+    zone: "$digest_submission"
+    size: "10m"
+    rate: "10r/s"
+
+site_locations:
+  - name: "/a/sauti-1/phone/restore"
+    balancer: "{{ deploy_env }}_commcare"
+    proxy_next_upstream_tries: 1
+    proxy_buffers: 8 64k
+    proxy_buffer_size: 64k
+    client_body_buffer_size: 512k
+    limit_reqs:
+      - zone_name: "restore"
+        burst: 100
+        nodelay: True
+  - name: "/a/sauti-1/receiver"
+    balancer: "{{ deploy_env }}_commcare_submissions"
+    proxy_next_upstream_tries: 1
+    proxy_buffers: 8 64k
+    proxy_buffer_size: 64k
+    client_body_buffer_size: 512k
+    limit_reqs:
+      - zone_name: "submissions"
+        burst: 100
+        nodelay: True

--- a/environments/softlayer/proxy.yml
+++ b/environments/softlayer/proxy.yml
@@ -8,3 +8,13 @@ primary_ssl_env: "softlayer"
 # Nginx only accepts on cert, so cat the site cert and chain:
 # $ cat india.commcarehq.org.crt intermediate.crt > india.commcarehq.org.combined.crt
 letsencrypt_cchq_ssl: True
+
+site_locations:
+  - name: /data_dumps/export/enikshay/public
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: '/etc/nginx/.htpasswd_enikshay_public'
+  - name: /data_dumps/export/enikshay/private
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: '/etc/nginx/.htpasswd_enikshay_private'

--- a/environments/softlayer/public.yml
+++ b/environments/softlayer/public.yml
@@ -105,13 +105,3 @@ localsettings:
   TRANSFER_SERVER: 'nginx'
   WS4REDIS_CONNECTION_HOST: "{{ groups.redis.0 }}"
   OBFUSCATE_PASSWORD_FOR_NIC_COMPLIANCE: True
-
-site_locations:
-  - name: /data_dumps/export/enikshay/public
-    try_files: "$uri $uri/index.html $uri/ =404"
-    auth_basic: '"Restricted Content"'
-    auth_basic_user_file: '/etc/nginx/.htpasswd_enikshay_public'
-  - name: /data_dumps/export/enikshay/private
-    try_files: "$uri $uri/index.html $uri/ =404"
-    auth_basic: '"Restricted Content"'
-    auth_basic_user_file: '/etc/nginx/.htpasswd_enikshay_private'

--- a/src/commcare_cloud/ansible/roles/nginx/vars/cchq_ssl.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/cchq_ssl.yml
@@ -12,6 +12,11 @@ nginx_sites:
       hosts: formplayer
       port: "{{ formplayer_port }}"
       method: "hash $cookie_sessionid consistent"
+   mappings:
+    - name: "$digest_submission"
+      variable: "$http_authorization"
+      value: "$server_name"
+   limit_req_zones: "{{ limit_req_zones|default([]) }}"
    proxy_cache_path:
     - name: "hq_media_cache"
       path: "{{ www_home }}/hq_media/cache"

--- a/src/commcare_cloud/environment/schemas/proxy.py
+++ b/src/commcare_cloud/environment/schemas/proxy.py
@@ -19,6 +19,9 @@ class ProxyConfig(jsonobject.JsonObject):
 
     special_sites = jsonobject.ListProperty(str)
 
+    limit_req_zones = jsonobject.ListProperty(lambda: LimitReqZone)
+    site_locations = jsonobject.ListProperty(lambda: SiteLocation)
+
     COMMTRACK_SITE_HOST = jsonobject.StringProperty(exclude_if_none=True)
     commtrack_nginx_combined_cert_value = jsonobject.StringProperty(exclude_if_none=True)
     commtrack_key_value = jsonobject.StringProperty(exclude_if_none=True)
@@ -48,3 +51,32 @@ class ProxyConfig(jsonobject.JsonObject):
     @classmethod
     def get_claimed_variables(cls):
         return set(cls._properties_by_key.keys())
+
+
+class LimitReqZone(jsonobject.JsonObject):
+    _allow_dynamic_properties = False
+    name = jsonobject.StringProperty()
+    zone = jsonobject.StringProperty(choices=["$digest_submission"])
+    size = jsonobject.StringProperty()
+    rate = jsonobject.StringProperty()
+
+
+class SiteLocation(jsonobject.JsonObject):
+    _allow_dynamic_properties = False
+
+    name = jsonobject.StringProperty(required=True)
+    balancer = jsonobject.StringProperty(exclude_if_none=True)
+    proxy_next_upstream_tries = jsonobject.IntegerProperty(exclude_if_none=True)
+    proxy_buffers = jsonobject.StringProperty(exclude_if_none=True)
+    proxy_buffer_size = jsonobject.StringProperty(exclude_if_none=True)
+    client_body_buffer_size = jsonobject.StringProperty(exclude_if_none=True)
+    limit_reqs = jsonobject.ListProperty(lambda: LimitReq, exclude_if_none=True)
+    try_files = jsonobject.StringProperty(exclude_if_none=True)
+    auth_basic = jsonobject.StringProperty(exclude_if_none=True)
+    auth_basic_user_file = jsonobject.StringProperty(exclude_if_none=True)
+
+
+class LimitReq(jsonobject.JsonObject):
+    zone_name = jsonobject.StringProperty()
+    burst = jsonobject.IntegerProperty()
+    nodelay = jsonobject.BooleanProperty()


### PR DESCRIPTION
This PR should only affect prod, but includes a logically related refactor to move `site_locations` to `proxy.yml` where its schema can be enforced.

Rates arbitrarily proposed here are 1r/s for restores and 10r/s for submissions, but I think that's probably very conservative. (It's 1/6 of the rate-limiting for ICDS.)

Here's the diff that'd go to the nginx conf:

```diff
+map $http_authorization $digest_submission {
+  ""     $server_name;
+  default     "";
+}

+limit_req_zone $digest_submission zone=restore:10m rate=1r/s;
+limit_req_zone $digest_submission zone=submissions:10m rate=10r/s;

 proxy_cache_path /home/cchq/www/production/hq_media/cache levels=1:2 keys_zone=hq_media_cache:10m
                  max_size=2g inactive=24h use_temp_path=off;
@@ -113,6 +120,22 @@
             proxy_next_upstream_tries 1;
             proxy_redirect http://www.commcarehq.org https://www.commcarehq.org;
               }
+  location /a/sauti-1/phone/restore {
+            proxy_pass http://production_commcare;
+                    client_body_buffer_size 512k;
+            proxy_buffers 8 64k;
+            proxy_buffer_size 64k;
+            proxy_next_upstream_tries 1;
+                    limit_req zone=restore burst=100 nodelay;
+      }
+  location /a/sauti-1/receiver {
+            proxy_pass http://production_commcare_submissions;
+                    client_body_buffer_size 512k;
+            proxy_buffers 8 64k;
+            proxy_buffer_size 64k;
+            proxy_next_upstream_tries 1;
+                    limit_req zone=submissions burst=100 nodelay;
+      }
```