### PR TITLE
Switch to using local couchdb2 for production auditcare and fixutres dbs

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -85,6 +85,20 @@ couch_dbs:
     username: "{{ localsettings_private.COUCH_USERNAME }}"
     password: "{{ localsettings_private.COUCH_PASSWORD }}"
     is_https: False
+  auditcare:
+    host: "{{ groups.couchdb2_proxy.0 }}"
+    port: "{{ couchdb2_proxy_port }}"
+    name: commcarehq__auditcare
+    username: "{{ localsettings_private.COUCH_USERNAME }}"
+    password: "{{ localsettings_private.COUCH_PASSWORD }}"
+    is_https: False
+  fixtures:
+    host: "{{ groups.couchdb2_proxy.0 }}"
+    port: "{{ couchdb2_proxy_port }}"
+    name: commcarehq__fixtures
+    username: "{{ localsettings_private.COUCH_USERNAME }}"
+    password: "{{ localsettings_private.COUCH_PASSWORD }}"
+    is_https: False
 
 couchdb2:
   username: "{{ localsettings_private.COUCH_USERNAME }}"


### PR DESCRIPTION
This PR is continuing to follow the same pattern as https://github.com/dimagi/commcare-cloud/pull/2340 and https://github.com/dimagi/commcare-cloud/pull/2350