### PR TITLE
Move production pillows to new aws machine

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -89,8 +89,10 @@ celery_processes:
       concurrency: 6
       max_tasks_per_child: 5
 pillows:
-  pillow0: {}
-  hqpillowtop3.internal-va.commcarehq.org:
+  hqpillowtop3.internal-va.commcarehq.org: {}
+  hqpillowtop2.internal-va.commcarehq.org: {}
+  hqpillowtop0.internal-va.commcarehq.org: {}
+  pillow0:
     CaseToElasticsearchPillow:
       num_processes: 4
     CaseSearchToElasticsearchPillow:
@@ -102,19 +104,7 @@ pillows:
     FormSubmissionMetadataTrackerPillow:
       num_processes: 4
     kafka-ucr-main:
-      start_process: 6
-      num_processes: 1
-      total_processes: 7
-  hqpillowtop2.internal-va.commcarehq.org:
-    kafka-ucr-main:
-      start_process: 0
-      num_processes: 4
-      total_processes: 7
-  hqpillowtop0.internal-va.commcarehq.org:
-    kafka-ucr-main:
-      start_process: 4
-      num_processes: 2
-      total_processes: 7
+      num_processes: 7
     AppDbChangeFeedPillow:
       num_processes: 1
     ApplicationToElasticsearchPillow:

--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -89,9 +89,6 @@ celery_processes:
       concurrency: 6
       max_tasks_per_child: 5
 pillows:
-  hqpillowtop3.internal-va.commcarehq.org: {}
-  hqpillowtop2.internal-va.commcarehq.org: {}
-  hqpillowtop0.internal-va.commcarehq.org: {}
   pillow0:
     CaseToElasticsearchPillow:
       num_processes: 4

--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -176,23 +176,11 @@ celery4
 [celery:vars]
 swap_size=8G
 
-[hqpillowtop0]
-hqpillowtop0.internal-va.commcarehq.org
-
-[hqpillowtop2]
-hqpillowtop2.internal-va.commcarehq.org
-
-[hqpillowtop3]
-hqpillowtop3.internal-va.commcarehq.org
-
 [pillow0]
 10.202.12.170 hostname=pillow0-production ec2=yes
 
 [pillowtop:children]
 pillow0
-hqpillowtop0
-hqpillowtop2
-hqpillowtop3
 
 [hqformplayer1]
 hqformplayer1.internal-va.commcarehq.org

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -176,23 +176,11 @@ celery4
 [celery:vars]
 swap_size=8G
 
-[hqpillowtop0]
-hqpillowtop0.internal-va.commcarehq.org
-
-[hqpillowtop2]
-hqpillowtop2.internal-va.commcarehq.org
-
-[hqpillowtop3]
-hqpillowtop3.internal-va.commcarehq.org
-
 [pillow0]
 {{ pillow0-production }} hostname=pillow0-production ec2=yes
 
 [pillowtop:children]
 pillow0
-hqpillowtop0
-hqpillowtop2
-hqpillowtop3
 
 [hqformplayer1]
 hqformplayer1.internal-va.commcarehq.org


### PR DESCRIPTION
This has already been deployed. All pillows now on pillow0, none on the old ones.