### PR TITLE
Send restores to "mobile_webworkers"

### DIFF
--- a/src/commcare_cloud/ansible/roles/nginx/vars/cchq_ssl.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/cchq_ssl.yml
@@ -37,7 +37,7 @@ nginx_sites:
       proxy_buffers: 8 64k
       proxy_buffer_size: 64k
       client_body_buffer_size: 512k
-    - name: '~ /a/[^/]+/(receiver|phone)'
+    - name: '~ /a/[^/]+/(receiver|phone)/'
       balancer: "{{ deploy_env }}_commcare_submissions"
       proxy_redirect: "http://{{ SITE_HOST }} https://{{ SITE_HOST }}"
       proxy_next_upstream_tries: 1

--- a/src/commcare_cloud/ansible/roles/nginx/vars/cchq_ssl.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/cchq_ssl.yml
@@ -37,7 +37,7 @@ nginx_sites:
       proxy_buffers: 8 64k
       proxy_buffer_size: 64k
       client_body_buffer_size: 512k
-    - name: '~ /a/[^/]+/receiver'
+    - name: '~ /a/[^/]+/(receiver|phone)'
       balancer: "{{ deploy_env }}_commcare_submissions"
       proxy_redirect: "http://{{ SITE_HOST }} https://{{ SITE_HOST }}"
       proxy_next_upstream_tries: 1


### PR DESCRIPTION
Previously only submissions go to the `[mobile_webworkers]`, now restores (and the other more minor endpoints under /phone/) go there too