### PR TITLE
Make public subnet accessible from other machines on the network

### DIFF
--- a/src/commcare_cloud/terraform/modules/network/main.tf
+++ b/src/commcare_cloud/terraform/modules/network/main.tf
@@ -190,6 +190,13 @@ resource "aws_security_group" "proxy-sg" {
     ipv6_cidr_blocks =  ["::/0"]
   }
 
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["${aws_vpc.main.cidr_block}"]
+  }
+
   egress = "${local.default_egress}"
 
   tags {


### PR DESCRIPTION
on all ports

This allows webworkers to make requests to the riak proxy.