### PR TITLE
Remove web[3-5]-production hq_webworkers

### DIFF
--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -17,15 +17,6 @@ hqproxy0
 [web2]
 10.202.10.238 hostname=web2-production ec2=yes
 
-[web3]
-10.202.10.192 hostname=web3-production ec2=yes
-
-[web4]
-10.202.10.113 hostname=web4-production ec2=yes
-
-[web5]
-10.202.10.50 hostname=web5-production ec2=yes
-
 [web6]
 10.202.11.98 hostname=web6-production ec2=yes
 
@@ -49,9 +40,6 @@ hqproxy0
 web0
 web1
 web2
-web3
-web4
-web5
 
 [mobile_webworkers:children]
 web6

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -17,15 +17,6 @@ hqproxy0
 [web2]
 {{ web2-production }} hostname=web2-production ec2=yes
 
-[web3]
-{{ web3-production }} hostname=web3-production ec2=yes
-
-[web4]
-{{ web4-production }} hostname=web4-production ec2=yes
-
-[web5]
-{{ web5-production }} hostname=web5-production ec2=yes
-
 [web6]
 {{ web6-production }} hostname=web6-production ec2=yes
 
@@ -49,9 +40,6 @@ hqproxy0
 web0
 web1
 web2
-web3
-web4
-web5
 
 [mobile_webworkers:children]
 web6


### PR DESCRIPTION
We had purposely allocated too many resources to this earlier, and now we're "rightsizing".

Already deployed.