### PR TITLE
Upgrade PyGithub to 1.43.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ couchdb-cluster-admin==0.4.2
 cryptography==2.3.1
 datadog==0.2.0
 decorator==4.3.0          # via datadog
+deprecated==1.2.4         # via pygithub
 dimagi-memoized==1.1.1
 dnspython==1.15.0
 docutils==0.14            # via botocore
@@ -43,7 +44,7 @@ passlib==1.7.1
 pyasn1==0.4.4             # via ndg-httpsclient, paramiko
 pycparser==2.19           # via cffi
 pycryptodome==3.6.6
-pygithub==1.40a1
+pygithub==1.43.3
 pyjwt==1.6.4              # via pygithub
 pynacl==1.3.0             # via paramiko
 pyopenssl==18.0.0
@@ -55,3 +56,4 @@ s3transfer==0.1.13        # via boto3
 simplejson==3.16.0        # via datadog
 six==1.11.0
 urllib3==1.23             # via botocore, requests
+wrapt==1.10.11            # via deprecated

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         'netaddr',
         'passlib',
         'pycryptodome>=3.6.6',  # security update
-        'PyGithub==1.40a1',
+        'PyGithub>=1.43.3',
         'pytz==2017.2',
         'six',
     ),


### PR DESCRIPTION
Was getting deploy errors on prod because of merged with long PR names that were truncated and ended with `...`
Unsure if this fixes it, but we were on a prerelease before so seemed worth it to upgrade.
@emord 
code buddy @esoergel 