### PR TITLE
Remove celery2 from rotation

### DIFF
--- a/environments/icds-cas/app-processes.yml
+++ b/environments/icds-cas/app-processes.yml
@@ -53,17 +53,17 @@ celery_processes:
       num_workers: 1
     ucr_indicator_queue:
       concurrency: 6
-  'celery2':
-    reminder_case_update_queue:
-      pooling: gevent
-      concurrency: 5
-      num_workers: 6
-    reminder_queue:
-      pooling: gevent
-      concurrency: 5
-      num_workers: 1
-    ucr_indicator_queue:
-      concurrency: 6
+  # 'celery2':
+  #   reminder_case_update_queue:
+  #     pooling: gevent
+  #     concurrency: 5
+  #     num_workers: 6
+  #   reminder_queue:
+  #     pooling: gevent
+  #     concurrency: 5
+  #     num_workers: 1
+  #   ucr_indicator_queue:
+  #     concurrency: 6
   'celery3':
     reminder_case_update_queue:
       pooling: gevent
@@ -71,8 +71,12 @@ celery_processes:
       num_workers: 6
     async_restore_queue:
       concurrency: 4
+    reminder_queue:
+      pooling: gevent
+      concurrency: 5
+      num_workers: 1
     ucr_indicator_queue:
-      concurrency: 8
+      concurrency: 4
     icds_dashboard_reports_queue:
       concurrency: 2
   'celery4':

--- a/environments/icds-cas/inventory/commcare.csv
+++ b/environments/icds-cas/inventory/commcare.csv
@@ -1,7 +1,6 @@
 hostname,host_address,group 1,group 2,group 3,var: hostname
 celery0,100.71.188.5,celery,,,MUMGCCWCDPRDC000
 celery1,100.71.188.11,celery,,,MUMGCCWCDPRDC001
-celery2,100.71.188.6,celery,,,MUMGCCWCDPRDC002
 celery3,100.71.188.13,celery,,,MUMGCCWCDPRDC003
 celery4,100.71.188.12,celery,,,MUMGCCWCDPRDC004
 celery5,100.71.188.7,celery,,,MUMGCCWCDPRDC005


### PR DESCRIPTION
@dimagi/scale-team 

@calellowitz and I were deploying today and saw that celery2 had a corrupt git folder. in the deploy output it looked like:

```
 [100.71.188.6] out: error: file ./objects/pack/pack-8c3f380a0e1e8af4ebdf638ece722adc4b14e2a2.pack is not a GIT packfile
 [100.71.188.6] out: error: file ./objects/pack/pack-8c3f380a0e1e8af4ebdf638ece722adc4b14e2a2.pack is not a GIT packfile
 [100.71.188.6] out: error: refs/remotes/origin/jls/ko-export-merge-conflicts does not point to a valid object!
```

I tried doing some `git fsck` and other things from stack overflow, but I believe we'll need to re-clone the repository.

I also tried running `clean_releases`, but received an error and then saw (files marked as directories):

```
```(icds) cchq@celery2:~/www/icds/releases$ ls -lh /home/cchq/www/icds/releases/2018-10-31_00.56/corehq/apps/sms/templates/sms/
total 20K
drwxr-xr-x 3 cchq cchq 4.0K Sep 12 00:19 chat_contacts.html
drwxr-xr-x 3 cchq cchq 4.0K Sep 12 00:19 compose.html
drwxr-xr-x 2 cchq cchq 4.0K Sep 12 00:19 gateway_list.html
drwxr-xr-x 3 cchq cchq 4.0K Sep 12 00:19 list_forwarding_rules.html
drwxr-xr-x 2 cchq cchq 4.0K Sep 12 00:19 manage_registration_invitations.html```
```

This means that multiple directories were potentially corrupted so it seems like it could have happened a couple of weeks ago, but I wasn't able to dig much further. Does this ring any bells to anyone? Was celery2 undergoing any maintenance in the past few days, or did we make any changes to it?