### PR TITLE
AWS enforce Multi Factor Auth

### DIFF
--- a/docs/commcare-cloud/commands/index.md
+++ b/docs/commcare-cloud/commands/index.md
@@ -11,7 +11,7 @@ All `commcare-cloud` commands take the following form:
 ```
 commcare-cloud [--control]
                <env>
-               {bootstrap-users,ansible-playbook,django-manage,aps,tmux,ap,validate-environment-settings,openvpn-activate-user,deploy-stack,service,update-supervisor-confs,update-users,ping,migrate_couchdb,lookup,run-module,update-config,copy-files,mosh,list-postgresql-dbs,after-reboot,ssh,downtime,fab,update-local-known-hosts,aws-list,aws-fill-inventory,migrate-couchdb,terraform,openvpn-claim-user,run-shell-command,terraform-migrate-state}
+               {bootstrap-users,ansible-playbook,django-manage,aps,aws-sign-in,tmux,ap,validate-environment-settings,openvpn-activate-user,deploy-stack,service,update-supervisor-confs,update-users,ping,migrate_couchdb,lookup,run-module,update-config,copy-files,mosh,list-postgresql-dbs,after-reboot,ssh,downtime,fab,update-local-known-hosts,aws-list,aws-fill-inventory,migrate-couchdb,terraform,openvpn-claim-user,run-shell-command,terraform-migrate-state}
                ...
 ```
 
@@ -1111,6 +1111,27 @@ so you can tell it how existing resources map to your new code.
 
 This is a tedious task, and often follows a very predictable renaming pattern.
 This command helps fill this gap.
+
+---
+
+#### `aws-sign-in`
+
+Use your MFA device to "sign in" to AWS for &lt;duration&gt; minutes (default 30)
+
+```
+commcare-cloud <env> aws-sign-in [--duration-minutes DURATION_MINUTES]
+```
+
+This will store the temporary session credentials in ~/.aws/credentials
+under a profile named with the pattern "&lt;aws_profile&gt;:profile".
+After this you can use other AWS-related commands for up to &lt;duration&gt; minutes
+before having to sign in again.
+
+##### Optional Arguments
+
+###### `--duration-minutes DURATION_MINUTES`
+
+Stay signed in for this many minutes
 
 ---
 

--- a/src/commcare_cloud/commands/terraform/aws.py
+++ b/src/commcare_cloud/commands/terraform/aws.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import print_function
 
 import getpass
@@ -5,9 +6,12 @@ import json
 import os
 import subprocess
 import textwrap
+from datetime import datetime
 
 import boto3
 import yaml
+from clint.textui import puts, colored
+from memoized import memoized
 from six.moves import shlex_quote
 from six.moves import configparser
 from six.moves import input
@@ -30,8 +34,9 @@ def check_output(cmd_parts, env):
 
 
 def aws_cli(environment, cmd_parts):
+
     return json.loads(
-        check_output(cmd_parts, env={'AWS_PROFILE': environment.terraform_config.aws_session_profile}))
+        check_output(cmd_parts, env={'AWS_PROFILE': aws_sign_in(environment.terraform_config.aws_profile)}))
 
 
 def get_aws_resources(environment):
@@ -156,19 +161,22 @@ class AwsFillInventory(CommandBase):
             f.write(out_string)
 
 
+DEFAULT_SIGN_IN_DURATION_MINUTES = 30
+
+
 class AwsSignIn(CommandBase):
     command = 'aws-sign-in'
     help = """
-        Use your MFA device to "sign in" to AWS for <duration> minutes (default 30)
+        Use your MFA device to "sign in" to AWS for <duration> minutes (default {})
 
         This will store the temporary session credentials in ~/.aws/credentials
         under a profile named with the pattern "<aws_profile>:profile".
         After this you can use other AWS-related commands for up to <duration> minutes
         before having to sign in again.
-    """
+    """.format(DEFAULT_SIGN_IN_DURATION_MINUTES)
 
     arguments = [
-        Argument('--duration-minutes', type=int, default=30, help="""
+        Argument('--duration-minutes', type=int, default=DEFAULT_SIGN_IN_DURATION_MINUTES, help="""
             Stay signed in for this many minutes
         """)
     ]
@@ -177,15 +185,40 @@ class AwsSignIn(CommandBase):
         environment = get_environment(args.env_name)
         duration_minutes = args.duration_minutes
         aws_profile = environment.terraform_config.aws_profile
-        default_username = getpass.getuser()
-        username = input("Enter username associated with credentials [{}]: ".format(default_username)) or default_username
-        mfa_token = input("Enter your MFA token: ")
-        generate_session_profile(aws_profile, username, mfa_token, duration_minutes)
-        print("You're sucessfully signed in!")
-        print("You will be able to use AWS from the command line for the next {} minutes."
-              .format(duration_minutes))
-        print("To use this session outside of commcare-cloud,"
-              "prefix your command with AWS_PROFILE={}:session".format(aws_profile))
+        aws_sign_in(aws_profile, duration_minutes, force_new=True)
+
+
+@memoized
+def aws_sign_in(aws_profile, duration_minutes=DEFAULT_SIGN_IN_DURATION_MINUTES,
+                force_new=False):
+    """
+    Create a temp session through MFA for a given aws profile
+
+    :param aws_profile: The name of an existing aws profile to create a temp session for
+    :param duration_minutes: How long to set the session expiration if a new one is created
+    :param force_new: If set to True, creates new credentials even if valid ones are found
+    :return: The name of temp session profile.
+             (Always the passed in profile followed by ':session')
+    """
+    aws_session_profile = '{}:session'.format(aws_profile)
+    if not force_new \
+            and _has_valid_session_credentials(aws_session_profile):
+        return aws_session_profile
+
+    default_username = getpass.getuser()
+    username = input("Enter username associated with credentials [{}]: ".format(
+        default_username)) or default_username
+    mfa_token = input("Enter your MFA token: ")
+    generate_session_profile(aws_profile, username, mfa_token, duration_minutes)
+
+    puts(colored.green(u"✓ Sign in accepted"))
+    puts(colored.cyan(
+        "You will be able to use AWS from the command line for the next {} minutes."
+        .format(duration_minutes)))
+    puts(colored.cyan(
+        "To use this session outside of commcare-cloud, "
+        "prefix your command with AWS_PROFILE={}:session".format(aws_profile)))
+    return aws_session_profile
 
 
 def generate_session_profile(aws_profile, username, mfa_token, duration_minutes):
@@ -205,11 +238,13 @@ def generate_session_profile(aws_profile, username, mfa_token, duration_minutes)
         aws_access_key_id=credentials['AccessKeyId'],
         aws_secret_access_key=credentials['SecretAccessKey'],
         aws_session_token=credentials['SessionToken'],
+        expiration=credentials['Expiration'],
     )
 
 
 def _write_credentials_to_aws_credentials(
         aws_profile, aws_access_key_id, aws_secret_access_key, aws_session_token,
+        expiration,
         aws_credentials_path=os.path.expanduser('~/.aws/credentials')):
     # followed code examples from https://gist.github.com/incognick/c121038dbd2180c683fda6ae5e30cba3
     config = configparser.ConfigParser()
@@ -219,5 +254,21 @@ def _write_credentials_to_aws_credentials(
     config.set(aws_profile, 'aws_access_key_id', aws_access_key_id)
     config.set(aws_profile, 'aws_secret_access_key', aws_secret_access_key)
     config.set(aws_profile, 'aws_session_token', aws_session_token)
+    config.set(aws_profile, 'expiration', expiration.strftime("%Y-%m-%dT%H:%M:%SZ"))
     with open(aws_credentials_path, 'w') as f:
         config.write(f)
+
+
+def _has_valid_session_credentials(
+        aws_profile, aws_credentials_path=os.path.expanduser('~/.aws/credentials')):
+    config = configparser.ConfigParser()
+    config.read(os.path.realpath(aws_credentials_path))
+    if aws_profile not in config.sections():
+        return False
+    try:
+        expiration = datetime.strptime(config.get(aws_profile, 'expiration'), "%Y-%m-%dT%H:%M:%SZ")
+    except configparser.NoOptionError:
+        return False
+
+    return datetime.utcnow() < expiration
+

--- a/src/commcare_cloud/commands/terraform/terraform.py
+++ b/src/commcare_cloud/commands/terraform/terraform.py
@@ -9,6 +9,7 @@ from six.moves import shlex_quote
 
 from commcare_cloud.cli_utils import print_command
 from commcare_cloud.commands.command_base import CommandBase, Argument
+from commcare_cloud.commands.terraform.aws import aws_sign_in
 from commcare_cloud.commands.utils import render_template
 from commcare_cloud.environment.main import get_environment
 from commcare_cloud.environment.paths import TERRAFORM_DIR
@@ -65,7 +66,7 @@ class Terraform(CommandBase):
             with open(os.path.join(run_dir, 'secrets.auto.tfvars'), 'w') as f:
                 print('rds_password = {}'.format(json.dumps(rds_password)), file=f)
 
-        env_vars = {'AWS_PROFILE': environment.terraform_config.aws_session_profile}
+        env_vars = {'AWS_PROFILE': aws_sign_in(environment.terraform_config.aws_profile)}
         all_env_vars = os.environ.copy()
         all_env_vars.update(env_vars)
         cmd_parts = ['terraform'] + unknown_args

--- a/src/commcare_cloud/commands/terraform/terraform.py
+++ b/src/commcare_cloud/commands/terraform/terraform.py
@@ -65,7 +65,7 @@ class Terraform(CommandBase):
             with open(os.path.join(run_dir, 'secrets.auto.tfvars'), 'w') as f:
                 print('rds_password = {}'.format(json.dumps(rds_password)), file=f)
 
-        env_vars = {'AWS_PROFILE': environment.terraform_config.aws_profile}
+        env_vars = {'AWS_PROFILE': environment.terraform_config.aws_session_profile}
         all_env_vars = os.environ.copy()
         all_env_vars.update(env_vars)
         cmd_parts = ['terraform'] + unknown_args

--- a/src/commcare_cloud/commands/terraform/terraform_migrate_state.py
+++ b/src/commcare_cloud/commands/terraform/terraform_migrate_state.py
@@ -18,6 +18,7 @@ from memoized import memoized_property
 from commcare_cloud.alias import commcare_cloud
 from commcare_cloud.cli_utils import ask, print_command
 from commcare_cloud.commands.command_base import CommandBase, CommandError
+from commcare_cloud.commands.terraform.aws import aws_sign_in
 from commcare_cloud.environment.main import get_environment
 
 
@@ -93,7 +94,8 @@ class RemoteMigrationStateManager(object):
 
     @memoized_property
     def s3_client(self):
-        return boto3.session.Session(profile_name=self.aws_profile).client('s3')
+
+        return boto3.session.Session(profile_name=aws_sign_in(self.aws_profile)).client('s3')
 
     def fetch(self):
         """
@@ -101,7 +103,7 @@ class RemoteMigrationStateManager(object):
 
         Essentially:
 
-        AWS_PROFILE={aws_session_profile} aws s3 cp s3://{state_bucket}/migration-state/{environment}.json {tempfile}
+        AWS_PROFILE={aws_profile} aws s3 cp s3://{state_bucket}/migration-state/{environment}.json {tempfile}
 
         wrapped as as a RemoteMigrationState object.
         """
@@ -131,7 +133,7 @@ class RemoteMigrationStateManager(object):
         Push RemoteMigrationState object to S3
 
         Essentially:
-        AWS_PROFILE={aws_session_profile} aws s3 cp {tempfile} s3://{state_bucket}/migration-state/{environment}.json
+        AWS_PROFILE={aws_profile} aws s3 cp {tempfile} s3://{state_bucket}/migration-state/{environment}.json
         after dumping the object to tempfile
         """
         temp_filename = tempfile.mktemp()

--- a/src/commcare_cloud/commands/terraform/terraform_migrate_state.py
+++ b/src/commcare_cloud/commands/terraform/terraform_migrate_state.py
@@ -101,7 +101,7 @@ class RemoteMigrationStateManager(object):
 
         Essentially:
 
-        AWS_PROFILE={aws_profile} aws s3 cp s3://{state_bucket}/migration-state/{environment}.json {tempfile}
+        AWS_PROFILE={aws_session_profile} aws s3 cp s3://{state_bucket}/migration-state/{environment}.json {tempfile}
 
         wrapped as as a RemoteMigrationState object.
         """
@@ -131,7 +131,7 @@ class RemoteMigrationStateManager(object):
         Push RemoteMigrationState object to S3
 
         Essentially:
-        AWS_PROFILE={aws_profile} aws s3 cp {tempfile} s3://{state_bucket}/migration-state/{environment}.json
+        AWS_PROFILE={aws_session_profile} aws s3 cp {tempfile} s3://{state_bucket}/migration-state/{environment}.json
         after dumping the object to tempfile
         """
         temp_filename = tempfile.mktemp()

--- a/src/commcare_cloud/commcare_cloud.py
+++ b/src/commcare_cloud/commcare_cloud.py
@@ -14,7 +14,7 @@ from commcare_cloud.cli_utils import print_command
 from commcare_cloud.commands.ansible.downtime import Downtime
 from commcare_cloud.commands.migrations.couchdb import MigrateCouchdb
 from commcare_cloud.commands.migrations.copy_files import CopyFiles
-from commcare_cloud.commands.terraform.aws import AwsList, AwsFillInventory
+from commcare_cloud.commands.terraform.aws import AwsList, AwsFillInventory, AwsSignIn
 from commcare_cloud.commands.terraform.openvpn import OpenvpnActivateUser, OpenvpnClaimUser
 from commcare_cloud.commands.terraform.terraform import Terraform
 from commcare_cloud.commands.terraform.terraform_migrate_state import TerraformMigrateState
@@ -69,6 +69,7 @@ COMMAND_GROUPS = OrderedDict([
         ListDatabases,
         Terraform,
         TerraformMigrateState,
+        AwsSignIn,
         AwsList,
         AwsFillInventory,
         OpenvpnActivateUser,

--- a/src/commcare_cloud/environment/schemas/terraform.py
+++ b/src/commcare_cloud/environment/schemas/terraform.py
@@ -27,6 +27,10 @@ class TerraformConfig(jsonobject.JsonObject):
             data['aws_profile'] = data.get('account_alias')
         return super(TerraformConfig, cls).wrap(data)
 
+    @property
+    def aws_session_profile(self):
+        return '{}:session'.format(self.aws_profile)
+
 
 class VpnConnectionConfig(jsonobject.JsonObject):
     _allow_dynamic_properties = False

--- a/src/commcare_cloud/environment/schemas/terraform.py
+++ b/src/commcare_cloud/environment/schemas/terraform.py
@@ -27,10 +27,6 @@ class TerraformConfig(jsonobject.JsonObject):
             data['aws_profile'] = data.get('account_alias')
         return super(TerraformConfig, cls).wrap(data)
 
-    @property
-    def aws_session_profile(self):
-        return '{}:session'.format(self.aws_profile)
-
 
 class VpnConnectionConfig(jsonobject.JsonObject):
     _allow_dynamic_properties = False

--- a/src/commcare_cloud/terraform/modules/iam/EnforceMFAPolicy.json
+++ b/src/commcare_cloud/terraform/modules/iam/EnforceMFAPolicy.json
@@ -1,0 +1,98 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AllowAllUsersToListAccounts",
+            "Effect": "Allow",
+            "Action": [
+                "iam:ListAccountAliases",
+                "iam:ListUsers",
+                "iam:ListVirtualMFADevices",
+                "iam:GetAccountPasswordPolicy",
+                "iam:GetAccountSummary"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "AllowIndividualUserToSeeAndManageOnlyTheirOwnAccountInformation",
+            "Effect": "Allow",
+            "Action": [
+                "iam:ChangePassword",
+                "iam:CreateAccessKey",
+                "iam:CreateLoginProfile",
+                "iam:DeleteAccessKey",
+                "iam:DeleteLoginProfile",
+                "iam:GetLoginProfile",
+                "iam:ListAccessKeys",
+                "iam:UpdateAccessKey",
+                "iam:UpdateLoginProfile",
+                "iam:ListSigningCertificates",
+                "iam:DeleteSigningCertificate",
+                "iam:UpdateSigningCertificate",
+                "iam:UploadSigningCertificate",
+                "iam:ListSSHPublicKeys",
+                "iam:GetSSHPublicKey",
+                "iam:DeleteSSHPublicKey",
+                "iam:UpdateSSHPublicKey",
+                "iam:UploadSSHPublicKey"
+            ],
+            "Resource": "arn:aws:iam::*:user/${aws:username}"
+        },
+        {
+            "Sid": "AllowIndividualUserToViewAndManageTheirOwnMFA",
+            "Effect": "Allow",
+            "Action": [
+                "iam:CreateVirtualMFADevice",
+                "iam:DeleteVirtualMFADevice",
+                "iam:EnableMFADevice",
+                "iam:ListMFADevices",
+                "iam:ResyncMFADevice"
+            ],
+            "Resource": [
+                "arn:aws:iam::*:mfa/${aws:username}",
+                "arn:aws:iam::*:user/${aws:username}"
+            ]
+        },
+        {
+            "Sid": "AllowIndividualUserToDeactivateOnlyTheirOwnMFAOnlyWhenUsingMFA",
+            "Effect": "Allow",
+            "Action": [
+                "iam:DeactivateMFADevice"
+            ],
+            "Resource": [
+                "arn:aws:iam::*:mfa/${aws:username}",
+                "arn:aws:iam::*:user/${aws:username}"
+            ],
+            "Condition": {
+                "Bool": {
+                    "aws:MultiFactorAuthPresent": "true"
+                }
+            }
+        },
+        {
+            "Sid": "BlockMostAccessUnlessSignedInWithMFA",
+            "Effect": "Deny",
+            "NotAction": [
+                "iam:CreateVirtualMFADevice",
+                "iam:DeleteVirtualMFADevice",
+                "iam:ListVirtualMFADevices",
+                "iam:EnableMFADevice",
+                "iam:ResyncMFADevice",
+                "iam:ListAccountAliases",
+                "iam:ListUsers",
+                "iam:ListSSHPublicKeys",
+                "iam:ListAccessKeys",
+                "iam:ListServiceSpecificCredentials",
+                "iam:ListMFADevices",
+                "iam:GetAccountSummary",
+                "sts:GetSessionToken"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "BoolIfExists": {
+                    "aws:MultiFactorAuthPresent": "false"
+                }
+            }
+        }
+    ]
+}

--- a/src/commcare_cloud/terraform/modules/iam/main.tf
+++ b/src/commcare_cloud/terraform/modules/iam/main.tf
@@ -12,3 +12,15 @@ resource "aws_iam_group_policy_attachment" "administrators" {
   group = "${aws_iam_group.administrators.name}"
   policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }
+
+resource "aws_iam_group_policy_attachment" "administrators_force_mfa" {
+  group = "${aws_iam_group.administrators.name}"
+  policy_arn = "${aws_iam_policy.force_mfa.arn}"
+}
+
+
+resource "aws_iam_policy" "force_mfa" {
+  name = "Force_MFA"
+  description = "This policy allows users to manage their own passwords and MFA devices but nothing else unless they authenticate with MFA"
+  policy = "${file("${path.module}/EnforceMFAPolicy.json")}"
+}


### PR DESCRIPTION
While writing documentation on our AWS processes, I didn't feel great about the AWS default of storing access keys in plaintext at ~/.aws/credentials indefinitely, and I had a backlog item to force two-factor auth for all our IAM users.

Once I got started looking into it, a solution came together that satisfies both. This PR has the following changes:
- Forces 2FA for all our IAM users, including for CLI use
- Supports entering 2FA token via command line and storing the resulting session credentials
- They're still stored in ~/.aws/credentials, but now the permanent ones are pretty weak by themselves, and the strong ones are short-lived (30 minutes by default in this PR)

While a theoretical malicious program will still be able to find your strong auth, this change at least limits the period of time during which they can use it.