### PR TITLE
reduced worker_memory for UCR

### DIFF
--- a/environments/icds-cas/inventory/postgresql.csv
+++ b/environments/icds-cas/inventory/postgresql.csv
@@ -37,7 +37,7 @@ pgwarehouse0,100.71.184.23,postgresql,,MUMGCCWCDPRDPW00,"[""/dev/vdb""]","[""/de
 group,I.var: pgbouncer_max_connections,I.var: pgbouncer_default_pool,I.var: postgresql_max_connections,S.var: postgresql_work_mem,S.var: postgresql_shared_buffers,,,,,
 postgres,,,,,,,,,,
 pg_standby,,,,,,,,,,
-ucr_dbs,3500,775,800,32MB,12GB,,,,,
+ucr_dbs,3500,775,800,3072kB,12GB,,,,,
 shard_standby_dbs,3500,775,800,41943kB,12GB,,,,,
 shard_dbs,3500,775,800,41943kB,12GB,,,,,
 main_dbs,3500,775,400,41943kB,12GB,,,,,

--- a/environments/icds-cas/inventory/postgresql.csv
+++ b/environments/icds-cas/inventory/postgresql.csv
@@ -37,7 +37,7 @@ pgwarehouse0,100.71.184.23,postgresql,,MUMGCCWCDPRDPW00,"[""/dev/vdb""]","[""/de
 group,I.var: pgbouncer_max_connections,I.var: pgbouncer_default_pool,I.var: postgresql_max_connections,S.var: postgresql_work_mem,S.var: postgresql_shared_buffers,,,,,
 postgres,,,,,,,,,,
 pg_standby,,,,,,,,,,
-ucr_dbs,3500,775,800,3072kB,12GB,,,,,
+ucr_dbs,3500,775,800,4096kB,12GB,,,,,
 shard_standby_dbs,3500,775,800,41943kB,12GB,,,,,
 shard_dbs,3500,775,800,41943kB,12GB,,,,,
 main_dbs,3500,775,400,41943kB,12GB,,,,,

--- a/environments/icds-cas/inventory/postgresql.csv
+++ b/environments/icds-cas/inventory/postgresql.csv
@@ -37,7 +37,7 @@ pgwarehouse0,100.71.184.23,postgresql,,MUMGCCWCDPRDPW00,"[""/dev/vdb""]","[""/de
 group,I.var: pgbouncer_max_connections,I.var: pgbouncer_default_pool,I.var: postgresql_max_connections,S.var: postgresql_work_mem,S.var: postgresql_shared_buffers,,,,,
 postgres,,,,,,,,,,
 pg_standby,,,,,,,,,,
-ucr_dbs,3500,775,800,4096kB,12GB,,,,,
+ucr_dbs,3500,775,500,4096kB,12GB,,,,,
 shard_standby_dbs,3500,775,800,41943kB,12GB,,,,,
 shard_dbs,3500,775,800,41943kB,12GB,,,,,
 main_dbs,3500,775,400,41943kB,12GB,,,,,


### PR DESCRIPTION
Decreased it based on the suggestion from PgTune, and postgresqltuner.pl and this PR here
https://github.com/dimagi/commcare-cloud/pull/1707
```
-----  Memory usage  -----
[INFO]    configured work_mem: 32.00 MB
[INFO]    Using an average ratio of work_mem buffers by connection of 150% (use --wmp to change it)
[INFO]    total work_mem (per connection): 48.00 MB
[INFO]    shared_buffers: 12.00 GB
[INFO]    Track activity reserved size : 1.58 MB
[INFO]    maintenance_work_mem=2.00 GB
[INFO]    Max memory usage :
		  shared_buffers (12.00 GB)
		+ max_connections * work_mem * average_work_mem_buffers_per_connection (800 * 32.00 MB * 150 / 100 = 37.50 GB)
		+ autovacuum_max_workers * maintenance_work_mem (3 * 2.00 GB = 6.00 GB)
		+ track activity size (1.58 MB)
		= 55.50 GB
```
`[BAD]     Max possible memory usage for PostgreSQL is more than system total RAM. Add more RAM or reduce PostgreSQL memory`