### PR TITLE
Remove hqdjangomanage0 (rackspace)

### DIFF
--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -361,14 +361,10 @@ hqstandby2
 [control]
 10.202.10.79 hostname=control-production ec2=yes
 
-[hqdjangomanage0]
-hqdjangomanage0.internal-va.commcarehq.org
-
 [djangomanage0]
 10.202.10.185 hostname=djangomanage0-production ec2=yes
 
 [django_manage:children]
-hqdjangomanage0
 djangomanage0
 
 [openvpn]

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -361,12 +361,8 @@ hqstandby2
 [control]
 {{ control-production }} hostname=control-production ec2=yes
 
-[hqdjangomanage0]
-hqdjangomanage0.internal-va.commcarehq.org
-
 [djangomanage0]
 {{ djangomanage0-production }} hostname=djangomanage0-production ec2=yes
 
 [django_manage:children]
-hqdjangomanage0
 djangomanage0


### PR DESCRIPTION
FYI @jmtroth0 the new django_manage machine's on AWS. Let me know if there's anything you want me to do in terms of log files on the old one