### PR TITLE
Add ksampat to users for the purpose of VPN

### DIFF
--- a/environments/_users/dimagi-support.yml
+++ b/environments/_users/dimagi-support.yml
@@ -1,0 +1,4 @@
+dev_users:
+  present:
+    - ksampat
+  absent: []

--- a/environments/production/meta.yml
+++ b/environments/production/meta.yml
@@ -2,5 +2,6 @@ deploy_env: production
 env_monitoring_id: production
 users:
   - dimagi
+  - dimagi-support
   - g2
 slack_alerts_channel: alerts-production


### PR DESCRIPTION
Added ksampat with empty ssh key, which has the effect of giving him access to the productoin AWS VPN without ssh access to the machines.