### PR TITLE
Increase pillow0-production RAM to 128G

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -190,10 +190,11 @@ servers:
     volume_size: 150
 
   - server_name: "pillow0-production"
-    server_instance_type: r5.2xlarge
+    server_instance_type: r5a.4xlarge
     network_tier: "app-private"
     az: "c"
     volume_size: 150
+
   - server_name: "formplayer0-production"
     server_instance_type: t3.large
     network_tier: "app-private"


### PR DESCRIPTION
Upgrade to r5a.4xlarge

It kept occasionally maxing out on memory and killing helper processes (datadog, sshd, etc.), about once or twice a week. Was $368/mo, now is $660/mo (not including disk which is $15/mo in both cases)