### PR TITLE
Update Ubuntu AMI

### DIFF
--- a/src/commcare_cloud/commands/terraform/templates/variables.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/variables.tf.j2
@@ -17,7 +17,7 @@ variable "openvpn_instance_type" {
   default = "t2.small"
 }
 variable "server_image" {
-  default = "ami-0d3e7972"
+  default = "ami-07cf43e1798df5582"
 }
 variable "dns_zone_id" {}
 variable "dns_domain" {}

--- a/src/commcare_cloud/terraform/modules/server/main.tf
+++ b/src/commcare_cloud/terraform/modules/server/main.tf
@@ -16,7 +16,7 @@ resource aws_instance "server" {
     delete_on_termination = true
   }
   lifecycle {
-    ignore_changes = ["user_data", "key_name", "root_block_device.0.delete_on_termination", "ebs_optimized"]
+    ignore_changes = ["user_data", "key_name", "root_block_device.0.delete_on_termination", "ebs_optimized", "ami"]
   }
   tags {
     Name        = "${var.server_name}"


### PR DESCRIPTION
I've noticed that our EC2 instances print

```
*** System restart required ***
```
on login, on day one. I'm guessing that's because it immediately finds something to autoupdate, because we're not starting on the latest AMI for Ubuntu 14.04. This PR updates to the appropriate AMI currently listed on https://cloud-images.ubuntu.com/locator/ec2/ (Search for "us-east 14.04 amd64 hvm:ebs").