### PR TITLE
Temp: make client_max_body_size on couchdb2_proxy ridiculously high

### DIFF
--- a/src/commcare_cloud/ansible/roles/nginx/vars/couchdb2.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/couchdb2.yml
@@ -7,7 +7,7 @@ nginx_sites:
       port: "{{ couchdb2_port }}"
    file_name: "{{ deploy_env }}_couchdb_{{ couchdb2_proxy_port }}"
    listen: "'{{ couchdb2_proxy_port }}'"
-   client_max_body_size: "16G"
+   client_max_body_size: "100M"
    upstream_port: "{{ couchdb2_port }}"
    proxy_set_headers:
    - "Host $http_host"
@@ -17,7 +17,7 @@ nginx_sites:
      - name: /
        balancer: "{{ deploy_env }}_couchdb_{{ couchdb2_proxy_port }}"
        proxy_redirect: ' off'
-       client_max_body_size: '16G'
+       client_max_body_size: '100M'
        client_body_buffer_size: ' 512k'
        proxy_max_temp_file_size: ' 0'
        proxy_read_timeout: ' 65s'

--- a/src/commcare_cloud/ansible/roles/nginx/vars/couchdb2.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/couchdb2.yml
@@ -7,7 +7,7 @@ nginx_sites:
       port: "{{ couchdb2_port }}"
    file_name: "{{ deploy_env }}_couchdb_{{ couchdb2_proxy_port }}"
    listen: "'{{ couchdb2_proxy_port }}'"
-   client_max_body_size: "1M"
+   client_max_body_size: "16G"
    upstream_port: "{{ couchdb2_port }}"
    proxy_set_headers:
    - "Host $http_host"
@@ -17,7 +17,7 @@ nginx_sites:
      - name: /
        balancer: "{{ deploy_env }}_couchdb_{{ couchdb2_proxy_port }}"
        proxy_redirect: ' off'
-       client_max_body_size: ' 10m'
+       client_max_body_size: '16G'
        client_body_buffer_size: ' 512k'
        proxy_max_temp_file_size: ' 0'
        proxy_read_timeout: ' 65s'


### PR DESCRIPTION
I finally found what was blocking the cloudant to couchdb2 migration, and it was that couchdb2_proxy was blocking requests larger than 10MB, and not all but a good few _bulk_docs requests that happen during replication have been going over 10MB, getting an response from nginx, and failing to parse it as JSON, killing the replication process.

Setting the limit to something absurdly high like this fixes the problem, but we probably don't want to set the limit that high.

Pinging Simon and Emord in case you have insight into why these original numbers were chosen.

Update: the easiest way to deploy this change is
```
deploy-stack --tags=proxy --limit=couchdb2_proxy
```