### PR TITLE
remove CONN_MAX_AGE

### DIFF
--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -36,7 +36,6 @@ DATABASES = { {% for config in postgresql_dbs.all %}
         'PORT': {{ config.port }},
         'OPTIONS': {{ config.options|to_json }},
         'DISABLE_SERVER_SIDE_CURSORS': True,
-        'CONN_MAX_AGE': 500,
         {% if not config.django_migrate -%}
         'MIGRATE': False,
         {% endif -%}


### PR DESCRIPTION
* setting is not respected by celery < v4.2
  * https://github.com/celery/celery/pull/4292
* 'gevent' gunicorn worker class can 'leak' connections
  * https://github.com/benoitc/gunicorn/issues/996#issuecomment-93301359

After having this deployed for ~ 1 day I'm not seeing any improvement in performance and the large increase in open connections could cause issues on db hosts (e.g. max file descriptors). Given that and issues described above I think safest to revert.

reverts setting change from https://github.com/dimagi/commcare-cloud/pull/2396