### PR TITLE
Fix terraform for user with empty public key file

### DIFF
--- a/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
@@ -120,10 +120,12 @@ module "Users" {
 }
 
 {%- for user in (users if manage_users else []) %}
+{%- if user.public_key %}
 resource "aws_key_pair" {{ user.username|tojson }} {
   key_name = {{ user.username|tojson }}
   public_key = {{ user.public_key|tojson }}
 }
+{%- endif %}
 module "iam_user__{{ user.username }}" {
   source = "./modules/iam/user"
   username = {{ user.username|tojson }}


### PR DESCRIPTION
This would previously fail (harmlessly) every time you run terraform because aws rejects the empty public key