### PR TITLE
purge airflow logs

### DIFF
--- a/src/commcare_cloud/ansible/roles/airflow/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/airflow/tasks/main.yml
@@ -62,3 +62,12 @@
   environment:
     AIRFLOW_HOME: "{{ airflow_home }}"
 
+- name: Purge old logs
+  become: yes
+  cron:
+    name: "Purge old airflow logs"
+    special_time: daily
+    job: "/usr/sbin/tmpreaper --mtime 21d {{ airflow_home }}/logs"
+    user: root
+    cron_file: purge_airflow_logs
+  tags: cron


### PR DESCRIPTION
@pr33thi @snopoke @sravfeyn @NitigyaS 
Airflow rotates logs (one per day for the scheduler, one per dag run for the task logs), but does not purge old ones by default. This has caused disk space issues a couple times in the past. This command should resolve that