### PR TITLE
Support defining secondary volumes in terraform

### DIFF
--- a/src/commcare_cloud/commands/terraform/migrations/0003_make_proxy_server_like_others.py
+++ b/src/commcare_cloud/commands/terraform/migrations/0003_make_proxy_server_like_others.py
@@ -1,0 +1,8 @@
+def get_new_resource_address(environment, old_resource_address):
+    import re
+    server_matcher = re.compile(r'^module\.proxy_server__([\w-]+)\.aws_instance\.server$')
+    match = server_matcher.match(old_resource_address)
+    if match:
+        return 'module.server__{}.aws_instance.server'.format(match.group(1))
+    else:
+        return None

--- a/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
@@ -52,6 +52,8 @@ module "server__{{ server.server_name }}" {
   network_tier = {{ server.network_tier|tojson }}
   az = {{ server.az|tojson }}
   volume_size = {{ server.volume_size|tojson }}
+  secondary_volume_size = {{ server.block_device.volume_size|default(0)|tojson }}
+  secondary_volume_type = {{ server.block_device.volume_type|default("")|tojson }}
 
   server_image = "${var.server_image}"
   environment = "${var.environment}"

--- a/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
@@ -43,7 +43,7 @@ locals {
   }
 }
 
-{% for server in servers %}
+{% for server in servers + proxy_servers %}
 module "server__{{ server.server_name }}" {
   source = "./modules/server"
 
@@ -63,27 +63,10 @@ module "server__{{ server.server_name }}" {
 {% endfor %}
 
 {% for server in proxy_servers %}
-module "proxy_server__{{ server.server_name }}" {
-  source = "./modules/server"
-
-  server_name = {{ server.server_name|tojson }}
-  server_instance_type = {{ server.server_instance_type|tojson }}
-  network_tier = {{ server.network_tier|tojson }}
-  az = {{ server.az|tojson }}
-  volume_size = {{ server.volume_size|tojson }}
-
-  server_image = "${var.server_image}"
-  environment = "${var.environment}"
-  vpc_id = "${module.network.vpc-id}"
-  subnet_options = "${local.subnet_options}"
-  security_group_options = "${local.security_group_options}"
-  key_name = "${var.key_name}"
-}
-
 resource "aws_eip" "proxy__{{ server.server_name }}" {
   vpc = true
-  instance = "${module.proxy_server__{{ server.server_name }}.server}"
-  associate_with_private_ip = "${module.proxy_server__{{ server.server_name }}.server_private_ip}"
+  instance = "${module.server__{{ server.server_name }}.server}"
+  associate_with_private_ip = "${module.server__{{ server.server_name }}.server_private_ip}"
 }
 {% endfor %}
 

--- a/src/commcare_cloud/commands/terraform/terraform_migrate_state.py
+++ b/src/commcare_cloud/commands/terraform/terraform_migrate_state.py
@@ -66,7 +66,7 @@ class TerraformMigrateState(CommandBase):
                     for migration in unapplied_migrations)
         ))
         print("which will result in the following moves being made:")
-        migration_plans = make_migration_plans(environment, state, migrations, log=print)
+        migration_plans = make_migration_plans(environment, state, unapplied_migrations, log=print)
         if ask("Do you want to apply this migration?"):
             apply_migration_plans(
                 environment, migration_plans,

--- a/src/commcare_cloud/environment/schemas/terraform.py
+++ b/src/commcare_cloud/environment/schemas/terraform.py
@@ -51,6 +51,13 @@ class ServerConfig(jsonobject.JsonObject):
     network_tier = jsonobject.StringProperty(choices=['app-private', 'public', 'db-private'])
     az = jsonobject.StringProperty()
     volume_size = jsonobject.IntegerProperty(default=20)
+    block_device = jsonobject.ObjectProperty(lambda: BlockDevice, default=None)
+
+
+class BlockDevice(jsonobject.JsonObject):
+    _allow_dynamic_properties = False
+    volume_type = jsonobject.StringProperty(default='gp2', choices=['gp2', 'io1', 'standard'])
+    volume_size = jsonobject.IntegerProperty(required=True)
 
 
 class RdsInstanceConfig(jsonobject.JsonObject):

--- a/src/commcare_cloud/terraform/modules/server/main.tf
+++ b/src/commcare_cloud/terraform/modules/server/main.tf
@@ -23,3 +23,17 @@ resource aws_instance "server" {
     Environment = "${var.environment}"
   }
 }
+
+resource "aws_ebs_volume" "ebs_volume" {
+  count = "${var.secondary_volume_size > 0 ? 1 : 0}"
+  availability_zone = "${aws_instance.server.availability_zone}"
+  size = "${var.secondary_volume_size}"
+  type = "${var.secondary_volume_type}"
+}
+
+resource "aws_volume_attachment" "ebs_att" {
+  count = "${var.secondary_volume_size > 0 ? 1 : 0}"
+  device_name = "/dev/sdf"
+  volume_id   = "${aws_ebs_volume.ebs_volume.id}"
+  instance_id = "${aws_instance.server.id}"
+}

--- a/src/commcare_cloud/terraform/modules/server/variables.tf
+++ b/src/commcare_cloud/terraform/modules/server/variables.tf
@@ -16,4 +16,6 @@ variable "server_name" {}
 variable "server_instance_type" {}
 variable "network_tier" {}
 variable "volume_size" {}
+variable "secondary_volume_size" {}
+variable "secondary_volume_type" {}
 variable "az" {}


### PR DESCRIPTION
There's a hard limitation on Linux AMIs that the boot volume can't be larger than 2TB. Mostly we don't notice that but for CouchDB, we want volumes larger than 2TB. The right way to do this is to have small boot volumes (for the OS, etc) and a secondary volume—which has no size limitation—that we mount at /opt/data. That would be done like this:

```
# terraform.yml
servers:
  - server_name: "couch0-production"
    server_instance_type: m5.4xlarge
    network_tier: "db-private"
    az: "a"
    volume_size: 40
    block_device:
      volume_size: 4000
```

This PR doesn't change any resources (though it does change the terraform resource address of the proxy machine as part of a refactor, but with no change to the actual AWS ec2 instance). In order to continue using terraform, you have to first run `cchq <env> terraform-migrate-state`. Already ran this on production, so just need to run it on staging too.