### PR TITLE
Add prefetch multiplier

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -79,6 +79,7 @@ celery_processes:
       concurrency: 2
       max_tasks_per_child: 1
       optimize: True
+      prefetch_multiplier: 2
     export_download_queue:
       concurrency: 4
       max_tasks_per_child: 5

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_celery_workers.conf.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_celery_workers.conf.j2
@@ -5,7 +5,7 @@
 [program:{{ project }}-{{ deploy_env }}-celery_{{ queue_names }}_{{worker_num}}]
 environment={% for name, value in item.env_vars.items() %}{% if value %}{{ name }}="{{ value }}",{% endif %}{% endfor %}
 
-command=/bin/bash {{ service_home }}/{{ deploy_env }}_celery_bash_runner{% if celery_params.optimize %}_optimized{% endif %}.sh --queues={{ queue_names }} --events --loglevel=INFO --hostname={{ inventory_hostname }}_{{ queue_names }}_{{ worker_num }} {% if celery_params.pooling == 'prefork' %} --autoscale={{ celery_params.concurrency }},0 -Ofair --maxtasksperchild={{ celery_params.max_tasks_per_child }}{% endif %}{% if celery_params.pooling == 'gevent' %} -P gevent --concurrency={{ celery_params.concurrency }}{% endif %} --without-gossip
+command=/bin/bash {{ service_home }}/{{ deploy_env }}_celery_bash_runner{% if celery_params.optimize %}_optimized{% endif %}.sh --queues={{ queue_names }} --events --loglevel=INFO --hostname={{ inventory_hostname }}_{{ queue_names }}_{{ worker_num }} {% if celery_params.pooling == 'prefork' %} --autoscale={{ celery_params.concurrency }},0 -Ofair --maxtasksperchild={{ celery_params.max_tasks_per_child }}{% if celery_params.prefetch_multiplier %} --worker_prefetch_multiplier={{ celery_params.prefetch_multiplier }}{% endif %}{% endif %}{% if celery_params.pooling == 'gevent' %} -P gevent --concurrency={{ celery_params.concurrency }}{% endif %} --without-gossip
 directory={{ code_home }}
 user={{ cchq_user }}
 numprocs=1

--- a/src/commcare_cloud/environment/schemas/app_processes.py
+++ b/src/commcare_cloud/environment/schemas/app_processes.py
@@ -17,6 +17,7 @@ class CeleryOptions(jsonobject.JsonObject):
     concurrency = jsonobject.IntegerProperty(default=1)
     pooling = jsonobject.StringProperty(choices=['gevent', 'prefork'], default='prefork')
     max_tasks_per_child = jsonobject.IntegerProperty(default=50)
+    prefetch_multiplier = jsonobject.IntegerProperty()
     num_workers = jsonobject.IntegerProperty(default=1)
     optimize = jsonobject.BooleanProperty(default=False)
 


### PR DESCRIPTION
Following up on https://github.com/dimagi/commcare-hq/pull/22500#issuecomment-442479071

http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-worker_prefetch_multiplier

Prefetch multiplier is 4 by default.
Setting it to 2 to first test a theory on how prefetch count is calculated

and then would set it to 1 to disable prefetch for saved exports