### PR TITLE
Fix pillow process number

### DIFF
--- a/environments/icds-cas/app-processes.yml
+++ b/environments/icds-cas/app-processes.yml
@@ -295,11 +295,11 @@ pillows:
       total_processes: 120
   'pillow10':
     kafka-ucr-static-cases:
-      start_process: 46
+      start_process: 45
       num_processes: 9
       total_processes: 120
     CaseToElasticsearchPillow:
-      start_process: 46
+      start_process: 45
       num_processes: 9
       total_processes: 120
   'pillow11':


### PR DESCRIPTION
https://sentry.io/dimagi/commcarehq/issues/707483906/events/37838715586/

This was introduced by me 16 days ago https://github.com/dimagi/commcare-cloud/pull/2368

Two servers were processing the same changes at around the same time so there were a large number of duplicate key errors even though we delete and then insert.

For the future this needs to be fixed one of two ways:

A) some more automatic configuration. This should be much easier now than when I first implented this since we have some configuration management with commcare-cloud, but still a bit tricky to handle since partitioning logic is split between commcare-hq and commcare-cloud

B) Upgrade to kafka > 0.9 and allow kafka to handle partition assignment and offsets for us. I think this is probably the better use of time because, it would make the pillow code much simpler by removing all references to processes and partitions and the configuration more similar to celery processes.

I was reviewing https://kafka.apache.org/documentation/#upgrade and I think we could do it fairly quickly. We'd need java 8 for 2.x, if we don't have java 8 we could just upgrade to 1.1.x. 

> If you are willing to accept downtime, you can simply take all the brokers down, update the code and start them back up. They will start with the new protocol by default.

We could do a partial downtime where we stop pillows and reject form submissions to do this, the rest of the site could stay up.

Also note that for the foreseeable future this configuration will only be used for ICDS as all other environments only have one pillow server, so the start process configuration is not required for them.
