### PR TITLE
Temporarily comment out web0 from the staging inventory

### DIFF
--- a/environments/staging/inventory.ini
+++ b/environments/staging/inventory.ini
@@ -10,15 +10,16 @@
 # Amazon EC2
 proxy1
 
-[web0]
-10.201.10.104 swap_size=1G hostname=web0-staging ec2=yes
+# Temporarily commenting this out while it's removed from the rotation for the aws migration's couchdb2 reindex
+# [web0]
+# 10.201.10.104 swap_size=1G hostname=web0-staging ec2=yes
 
 [web1]
 10.201.11.46 swap_size=1G hostname=web1-staging ec2=yes
 
 [webworkers:children]
 # Amazon EC2
-web0
+# web0
 web1
 
 [hqdb1]
@@ -151,7 +152,7 @@ rds_pg0
 
 [django_manage:children]
 # Amazon EC2
-web0
+# web0
 
 [openvpn]
 10.201.20.112  # ansible_host=54.227.170.89

--- a/environments/staging/inventory.ini
+++ b/environments/staging/inventory.ini
@@ -10,15 +10,15 @@
 # Amazon EC2
 proxy1
 
-# Temporarily commenting this out while it's removed from the rotation for the aws migration's couchdb2 reindex
-# [web0]
-# 10.201.10.104 swap_size=1G hostname=web0-staging ec2=yes
+[web0]
+10.201.10.104 swap_size=1G hostname=web0-staging ec2=yes
 
 [web1]
 10.201.11.46 swap_size=1G hostname=web1-staging ec2=yes
 
 [webworkers:children]
 # Amazon EC2
+# Temporarily commenting this out while it's removed from the rotation for the aws migration's couchdb2 reindex
 # web0
 web1
 
@@ -152,7 +152,7 @@ rds_pg0
 
 [django_manage:children]
 # Amazon EC2
-# web0
+web0
 
 [openvpn]
 10.201.20.112  # ansible_host=54.227.170.89

--- a/environments/staging/inventory.ini.j2
+++ b/environments/staging/inventory.ini.j2
@@ -10,15 +10,15 @@
 # Amazon EC2
 proxy1
 
-# Temporarily commenting this out while it's removed from the rotation for the aws migration's couchdb2 reindex
-# [web0]
-# {{ web0-staging }} swap_size=1G hostname=web0-staging ec2=yes
+[web0]
+{{ web0-staging }} swap_size=1G hostname=web0-staging ec2=yes
 
 [web1]
 {{ web1-staging }} swap_size=1G hostname=web1-staging ec2=yes
 
 [webworkers:children]
 # Amazon EC2
+# Temporarily commenting this out while it's removed from the rotation for the aws migration's couchdb2 reindex
 # web0
 web1
 
@@ -152,4 +152,4 @@ rds_pg0
 
 [django_manage:children]
 # Amazon EC2
-# web0
+web0

--- a/environments/staging/inventory.ini.j2
+++ b/environments/staging/inventory.ini.j2
@@ -10,15 +10,16 @@
 # Amazon EC2
 proxy1
 
-[web0]
-{{ web0-staging }} swap_size=1G hostname=web0-staging ec2=yes
+# Temporarily commenting this out while it's removed from the rotation for the aws migration's couchdb2 reindex
+# [web0]
+# {{ web0-staging }} swap_size=1G hostname=web0-staging ec2=yes
 
 [web1]
 {{ web1-staging }} swap_size=1G hostname=web1-staging ec2=yes
 
 [webworkers:children]
 # Amazon EC2
-web0
+# web0
 web1
 
 [hqdb1]
@@ -151,4 +152,4 @@ rds_pg0
 
 [django_manage:children]
 # Amazon EC2
-web0
+# web0


### PR DESCRIPTION
I have removed web0 from the rotation for staging so that it can reindex the couch databases on the new aws couch machine. It needs to be commented out for staging deploys to still work. This is a temp fix, and will be reverted after the aws couch migration is complete.

@dannyroberts
fyi @gbova  
code buddy @calellowitz 