### PR TITLE
Add 5TB disk to couch*-production

### DIFF
--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -234,13 +234,13 @@ es_data
 
 
 [couch0]
-10.202.40.211 hostname=couch0-production ec2=yes
+10.202.40.211 hostname=couch0-production ec2=yes datavol_device=/dev/nvme1n
 
 [couch1]
 10.202.41.83 hostname=couch1-production ec2=yes datavol_device=/dev/nvme1n
 
 [couch2]
-10.202.42.85 hostname=couch2-production ec2=yes
+10.202.42.85 hostname=couch2-production ec2=yes datavol_device=/dev/nvme1n
 
 [couchdb2:children]
 couch0

--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -234,13 +234,13 @@ es_data
 
 
 [couch0]
-10.202.40.211 hostname=couch0-production ec2=yes datavol_device=/dev/nvme1n
+10.202.40.211 hostname=couch0-production ec2=yes
 
 [couch1]
-10.202.41.83 hostname=couch1-production ec2=yes datavol_device=/dev/nvme1n
+10.202.41.83 hostname=couch1-production ec2=yes
 
 [couch2]
-10.202.42.85 hostname=couch2-production ec2=yes datavol_device=/dev/nvme1n
+10.202.42.85 hostname=couch2-production ec2=yes
 
 [couchdb2:children]
 couch0
@@ -249,6 +249,7 @@ couch2
 
 [couchdb2:vars]
 swap_size=8G
+datavol_device=/dev/nvme1n
 
 [couchproxy0]
 10.202.40.162 hostname=couchproxy0-production ec2=yes

--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -237,7 +237,7 @@ es_data
 10.202.40.211 hostname=couch0-production ec2=yes
 
 [couch1]
-10.202.41.83 hostname=couch1-production ec2=yes
+10.202.41.83 hostname=couch1-production ec2=yes datavol_device=/dev/nvme1n
 
 [couch2]
 10.202.42.85 hostname=couch2-production ec2=yes

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -237,7 +237,7 @@ es_data
 {{ couch0-production }} hostname=couch0-production ec2=yes
 
 [couch1]
-{{ couch1-production }} hostname=couch1-production ec2=yes
+{{ couch1-production }} hostname=couch1-production ec2=yes datavol_device=/dev/nvme1n
 
 [couch2]
 {{ couch2-production }} hostname=couch2-production ec2=yes

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -234,13 +234,13 @@ es_data
 
 
 [couch0]
-{{ couch0-production }} hostname=couch0-production ec2=yes
+{{ couch0-production }} hostname=couch0-production ec2=yes datavol_device=/dev/nvme1n
 
 [couch1]
 {{ couch1-production }} hostname=couch1-production ec2=yes datavol_device=/dev/nvme1n
 
 [couch2]
-{{ couch2-production }} hostname=couch2-production ec2=yes
+{{ couch2-production }} hostname=couch2-production ec2=yes datavol_device=/dev/nvme1n
 
 [couchdb2:children]
 couch0

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -234,13 +234,13 @@ es_data
 
 
 [couch0]
-{{ couch0-production }} hostname=couch0-production ec2=yes datavol_device=/dev/nvme1n
+{{ couch0-production }} hostname=couch0-production ec2=yes
 
 [couch1]
-{{ couch1-production }} hostname=couch1-production ec2=yes datavol_device=/dev/nvme1n
+{{ couch1-production }} hostname=couch1-production ec2=yes
 
 [couch2]
-{{ couch2-production }} hostname=couch2-production ec2=yes datavol_device=/dev/nvme1n
+{{ couch2-production }} hostname=couch2-production ec2=yes
 
 [couchdb2:children]
 couch0
@@ -249,6 +249,7 @@ couch2
 
 [couchdb2:vars]
 swap_size=8G
+datavol_device=/dev/nvme1n
 
 [couchproxy0]
 {{ couchproxy0-production }} hostname=couchproxy0-production ec2=yes

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -156,6 +156,8 @@ servers:
     network_tier: "db-private"
     az: "b"
     volume_size: 6000  # this was a mistake, but it's harder to reduce the size of disk
+    block_device:
+      volume_size: 5000
   - server_name: "couch2-production"
     server_instance_type: m5.4xlarge
     network_tier: "db-private"

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -151,6 +151,8 @@ servers:
     network_tier: "db-private"
     az: "a"
     volume_size: 4000
+    block_device:
+      volume_size: 5000
   - server_name: "couch1-production"
     server_instance_type: m5.4xlarge
     network_tier: "db-private"
@@ -163,6 +165,8 @@ servers:
     network_tier: "db-private"
     az: "c"
     volume_size: 4000
+    block_device:
+      volume_size: 5000
 
   - server_name: "rabbit0-production"
     server_instance_type: t3.large


### PR DESCRIPTION
I've added a 5TB non-boot volume to each of the production couch machines. (They're already added.)

`couch1-production` already has its data migrated to this new volume, and that volume is properly mounted at `/opt/data/`.
As of now (2018-11-28 @ 10:30pm ET) `couch0-production` and `couch2-production` are in the process of copying their `/opt/data` to the new volume. This is being done in a tmux under the ansible user as an rsync in a loop. Both nodes are still operational, it's just copying the data in the background. Tomorrow morning when I wake up, I'm going to (one node at a time) shut off couch, do a final rsync, reboot the machine to make sure the drives are in their natural unmounted state, move the old /opt/data out of the way (e.g. to /opt/data-backup), and then mount the new volume at /opt/data using after-reboot.