### PR TITLE
Simplify terraform RDS

### DIFF
--- a/src/commcare_cloud/commands/terraform/migrations/0004_name_rds_instances.py
+++ b/src/commcare_cloud/commands/terraform/migrations/0004_name_rds_instances.py
@@ -1,0 +1,12 @@
+def get_new_resource_address(environment, old_resource_address):
+    import re
+    server_matcher = re.compile(r'module\.postgresql-(\d+)\.(.*)$')
+
+    match = server_matcher.match(old_resource_address)
+    if match:
+        index = int(match.group(1))
+        rest = match.group(2)
+        server_config = environment.terraform_config.rds_instances[index]
+        return 'module.postgresql__{}.{}'.format(server_config.identifier, rest)
+    else:
+        return None

--- a/src/commcare_cloud/commands/terraform/templates/postgresql.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/postgresql.tf.j2
@@ -1,19 +1,22 @@
-{% with count = 5 -%}
-locals {
-  rds_instances = [
-    {%- for i in range(count) %}
-    "${merge(local.default_rds, var.rds_instances[{{ i }} < length(var.rds_instances) ? {{ i }} : 0])}",
-    {%- endfor %}
-  ]
-}
-
-{% for i in range(count) %}
-module "postgresql-{{ i }}" {
+{%- for rds_instance in rds_instances %}
+module "postgresql__{{ rds_instance.identifier }}" {
   source = "./modules/postgresql"
-  rds_instance = "${local.rds_instances[{{ i }}]}"
-  subnet_ids = "${local.rds_subnet_ids}"
-  vpc_security_group_ids = "${local.rds_vpc_security_group_ids}"
-  create = "${ {{ i }} < length(var.rds_instances) ? 1 : 0 }"
+  rds_instance = {
+    password = "${var.rds_password}"
+    identifier = {{ rds_instance.identifier|tojson }}
+    instance_type = {{ rds_instance.instance_type|tojson }}
+    storage = {{ rds_instance.storage|tojson }}
+    create = {{ rds_instance.create|tojson }}
+    username = {{ rds_instance.username|tojson }}
+    backup_window = {{ rds_instance.backup_window|tojson }}
+    backup_retention = {{ rds_instance.backup_retention|tojson }}
+    maintenance_window = {{ rds_instance.maintenance_window|tojson }}
+    port = {{ rds_instance.port|tojson }}
+    parameter_group_name = {{ rds_instance.parameter_group_name|tojson }}
+
+  }
+  subnet_ids = "${values(module.network.subnets-db-private)}"
+  vpc_security_group_ids = ["${module.network.rds-sg}", "${module.network.vpn-connections-sg}"]
+  create = "true"
 }
 {%- endfor %}
-{%- endwith %}

--- a/src/commcare_cloud/commands/terraform/templates/terraform.tfvars.j2
+++ b/src/commcare_cloud/commands/terraform/templates/terraform.tfvars.j2
@@ -60,16 +60,4 @@ proxy_servers = [
 {%- endfor %}
 ]
 
-rds_instances = [
-{%- for rds_instance in rds_instances %}
-  {
-    password = "${var.rds_password}"
-    identifier = {{ rds_instance.identifier|tojson }}
-    instance_type = {{ rds_instance.instance_type|tojson }}
-    storage = {{ rds_instance.storage|tojson }}
-    create = {{ rds_instance.create|tojson }}
-  },
-{%- endfor %}
-]
-
 account_alias = {{ (account_alias or "")|tojson }}

--- a/src/commcare_cloud/commands/terraform/templates/variables.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/variables.tf.j2
@@ -60,29 +60,3 @@ variable "proxy_servers" {
   type = "list"
   default = []
 }
-
-
-locals {
-  default_rds = {
-    storage = ""
-    instance_type = "db.t3.medium"
-    identifier = ""
-    username = "root"
-    storage_type = "gp2"
-    backup_window = "06:27-06:57"
-    backup_retention = 30
-    maintenance_window = "thu:04:47-thu:05:17"
-    auto_minor_version_upgrade = false
-    multi_az = false
-    storage_encrypted = true
-    port = 5432
-    password = ""  # must be overridden
-    prevent_destroy = true
-    instance_count = 1
-    parameter_group_name = "default.postgres9.6"
-  }
-  # todo: fold these two into default_rds once terraform 0.12 comes out
-  # todo: allow heterogeneous maps as module variables
-  rds_subnet_ids = "${values(module.network.subnets-db-private)}"
-  rds_vpc_security_group_ids = ["${module.network.rds-sg}", "${module.network.vpn-connections-sg}"]
-}

--- a/src/commcare_cloud/environment/schemas/terraform.py
+++ b/src/commcare_cloud/environment/schemas/terraform.py
@@ -62,10 +62,16 @@ class BlockDevice(jsonobject.JsonObject):
 
 class RdsInstanceConfig(jsonobject.JsonObject):
     _allow_dynamic_properties = False
-    identifier = jsonobject.StringProperty()
-    instance_type = jsonobject.StringProperty()  # should start with 'db.'
+    identifier = jsonobject.StringProperty(required=True)
+    instance_type = jsonobject.StringProperty(required=True)  # should start with 'db.'
     storage = jsonobject.IntegerProperty()
     create = jsonobject.BooleanProperty(default=True)
+    username = "root"
+    backup_window = "06:27-06:57"
+    backup_retention = 30
+    maintenance_window = "thu:04:47-thu:05:17"
+    port = 5432
+    parameter_group_name = "default.postgres9.6"
 
 
 class RedisConfig(jsonobject.JsonObject):


### PR DESCRIPTION
includes a rename with a corresponding terraform state migration

This is a prefactor for the change I want to make to be able to use terraform to set RDS parameters like `max_connections`. This removes a couple layers of indirection as well as some misleading unused variables.