### PR TITLE
Get staging terraform.yml up to date with reality

### DIFF
--- a/environments/staging/terraform.yml
+++ b/environments/staging/terraform.yml
@@ -74,17 +74,17 @@ servers:
     server_instance_type: "t2.large"
     network_tier: "db-private"
     az: "a"
-    volume_size: 50
+    volume_size: 100
   - server_name: "couch1-staging"
     server_instance_type: "t2.large"
     network_tier: "db-private"
     az: "a"
-    volume_size: 50
+    volume_size: 100
   - server_name: "couch2-staging"
     server_instance_type: "t2.large"
     network_tier: "db-private"
     az: "a"
-    volume_size: 50
+    volume_size: 400
   - server_name: "rabbit0-staging"
     server_instance_type: "t3.large"
     network_tier: "app-private"


### PR DESCRIPTION
Context is that an effort to increase couch disk sizes was underway and
then interrupted. Will be resumed later, but this commit updates to
what's currently there.