### PR TITLE
Manage RDS (postgresql) parameters in terraform

### DIFF
--- a/src/commcare_cloud/commands/terraform/templates/postgresql.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/postgresql.tf.j2
@@ -12,9 +12,16 @@ module "postgresql__{{ rds_instance.identifier }}" {
     backup_retention = {{ rds_instance.backup_retention|tojson }}
     maintenance_window = {{ rds_instance.maintenance_window|tojson }}
     port = {{ rds_instance.port|tojson }}
-    parameter_group_name = {{ rds_instance.parameter_group_name|tojson }}
-
   }
+  parameters = [
+    {%- for param in postgresql_params %}
+    {
+      name = {{ param.name|tojson }}
+      value = {{ param.value|tojson }}
+      apply_method = {{ param.apply_method|tojson }}
+    },
+    {%- endfor %}
+  ]
   subnet_ids = "${values(module.network.subnets-db-private)}"
   vpc_security_group_ids = ["${module.network.rds-sg}", "${module.network.vpn-connections-sg}"]
   create = "true"

--- a/src/commcare_cloud/terraform/modules/postgresql/main.tf
+++ b/src/commcare_cloud/terraform/modules/postgresql/main.tf
@@ -20,6 +20,8 @@ module "postgresql" {
   password = "${var.rds_instance["password"]}"
   port     = "${var.rds_instance["port"]}"
 
+  deletion_protection = "true"
+
   iam_database_authentication_enabled = false
 
   vpc_security_group_ids = "${var.vpc_security_group_ids}"

--- a/src/commcare_cloud/terraform/modules/postgresql/main.tf
+++ b/src/commcare_cloud/terraform/modules/postgresql/main.tf
@@ -43,8 +43,7 @@ module "postgresql" {
   final_snapshot_identifier = "final-snapshot-${var.rds_instance["identifier"]}"
   copy_tags_to_snapshot = true
 
-  parameter_group_name = "${var.rds_instance["parameter_group_name"]}"
-  parameters = []
+  parameters = "${var.parameters}"
 
   options = []
   storage_encrypted = true

--- a/src/commcare_cloud/terraform/modules/postgresql/variables.tf
+++ b/src/commcare_cloud/terraform/modules/postgresql/variables.tf
@@ -3,6 +3,9 @@ variable "rds_instance" {
   type = "map"
 }
 
+variable "parameters" {
+  type = "list"
+}
 variable "vpc_security_group_ids" {
   type = "list"
 }


### PR DESCRIPTION
Builds off of https://github.com/dimagi/commcare-cloud/pull/2465.

The only param currently managed (after this change) is `max_connections`—everything else is ignored—but it's set up to make it very easy to manage other params, basically by just adding them to a whitelist mapping the param name to the ansible variable name. (Currently assumes it'll be one of the variables in `postgresql/defaults/main.yml`).