### PR TITLE
Test prod without pgbouncer

### DIFF
--- a/environments/production/postgresql.yml
+++ b/environments/production/postgresql.yml
@@ -13,6 +13,19 @@ override:
   postgresql_wal_buffers: 16MB
   postgresql_max_wal_size: 2GB
 
+host_settings:
+  hqdb0:
+    port: 5432
+  hqdb1:
+    port: 5432
+  hqdb3:
+    port: 5432
+  hqdb5:
+    port: 5432
+  pgsynclog1:
+    port: 5432
+
+
 
 LOAD_BALANCED_APPS:
   auth:
@@ -38,6 +51,7 @@ dbs:
   form_processing:
     proxy:
       host: hqdb1
+      port: 6432
     partitions:
       p1:
         shards: [0, 204]

--- a/environments/production/postgresql.yml
+++ b/environments/production/postgresql.yml
@@ -7,7 +7,7 @@ override:
   pgbouncer_pool_mode: transaction
   pgbouncer_pool_timeout: 1
   pgbouncer_reserve_pool: 5
-  postgresql_max_connections: 300
+  postgresql_max_connections: 1000
   postgresql_version: '9.6'
   postgresql_checkpoint_completion_target: '0.7'
   postgresql_wal_buffers: 16MB


### PR DESCRIPTION
Reason: RDS doesn't allow us to install pgbouncer on the postgrs machines themselves, so the plan is to increase the connection limit and just have pgbouncer installed on the proxy machine. We're applying this change to production now, so we can make sure that doesn't cause any big problems. Note: I haven't applied these changes yet, but did run in check mode

@dannyroberts 
code buddy @calellowitz 