### PR TITLE
Revert "Test prod without pgbouncer"

### DIFF
--- a/environments/production/postgresql.yml
+++ b/environments/production/postgresql.yml
@@ -8,24 +8,11 @@ override:
   pgbouncer_pool_mode: transaction
   pgbouncer_pool_timeout: 1
   pgbouncer_reserve_pool: 5
-  postgresql_max_connections: 1000
+  postgresql_max_connections: 300
   postgresql_version: '9.6'
   postgresql_checkpoint_completion_target: '0.7'
   postgresql_wal_buffers: 16MB
   postgresql_max_wal_size: 2GB
-
-host_settings:
-  hqdb0:
-    port: 5432
-  hqdb1:
-    port: 5432
-  hqdb3:
-    port: 5432
-  hqdb5:
-    port: 5432
-  pgsynclog1:
-    port: 5432
-
 
 
 LOAD_BALANCED_APPS:
@@ -52,7 +39,6 @@ dbs:
   form_processing:
     proxy:
       host: hqdb1
-      port: 6432
     partitions:
       p1:
         shards: [0, 204]


### PR DESCRIPTION
Reverts dimagi/commcare-cloud#2468

@calellowitz 
@dannyroberts 
Reverting the whole pr (not just the port changes) because the connections are maxed at 290 with pgbouncer, so the increase to 1000 would have no effect:  https://github.com/dimagi/commcare-cloud/blob/master/environments/production/postgresql.yml#L6


