### PR TITLE
Allow pgbouncer in front of remote dbs, and configure on staging

### DIFF
--- a/environments/staging/postgresql.yml
+++ b/environments/staging/postgresql.yml
@@ -1,9 +1,5 @@
 DEFAULT_POSTGRESQL_HOST: rds_pg0
 
-host_settings:
-  rds_pg0:
-    port: 5432
-
 override:
   pgbouncer_pool_mode: transaction
   pgbouncer_max_connections: 800
@@ -12,29 +8,41 @@ override:
 
 dbs:
   main:
+    pgbouncer_host: pgproxy0
     query_stats: True
   ucr:
+    pgbouncer_host: pgproxy0
     query_stats: True
+  synclogs:
+    pgbouncer_host: pgproxy0
+  formplayer:
+    pgbouncer_host: pgproxy0
   form_processing:
     proxy:
       host: pgproxy0
     partitions:
       p1:
+        pgbouncer_host: pgproxy0
         shards: [0, 99]
         query_stats: True
       p2:
+        pgbouncer_host: pgproxy0
         shards: [100, 199]
         query_stats: True
       p3:
+        pgbouncer_host: pgproxy0
         shards: [200, 299]
         query_stats: True
       p4:
+        pgbouncer_host: pgproxy0
         shards: [300, 399]
         query_stats: True
       p5:
+        pgbouncer_host: pgproxy0
         shards: [400, 511]
         query_stats: True
   custom:
     - name: airflow
+      pgbouncer_host: pgproxy0
       django_migrate: False
 

--- a/src/commcare_cloud/ansible/roles/airflow/templates/airflow.cfg.j2
+++ b/src/commcare_cloud/ansible/roles/airflow/templates/airflow.cfg.j2
@@ -18,7 +18,7 @@ executor = LocalExecutor
 # The SqlAlchemy connection string to the metadata database.
 # SqlAlchemy supports many different database engine, more information
 # their website
-sql_alchemy_conn = postgresql://{{ postgres_users.commcare.username }}:{{ postgres_users.commcare.password }}@{{ postgresql_dbs.main.host }}:{{ postgresql_dbs.main.port }}/airflow
+sql_alchemy_conn = postgresql://{{ postgres_users.commcare.username }}:{{ postgres_users.commcare.password }}@{{ postgresql_dbs.main.pgbouncer_host }}:{{ postgresql_dbs.main.port }}/airflow
 
 # The SqlAlchemy pool size is the maximum number of database connections
 # in the pool.

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -32,7 +32,7 @@ DATABASES = { {% for config in postgresql_dbs.all %}
         'NAME': '{{ config.name }}',
         'USER': '{{ config.user }}',
         'PASSWORD': '{{ config.password }}',
-        'HOST': '{% if config.host == inventory_hostname %}127.0.0.1{% else %}{{ config.host }}{% endif %}',
+        'HOST': '{% if config.pgbouncer_host == inventory_hostname %}127.0.0.1{% else %}{{ config.pgbouncer_host }}{% endif %}',
         'PORT': {{ config.port }},
         'OPTIONS': {{ config.options|to_json }},
         'DISABLE_SERVER_SIDE_CURSORS': True,

--- a/src/commcare_cloud/ansible/roles/formplayer/templates/application.properties.j2
+++ b/src/commcare_cloud/ansible/roles/formplayer/templates/application.properties.j2
@@ -28,18 +28,18 @@ couch.databaseName={{ couch_dbs.default.name }}
 
 // Properties for HQ db
 datasource.hq.driverClassName=org.postgresql.Driver
-datasource.hq.url=jdbc:postgresql://{{ postgresql_dbs.main.host }}:{{ postgresql_dbs.main.port }}/commcarehq?prepareThreshold=0
+datasource.hq.url=jdbc:postgresql://{{ postgresql_dbs.main.pgbouncer_host }}:{{ postgresql_dbs.main.port }}/commcarehq?prepareThreshold=0
 datasource.hq.username={{ postgres_users.commcare.username }}
 datasource.hq.password={{ postgres_users.commcare.password }}
 
 datasource.formplayer.driverClassName=org.postgresql.Driver
-datasource.formplayer.url=jdbc:postgresql://{{ postgresql_dbs.formplayer.host }}:{{ postgresql_dbs.formplayer.port
+datasource.formplayer.url=jdbc:postgresql://{{ postgresql_dbs.formplayer.pgbouncer_host }}:{{ postgresql_dbs.formplayer.port
 }}/{{ formplayer_db_name }}?prepareThreshold=0
 datasource.formplayer.username={{ postgres_users.commcare.username }}
 datasource.formplayer.password={{ postgres_users.commcare.password }}
 
 // set flyway URL to Formplayer's own DB
-flyway.url=jdbc:postgresql://{{ postgresql_dbs.formplayer.host }}:{{ postgresql_dbs.formplayer.port }}/{{ formplayer_db_name }}?prepareThreshold=0
+flyway.url=jdbc:postgresql://{{ postgresql_dbs.formplayer.pgbouncer_host }}:{{ postgresql_dbs.formplayer.port }}/{{ formplayer_db_name }}?prepareThreshold=0
 flyway.user={{ postgres_users.commcare.username }}
 flyway.password={{ postgres_users.commcare.password }}
 flyway.driverClassName=org.postgresql.Driver

--- a/src/commcare_cloud/ansible/roles/postgresql/templates/pgbouncer.ini.j2
+++ b/src/commcare_cloud/ansible/roles/postgresql/templates/pgbouncer.ini.j2
@@ -9,9 +9,9 @@
 [databases]
 {% for db in postgresql_dbs.all %}
 {% if db.create %}
-{% set db_host = db.host %}
-{% if db_host == inventory_hostname or db_host == hot_standby_master|default(None) or is_monolith|bool %}
-{{ db.name }} = host=localhost port={{postgresql_port}}
+{% set db_pgbouncer_host = db.host %}
+{% if db_pgbouncer_host == inventory_hostname or db_pgbouncer_host == hot_standby_master|default(None) or is_monolith|bool %}
+{{ db.name }} = host={{ "localhost" if db.host == db_pgbouncer_host else db.host }} port={{postgresql_port}}
 {% endif %}
 {% endif %}
 {% endfor %}

--- a/src/commcare_cloud/ansible/roles/postgresql/templates/pgbouncer.ini.j2
+++ b/src/commcare_cloud/ansible/roles/postgresql/templates/pgbouncer.ini.j2
@@ -9,7 +9,7 @@
 [databases]
 {% for db in postgresql_dbs.all %}
 {% if db.create %}
-{% set db_pgbouncer_host = db.host %}
+{% set db_pgbouncer_host = db.pgbouncer_host %}
 {% if db_pgbouncer_host == inventory_hostname or db_pgbouncer_host == hot_standby_master|default(None) or is_monolith|bool %}
 {{ db.name }} = host={{ "localhost" if db.host == db_pgbouncer_host else db.host }} port={{postgresql_port}}
 {% endif %}

--- a/src/commcare_cloud/environment/schemas/postgresql.py
+++ b/src/commcare_cloud/environment/schemas/postgresql.py
@@ -115,6 +115,11 @@ class PostgresqlConfig(jsonobject.JsonObject):
                 db.host = self.DEFAULT_POSTGRESQL_HOST
             elif db.host != '127.0.0.1':
                 db.host = environment.translate_host(db.host, environment.paths.postgresql_yml)
+
+            if db.pgbouncer_host is None:
+                db.pgbouncer_host = db.host
+            else:
+                db.pgbouncer_host = environment.translate_host(db.pgbouncer_host, environment.paths.postgresql_yml)
             if db.port is None:
                 if db.host in host_settings:
                     db.port = host_settings[db.host].port
@@ -184,6 +189,7 @@ class DBOptions(jsonobject.JsonObject):
 
     name = jsonobject.StringProperty(required=True)
     host = jsonobject.StringProperty()
+    pgbouncer_host = jsonobject.StringProperty(default=None)
     port = jsonobject.IntegerProperty(default=None)
     user = jsonobject.StringProperty()
     password = jsonobject.StringProperty()

--- a/tests/postgresql_config/2018-04-04-development-snapshot/.generated.yml
+++ b/tests/postgresql_config/2018-04-04-development-snapshot/.generated.yml
@@ -4,6 +4,7 @@ postgresql_dbs:
     django_alias: default
     django_migrate: true
     host: 192.168.33.16
+    pgbouncer_host: 192.168.33.16
     name: commcarehq
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -14,6 +15,7 @@ postgresql_dbs:
     django_alias: ucr
     django_migrate: false
     host: 192.168.33.16
+    pgbouncer_host: 192.168.33.16
     name: commcarehq_ucr
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -24,6 +26,7 @@ postgresql_dbs:
     django_alias: null
     django_migrate: true
     host: 192.168.33.16
+    pgbouncer_host: 192.168.33.16
     name: formplayer
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -37,6 +40,7 @@ postgresql_dbs:
     django_alias: null
     django_migrate: true
     host: 192.168.33.16
+    pgbouncer_host: 192.168.33.16
     name: formplayer
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -48,6 +52,7 @@ postgresql_dbs:
     django_alias: default
     django_migrate: true
     host: 192.168.33.16
+    pgbouncer_host: 192.168.33.16
     name: commcarehq
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -61,6 +66,7 @@ postgresql_dbs:
     django_alias: ucr
     django_migrate: false
     host: 192.168.33.16
+    pgbouncer_host: 192.168.33.16
     name: commcarehq_ucr
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'

--- a/tests/postgresql_config/2018-04-04-enikshay-snapshot/.generated.yml
+++ b/tests/postgresql_config/2018-04-04-enikshay-snapshot/.generated.yml
@@ -4,6 +4,7 @@ postgresql_dbs:
     django_alias: default
     django_migrate: true
     host: 172.25.3.5
+    pgbouncer_host: 172.25.3.5
     name: commcarehq
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -14,6 +15,7 @@ postgresql_dbs:
     django_alias: p1
     django_migrate: true
     host: 172.25.3.5
+    pgbouncer_host: 172.25.3.5
     name: commcarehq_p1
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -25,6 +27,7 @@ postgresql_dbs:
     django_alias: p10
     django_migrate: true
     host: 172.25.3.5
+    pgbouncer_host: 172.25.3.5
     name: commcarehq_p10
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -36,6 +39,7 @@ postgresql_dbs:
     django_alias: p2
     django_migrate: true
     host: 172.25.3.5
+    pgbouncer_host: 172.25.3.5
     name: commcarehq_p2
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -47,6 +51,7 @@ postgresql_dbs:
     django_alias: p3
     django_migrate: true
     host: 172.25.3.5
+    pgbouncer_host: 172.25.3.5
     name: commcarehq_p3
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -58,6 +63,7 @@ postgresql_dbs:
     django_alias: p4
     django_migrate: true
     host: 172.25.3.5
+    pgbouncer_host: 172.25.3.5
     name: commcarehq_p4
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -69,6 +75,7 @@ postgresql_dbs:
     django_alias: p5
     django_migrate: true
     host: 172.25.3.5
+    pgbouncer_host: 172.25.3.5
     name: commcarehq_p5
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -80,6 +87,7 @@ postgresql_dbs:
     django_alias: p6
     django_migrate: true
     host: 172.25.3.5
+    pgbouncer_host: 172.25.3.5
     name: commcarehq_p6
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -91,6 +99,7 @@ postgresql_dbs:
     django_alias: p7
     django_migrate: true
     host: 172.25.3.5
+    pgbouncer_host: 172.25.3.5
     name: commcarehq_p7
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -102,6 +111,7 @@ postgresql_dbs:
     django_alias: p8
     django_migrate: true
     host: 172.25.3.5
+    pgbouncer_host: 172.25.3.5
     name: commcarehq_p8
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -113,6 +123,7 @@ postgresql_dbs:
     django_alias: p9
     django_migrate: true
     host: 172.25.3.5
+    pgbouncer_host: 172.25.3.5
     name: commcarehq_p9
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -124,6 +135,7 @@ postgresql_dbs:
     django_alias: proxy
     django_migrate: true
     host: 172.25.3.5
+    pgbouncer_host: 172.25.3.5
     name: commcarehq_proxy
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -134,6 +146,7 @@ postgresql_dbs:
     django_alias: synclogs
     django_migrate: true
     host: 172.25.3.5
+    pgbouncer_host: 172.25.3.5
     name: commcarehq_synclogs
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -144,6 +157,7 @@ postgresql_dbs:
     django_alias: ucr
     django_migrate: false
     host: 172.25.3.5
+    pgbouncer_host: 172.25.3.5
     name: commcarehq_ucr
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -154,6 +168,7 @@ postgresql_dbs:
     django_alias: null
     django_migrate: true
     host: 172.25.3.5
+    pgbouncer_host: 172.25.3.5
     name: formplayer
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -168,6 +183,7 @@ postgresql_dbs:
         django_alias: p1
         django_migrate: true
         host: 172.25.3.5
+        pgbouncer_host: 172.25.3.5
         name: commcarehq_p1
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -180,6 +196,7 @@ postgresql_dbs:
         django_alias: p10
         django_migrate: true
         host: 172.25.3.5
+        pgbouncer_host: 172.25.3.5
         name: commcarehq_p10
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -192,6 +209,7 @@ postgresql_dbs:
         django_alias: p2
         django_migrate: true
         host: 172.25.3.5
+        pgbouncer_host: 172.25.3.5
         name: commcarehq_p2
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -204,6 +222,7 @@ postgresql_dbs:
         django_alias: p3
         django_migrate: true
         host: 172.25.3.5
+        pgbouncer_host: 172.25.3.5
         name: commcarehq_p3
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -216,6 +235,7 @@ postgresql_dbs:
         django_alias: p4
         django_migrate: true
         host: 172.25.3.5
+        pgbouncer_host: 172.25.3.5
         name: commcarehq_p4
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -228,6 +248,7 @@ postgresql_dbs:
         django_alias: p5
         django_migrate: true
         host: 172.25.3.5
+        pgbouncer_host: 172.25.3.5
         name: commcarehq_p5
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -240,6 +261,7 @@ postgresql_dbs:
         django_alias: p6
         django_migrate: true
         host: 172.25.3.5
+        pgbouncer_host: 172.25.3.5
         name: commcarehq_p6
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -252,6 +274,7 @@ postgresql_dbs:
         django_alias: p7
         django_migrate: true
         host: 172.25.3.5
+        pgbouncer_host: 172.25.3.5
         name: commcarehq_p7
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -264,6 +287,7 @@ postgresql_dbs:
         django_alias: p8
         django_migrate: true
         host: 172.25.3.5
+        pgbouncer_host: 172.25.3.5
         name: commcarehq_p8
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -276,6 +300,7 @@ postgresql_dbs:
         django_alias: p9
         django_migrate: true
         host: 172.25.3.5
+        pgbouncer_host: 172.25.3.5
         name: commcarehq_p9
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -288,6 +313,7 @@ postgresql_dbs:
       django_alias: proxy
       django_migrate: true
       host: 172.25.3.5
+      pgbouncer_host: 172.25.3.5
       name: commcarehq_proxy
       options: {}
       password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -299,6 +325,7 @@ postgresql_dbs:
     django_alias: null
     django_migrate: true
     host: 172.25.3.5
+    pgbouncer_host: 172.25.3.5
     name: formplayer
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -310,6 +337,7 @@ postgresql_dbs:
     django_alias: default
     django_migrate: true
     host: 172.25.3.5
+    pgbouncer_host: 172.25.3.5
     name: commcarehq
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -322,6 +350,7 @@ postgresql_dbs:
     django_alias: synclogs
     django_migrate: true
     host: 172.25.3.5
+    pgbouncer_host: 172.25.3.5
     name: commcarehq_synclogs
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -333,6 +362,7 @@ postgresql_dbs:
     django_alias: ucr
     django_migrate: false
     host: 172.25.3.5
+    pgbouncer_host: 172.25.3.5
     name: commcarehq_ucr
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'

--- a/tests/postgresql_config/2018-04-04-icds-new-snapshot/.generated.yml
+++ b/tests/postgresql_config/2018-04-04-icds-new-snapshot/.generated.yml
@@ -4,6 +4,7 @@ postgresql_dbs:
     django_alias: default
     django_migrate: true
     host: 10.247.164.26
+    pgbouncer_host: 10.247.164.26
     name: commcarehq
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -14,6 +15,7 @@ postgresql_dbs:
     django_alias: icds-ucr
     django_migrate: true
     host: 10.247.164.25
+    pgbouncer_host: 10.247.164.25
     name: commcarehq_icds_aggregatedata
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -24,6 +26,7 @@ postgresql_dbs:
     django_alias: icds-ucr-standby1
     django_migrate: false
     host: 10.247.164.24
+    pgbouncer_host: 10.247.164.24
     hq_acceptable_standby_delay: 30
     name: commcarehq_icds_aggregatedata
     options: {}
@@ -35,6 +38,7 @@ postgresql_dbs:
     django_alias: p1
     django_migrate: true
     host: 10.247.164.66
+    pgbouncer_host: 10.247.164.66
     name: commcarehq_p1
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -46,6 +50,7 @@ postgresql_dbs:
     django_alias: p10
     django_migrate: true
     host: 10.247.164.64
+    pgbouncer_host: 10.247.164.64
     name: commcarehq_p10
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -57,6 +62,7 @@ postgresql_dbs:
     django_alias: p2
     django_migrate: true
     host: 10.247.164.66
+    pgbouncer_host: 10.247.164.66
     name: commcarehq_p2
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -68,6 +74,7 @@ postgresql_dbs:
     django_alias: p3
     django_migrate: true
     host: 10.247.164.21
+    pgbouncer_host: 10.247.164.21
     name: commcarehq_p3
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -79,6 +86,7 @@ postgresql_dbs:
     django_alias: p4
     django_migrate: true
     host: 10.247.164.21
+    pgbouncer_host: 10.247.164.21
     name: commcarehq_p4
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -90,6 +98,7 @@ postgresql_dbs:
     django_alias: p5
     django_migrate: true
     host: 10.247.164.21
+    pgbouncer_host: 10.247.164.21
     name: commcarehq_p5
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -101,6 +110,7 @@ postgresql_dbs:
     django_alias: p6
     django_migrate: true
     host: 10.247.164.20
+    pgbouncer_host: 10.247.164.20
     name: commcarehq_p6
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -112,6 +122,7 @@ postgresql_dbs:
     django_alias: p7
     django_migrate: true
     host: 10.247.164.20
+    pgbouncer_host: 10.247.164.20
     name: commcarehq_p7
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -123,6 +134,7 @@ postgresql_dbs:
     django_alias: p8
     django_migrate: true
     host: 10.247.164.20
+    pgbouncer_host: 10.247.164.20
     name: commcarehq_p8
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -134,6 +146,7 @@ postgresql_dbs:
     django_alias: p9
     django_migrate: true
     host: 10.247.164.64
+    pgbouncer_host: 10.247.164.64
     name: commcarehq_p9
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -145,6 +158,7 @@ postgresql_dbs:
     django_alias: proxy
     django_migrate: true
     host: 10.247.164.56
+    pgbouncer_host: 10.247.164.56
     name: commcarehq_proxy
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -155,6 +169,7 @@ postgresql_dbs:
     django_alias: synclogs
     django_migrate: true
     host: 10.247.164.70
+    pgbouncer_host: 10.247.164.70
     name: commcarehq_synclogs
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -165,6 +180,7 @@ postgresql_dbs:
     django_alias: ucr
     django_migrate: false
     host: 10.247.164.25
+    pgbouncer_host: 10.247.164.25
     name: commcarehq_ucr
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -175,6 +191,7 @@ postgresql_dbs:
     django_alias: null
     django_migrate: true
     host: 10.247.164.25
+    pgbouncer_host: 10.247.164.25
     name: formplayer
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -186,6 +203,7 @@ postgresql_dbs:
     django_alias: icds-ucr
     django_migrate: true
     host: 10.247.164.25
+    pgbouncer_host: 10.247.164.25
     name: commcarehq_icds_aggregatedata
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -199,6 +217,7 @@ postgresql_dbs:
         django_alias: p1
         django_migrate: true
         host: 10.247.164.66
+        pgbouncer_host: 10.247.164.66
         name: commcarehq_p1
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -211,6 +230,7 @@ postgresql_dbs:
         django_alias: p10
         django_migrate: true
         host: 10.247.164.64
+        pgbouncer_host: 10.247.164.64
         name: commcarehq_p10
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -223,6 +243,7 @@ postgresql_dbs:
         django_alias: p2
         django_migrate: true
         host: 10.247.164.66
+        pgbouncer_host: 10.247.164.66
         name: commcarehq_p2
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -235,6 +256,7 @@ postgresql_dbs:
         django_alias: p3
         django_migrate: true
         host: 10.247.164.21
+        pgbouncer_host: 10.247.164.21
         name: commcarehq_p3
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -247,6 +269,7 @@ postgresql_dbs:
         django_alias: p4
         django_migrate: true
         host: 10.247.164.21
+        pgbouncer_host: 10.247.164.21
         name: commcarehq_p4
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -259,6 +282,7 @@ postgresql_dbs:
         django_alias: p5
         django_migrate: true
         host: 10.247.164.21
+        pgbouncer_host: 10.247.164.21
         name: commcarehq_p5
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -271,6 +295,7 @@ postgresql_dbs:
         django_alias: p6
         django_migrate: true
         host: 10.247.164.20
+        pgbouncer_host: 10.247.164.20
         name: commcarehq_p6
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -283,6 +308,7 @@ postgresql_dbs:
         django_alias: p7
         django_migrate: true
         host: 10.247.164.20
+        pgbouncer_host: 10.247.164.20
         name: commcarehq_p7
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -295,6 +321,7 @@ postgresql_dbs:
         django_alias: p8
         django_migrate: true
         host: 10.247.164.20
+        pgbouncer_host: 10.247.164.20
         name: commcarehq_p8
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -307,6 +334,7 @@ postgresql_dbs:
         django_alias: p9
         django_migrate: true
         host: 10.247.164.64
+        pgbouncer_host: 10.247.164.64
         name: commcarehq_p9
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -319,6 +347,7 @@ postgresql_dbs:
       django_alias: proxy
       django_migrate: true
       host: 10.247.164.56
+      pgbouncer_host: 10.247.164.56
       name: commcarehq_proxy
       options: {}
       password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -330,6 +359,7 @@ postgresql_dbs:
     django_alias: null
     django_migrate: true
     host: 10.247.164.25
+    pgbouncer_host: 10.247.164.25
     name: formplayer
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -341,6 +371,7 @@ postgresql_dbs:
     django_alias: default
     django_migrate: true
     host: 10.247.164.26
+    pgbouncer_host: 10.247.164.26
     name: commcarehq
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -352,6 +383,7 @@ postgresql_dbs:
     django_alias: icds-ucr-standby1
     django_migrate: false
     host: 10.247.164.24
+    pgbouncer_host: 10.247.164.24
     hq_acceptable_standby_delay: 30
     name: commcarehq_icds_aggregatedata
     options: {}
@@ -364,6 +396,7 @@ postgresql_dbs:
     django_alias: synclogs
     django_migrate: true
     host: 10.247.164.70
+    pgbouncer_host: 10.247.164.70
     name: commcarehq_synclogs
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -375,6 +408,7 @@ postgresql_dbs:
     django_alias: ucr
     django_migrate: false
     host: 10.247.164.25
+    pgbouncer_host: 10.247.164.25
     name: commcarehq_ucr
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'

--- a/tests/postgresql_config/2018-04-04-l10k-snapshot/.generated.yml
+++ b/tests/postgresql_config/2018-04-04-l10k-snapshot/.generated.yml
@@ -4,6 +4,7 @@ postgresql_dbs:
     django_alias: default
     django_migrate: true
     host: 127.0.0.1
+    pgbouncer_host: 127.0.0.1
     name: commcarehq
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -14,6 +15,7 @@ postgresql_dbs:
     django_alias: synclogs
     django_migrate: true
     host: 127.0.0.1
+    pgbouncer_host: 127.0.0.1
     name: commcarehq_synclogs
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -24,6 +26,7 @@ postgresql_dbs:
     django_alias: ucr
     django_migrate: true
     host: 127.0.0.1
+    pgbouncer_host: 127.0.0.1
     name: commcarehq_ucr
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -34,6 +37,7 @@ postgresql_dbs:
     django_alias: null
     django_migrate: true
     host: 127.0.0.1
+    pgbouncer_host: 127.0.0.1
     name: formplayer
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -47,6 +51,7 @@ postgresql_dbs:
     django_alias: null
     django_migrate: true
     host: 127.0.0.1
+    pgbouncer_host: 127.0.0.1
     name: formplayer
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -58,6 +63,7 @@ postgresql_dbs:
     django_alias: default
     django_migrate: true
     host: 127.0.0.1
+    pgbouncer_host: 127.0.0.1
     name: commcarehq
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -70,6 +76,7 @@ postgresql_dbs:
     django_alias: synclogs
     django_migrate: true
     host: 127.0.0.1
+    pgbouncer_host: 127.0.0.1
     name: commcarehq_synclogs
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -81,6 +88,7 @@ postgresql_dbs:
     django_alias: ucr
     django_migrate: true
     host: 127.0.0.1
+    pgbouncer_host: 127.0.0.1
     name: commcarehq_ucr
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'

--- a/tests/postgresql_config/2018-04-04-pna-snapshot/.generated.yml
+++ b/tests/postgresql_config/2018-04-04-pna-snapshot/.generated.yml
@@ -4,6 +4,7 @@ postgresql_dbs:
     django_alias: default
     django_migrate: true
     host: 196.207.230.171
+    pgbouncer_host: 196.207.230.171
     name: commcarehq
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -14,6 +15,7 @@ postgresql_dbs:
     django_alias: p1
     django_migrate: true
     host: 196.207.230.171
+    pgbouncer_host: 196.207.230.171
     name: commcarehq_p1
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -25,6 +27,7 @@ postgresql_dbs:
     django_alias: p10
     django_migrate: true
     host: 196.207.230.171
+    pgbouncer_host: 196.207.230.171
     name: commcarehq_p10
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -36,6 +39,7 @@ postgresql_dbs:
     django_alias: p2
     django_migrate: true
     host: 196.207.230.171
+    pgbouncer_host: 196.207.230.171
     name: commcarehq_p2
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -47,6 +51,7 @@ postgresql_dbs:
     django_alias: p3
     django_migrate: true
     host: 196.207.230.171
+    pgbouncer_host: 196.207.230.171
     name: commcarehq_p3
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -58,6 +63,7 @@ postgresql_dbs:
     django_alias: p4
     django_migrate: true
     host: 196.207.230.171
+    pgbouncer_host: 196.207.230.171
     name: commcarehq_p4
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -69,6 +75,7 @@ postgresql_dbs:
     django_alias: p5
     django_migrate: true
     host: 196.207.230.171
+    pgbouncer_host: 196.207.230.171
     name: commcarehq_p5
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -80,6 +87,7 @@ postgresql_dbs:
     django_alias: p6
     django_migrate: true
     host: 196.207.230.171
+    pgbouncer_host: 196.207.230.171
     name: commcarehq_p6
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -91,6 +99,7 @@ postgresql_dbs:
     django_alias: p7
     django_migrate: true
     host: 196.207.230.171
+    pgbouncer_host: 196.207.230.171
     name: commcarehq_p7
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -102,6 +111,7 @@ postgresql_dbs:
     django_alias: p8
     django_migrate: true
     host: 196.207.230.171
+    pgbouncer_host: 196.207.230.171
     name: commcarehq_p8
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -113,6 +123,7 @@ postgresql_dbs:
     django_alias: p9
     django_migrate: true
     host: 196.207.230.171
+    pgbouncer_host: 196.207.230.171
     name: commcarehq_p9
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -124,6 +135,7 @@ postgresql_dbs:
     django_alias: proxy
     django_migrate: true
     host: 196.207.230.171
+    pgbouncer_host: 196.207.230.171
     name: commcarehq_proxy
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -134,6 +146,7 @@ postgresql_dbs:
     django_alias: synclogs
     django_migrate: true
     host: 196.207.230.171
+    pgbouncer_host: 196.207.230.171
     name: commcarehq_synclogs
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -144,6 +157,7 @@ postgresql_dbs:
     django_alias: ucr
     django_migrate: false
     host: 196.207.230.171
+    pgbouncer_host: 196.207.230.171
     name: commcarehq_ucr
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -154,6 +168,7 @@ postgresql_dbs:
     django_alias: null
     django_migrate: true
     host: 196.207.230.171
+    pgbouncer_host: 196.207.230.171
     name: formplayer
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -168,6 +183,7 @@ postgresql_dbs:
         django_alias: p1
         django_migrate: true
         host: 196.207.230.171
+        pgbouncer_host: 196.207.230.171
         name: commcarehq_p1
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -180,6 +196,7 @@ postgresql_dbs:
         django_alias: p10
         django_migrate: true
         host: 196.207.230.171
+        pgbouncer_host: 196.207.230.171
         name: commcarehq_p10
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -192,6 +209,7 @@ postgresql_dbs:
         django_alias: p2
         django_migrate: true
         host: 196.207.230.171
+        pgbouncer_host: 196.207.230.171
         name: commcarehq_p2
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -204,6 +222,7 @@ postgresql_dbs:
         django_alias: p3
         django_migrate: true
         host: 196.207.230.171
+        pgbouncer_host: 196.207.230.171
         name: commcarehq_p3
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -216,6 +235,7 @@ postgresql_dbs:
         django_alias: p4
         django_migrate: true
         host: 196.207.230.171
+        pgbouncer_host: 196.207.230.171
         name: commcarehq_p4
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -228,6 +248,7 @@ postgresql_dbs:
         django_alias: p5
         django_migrate: true
         host: 196.207.230.171
+        pgbouncer_host: 196.207.230.171
         name: commcarehq_p5
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -240,6 +261,7 @@ postgresql_dbs:
         django_alias: p6
         django_migrate: true
         host: 196.207.230.171
+        pgbouncer_host: 196.207.230.171
         name: commcarehq_p6
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -252,6 +274,7 @@ postgresql_dbs:
         django_alias: p7
         django_migrate: true
         host: 196.207.230.171
+        pgbouncer_host: 196.207.230.171
         name: commcarehq_p7
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -264,6 +287,7 @@ postgresql_dbs:
         django_alias: p8
         django_migrate: true
         host: 196.207.230.171
+        pgbouncer_host: 196.207.230.171
         name: commcarehq_p8
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -276,6 +300,7 @@ postgresql_dbs:
         django_alias: p9
         django_migrate: true
         host: 196.207.230.171
+        pgbouncer_host: 196.207.230.171
         name: commcarehq_p9
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -288,6 +313,7 @@ postgresql_dbs:
       django_alias: proxy
       django_migrate: true
       host: 196.207.230.171
+      pgbouncer_host: 196.207.230.171
       name: commcarehq_proxy
       options: {}
       password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -299,6 +325,7 @@ postgresql_dbs:
     django_alias: null
     django_migrate: true
     host: 196.207.230.171
+    pgbouncer_host: 196.207.230.171
     name: formplayer
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -310,6 +337,7 @@ postgresql_dbs:
     django_alias: default
     django_migrate: true
     host: 196.207.230.171
+    pgbouncer_host: 196.207.230.171
     name: commcarehq
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -322,6 +350,7 @@ postgresql_dbs:
     django_alias: synclogs
     django_migrate: true
     host: 196.207.230.171
+    pgbouncer_host: 196.207.230.171
     name: commcarehq_synclogs
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -333,6 +362,7 @@ postgresql_dbs:
     django_alias: ucr
     django_migrate: false
     host: 196.207.230.171
+    pgbouncer_host: 196.207.230.171
     name: commcarehq_ucr
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'

--- a/tests/postgresql_config/2018-04-04-production-snapshot/.generated.yml
+++ b/tests/postgresql_config/2018-04-04-production-snapshot/.generated.yml
@@ -4,6 +4,7 @@ postgresql_dbs:
     django_alias: default
     django_migrate: true
     host: hqdb0.internal-va.commcarehq.org
+    pgbouncer_host: hqdb0.internal-va.commcarehq.org
     name: commcarehq
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -14,6 +15,7 @@ postgresql_dbs:
     django_alias: p1
     django_migrate: true
     host: hqdb1.internal-va.commcarehq.org
+    pgbouncer_host: hqdb1.internal-va.commcarehq.org
     name: commcarehq_p1
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -25,6 +27,7 @@ postgresql_dbs:
     django_alias: p2
     django_migrate: true
     host: hqdb1.internal-va.commcarehq.org
+    pgbouncer_host: hqdb1.internal-va.commcarehq.org
     name: commcarehq_p2
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -36,6 +39,7 @@ postgresql_dbs:
     django_alias: p3
     django_migrate: true
     host: hqdb2.internal-va.commcarehq.org
+    pgbouncer_host: hqdb2.internal-va.commcarehq.org
     name: commcarehq_p3
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -47,6 +51,7 @@ postgresql_dbs:
     django_alias: p4
     django_migrate: true
     host: hqdb2.internal-va.commcarehq.org
+    pgbouncer_host: hqdb2.internal-va.commcarehq.org
     name: commcarehq_p4
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -58,6 +63,7 @@ postgresql_dbs:
     django_alias: p5
     django_migrate: true
     host: hqdb2.internal-va.commcarehq.org
+    pgbouncer_host: hqdb2.internal-va.commcarehq.org
     name: commcarehq_p5
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -69,6 +75,7 @@ postgresql_dbs:
     django_alias: proxy
     django_migrate: true
     host: hqdb1.internal-va.commcarehq.org
+    pgbouncer_host: hqdb1.internal-va.commcarehq.org
     name: commcarehq_proxy
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -79,6 +86,7 @@ postgresql_dbs:
     django_alias: synclogs
     django_migrate: true
     host: pgsynclog.internal-va.commcarehq.org
+    pgbouncer_host: pgsynclog.internal-va.commcarehq.org
     name: commcarehq_synclogs
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -89,6 +97,7 @@ postgresql_dbs:
     django_alias: ucr
     django_migrate: false
     host: hqdb0.internal-va.commcarehq.org
+    pgbouncer_host: hqdb0.internal-va.commcarehq.org
     name: commcarehq_ucr
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -99,6 +108,7 @@ postgresql_dbs:
     django_alias: null
     django_migrate: true
     host: hqdb0.internal-va.commcarehq.org
+    pgbouncer_host: hqdb0.internal-va.commcarehq.org
     name: formplayer
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -113,6 +123,7 @@ postgresql_dbs:
         django_alias: p1
         django_migrate: true
         host: hqdb1.internal-va.commcarehq.org
+        pgbouncer_host: hqdb1.internal-va.commcarehq.org
         name: commcarehq_p1
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -125,6 +136,7 @@ postgresql_dbs:
         django_alias: p2
         django_migrate: true
         host: hqdb1.internal-va.commcarehq.org
+        pgbouncer_host: hqdb1.internal-va.commcarehq.org
         name: commcarehq_p2
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -137,6 +149,7 @@ postgresql_dbs:
         django_alias: p3
         django_migrate: true
         host: hqdb2.internal-va.commcarehq.org
+        pgbouncer_host: hqdb2.internal-va.commcarehq.org
         name: commcarehq_p3
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -149,6 +162,7 @@ postgresql_dbs:
         django_alias: p4
         django_migrate: true
         host: hqdb2.internal-va.commcarehq.org
+        pgbouncer_host: hqdb2.internal-va.commcarehq.org
         name: commcarehq_p4
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -161,6 +175,7 @@ postgresql_dbs:
         django_alias: p5
         django_migrate: true
         host: hqdb2.internal-va.commcarehq.org
+        pgbouncer_host: hqdb2.internal-va.commcarehq.org
         name: commcarehq_p5
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -173,6 +188,7 @@ postgresql_dbs:
       django_alias: proxy
       django_migrate: true
       host: hqdb1.internal-va.commcarehq.org
+      pgbouncer_host: hqdb1.internal-va.commcarehq.org
       name: commcarehq_proxy
       options: {}
       password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -184,6 +200,7 @@ postgresql_dbs:
     django_alias: null
     django_migrate: true
     host: hqdb0.internal-va.commcarehq.org
+    pgbouncer_host: hqdb0.internal-va.commcarehq.org
     name: formplayer
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -195,6 +212,7 @@ postgresql_dbs:
     django_alias: default
     django_migrate: true
     host: hqdb0.internal-va.commcarehq.org
+    pgbouncer_host: hqdb0.internal-va.commcarehq.org
     name: commcarehq
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -207,6 +225,7 @@ postgresql_dbs:
     django_alias: synclogs
     django_migrate: true
     host: pgsynclog.internal-va.commcarehq.org
+    pgbouncer_host: pgsynclog.internal-va.commcarehq.org
     name: commcarehq_synclogs
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -218,6 +237,7 @@ postgresql_dbs:
     django_alias: ucr
     django_migrate: false
     host: hqdb0.internal-va.commcarehq.org
+    pgbouncer_host: hqdb0.internal-va.commcarehq.org
     name: commcarehq_ucr
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'

--- a/tests/postgresql_config/2018-04-04-softlayer-snapshot/.generated.yml
+++ b/tests/postgresql_config/2018-04-04-softlayer-snapshot/.generated.yml
@@ -4,6 +4,7 @@ postgresql_dbs:
     django_alias: default
     django_migrate: true
     host: 10.162.36.205
+    pgbouncer_host: 10.162.36.205
     name: commcarehq
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -14,6 +15,7 @@ postgresql_dbs:
     django_alias: p1
     django_migrate: true
     host: 10.162.36.205
+    pgbouncer_host: 10.162.36.205
     name: commcarehq_p1
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -25,6 +27,7 @@ postgresql_dbs:
     django_alias: p2
     django_migrate: true
     host: 10.162.36.205
+    pgbouncer_host: 10.162.36.205
     name: commcarehq_p2
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -36,6 +39,7 @@ postgresql_dbs:
     django_alias: p3
     django_migrate: true
     host: 10.162.36.205
+    pgbouncer_host: 10.162.36.205
     name: commcarehq_p3
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -47,6 +51,7 @@ postgresql_dbs:
     django_alias: p4
     django_migrate: true
     host: 10.162.36.205
+    pgbouncer_host: 10.162.36.205
     name: commcarehq_p4
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -58,6 +63,7 @@ postgresql_dbs:
     django_alias: p5
     django_migrate: true
     host: 10.162.36.205
+    pgbouncer_host: 10.162.36.205
     name: commcarehq_p5
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -69,6 +75,7 @@ postgresql_dbs:
     django_alias: proxy
     django_migrate: true
     host: 10.162.36.205
+    pgbouncer_host: 10.162.36.205
     name: commcarehq_proxy
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -79,6 +86,7 @@ postgresql_dbs:
     django_alias: synclogs
     django_migrate: true
     host: 10.162.36.205
+    pgbouncer_host: 10.162.36.205
     name: commcarehq_synclogs
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -89,6 +97,7 @@ postgresql_dbs:
     django_alias: ucr
     django_migrate: true
     host: 10.162.36.205
+    pgbouncer_host: 10.162.36.205
     name: commcarehq_ucr
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -99,6 +108,7 @@ postgresql_dbs:
     django_alias: null
     django_migrate: true
     host: 10.162.36.205
+    pgbouncer_host: 10.162.36.205
     name: formplayer
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -109,6 +119,7 @@ postgresql_dbs:
     django_alias: icds-ucr
     django_migrate: true
     host: 10.162.36.205
+    pgbouncer_host: 10.162.36.205
     name: icds-ucr
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -120,6 +131,7 @@ postgresql_dbs:
     django_alias: icds-ucr
     django_migrate: true
     host: 10.162.36.205
+    pgbouncer_host: 10.162.36.205
     name: icds-ucr
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -133,6 +145,7 @@ postgresql_dbs:
         django_alias: p1
         django_migrate: true
         host: 10.162.36.205
+        pgbouncer_host: 10.162.36.205
         name: commcarehq_p1
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -145,6 +158,7 @@ postgresql_dbs:
         django_alias: p2
         django_migrate: true
         host: 10.162.36.205
+        pgbouncer_host: 10.162.36.205
         name: commcarehq_p2
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -157,6 +171,7 @@ postgresql_dbs:
         django_alias: p3
         django_migrate: true
         host: 10.162.36.205
+        pgbouncer_host: 10.162.36.205
         name: commcarehq_p3
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -169,6 +184,7 @@ postgresql_dbs:
         django_alias: p4
         django_migrate: true
         host: 10.162.36.205
+        pgbouncer_host: 10.162.36.205
         name: commcarehq_p4
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -181,6 +197,7 @@ postgresql_dbs:
         django_alias: p5
         django_migrate: true
         host: 10.162.36.205
+        pgbouncer_host: 10.162.36.205
         name: commcarehq_p5
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -193,6 +210,7 @@ postgresql_dbs:
       django_alias: proxy
       django_migrate: true
       host: 10.162.36.205
+      pgbouncer_host: 10.162.36.205
       name: commcarehq_proxy
       options: {}
       password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -204,6 +222,7 @@ postgresql_dbs:
     django_alias: null
     django_migrate: true
     host: 10.162.36.205
+    pgbouncer_host: 10.162.36.205
     name: formplayer
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -215,6 +234,7 @@ postgresql_dbs:
     django_alias: default
     django_migrate: true
     host: 10.162.36.205
+    pgbouncer_host: 10.162.36.205
     name: commcarehq
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -227,6 +247,7 @@ postgresql_dbs:
     django_alias: synclogs
     django_migrate: true
     host: 10.162.36.205
+    pgbouncer_host: 10.162.36.205
     name: commcarehq_synclogs
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -238,6 +259,7 @@ postgresql_dbs:
     django_alias: ucr
     django_migrate: true
     host: 10.162.36.205
+    pgbouncer_host: 10.162.36.205
     name: commcarehq_ucr
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'

--- a/tests/postgresql_config/2018-04-04-staging-snapshot/.generated.yml
+++ b/tests/postgresql_config/2018-04-04-staging-snapshot/.generated.yml
@@ -4,6 +4,7 @@ postgresql_dbs:
     django_alias: default
     django_migrate: true
     host: hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_host: hqdb1-staging.internal-va.commcarehq.org
     name: commcarehq
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -14,6 +15,7 @@ postgresql_dbs:
     django_alias: p1
     django_migrate: true
     host: hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_host: hqdb1-staging.internal-va.commcarehq.org
     name: commcarehq_p1
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -25,6 +27,7 @@ postgresql_dbs:
     django_alias: p2
     django_migrate: true
     host: hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_host: hqdb1-staging.internal-va.commcarehq.org
     name: commcarehq_p2
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -36,6 +39,7 @@ postgresql_dbs:
     django_alias: p3
     django_migrate: true
     host: hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_host: hqdb1-staging.internal-va.commcarehq.org
     name: commcarehq_p3
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -47,6 +51,7 @@ postgresql_dbs:
     django_alias: p4
     django_migrate: true
     host: hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_host: hqdb1-staging.internal-va.commcarehq.org
     name: commcarehq_p4
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -58,6 +63,7 @@ postgresql_dbs:
     django_alias: p5
     django_migrate: true
     host: hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_host: hqdb1-staging.internal-va.commcarehq.org
     name: commcarehq_p5
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -69,6 +75,7 @@ postgresql_dbs:
     django_alias: proxy
     django_migrate: true
     host: hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_host: hqdb1-staging.internal-va.commcarehq.org
     name: commcarehq_proxy
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -79,6 +86,7 @@ postgresql_dbs:
     django_alias: synclogs
     django_migrate: true
     host: hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_host: hqdb1-staging.internal-va.commcarehq.org
     name: commcarehq_synclogs
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -89,6 +97,7 @@ postgresql_dbs:
     django_alias: ucr
     django_migrate: false
     host: hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_host: hqdb1-staging.internal-va.commcarehq.org
     name: commcarehq_ucr
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -99,6 +108,7 @@ postgresql_dbs:
     django_alias: null
     django_migrate: true
     host: hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_host: hqdb1-staging.internal-va.commcarehq.org
     name: formplayer
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -113,6 +123,7 @@ postgresql_dbs:
         django_alias: p1
         django_migrate: true
         host: hqdb1-staging.internal-va.commcarehq.org
+        pgbouncer_host: hqdb1-staging.internal-va.commcarehq.org
         name: commcarehq_p1
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -125,6 +136,7 @@ postgresql_dbs:
         django_alias: p2
         django_migrate: true
         host: hqdb1-staging.internal-va.commcarehq.org
+        pgbouncer_host: hqdb1-staging.internal-va.commcarehq.org
         name: commcarehq_p2
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -137,6 +149,7 @@ postgresql_dbs:
         django_alias: p3
         django_migrate: true
         host: hqdb1-staging.internal-va.commcarehq.org
+        pgbouncer_host: hqdb1-staging.internal-va.commcarehq.org
         name: commcarehq_p3
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -149,6 +162,7 @@ postgresql_dbs:
         django_alias: p4
         django_migrate: true
         host: hqdb1-staging.internal-va.commcarehq.org
+        pgbouncer_host: hqdb1-staging.internal-va.commcarehq.org
         name: commcarehq_p4
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -161,6 +175,7 @@ postgresql_dbs:
         django_alias: p5
         django_migrate: true
         host: hqdb1-staging.internal-va.commcarehq.org
+        pgbouncer_host: hqdb1-staging.internal-va.commcarehq.org
         name: commcarehq_p5
         options: {}
         password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -173,6 +188,7 @@ postgresql_dbs:
       django_alias: proxy
       django_migrate: true
       host: hqdb1-staging.internal-va.commcarehq.org
+      pgbouncer_host: hqdb1-staging.internal-va.commcarehq.org
       name: commcarehq_proxy
       options: {}
       password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -184,6 +200,7 @@ postgresql_dbs:
     django_alias: null
     django_migrate: true
     host: hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_host: hqdb1-staging.internal-va.commcarehq.org
     name: formplayer
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -195,6 +212,7 @@ postgresql_dbs:
     django_alias: default
     django_migrate: true
     host: hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_host: hqdb1-staging.internal-va.commcarehq.org
     name: commcarehq
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -207,6 +225,7 @@ postgresql_dbs:
     django_alias: synclogs
     django_migrate: true
     host: hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_host: hqdb1-staging.internal-va.commcarehq.org
     name: commcarehq_synclogs
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -218,6 +237,7 @@ postgresql_dbs:
     django_alias: ucr
     django_migrate: false
     host: hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_host: hqdb1-staging.internal-va.commcarehq.org
     name: commcarehq_ucr
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'

--- a/tests/postgresql_config/2018-04-04-swiss-snapshot/.generated.yml
+++ b/tests/postgresql_config/2018-04-04-swiss-snapshot/.generated.yml
@@ -4,6 +4,7 @@ postgresql_dbs:
     django_alias: default
     django_migrate: true
     host: 127.0.0.1
+    pgbouncer_host: 127.0.0.1
     name: commcarehq
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -14,6 +15,7 @@ postgresql_dbs:
     django_alias: synclogs
     django_migrate: true
     host: 127.0.0.1
+    pgbouncer_host: 127.0.0.1
     name: commcarehq_synclogs
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -24,6 +26,7 @@ postgresql_dbs:
     django_alias: ucr
     django_migrate: false
     host: 127.0.0.1
+    pgbouncer_host: 127.0.0.1
     name: commcarehq_ucr
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -34,6 +37,7 @@ postgresql_dbs:
     django_alias: null
     django_migrate: true
     host: 127.0.0.1
+    pgbouncer_host: 127.0.0.1
     name: formplayer
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -47,6 +51,7 @@ postgresql_dbs:
     django_alias: null
     django_migrate: true
     host: 127.0.0.1
+    pgbouncer_host: 127.0.0.1
     name: formplayer
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -58,6 +63,7 @@ postgresql_dbs:
     django_alias: default
     django_migrate: true
     host: 127.0.0.1
+    pgbouncer_host: 127.0.0.1
     name: commcarehq
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -70,6 +76,7 @@ postgresql_dbs:
     django_alias: synclogs
     django_migrate: true
     host: 127.0.0.1
+    pgbouncer_host: 127.0.0.1
     name: commcarehq_synclogs
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'
@@ -81,6 +88,7 @@ postgresql_dbs:
     django_alias: ucr
     django_migrate: false
     host: 127.0.0.1
+    pgbouncer_host: 127.0.0.1
     name: commcarehq_ucr
     options: {}
     password: '{{ secrets.POSTGRES_USERS.commcare.password }}'


### PR DESCRIPTION
I tried or thought about a couple different approaches, and this seemed to be by a good margin the simplest. Basically there's a new `pgbouncer_host` option on each db, and it defaults to the same machine; throughout where looking up what host to access a db on, we'll now look at `pgbouncer_host` instead of `host`. On envs we're not changing, this should create no diff.

~Haven't yet been able to test this against staging (bad internet), but should be ready for review of the concept.~