### PR TITLE
Rearrange how dbs map to rds instances

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -234,19 +234,19 @@ proxy_servers:
 
 
 rds_instances:
-  - identifier: "pg0"
+  - identifier: "pg0-production"
     instance_type: "db.t2.xlarge"
     storage: 500
-  - identifier: "pg1"
+  - identifier: "pg1-production"
     instance_type: "db.t2.xlarge"
     storage: 500
-  - identifier: "pg3"
+  - identifier: "pg3-production"
     instance_type: "db.t2.xlarge"
     storage: 500
-  - identifier: "pg5"
+  - identifier: "pg5-production"
     instance_type: "db.t2.2xlarge"
     storage: 500
-  - identifier: "pgsynclog1"
+  - identifier: "pgsynclog1-production"
     instance_type: "db.t2.large"
     storage: 1000
 

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -234,19 +234,32 @@ proxy_servers:
 
 
 rds_instances:
-  - identifier: "pg0-production"
+  - identifier: "pgmain0-production"  # replaces old hqdb0
     instance_type: "db.t2.xlarge"
     storage: 500
-  - identifier: "pg1-production"
+  - identifier: "pgucr0-production"  # replaces old hqdb3
     instance_type: "db.t2.xlarge"
     storage: 500
-  - identifier: "pg3-production"
-    instance_type: "db.t2.xlarge"
-    storage: 500
-  - identifier: "pg5-production"
-    instance_type: "db.t2.2xlarge"
-    storage: 500
-  - identifier: "pgsynclog1-production"
+
+  # replace old hqdb1, hqdb5
+  - identifier: "pgshard1-production"
+    instance_type: "db.t2.large"
+    storage: 250
+  - identifier: "pgshard2-production"
+    instance_type: "db.t2.large"
+    storage: 250
+  - identifier: "pgshard3-production"
+    instance_type: "db.t2.large"
+    storage: 250
+  - identifier: "pgshard4-production"
+    instance_type: "db.t2.large"
+    storage: 250
+  - identifier: "pgshard5-production"
+    instance_type: "db.t2.large"
+    storage: 250
+
+  # replaces old pgsynclog1
+  - identifier: "pgsynclog0-production"
     instance_type: "db.t2.large"
     storage: 1000
 

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -240,9 +240,6 @@ rds_instances:
   - identifier: "pg1"
     instance_type: "db.t2.xlarge"
     storage: 500
-  - identifier: "pg2"
-    instance_type: "db.t2.xlarge"
-    storage: 500
   - identifier: "pg3"
     instance_type: "db.t2.xlarge"
     storage: 500


### PR DESCRIPTION
I discussed with @snopoke and he pointed out it'd be good to have one shard per db. I sized the each shard to be ~half the size of current hqdb1, which makes sense because hqdb2 has two partitions. Since hqdb5 is 2x hqdb1 but had 3 partitions, it's currently uneven, but after this change each partion will have the same amount of resources dedicated to it, and on average slightly more than now.