### PR TITLE
Make our RDS postgresql param support more complete

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -262,6 +262,11 @@ rds_instances:
   - identifier: "pgsynclog0-production"
     instance_type: "db.t2.large"
     storage: 1000
+    params:
+      work_mem: 2457kB
+      shared_buffers: 3840MB
+      effective_cache_size: 11520MB
+      maintenance_work_mem: 960MB
 
 redis:
   create: no

--- a/src/commcare_cloud/commands/terraform/postgresql_units.py
+++ b/src/commcare_cloud/commands/terraform/postgresql_units.py
@@ -1,0 +1,113 @@
+import re
+
+import six
+
+
+class Bytes(int):
+    pass
+
+
+class TimeInMilliseconds(int):
+    pass
+
+
+BYTE = Bytes(1)
+KB = Bytes(1024 * BYTE)
+MB = Bytes(1024 * KB)
+GB = Bytes(1024 * MB)
+# Postgres measures some things in terms of number of 8-kB blocks
+BLOCK_8KB = Bytes(8 * KB)
+
+MS = TimeInMilliseconds(1)
+SECOND = TimeInMilliseconds(1000 * MS)
+MINUTE = TimeInMilliseconds(60 * SECOND)
+
+UNITS = {
+    'kB': KB,
+    'MB': MB,
+    'GB': GB,
+    'ms': MS,
+    's': SECOND,
+    'm': MINUTE,
+}
+
+UNITS_BY_PARAM = {
+    'effective_cache_size': BLOCK_8KB,
+    'segment_size': BLOCK_8KB,
+    'shared_buffers': BLOCK_8KB,
+    'temp_buffers': BLOCK_8KB,
+    'wal_buffers': BLOCK_8KB,
+    'wal_segment_size': BLOCK_8KB,
+    'log_rotation_size': KB,
+    'log_temp_files': KB,
+    'maintenance_work_mem': KB,
+    'max_stack_depth': KB,
+    'ssl_renegotiation_limit': KB,
+    'temp_file_limit': KB,
+    'work_mem': KB,
+    'log_rotation_age': MINUTE,
+    'autovacuum_vacuum_cost_delay': MS,
+    'bgwriter_delay': MS,
+    'deadlock_timeout': MS,
+    'lock_timeout': MS,
+    'log_autovacuum_min_duration': MS,
+    'log_min_duration_statement': MS,
+    'max_standby_archive_delay': MS,
+    'max_standby_streaming_delay': MS,
+    'statement_timeout': MS,
+    'vacuum_cost_delay': MS,
+    'wal_receiver_timeout': MS,
+    'wal_sender_timeout': MS,
+    'wal_writer_delay': MS,
+    'archive_timeout': SECOND,
+    'authentication_timeout': SECOND,
+    'autovacuum_naptime': SECOND,
+    'checkpoint_timeout': SECOND,
+    'checkpoint_warning': SECOND,
+    'post_auth_delay': SECOND,
+    'pre_auth_delay': SECOND,
+    'tcp_keepalives_idle': SECOND,
+    'tcp_keepalives_interval': SECOND,
+    'wal_receiver_status_interval': SECOND,
+}
+
+
+def convert_to_unit(value, new_unit):
+    # type: (object, object) -> object
+    """
+    Converts string containing unit to integer measuring quantity in new unit
+
+    >>> convert_to_unit('1m', SECOND)
+    60
+    """
+    match = re.match(r'^(?P<number>\d+) *(?P<unit>\w+)$', value)
+    if match is None:
+        raise ValueError(
+            "Values must be given in '<int> <unit>' format (space optional): {}"
+            .format(value)
+        )
+    number_str, unit_str = match.groups()
+    number = int(number_str)
+    unit = UNITS[unit_str]
+
+    # make sure the units are for the same quantity (time / bytes):
+    if type(unit) != type(new_unit):
+        raise ValueError("{} can't be measured as unit {}"
+                         .format(value, type(new_unit).__name__))
+
+    # Unit arithmetic: number * unit = x * new_unit
+    # So: x = number * unit / new_unit
+    return number * unit / new_unit
+
+
+def convert_to_standard_unit(param, value):
+    if param not in UNITS_BY_PARAM:
+        return value
+    elif isinstance(value, six.integer_types):
+        return value
+    else:
+        try:
+            return convert_to_unit(value, new_unit=UNITS_BY_PARAM[param])
+        except ValueError as e:
+            e.message += " ({})".format(param)
+            raise

--- a/src/commcare_cloud/commands/terraform/templates/postgresql.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/postgresql.tf.j2
@@ -14,7 +14,7 @@ module "postgresql__{{ rds_instance.identifier }}" {
     port = {{ rds_instance.port|tojson }}
   }
   parameters = [
-    {%- for param in postgresql_params %}
+    {%- for param in postgresql_params[rds_instance.identifier] %}
     {
       name = {{ param.name|tojson }}
       value = {{ param.value|tojson }}

--- a/src/commcare_cloud/commands/terraform/terraform.py
+++ b/src/commcare_cloud/commands/terraform/terraform.py
@@ -85,30 +85,42 @@ class UnauthorizedUser(Exception):
         self.username = username
 
 
-def get_postgresql_params(environment):
+def format_param_for_terraform(param_name, param_value):
+    return {
+        'name': param_name,
+        'value': param_value,
+        # Anything listed as "dynamic" in
+        #   https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.PostgreSQL.CommonDBATasks.html
+        # will be applied *immediately*, ignoring this flag. See:
+        #   https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithParamGroups.html
+        'apply_method': 'pending-reboot'
+    }
+
+
+def get_postgresql_params_by_rds_instance(environment):
     """
-    Returns postgresql parameters as accepted by terraform
+    Returns a map from rds_instance identifier to postgresql parameters as accepted by terraform
 
     See aws db_parameter_group "parameter" argument.
     """
     postgresql_variables = get_role_defaults('postgresql')
     postgresql_variables.update(environment.postgresql_config.override)
-    param_values = {
+    environment_default_params = {
         'max_connections': postgresql_variables['postgresql_max_connections'],
     }
-    params_for_terraform = []
-    for param_name, param_value in param_values.items():
-        params_for_terraform.append({
-            'name': param_name,
-            'value': param_value,
-            # Anything listed as "dynamic" in
-            #   https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.PostgreSQL.CommonDBATasks.html
-            # will be applied *immediately*, ignoring this flag. See:
-            #   https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithParamGroups.html
-            'apply_method': 'pending-reboot'
-        })
-    return params_for_terraform
-
+    rds_instance_to_params = {}
+    for rds_instance in environment.terraform_config.rds_instances:
+        param_names = set(environment_default_params.keys()) | set(rds_instance.params.keys())
+        combined_params = {
+            param_name: (rds_instance.params[param_name] if param_name in rds_instance.params
+                         else environment_default_params[param_name])
+            for param_name in param_names
+        }
+        rds_instance_to_params[rds_instance.identifier] = [
+            format_param_for_terraform(param_name, param_value)
+            for param_name, param_value in combined_params.items()
+        ]
+    return rds_instance_to_params
 
 
 def generate_terraform_entrypoint(environment, key_name, run_dir):
@@ -122,7 +134,7 @@ def generate_terraform_entrypoint(environment, key_name, run_dir):
             'public_key': environment.get_authorized_key(username)
         } for username in environment.users_config.dev_users.present],
         'key_name': key_name,
-        'postgresql_params': get_postgresql_params(environment)
+        'postgresql_params': get_postgresql_params_by_rds_instance(environment)
     })
     template_root = os.path.join(os.path.dirname(__file__), 'templates')
     for template_file, output_file in (

--- a/src/commcare_cloud/commands/terraform/terraform.py
+++ b/src/commcare_cloud/commands/terraform/terraform.py
@@ -9,6 +9,7 @@ from six.moves import shlex_quote
 
 from commcare_cloud.cli_utils import print_command
 from commcare_cloud.commands.command_base import CommandBase, Argument
+from commcare_cloud.commands.terraform import postgresql_units
 from commcare_cloud.commands.terraform.aws import aws_sign_in, get_default_username, \
     print_help_message_about_the_commcare_cloud_default_username_env_var
 from commcare_cloud.commands.utils import render_template
@@ -88,7 +89,7 @@ class UnauthorizedUser(Exception):
 def format_param_for_terraform(param_name, param_value):
     return {
         'name': param_name,
-        'value': param_value,
+        'value': postgresql_units.convert_to_standard_unit(param_name, param_value),
         # Anything listed as "dynamic" in
         #   https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.PostgreSQL.CommonDBATasks.html
         # will be applied *immediately*, ignoring this flag. See:

--- a/src/commcare_cloud/commands/terraform/tests/test_postgresql_units.py
+++ b/src/commcare_cloud/commands/terraform/tests/test_postgresql_units.py
@@ -1,0 +1,51 @@
+from nose.tools import assert_equal, assert_raises
+from parameterized.test import assert_contains
+
+from commcare_cloud.commands.terraform.postgresql_units import convert_to_unit, SECOND, \
+    BLOCK_8KB, MS, convert_to_standard_unit
+
+
+def test_convert_to_unit__time():
+    # 1 minute is 60 seconds
+    assert_equal(convert_to_unit('1m', SECOND), 60)
+    assert_equal(convert_to_unit('1 m', SECOND), 60)
+
+
+def test_convert_to_unit__bytes():
+    # 12 GB is 12 * 1024 * 1024 / 8 "8kB blocks" = 1572864 "8kB blocks"
+    assert_equal(convert_to_unit('12GB', BLOCK_8KB), 1572864)
+    assert_equal(convert_to_unit('12 GB', BLOCK_8KB), 1572864)
+
+
+def test_convert_to_unit__bad_input():
+    # number part must be an int
+    with assert_raises(ValueError) as context:
+        convert_to_unit('12.5 GB', BLOCK_8KB)
+    assert_contains(context.exception.message, '12.5 GB')
+
+
+def test_convert_to_unit__mixed_units():
+    with assert_raises(ValueError) as context:
+        convert_to_unit('1kB', MS)
+    assert_contains(context.exception.message, '1kB')
+    assert_contains(context.exception.message, 'TimeInMilliseconds')
+
+
+def test_convert_to_standard_unit__time():
+    # authentication_timeout is measured in seconds
+    assert_equal(convert_to_standard_unit('authentication_timeout', '1m'), 60)
+
+
+def test_convert_to_standard_unit__bytes():
+    # effective_cache_size is measured in 8kB blocks
+    # 11520MB = 11520 * 1024 / 8 "8kB blocks" = 1474560 "8kB blocks"
+    assert_equal(convert_to_standard_unit('effective_cache_size', '11520MB'), 1474560)
+
+
+def test_convert_to_standard_unit__mixed_units():
+    # authentication_timeout is measured in seconds
+    with assert_raises(ValueError) as context:
+        convert_to_standard_unit('authentication_timeout', '1kB')
+    assert_contains(context.exception.message, '1kB')
+    assert_contains(context.exception.message, 'TimeInMilliseconds')
+    assert_contains(context.exception.message, ' (authentication_timeout)')

--- a/src/commcare_cloud/environment/schemas/terraform.py
+++ b/src/commcare_cloud/environment/schemas/terraform.py
@@ -71,6 +71,7 @@ class RdsInstanceConfig(jsonobject.JsonObject):
     backup_retention = 30
     maintenance_window = "sat:08:27-sat:08:57"
     port = 5432
+    params = jsonobject.DictProperty()
 
 
 class RedisConfig(jsonobject.JsonObject):

--- a/src/commcare_cloud/environment/schemas/terraform.py
+++ b/src/commcare_cloud/environment/schemas/terraform.py
@@ -71,7 +71,6 @@ class RdsInstanceConfig(jsonobject.JsonObject):
     backup_retention = 30
     maintenance_window = "sat:08:27-sat:08:57"
     port = 5432
-    parameter_group_name = "default.postgres9.6"
 
 
 class RedisConfig(jsonobject.JsonObject):


### PR DESCRIPTION
- Now supports params for individual instances (rather than just environment-global ones)
- Now supports params that have a unit attached to them ("90MB", etc.) as opposed to just a simple int like max_connections
- Rolled it out to just one production rds instance to make sure it works for when we need in a theoretical firefighting situation (but not to all of them, because we're moving db-to-machine allocations around and I want to give RDS's "sensical" defaults a try on the new allocation first.)