### PR TITLE
Prepare for multi-az rds instances and test on staging

### DIFF
--- a/docs/commcare-cloud/commands/index.md
+++ b/docs/commcare-cloud/commands/index.md
@@ -1085,7 +1085,7 @@ Gives additional databases on the server.
 Run terraform for this env with the given arguments
 
 ```
-commcare-cloud <env> terraform [--skip-secrets] [--username USERNAME]
+commcare-cloud <env> terraform [--skip-secrets] [--apply-immediately] [--username USERNAME]
 ```
 
 ##### Optional Arguments
@@ -1095,6 +1095,13 @@ commcare-cloud <env> terraform [--skip-secrets] [--username USERNAME]
 Skip regenerating the secrets file.
 
 Good for not having to enter vault password again.
+
+###### `--apply-immediately`
+
+Apply immediately regardless fo the default.
+
+In RDS where the default is to apply in the next maintenance window,
+use this to apply immediately instead. This may result in a service interruption.
 
 ###### `--username USERNAME`
 

--- a/environments/staging/terraform.yml
+++ b/environments/staging/terraform.yml
@@ -122,6 +122,7 @@ rds_instances:
   - identifier: "pg0-staging"
     instance_type: "db.t2.large"
     storage: 160
+    multi_az: yes
 
 redis:
   create: no

--- a/environments/staging/terraform.yml
+++ b/environments/staging/terraform.yml
@@ -120,7 +120,7 @@ proxy_servers:
 
 rds_instances:
   - identifier: "pg0-staging"
-    instance_type: "db.t2.large"
+    instance_type: "db.t2.medium"
     storage: 160
     multi_az: yes
 

--- a/src/commcare_cloud/commands/terraform/templates/postgresql.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/postgresql.tf.j2
@@ -26,5 +26,6 @@ module "postgresql__{{ rds_instance.identifier }}" {
   subnet_ids = "${values(module.network.subnets-db-private)}"
   vpc_security_group_ids = ["${module.network.rds-sg}", "${module.network.vpn-connections-sg}"]
   create = "true"
+  apply_immediately = "{{ "true" if apply_immediately else "false" }}"
 }
 {%- endfor %}

--- a/src/commcare_cloud/commands/terraform/templates/postgresql.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/postgresql.tf.j2
@@ -5,6 +5,7 @@ module "postgresql__{{ rds_instance.identifier }}" {
     password = "${var.rds_password}"
     identifier = {{ rds_instance.identifier|tojson }}
     instance_type = {{ rds_instance.instance_type|tojson }}
+    multi_az = "{{ "true" if rds_instance.multi_az else "false" }}"
     storage = {{ rds_instance.storage|tojson }}
     create = {{ rds_instance.create|tojson }}
     username = {{ rds_instance.username|tojson }}

--- a/src/commcare_cloud/environment/schemas/terraform.py
+++ b/src/commcare_cloud/environment/schemas/terraform.py
@@ -64,6 +64,7 @@ class RdsInstanceConfig(jsonobject.JsonObject):
     _allow_dynamic_properties = False
     identifier = jsonobject.StringProperty(required=True)
     instance_type = jsonobject.StringProperty(required=True)  # should start with 'db.'
+    multi_az = jsonobject.BooleanProperty(default=False)
     storage = jsonobject.IntegerProperty()
     create = jsonobject.BooleanProperty(default=True)
     username = "root"

--- a/src/commcare_cloud/terraform/modules/postgresql/main.tf
+++ b/src/commcare_cloud/terraform/modules/postgresql/main.tf
@@ -22,6 +22,8 @@ module "postgresql" {
 
   deletion_protection = "true"
 
+  multi_az = "${var.rds_instance["multi_az"]}"
+
   iam_database_authentication_enabled = false
 
   vpc_security_group_ids = "${var.vpc_security_group_ids}"

--- a/src/commcare_cloud/terraform/modules/postgresql/main.tf
+++ b/src/commcare_cloud/terraform/modules/postgresql/main.tf
@@ -15,6 +15,8 @@ module "postgresql" {
   instance_class    = "${var.rds_instance["instance_type"]}"
   allocated_storage = "${var.rds_instance["storage"]}"
 
+  apply_immediately     = "${var.apply_immediately}"
+
   name     = ""
   username = "${var.rds_instance["username"]}"
   password = "${var.rds_instance["password"]}"

--- a/src/commcare_cloud/terraform/modules/postgresql/variables.tf
+++ b/src/commcare_cloud/terraform/modules/postgresql/variables.tf
@@ -15,3 +15,5 @@ variable "subnet_ids" {
 }
 
 variable "create" {}
+
+variable "apply_immediately" {}


### PR DESCRIPTION
Loading is faster with multi-az turned off, so I'm not going to turn on multi-az (essentially hot standby) on prod until after the migration. But I wanted to be ready to do so with the implications tested on staging.

Takeaways for the rollout:
- Turning on multi-az did put the RDS instance into a "Modifying..." state for a while, but didn't appear to cause any downtime.
- Once staging was on multi-az, I resized an instance to see what the downtime of that is. I didn't personally notice it just clicking around, but sentry reports a total of 3 postgresql errors coming from things that pummel it with routine queries like the `run_sms_queue` and pillowtop. So not perfect, but very limited service interruption for changing the instance type (i.e. changing RAM, CPU, etc.)