### PR TITLE
Revert "add tamil location"

### DIFF
--- a/environments/icds-cas/public.yml
+++ b/environments/icds-cas/public.yml
@@ -85,10 +85,6 @@ site_locations:
     try_files: "$uri $uri/index.html $uri/ =404"
     auth_basic: '"Restricted Content"'
     auth_basic_user_file: "/etc/nginx/.htpasswd_ls_telugu"
-  - name: /ls_tamil
-    try_files: "$uri $uri/index.html $uri/ =404"
-    auth_basic: '"Restricted Content"'
-    auth_basic_user_file: "/etc/nginx/.htpasswd_ls_tamil"
   - name: /hindi_files 
     try_files: "$uri $uri/index.html $uri/ =404"
     auth_basic: '"Restricted Content"'


### PR DESCRIPTION
Reverts dimagi/commcare-cloud#2460

Turns out this is not needed right now so should be removed. Leaving the httpassword file around so that this can be added back when needed.