### PR TITLE
Tune production RDS for pg_restore (revert after migration)

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -252,10 +252,10 @@ rds_instances:
     storage: 500
     backup_retention: 0
     params:
-      maintenance_work_mem: 500MB
-      min_wal_size: 160MB
-      max_wal_size: 512MB
-      checkpoint_timeout: 300
+      maintenance_work_mem: 2GB
+      min_wal_size: 4GB
+      max_wal_size: 8GB
+      checkpoint_timeout: 60m
       synchronous_commit: 'off'
       autovacuum: 0
   - identifier: "pgucr0-production"  # replaces old hqdb3
@@ -263,10 +263,10 @@ rds_instances:
     storage: 500
     backup_retention: 0
     params:
-      maintenance_work_mem: 500MB
-      min_wal_size: 160MB
-      max_wal_size: 512MB
-      checkpoint_timeout: 300
+      maintenance_work_mem: 2GB
+      min_wal_size: 4GB
+      max_wal_size: 8GB
+      checkpoint_timeout: 60m
       synchronous_commit: 'off'
       autovacuum: 0
 
@@ -276,10 +276,10 @@ rds_instances:
     storage: 250
     backup_retention: 0
     params:
-      maintenance_work_mem: 500MB
-      min_wal_size: 160MB
-      max_wal_size: 512MB
-      checkpoint_timeout: 300
+      maintenance_work_mem: 2GB
+      min_wal_size: 4GB
+      max_wal_size: 8GB
+      checkpoint_timeout: 60m
       synchronous_commit: 'off'
       autovacuum: 0
   - identifier: "pgshard2-production"
@@ -287,10 +287,10 @@ rds_instances:
     storage: 250
     backup_retention: 0
     params:
-      maintenance_work_mem: 500MB
-      min_wal_size: 160MB
-      max_wal_size: 512MB
-      checkpoint_timeout: 300
+      maintenance_work_mem: 2GB
+      min_wal_size: 4GB
+      max_wal_size: 8GB
+      checkpoint_timeout: 60m
       synchronous_commit: 'off'
       autovacuum: 0
   - identifier: "pgshard3-production"
@@ -298,10 +298,10 @@ rds_instances:
     storage: 250
     backup_retention: 0
     params:
-      maintenance_work_mem: 500MB
-      min_wal_size: 160MB
-      max_wal_size: 512MB
-      checkpoint_timeout: 300
+      maintenance_work_mem: 2GB
+      min_wal_size: 4GB
+      max_wal_size: 8GB
+      checkpoint_timeout: 60m
       synchronous_commit: 'off'
       autovacuum: 0
   - identifier: "pgshard4-production"
@@ -309,10 +309,10 @@ rds_instances:
     storage: 250
     backup_retention: 0
     params:
-      maintenance_work_mem: 500MB
-      min_wal_size: 160MB
-      max_wal_size: 512MB
-      checkpoint_timeout: 300
+      maintenance_work_mem: 2GB
+      min_wal_size: 4GB
+      max_wal_size: 8GB
+      checkpoint_timeout: 60m
       synchronous_commit: 'off'
       autovacuum: 0
   - identifier: "pgshard5-production"
@@ -320,10 +320,10 @@ rds_instances:
     storage: 250
     backup_retention: 0
     params:
-      maintenance_work_mem: 500MB
-      min_wal_size: 160MB
-      max_wal_size: 512MB
-      checkpoint_timeout: 300
+      maintenance_work_mem: 2GB
+      min_wal_size: 4GB
+      max_wal_size: 8GB
+      checkpoint_timeout: 60m
       synchronous_commit: 'off'
       autovacuum: 0
 
@@ -338,10 +338,10 @@ rds_instances:
 #      maintenance_work_mem: 960MB
     backup_retention: 0
     params:
-      maintenance_work_mem: 500MB
-      min_wal_size: 160MB
-      max_wal_size: 512MB
-      checkpoint_timeout: 300
+      maintenance_work_mem: 2GB
+      min_wal_size: 4GB
+      max_wal_size: 8GB
+      checkpoint_timeout: 60m
       synchronous_commit: 'off'
       autovacuum: 0
 

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -250,36 +250,100 @@ rds_instances:
   - identifier: "pgmain0-production"  # replaces old hqdb0
     instance_type: "db.t2.xlarge"
     storage: 500
+    backup_retention: 0
+    params:
+      maintenance_work_mem: 500MB
+      min_wal_size: 160MB
+      max_wal_size: 512MB
+      checkpoint_timeout: 300
+      synchronous_commit: 'off'
+      autovacuum: 0
   - identifier: "pgucr0-production"  # replaces old hqdb3
     instance_type: "db.t2.xlarge"
     storage: 500
+    backup_retention: 0
+    params:
+      maintenance_work_mem: 500MB
+      min_wal_size: 160MB
+      max_wal_size: 512MB
+      checkpoint_timeout: 300
+      synchronous_commit: 'off'
+      autovacuum: 0
 
   # replace old hqdb1, hqdb5
   - identifier: "pgshard1-production"
     instance_type: "db.t2.large"
     storage: 250
+    backup_retention: 0
+    params:
+      maintenance_work_mem: 500MB
+      min_wal_size: 160MB
+      max_wal_size: 512MB
+      checkpoint_timeout: 300
+      synchronous_commit: 'off'
+      autovacuum: 0
   - identifier: "pgshard2-production"
     instance_type: "db.t2.large"
     storage: 250
+    backup_retention: 0
+    params:
+      maintenance_work_mem: 500MB
+      min_wal_size: 160MB
+      max_wal_size: 512MB
+      checkpoint_timeout: 300
+      synchronous_commit: 'off'
+      autovacuum: 0
   - identifier: "pgshard3-production"
     instance_type: "db.t2.large"
     storage: 250
+    backup_retention: 0
+    params:
+      maintenance_work_mem: 500MB
+      min_wal_size: 160MB
+      max_wal_size: 512MB
+      checkpoint_timeout: 300
+      synchronous_commit: 'off'
+      autovacuum: 0
   - identifier: "pgshard4-production"
     instance_type: "db.t2.large"
     storage: 250
+    backup_retention: 0
+    params:
+      maintenance_work_mem: 500MB
+      min_wal_size: 160MB
+      max_wal_size: 512MB
+      checkpoint_timeout: 300
+      synchronous_commit: 'off'
+      autovacuum: 0
   - identifier: "pgshard5-production"
     instance_type: "db.t2.large"
     storage: 250
+    backup_retention: 0
+    params:
+      maintenance_work_mem: 500MB
+      min_wal_size: 160MB
+      max_wal_size: 512MB
+      checkpoint_timeout: 300
+      synchronous_commit: 'off'
+      autovacuum: 0
 
   # replaces old pgsynclog1
   - identifier: "pgsynclog0-production"
     instance_type: "db.t2.large"
     storage: 1000
+#    params:
+#      work_mem: 2457kB
+#      shared_buffers: 3840MB
+#      effective_cache_size: 11520MB
+#      maintenance_work_mem: 960MB
+    backup_retention: 0
     params:
-      work_mem: 2457kB
-      shared_buffers: 3840MB
-      effective_cache_size: 11520MB
-      maintenance_work_mem: 960MB
+      maintenance_work_mem: 500MB
+      min_wal_size: 160MB
+      max_wal_size: 512MB
+      checkpoint_timeout: 300
+      synchronous_commit: 'off'
+      autovacuum: 0
 
 redis:
   create: no


### PR DESCRIPTION
Follows https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_BestPractices.html#CHAP_BestPractices.PostgreSQL for what you should do to speed up a `pg_restore`