### PR TITLE
Revert "Tune production RDS for pg_restore (revert after migration)"

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -250,100 +250,36 @@ rds_instances:
   - identifier: "pgmain0-production"  # replaces old hqdb0
     instance_type: "db.t2.xlarge"
     storage: 500
-    backup_retention: 0
-    params:
-      maintenance_work_mem: 2GB
-      min_wal_size: 4GB
-      max_wal_size: 8GB
-      checkpoint_timeout: 60m
-      synchronous_commit: 'off'
-      autovacuum: 0
   - identifier: "pgucr0-production"  # replaces old hqdb3
     instance_type: "db.t2.xlarge"
     storage: 500
-    backup_retention: 0
-    params:
-      maintenance_work_mem: 2GB
-      min_wal_size: 4GB
-      max_wal_size: 8GB
-      checkpoint_timeout: 60m
-      synchronous_commit: 'off'
-      autovacuum: 0
 
   # replace old hqdb1, hqdb5
   - identifier: "pgshard1-production"
     instance_type: "db.t2.large"
     storage: 250
-    backup_retention: 0
-    params:
-      maintenance_work_mem: 2GB
-      min_wal_size: 4GB
-      max_wal_size: 8GB
-      checkpoint_timeout: 60m
-      synchronous_commit: 'off'
-      autovacuum: 0
   - identifier: "pgshard2-production"
     instance_type: "db.t2.large"
     storage: 250
-    backup_retention: 0
-    params:
-      maintenance_work_mem: 2GB
-      min_wal_size: 4GB
-      max_wal_size: 8GB
-      checkpoint_timeout: 60m
-      synchronous_commit: 'off'
-      autovacuum: 0
   - identifier: "pgshard3-production"
     instance_type: "db.t2.large"
     storage: 250
-    backup_retention: 0
-    params:
-      maintenance_work_mem: 2GB
-      min_wal_size: 4GB
-      max_wal_size: 8GB
-      checkpoint_timeout: 60m
-      synchronous_commit: 'off'
-      autovacuum: 0
   - identifier: "pgshard4-production"
     instance_type: "db.t2.large"
     storage: 250
-    backup_retention: 0
-    params:
-      maintenance_work_mem: 2GB
-      min_wal_size: 4GB
-      max_wal_size: 8GB
-      checkpoint_timeout: 60m
-      synchronous_commit: 'off'
-      autovacuum: 0
   - identifier: "pgshard5-production"
     instance_type: "db.t2.large"
     storage: 250
-    backup_retention: 0
-    params:
-      maintenance_work_mem: 2GB
-      min_wal_size: 4GB
-      max_wal_size: 8GB
-      checkpoint_timeout: 60m
-      synchronous_commit: 'off'
-      autovacuum: 0
 
   # replaces old pgsynclog1
   - identifier: "pgsynclog0-production"
     instance_type: "db.t2.large"
     storage: 1000
-#    params:
-#      work_mem: 2457kB
-#      shared_buffers: 3840MB
-#      effective_cache_size: 11520MB
-#      maintenance_work_mem: 960MB
-    backup_retention: 0
     params:
-      maintenance_work_mem: 2GB
-      min_wal_size: 4GB
-      max_wal_size: 8GB
-      checkpoint_timeout: 60m
-      synchronous_commit: 'off'
-      autovacuum: 0
+      work_mem: 2457kB
+      shared_buffers: 3840MB
+      effective_cache_size: 11520MB
+      maintenance_work_mem: 960MB
 
 redis:
   create: no


### PR DESCRIPTION
Reverts dimagi/commcare-cloud#2499

Return RDS settings back to normal after migration to RDS. (They were set to settings optimized for doing a `pg_restore` but probably inappropriate for normal suage, so reverting this afterwards was the plan all along.)