### PR TITLE
Remove unused webworkers and "rightsize" the rest

### DIFF
--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -27,15 +27,11 @@ hqproxy0
 [hq_webworkers:children]
 web0
 web1
-web2
 
 [mobile_webworkers:children]
 web6
 web7
 web8
-web9
-web10
-web11
 
 [webworkers:children]
 hq_webworkers

--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -14,9 +14,6 @@ hqproxy0
 [web1]
 10.202.10.84 hostname=web1-production ec2=yes datadog_integration_tcp_check=yes
 
-[web2]
-10.202.10.238 hostname=web2-production ec2=yes
-
 [web6]
 10.202.11.98 hostname=web6-production ec2=yes
 
@@ -25,15 +22,6 @@ hqproxy0
 
 [web8]
 10.202.11.30 hostname=web8-production ec2=yes
-
-[web9]
-10.202.11.197 hostname=web9-production ec2=yes
-
-[web10]
-10.202.11.188 hostname=web10-production ec2=yes
-
-[web11]
-10.202.11.153 hostname=web11-production ec2=yes
 
 
 [hq_webworkers:children]

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -27,15 +27,11 @@ hqproxy0
 [hq_webworkers:children]
 web0
 web1
-web2
 
 [mobile_webworkers:children]
 web6
 web7
 web8
-web9
-web10
-web11
 
 [webworkers:children]
 hq_webworkers

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -14,9 +14,6 @@ hqproxy0
 [web1]
 {{ web1-production }} hostname=web1-production ec2=yes datadog_integration_tcp_check=yes
 
-[web2]
-{{ web2-production }} hostname=web2-production ec2=yes
-
 [web6]
 {{ web6-production }} hostname=web6-production ec2=yes
 
@@ -25,15 +22,6 @@ hqproxy0
 
 [web8]
 {{ web8-production }} hostname=web8-production ec2=yes
-
-[web9]
-{{ web9-production }} hostname=web9-production ec2=yes
-
-[web10]
-{{ web10-production }} hostname=web10-production ec2=yes
-
-[web11]
-{{ web11-production }} hostname=web11-production ec2=yes
 
 
 [hq_webworkers:children]

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -53,21 +53,6 @@ servers:
     network_tier: "app-private"
     az: "a"
     volume_size: 40
-  - server_name: "web3-production"
-    server_instance_type: m5.2xlarge
-    network_tier: "app-private"
-    az: "a"
-    volume_size: 40
-  - server_name: "web4-production"
-    server_instance_type: m5.2xlarge
-    network_tier: "app-private"
-    az: "a"
-    volume_size: 40
-  - server_name: "web5-production"
-    server_instance_type: m5.2xlarge
-    network_tier: "app-private"
-    az: "a"
-    volume_size: 40
 
   - server_name: "web6-production"
     server_instance_type: m5.2xlarge

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -39,48 +39,28 @@ servers:
     volume_size: 80
 
   - server_name: "web0-production"
-    server_instance_type: m5.2xlarge
+    server_instance_type: r5.xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 40
   - server_name: "web1-production"
-    server_instance_type: m5.2xlarge
-    network_tier: "app-private"
-    az: "a"
-    volume_size: 40
-  - server_name: "web2-production"
-    server_instance_type: m5.2xlarge
+    server_instance_type: r5.xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 40
 
   - server_name: "web6-production"
-    server_instance_type: m5.2xlarge
+    server_instance_type: r5.xlarge
     network_tier: "app-private"
     az: "b"
     volume_size: 40
   - server_name: "web7-production"
-    server_instance_type: m5.2xlarge
+    server_instance_type: r5.xlarge
     network_tier: "app-private"
     az: "b"
     volume_size: 40
   - server_name: "web8-production"
-    server_instance_type: m5.2xlarge
-    network_tier: "app-private"
-    az: "b"
-    volume_size: 40
-  - server_name: "web9-production"
-    server_instance_type: m5.2xlarge
-    network_tier: "app-private"
-    az: "b"
-    volume_size: 40
-  - server_name: "web10-production"
-    server_instance_type: m5.2xlarge
-    network_tier: "app-private"
-    az: "b"
-    volume_size: 40
-  - server_name: "web11-production"
-    server_instance_type: m5.2xlarge
+    server_instance_type: r5.xlarge
     network_tier: "app-private"
     az: "b"
     volume_size: 40


### PR DESCRIPTION
I'd originally made webworkers absurdly large to rule out resource scarcity as a cause during firefighting of Oct slowness. After looking at the eye-popping numbers from Nov, I think it's time to go back to a reasonable size. Rolling these changes out will save us $1,600/mo. (The first commit just removes machines that were already stopped, so it doesn't affect anything—performance or price.)

From looking at datadog graphs (https://app.datadoghq.com/dash/510484/host-groups?tile_size=m&page=0&is_auto=false&from_ts=1541937600000&to_ts=1544529600000&live=true&tpl_var_host_group=webworkers), I made some estimates about peak resource usage on the two webworker types, and settled on the following:

hq_webworkers: 33% the CPU, 67% the RAM
mobile_webworkers: 25% the CPU, 50% the RAM

m5.2xlarge (old) and r5.xlarge (new) both have 32GB RAM, but r5.xlarge has half the CPU (4 instead of 8). Also going from 3 to 2 hq_webworkers and 6 to 3 mobile_webworkers.