### PR TITLE
Increase CPU on production webworkers

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -39,28 +39,28 @@ servers:
     volume_size: 80
 
   - server_name: "web0-production"
-    server_instance_type: r5.xlarge
+    server_instance_type: m5.2xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 40
   - server_name: "web1-production"
-    server_instance_type: r5.xlarge
+    server_instance_type: m5.2xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 40
 
   - server_name: "web6-production"
-    server_instance_type: r5.xlarge
+    server_instance_type: m5.2xlarge
     network_tier: "app-private"
     az: "b"
     volume_size: 40
   - server_name: "web7-production"
-    server_instance_type: r5.xlarge
+    server_instance_type: m5.2xlarge
     network_tier: "app-private"
     az: "b"
     volume_size: 40
   - server_name: "web8-production"
-    server_instance_type: r5.xlarge
+    server_instance_type: m5.2xlarge
     network_tier: "app-private"
     az: "b"
     volume_size: 40


### PR DESCRIPTION
CPU on the new machines is too low: 
https://app.datadoghq.com/dash/510484/host-groups?screenId=510484&screenName=host-groups&from_ts=1544617920000&is_auto=false&live=true&page=0&tile_size=m&to_ts=1544632320000&tpl_var_environment=production&tpl_var_host_group=webworkers&fullscreen_widget=380325265

Once approved, I'll roll out the changes one by one and then merge this in.

@dannyroberts @snopoke 