### PR TITLE
Change openvpn server from t2 to t3 instance class

### DIFF
--- a/src/commcare_cloud/commands/terraform/templates/variables.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/variables.tf.j2
@@ -14,7 +14,7 @@ variable "openvpn_image" {
   default = ""  # will be auto-assigned by openvpn module if not set
 }
 variable "openvpn_instance_type" {
-  default = "t2.small"
+  default = "t3.small"
 }
 variable "server_image" {
   default = "ami-07cf43e1798df5582"


### PR DESCRIPTION
Rolling this out will result in downtime for the VPN entry point machine as it stops and starts.

Will run for staging first after alerting #staging. If that goes well (can still log onto the staging vpn and access staging machines, etc.) then will alert #web-team and roll out at a time when few devs are likely to be using the VPN.