### PR TITLE
Move this line to the bottom of the file so it doesn't get overwritten

### DIFF
--- a/src/commcare_cloud/ansible/roles/bootstrap-users/templates/sudoers.j2
+++ b/src/commcare_cloud/ansible/roles/bootstrap-users/templates/sudoers.j2
@@ -23,7 +23,6 @@ Cmnd_Alias UPSTART = /sbin/stop, /sbin/start, /sbin/initctl
 Cmnd_Alias HQCOMMANDS = PACKAGES, GIT, PYTHON, SUPERVISORD, CHOWN_CONF, CHMOD_CONF, MV_CONF, UPSTART, NGINX
 
 HIPAA_USERS ALL = (root) ALL
-{{ cchq_user }}    ALL = (ALL) NOPASSWD: HQCOMMANDS
 
 HIPAA_ACTOR ALL = (ALL) ALL
 HIPAA_USERS ALL = (HIPAA_ACTOR) NOPASSWD: ALL
@@ -40,3 +39,5 @@ root    ALL=(ALL:ALL) ALL
 
 # https://help.ubuntu.com/community/EnvironmentVariables#sudo_caveat
 Defaults env_keep += "http_proxy https_proxy HTTP_PROXY HTTPS_PROXY no_proxy NO_PROXY"
+
+{{ cchq_user }}    ALL = (ALL) NOPASSWD: HQCOMMANDS


### PR DESCRIPTION
This solves an issue that was seen in the echis domain. They had the `cchq` user in the `sudo` user group, so the `{{ cchq_user }}    ALL = (ALL) NOPASSWD: HQCOMMANDS` line was overwritten by a different line, and various sudo commands did not work for the cchq user that should have worked.

@dannyroberts @calellowitz 