### PR TITLE
Make cert new cron job reload nginx after renewing

### DIFF
--- a/changelog/0010-letsencrypt-restart-nginx.yml
+++ b/changelog/0010-letsencrypt-restart-nginx.yml
@@ -1,0 +1,27 @@
+title: Restart nginx after every letsencrypt cert auto-renewal
+key: letsencrypt-restart-nginx
+date: 2019-01-02
+
+optional_per_env: yes
+
+min_commcare_version:
+max_commcare_version:
+
+context: |
+  Previously you had to manually restart nginx every time letsencrypt auto-renewed,
+  which was about every two months.
+
+details: |
+  This migration applies an update to the cron job that triggers renewing the letsencrypt cert,
+  that makes it also restart nginx directly after renewing.
+  This makes the cert renewal process completely automatic
+  so that staying on an up-to-date cert indefinitely
+  should no longer require human intervention.
+
+update_steps: |
+  To apply, simply run
+  ```
+  commcare-cloud <env> ansible-playbook deploy_proxy.yml
+  ```
+  using the latest version of commcare-cloud.
+  The change was introduced in https://github.com/dimagi/commcare-cloud/pull/2532.

--- a/docs/changelog/0010-letsencrypt-restart-nginx.md
+++ b/docs/changelog/0010-letsencrypt-restart-nginx.md
@@ -1,0 +1,28 @@
+# 10. Restart nginx after every letsencrypt cert auto-renewal
+
+**Date:** 2019-01-02
+
+**Optional per env:** Yes
+
+## CommCare Version Dependency
+This change is not known to be dependent on any particular version of CommCare.
+
+
+## Change Context
+Previously you had to manually restart nginx every time letsencrypt auto-renewed,
+which was about every two months.
+
+## Details
+This migration applies an update to the cron job that triggers renewing the letsencrypt cert,
+that makes it also restart nginx directly after renewing.
+This makes the cert renewal process completely automatic
+so that staying on an up-to-date cert indefinitely
+should no longer require human intervention.
+
+## Steps to update
+To apply, simply run
+```
+commcare-cloud <env> ansible-playbook deploy_proxy.yml
+```
+using the latest version of commcare-cloud.
+The change was introduced in https://github.com/dimagi/commcare-cloud/pull/2532.

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -11,6 +11,10 @@ an action on your part will be marked "_action optional_".
 
 ## Changelog
 
+### **2019-01-02** [Restart nginx after every letsencrypt cert auto-renewal](0010-letsencrypt-restart-nginx.md)
+Previously you had to manually restart nginx every time letsencrypt auto-renewed,
+which was about every two months.
+
 ### **2018-12-15** [Blob Metadata Migration - part 2](0009-blob-metadata-part-2.md) (_action required_)
 Form submission attachment metadata is being consolidated in the blob
 metadata table in SQL. This migration consists of a series of commands that

--- a/src/commcare_cloud/ansible/letsencrypt_cert.yml
+++ b/src/commcare_cloud/ansible/letsencrypt_cert.yml
@@ -73,19 +73,6 @@
         name: nginx
         state: reloaded
 
-    - name: Final instructions
-      pause:
-        prompt: |
-
-          Hello person who ran letsencrypt_cert.yml.
-
-          Now you just have to finalize things by
-            - making sure `fake_ssl_cert` is set to `no` (or is absent) in `proxy.yml`
-            - running `commcare-cloud <env> ansible-playbook deploy_proxy.yml`
-            - optionally, copying the important files from `proxy` `/etc/pki/tls/`
-              to an encrypted file in the environment settings.
-
-
     - name: Add certbot cron
       cron:
         name: "Certbot Renew"

--- a/src/commcare_cloud/ansible/letsencrypt_cert.yml
+++ b/src/commcare_cloud/ansible/letsencrypt_cert.yml
@@ -36,33 +36,17 @@
         group: www-data
       ignore_errors: '{{ ansible_check_mode }}'
 
-
-    - name: Reload Nginx
-      service:
-        name: nginx
-        state: reloaded
-
-
     - name: Check that a test page returns a status 200
       uri:
         url: 'https://{{SITE_HOST}}/.well-known/acme-challenge/test.txt'
         validate_certs: no
 
-    - name: 'Verify that there exists a certbot Directory /etc/letsencrypt/live/{{ SITE_HOST }}'
-      stat:
-        path: "/etc/letsencrypt/live/{{ SITE_HOST }}"
-      register: certdir
-
-    - name: 'Take Backup of /etc/letsencrypt/live/{{ SITE_HOST }} to /etc/letsencrypt/live/{{ SITE_HOST }}.back'
-      command: "mv /etc/letsencrypt/live/{{ SITE_HOST }} /etc/letsencrypt/live/{{ SITE_HOST }}.back"
-      when: certdir.stat.exists
-
     - name: Run Certbot command when there is a www host
-      command: 'certbot certonly --webroot -w /var/www/letsencrypt/ -m {{ root_email }} --agree-tos -d {{SITE_HOST}} -d {{ NO_WWW_SITE_HOST }}'
+      command: 'certbot certonly --webroot -w /var/www/letsencrypt/ -m {{ root_email }} --agree-tos -n -d {{SITE_HOST}} -d {{ NO_WWW_SITE_HOST }}'
       when: NO_WWW_SITE_HOST|bool
 
     - name: Run Certbot command when there is no www host
-      command: 'certbot certonly --webroot -w /var/www/letsencrypt/ -m {{ root_email }} --agree-tos -d {{SITE_HOST}}'
+      command: 'certbot certonly --webroot -w /var/www/letsencrypt/ -m {{ root_email }} --agree-tos -n -d {{SITE_HOST}}'
       when: not NO_WWW_SITE_HOST
 
     - name: 'Link Certificate /etc/pki/tls/certs/{{ deploy_env }}_nginx_combined.crt to /etc/letsencrypt/live/{{SITE_HOST}}/fullchain.pem'

--- a/src/commcare_cloud/ansible/letsencrypt_cert.yml
+++ b/src/commcare_cloud/ansible/letsencrypt_cert.yml
@@ -105,7 +105,7 @@
     - name: Add certbot cron
       cron:
         name: "Certbot Renew"
-        job: "test -x /usr/bin/certbot && perl -e 'sleep int(rand(3600))' && certbot -q renew"
+        job: "test -x /usr/bin/certbot && perl -e 'sleep int(rand(3600))' && certbot -q renew --renew-hook '/etc/init.d/nginx reload'"
         minute: "0"
         hour: "0/12"
         user: root

--- a/src/commcare_cloud/ansible/letsencrypt_cert.yml
+++ b/src/commcare_cloud/ansible/letsencrypt_cert.yml
@@ -59,7 +59,7 @@
 
     - name: Run Certbot command when there is a www host
       command: 'certbot certonly --webroot -w /var/www/letsencrypt/ -m {{ root_email }} --agree-tos -d {{SITE_HOST}} -d {{ NO_WWW_SITE_HOST }}'
-      when: NO_WWW_SITE_HOST is defined
+      when: NO_WWW_SITE_HOST|bool
 
     - name: Run Certbot command when there is no www host
       command: 'certbot certonly --webroot -w /var/www/letsencrypt/ -m {{ root_email }} --agree-tos -d {{SITE_HOST}}'

--- a/src/commcare_cloud/ansible/letsencrypt_cert.yml
+++ b/src/commcare_cloud/ansible/letsencrypt_cert.yml
@@ -65,9 +65,6 @@
         remote_src: yes
         force: yes
 
-    - name: Dump Certificate and keys
-      command: 'cat /etc/pki/tls/private/{{ deploy_env }}_nginx_commcarehq.org.key /etc/pki/tls/certs/{{ deploy_env }}_nginx_combined.crt '
-
     - name: Reload Nginx
       service:
         name: nginx


### PR DESCRIPTION
using the built-in hook. Will have to roll this out to every env that
uses letsencrypt before it'll take effect.

Noticed from the discussion we currently do this manually, which adds to the confusion around certs.

@NitigyaS see any problems with this?