### PR TITLE
Remove old prod rackspace proxy hqproxy0

### DIFF
--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -1,12 +1,8 @@
-[hqproxy0]
-hqproxy0.internal-va.commcarehq.org
-
 [proxy0]
 10.202.20.138 hostname=proxy0-production public_ip=100.24.216.221 ec2=yes
 
 [proxy:children]
 proxy0
-hqproxy0
 
 [web0]
 10.202.10.233 hostname=web0-production ec2=yes

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -1,12 +1,8 @@
-[hqproxy0]
-hqproxy0.internal-va.commcarehq.org
-
 [proxy0]
 {{ proxy0-production }} hostname=proxy0-production public_ip={{ proxy0-production.public_ip }} ec2=yes
 
 [proxy:children]
 proxy0
-hqproxy0
 
 [web0]
 {{ web0-production }} hostname=web0-production ec2=yes


### PR DESCRIPTION
This came up recently as causing issues. There's no reason for us to still have this machine in the inventory.