### PR TITLE
Halve RAM on production couch nodes

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -128,7 +128,7 @@ servers:
     volume_size: 80
     group: "couchdb2_proxy"
   - server_name: "couch0-production"
-    server_instance_type: m5.4xlarge
+    server_instance_type: c5.4xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 4000
@@ -136,7 +136,7 @@ servers:
       volume_size: 5000
     group: "couchdb2"
   - server_name: "couch1-production"
-    server_instance_type: m5.4xlarge
+    server_instance_type: c5.4xlarge
     network_tier: "db-private"
     az: "b"
     volume_size: 6000  # this was a mistake, but it's harder to reduce the size of disk
@@ -144,7 +144,7 @@ servers:
       volume_size: 5000
     group: "couchdb2"
   - server_name: "couch2-production"
-    server_instance_type: m5.4xlarge
+    server_instance_type: c5.4xlarge
     network_tier: "db-private"
     az: "c"
     volume_size: 4000


### PR DESCRIPTION
keeping CPU the same. m5.4xlarge => c5.4xlarge

These are a bit less expensive. We seem to make good use of the CPU, but not almost any of the RAM. I'll be locking in reservations for ec2 instances, so I'm doing a pass to make sure we're at least on the right instances classes for our major instances.