### PR TITLE
Turn on termination protection for all ec2 instances

### DIFF
--- a/src/commcare_cloud/terraform/modules/openvpn/main.tf
+++ b/src/commcare_cloud/terraform/modules/openvpn/main.tf
@@ -14,6 +14,8 @@ resource aws_instance "vpn_host" {
     reboot
     EOF
 
+  disable_api_termination = true
+
   root_block_device {
     volume_size           = 40
     volume_type           = "gp2"

--- a/src/commcare_cloud/terraform/modules/server/main.tf
+++ b/src/commcare_cloud/terraform/modules/server/main.tf
@@ -10,6 +10,9 @@ resource aws_instance "server" {
   credit_specification {
     cpu_credits = "unlimited"
   }
+
+  disable_api_termination = true
+
   root_block_device {
     volume_size           = "${var.volume_size}"
     volume_type           = "gp2"


### PR DESCRIPTION
This just adds an extra layer of friction for deleting machines, so that it's less likely that the disaster scenario of by mistake deleting important machines could happen. To delete a machine, you'll have to first turn off termination protection on that machine, which you can do from the AWS console