### PR TITLE
Add tags to AWS volumes

### DIFF
--- a/src/commcare_cloud/terraform/modules/server/main.tf
+++ b/src/commcare_cloud/terraform/modules/server/main.tf
@@ -21,7 +21,7 @@ resource aws_instance "server" {
   tags {
     Name        = "${var.server_name}"
     Environment = "${var.environment}"
-    group_tag = "${var.group_tag}"
+    Group = "${var.group_tag}"
   }
 }
 

--- a/src/commcare_cloud/terraform/modules/server/main.tf
+++ b/src/commcare_cloud/terraform/modules/server/main.tf
@@ -23,6 +23,12 @@ resource aws_instance "server" {
     Environment = "${var.environment}"
     Group = "${var.group_tag}"
   }
+  volume_tags {
+    Name = "vol-${var.server_name}"
+    ServerName = "${var.server_name}"
+    Environment = "${var.environment}"
+    Group = "${var.group_tag}"
+  }
 }
 
 resource "aws_ebs_volume" "ebs_volume" {


### PR DESCRIPTION
Also call the group tag "Group" instead of "group_tag".