### PR TITLE
Add back in java for webworkers

### DIFF
--- a/src/commcare_cloud/ansible/roles/webworker/meta/main.yml
+++ b/src/commcare_cloud/ansible/roles/webworker/meta/main.yml
@@ -2,4 +2,5 @@
 # roles/webworker/meta/main.yml
 
 dependencies:
+  - role: java  # Needed for j2me builds
   - role: shared_dir


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-79
https://sentry.io/dimagi/commcarehq/issues/753987314/
Reverts https://github.com/dimagi/commcare-cloud/pull/787

This is needed on prod for j2me projects to build jad files.  Is there another way to make java available that's more targeted?  Is that necessary?

@dannyroberts @orangejenny 
What's the best way to roll this out without subjecting myself to field testing the current state of our full stack deploy?