### PR TITLE
Give softlayer background_queue dedicated process

### DIFF
--- a/environments/softlayer/app-processes.yml
+++ b/environments/softlayer/app-processes.yml
@@ -12,21 +12,16 @@ celery_processes:
     sms_queue:
       pooling: gevent
       concurrency: 10
-    async_restore_queue,celery_periodic,email_queue:
-      concurrency: 2
-    repeat_record_queue,sumologic_logs_queue,reminder_case_update_queue,icds_aggregation_queue:
+    async_restore_queue,celery_periodic,email_queue,repeat_record_queue,sumologic_logs_queue,reminder_case_update_queue,icds_aggregation_queue:
       pooling: gevent
       concurrency: 200
-    ucr_queue,ucr_indicator_queue,celery,export_download_queue,reminder_rule_queue,case_import_queue:
-      concurrency: 2
+    ucr_queue,ucr_indicator_queue,celery,export_download_queue,reminder_rule_queue,case_import_queue,case_rule_queue,icds_dashboard_reports_queue,analytics_queue:
+      concurrency: 3
       max_tasks_per_child: 5
     saved_exports_queue:
       concurrency: 2
       max_tasks_per_child: 1
       optimize: True
-    case_rule_queue,icds_dashboard_reports_queue,analytics_queue:
-      concurrency: 2
-      max_tasks_per_child: 1
     background_queue:
       concurrency: 5
       max_tasks_per_child: 1

--- a/environments/softlayer/app-processes.yml
+++ b/environments/softlayer/app-processes.yml
@@ -4,11 +4,19 @@ celery_processes:
   'celery0':
     beat: {}
     flower: {}
-    async_restore_queue,celery_periodic,email_queue,submission_reprocessing_queue:
-      concurrency: 2
-    repeat_record_queue,sumologic_logs_queue,reminder_queue,sms_queue,reminder_case_update_queue,icds_aggregation_queue:
+    reminder_queue:
       pooling: gevent
-      concurrency: 220
+      concurrency: 5
+    submission_reprocessing_queue:
+      concurrency: 1
+    sms_queue:
+      pooling: gevent
+      concurrency: 10
+    async_restore_queue,celery_periodic,email_queue:
+      concurrency: 2
+    repeat_record_queue,sumologic_logs_queue,reminder_case_update_queue,icds_aggregation_queue:
+      pooling: gevent
+      concurrency: 200
     ucr_queue,ucr_indicator_queue,celery,export_download_queue,reminder_rule_queue,case_import_queue:
       concurrency: 2
       max_tasks_per_child: 5

--- a/environments/softlayer/app-processes.yml
+++ b/environments/softlayer/app-processes.yml
@@ -4,36 +4,23 @@ celery_processes:
   'celery0':
     beat: {}
     flower: {}
-    reminder_queue:
-      pooling: gevent
-      concurrency: 5
-    submission_reprocessing_queue:
-      concurrency: 1
-    sms_queue:
-      pooling: gevent
-      concurrency: 10
-    celery_periodic,email_queue:
+    async_restore_queue,celery_periodic,email_queue,submission_reprocessing_queue:
       concurrency: 2
-    repeat_record_queue,sumologic_logs_queue:
+    repeat_record_queue,sumologic_logs_queue,reminder_queue,sms_queue,reminder_case_update_queue,icds_aggregation_queue:
       pooling: gevent
-      concurrency: 200
-    ucr_queue,ucr_indicator_queue:
-      concurrency: 1
-      max_tasks_per_child: 5
-    celery,export_download_queue,reminder_rule_queue,case_import_queue:
+      concurrency: 220
+    ucr_queue,ucr_indicator_queue,celery,export_download_queue,reminder_rule_queue,case_import_queue:
       concurrency: 2
       max_tasks_per_child: 5
     saved_exports_queue:
       concurrency: 2
       max_tasks_per_child: 1
       optimize: True
-    reminder_case_update_queue,icds_aggregation_queue:
-      pooling: gevent
-      concurrency: 5
-    async_restore_queue:
-      concurrency: 1
-    background_queue,case_rule_queue,icds_dashboard_reports_queue,analytics_queue:
+    case_rule_queue,icds_dashboard_reports_queue,analytics_queue:
       concurrency: 2
+      max_tasks_per_child: 1
+    background_queue:
+      concurrency: 5
       max_tasks_per_child: 1
 pillows:
   'pillow1':


### PR DESCRIPTION
and consolidate other queues.
There is also one fewer worker processes total,
leaving a little more memory and CPU headroom.