### PR TITLE
Switch to using local couchdb2 for production commcarehq db!

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -47,86 +47,9 @@ run_websockets_wsgi: True
 
 couch_dbs:
   default:
-    host: commcarehq.cloudant.com
-    port: 443
+    host: "{{ groups.couchdb2_proxy.0 }}"
+    port: "{{ couchdb2_proxy_port }}"
     name: commcarehq
-    username: "{{ localsettings_private.COUCH_USERNAME }}"
-    password: "{{ localsettings_private.COUCH_PASSWORD }}"
-    is_https: True
-  domains:
-    host: "{{ groups.couchdb2_proxy.0 }}"
-    port: "{{ couchdb2_proxy_port }}"
-    name: commcarehq__domains
-    username: "{{ localsettings_private.COUCH_USERNAME }}"
-    password: "{{ localsettings_private.COUCH_PASSWORD }}"
-    is_https: False
-  users:
-    host: "{{ groups.couchdb2_proxy.0 }}"
-    port: "{{ couchdb2_proxy_port }}"
-    name: commcarehq__users
-    username: "{{ localsettings_private.COUCH_USERNAME }}"
-    password: "{{ localsettings_private.COUCH_PASSWORD }}"
-    is_https: False
-  apps:
-    host: "{{ groups.couchdb2_proxy.0 }}"
-    port: "{{ couchdb2_proxy_port }}"
-    name: commcarehq__apps
-    username: "{{ localsettings_private.COUCH_USERNAME }}"
-    password: "{{ localsettings_private.COUCH_PASSWORD }}"
-    is_https: False
-  fluff-bihar:
-    host: "{{ groups.couchdb2_proxy.0 }}"
-    port: "{{ couchdb2_proxy_port }}"
-    name: commcarehq__fluff-bihar
-    username: "{{ localsettings_private.COUCH_USERNAME }}"
-    password: "{{ localsettings_private.COUCH_PASSWORD }}"
-    is_https: False
-  fluff-mc:
-    host: "{{ groups.couchdb2_proxy.0 }}"
-    port: "{{ couchdb2_proxy_port }}"
-    name: commcarehq__fluff-mc
-    username: "{{ localsettings_private.COUCH_USERNAME }}"
-    password: "{{ localsettings_private.COUCH_PASSWORD }}"
-    is_https: False
-  auditcare:
-    host: "{{ groups.couchdb2_proxy.0 }}"
-    port: "{{ couchdb2_proxy_port }}"
-    name: commcarehq__auditcare
-    username: "{{ localsettings_private.COUCH_USERNAME }}"
-    password: "{{ localsettings_private.COUCH_PASSWORD }}"
-    is_https: False
-  fixtures:
-    host: "{{ groups.couchdb2_proxy.0 }}"
-    port: "{{ couchdb2_proxy_port }}"
-    name: commcarehq__fixtures
-    username: "{{ localsettings_private.COUCH_USERNAME }}"
-    password: "{{ localsettings_private.COUCH_PASSWORD }}"
-    is_https: False
-  meta:
-    host: "{{ groups.couchdb2_proxy.0 }}"
-    port: "{{ couchdb2_proxy_port }}"
-    name: commcarehq__meta
-    username: "{{ localsettings_private.COUCH_USERNAME }}"
-    password: "{{ localsettings_private.COUCH_PASSWORD }}"
-    is_https: False
-  receiverwrapper:
-    host: "{{ groups.couchdb2_proxy.0 }}"
-    port: "{{ couchdb2_proxy_port }}"
-    name: commcarehq__receiverwrapper
-    username: "{{ localsettings_private.COUCH_USERNAME }}"
-    password: "{{ localsettings_private.COUCH_PASSWORD }}"
-    is_https: False
-  m4change:
-    host: "{{ groups.couchdb2_proxy.0 }}"
-    port: "{{ couchdb2_proxy_port }}"
-    name: commcarehq__m4change
-    username: "{{ localsettings_private.COUCH_USERNAME }}"
-    password: "{{ localsettings_private.COUCH_PASSWORD }}"
-    is_https: False
-  mvp-indicators:
-    host: "{{ groups.couchdb2_proxy.0 }}"
-    port: "{{ couchdb2_proxy_port }}"
-    name: commcarehq__mvp-indicators
     username: "{{ localsettings_private.COUCH_USERNAME }}"
     password: "{{ localsettings_private.COUCH_PASSWORD }}"
     is_https: False

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -547,7 +547,7 @@ INDICATOR_NAMESPACES = {
     ),
 }
 # should be 'ok' if couchdb version < 1.1.0, or cloudant, else 'update_after'
-COUCH_STALE_QUERY = '{{ localsettings.COUCH_STALE_QUERY | default('ok') }}'
+COUCH_STALE_QUERY = '{{ localsettings.COUCH_STALE_QUERY | default('update_after') }}'
 
 API_THROTTLE_REQUESTS = 5
 API_THROTTLE_TIMEFRAME = 10


### PR DESCRIPTION
This puts us entirely on local couchdb2 and entirely off cloudant.