### PR TITLE
Increase data volume on couchdb2 machines to 7.5 TB

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -133,7 +133,7 @@ servers:
     az: "a"
     volume_size: 4000
     block_device:
-      volume_size: 5000
+      volume_size: 7500
     group: "couchdb2"
   - server_name: "couch1-production"
     server_instance_type: c5.4xlarge
@@ -141,7 +141,7 @@ servers:
     az: "b"
     volume_size: 6000  # this was a mistake, but it's harder to reduce the size of disk
     block_device:
-      volume_size: 5000
+      volume_size: 7500
     group: "couchdb2"
   - server_name: "couch2-production"
     server_instance_type: c5.4xlarge
@@ -149,7 +149,7 @@ servers:
     az: "c"
     volume_size: 4000
     block_device:
-      volume_size: 5000
+      volume_size: 7500
     group: "couchdb2"
 
   - server_name: "rabbit0-production"


### PR DESCRIPTION
disks were over 80% full at 6TB, so I further increased it.
These changes are already rolled out.