### PR TITLE
Temporarily increase couch0-production for view indexing

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -128,7 +128,7 @@ servers:
     volume_size: 80
     group: "couchdb2_proxy"
   - server_name: "couch0-production"
-    server_instance_type: c5.4xlarge
+    server_instance_type: c5.18xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 4000


### PR DESCRIPTION
I set commcarehq db to only store shards on couch0, and I'll index it there. This is following @emord's suggestion in #interrupt-team