### PR TITLE
Revert "Temporarily increase couch0-production for view indexing"

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -128,7 +128,7 @@ servers:
     volume_size: 80
     group: "couchdb2_proxy"
   - server_name: "couch0-production"
-    server_instance_type: c5.18xlarge
+    server_instance_type: c5.4xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 4000


### PR DESCRIPTION
Reverts dimagi/commcare-cloud#2579

The do-everything-on-couch0 approach has really not been working well. Plan is to revert this to make couch0 normal-sized again, and then add dedicated nodes for the commcarehq db indexing