### PR TITLE
Run "Assert couchdb shard files exist" as root

### DIFF
--- a/src/commcare_cloud/commands/migrations/plays/assert_couch_files.yml
+++ b/src/commcare_cloud/commands/migrations/plays/assert_couch_files.yml
@@ -1,6 +1,7 @@
 ---
 - name: Assert couchdb shard files exist
   hosts: couchdb2
+  become: yes
   tasks:
     - name: stat shards
       stat:


### PR DESCRIPTION
for shard files not created by couchdb-migrate,
the owner may be set such that the ansible user cannot perform operations
without escalation

Ran into this recently @snopoke I think this is the error I'd seen before (while working on softlayer) that I'd previously mistakenly identified as a checksum error.