### PR TITLE
Enable ebs_optimized on new machines

### DIFF
--- a/src/commcare_cloud/terraform/modules/server/main.tf
+++ b/src/commcare_cloud/terraform/modules/server/main.tf
@@ -12,7 +12,7 @@ resource aws_instance "server" {
   }
 
   disable_api_termination = true
-
+  ebs_optimized = true
   root_block_device {
     volume_size           = "${var.volume_size}"
     volume_type           = "gp2"


### PR DESCRIPTION
it is in ignore_changes, so this won't affect existing machines.
I think this was a mistake from the beginning, and is due to terraform
giving ebs_optimized a default of False even though AWS defaults it to true
for latest generation machines.