### PR TITLE
Added cd into code directory when running django-manage

### DIFF
--- a/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -208,7 +208,7 @@ class DjangoManage(CommandBase):
             code_dir = '/home/{cchq_user}/www/{deploy_env}/current'.format(
                 cchq_user=cchq_user, deploy_env=deploy_env)
         remote_command = (
-            '{code_dir}/python_env/bin/python {code_dir}/manage.py {args}'
+            'bash -c "cd {code_dir}; {code_dir}/python_env/bin/python {code_dir}/manage.py {args}"'
             .format(
                 cchq_user=cchq_user,
                 code_dir=code_dir,

--- a/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -208,7 +208,7 @@ class DjangoManage(CommandBase):
             code_dir = '/home/{cchq_user}/www/{deploy_env}/current'.format(
                 cchq_user=cchq_user, deploy_env=deploy_env)
         remote_command = (
-            'bash -c "cd {code_dir}; {code_dir}/python_env/bin/python {code_dir}/manage.py {args}"'
+            'bash -c "cd {code_dir}; python_env/bin/python manage.py {args}"'
             .format(
                 cchq_user=cchq_user,
                 code_dir=code_dir,


### PR DESCRIPTION
@calellowitz 

fyi @mkangia This is why I was seeing `ReportConfigurationNotFoundError` when working in shell: the paths to the static report json configs are relative, so when the shell was running from `/home/my_username` it would error out.