### PR TITLE
rename elasticsearch cluster on NIC

### DIFF
--- a/environments/icds-new/public.yml
+++ b/environments/icds-new/public.yml
@@ -6,7 +6,7 @@ riak_backend: "bitcask"
 riak_ring_size: 64
 
 elasticsearch_endpoint: '{{ groups.es0.0 }}'
-elasticsearch_cluster_name: 'icds-2.0'
+elasticsearch_cluster_name: 'icds-nic'
 elasticsearch_version: 1.7.6
 elasticsearch_download_sha256: 78affc30353730ec245dad1f17de242a4ad12cf808eaa87dd878e1ca10ed77df.
 


### PR DESCRIPTION
I also had to manually run the following:

`cchq icds-new run-shell-command elasticsearch 'mv /opt/data/elasticsearch-1.7.6/data/icds-2.0 /opt/data/elasticsearch-1.7.6/data/icds-nic' --become`

Seems like all is well:

```curl -XGET http://10.247.164.15:9200/_cluster/health?pretty=true
{
  "cluster_name" : "icds-nic",
  "status" : "green",
  "timed_out" : false,
  "number_of_nodes" : 4,
  "number_of_data_nodes" : 4,
  "active_primary_shards" : 56,
  "active_shards" : 58,
  "relocating_shards" : 0,
  "initializing_shards" : 0,
  "unassigned_shards" : 0,
  "delayed_unassigned_shards" : 0,
  "number_of_pending_tasks" : 0,
  "number_of_in_flight_fetch" : 0
}
```

(also verified index sizes look reasonable using `curl -XGET http://10.247.164.15:9200/_stats/index,store?pretty=true`)