### PR TITLE
Add celery4 queues to celery0 with gevent

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -25,6 +25,16 @@ celery_processes:
     async_restore_queue:
       concurrency: 2
       max_tasks_per_child: 5
+    celery,case_import_queue:
+      pooling: gevent
+      concurrency: 6
+      max_tasks_per_child: 5
+      num_workers: 2
+    export_download_queue:
+      pooling: gevent
+      concurrency: 6
+      max_tasks_per_child: 5
+      num_workers: 2
   celery1:
     flower: {}
     reminder_queue:


### PR DESCRIPTION
I chose celery0 because it has the most unused RAM. I chose to add gevent to reduce the amount of RAM needed to add these to that machine.