### PR TITLE
Revert "Add celery4 queues to celery0 with gevent"

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -25,16 +25,6 @@ celery_processes:
     async_restore_queue:
       concurrency: 2
       max_tasks_per_child: 5
-    celery,case_import_queue:
-      pooling: gevent
-      concurrency: 6
-      max_tasks_per_child: 5
-      num_workers: 2
-    export_download_queue:
-      pooling: gevent
-      concurrency: 6
-      max_tasks_per_child: 5
-      num_workers: 2
   celery1:
     flower: {}
     reminder_queue:


### PR DESCRIPTION
Reverts dimagi/commcare-cloud#2597

There's no need now that celery4 is working well again, and it caused problems on celery0.

For the last day or so, `celery`, `case_import_queue`, and `export_download_queue` have all been running on both `celery0` and `celery4`