### PR TITLE
Increase reads going to UCR standbys

### DIFF
--- a/environments/icds-cas/postgresql.yml
+++ b/environments/icds-cas/postgresql.yml
@@ -5,10 +5,10 @@ REPORTING_DATABASES:
     WRITE: icds-ucr
     READ:
       - [icds-ucr, 1]
-      - [icds-ucr-standby0, 5]
-      - [icds-ucr-standby1, 5]
-      - [icds-ucr-standby2, 5]
-      - [icds-ucr-standby3, 5]
+      - [icds-ucr-standby0, 10]
+      - [icds-ucr-standby1, 10]
+      - [icds-ucr-standby2, 10]
+      - [icds-ucr-standby3, 10]
   icds-test-ucr: icds-ucr
 
 LOAD_BALANCED_APPS:


### PR DESCRIPTION
@snopoke Thoughts on deploying this tomorrow (today for you). Suggesting this to try lowering load on the main database

the standbys are almost always half of the disk read i/o as the main https://app.datadoghq.com/metric/explorer?live=true&page=0&is_auto=false&from_ts=1546746838050&to_ts=1549338838050&tile_size=m&exp_metric=system.io.rkb_s&exp_scope=environment%3Aicds%2Cgroup%3Aucr_dbs&exp_group=host&exp_agg=avg&exp_row_type=metric

should only need to restart celery (really should just need icds_dashboard_reports_queue) and webworkers:

```
cchq icds webworker restart --limit=web0,web1,web2,web3,web4,web5
cchq icds webworker restart --limit=web6,web7,web8,web9,web10,web11
... other webworkers
cchq icds celery restart 
```

I think that would be safe to do during load. Other services could wait until after deploy