### PR TITLE
Expand existing nodes for final couchdb cluster

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -154,68 +154,68 @@ servers:
 
   # couch main-db cluster: 8 nodes, one per shard
   - server_name: "couch3-production"
-    server_instance_type: c5.xlarge
+    server_instance_type: c5.2xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 80
     block_device:
-      volume_size: 4200
+      volume_size: 5300
     group: "couchdb2:main"
   - server_name: "couch4-production"
-    server_instance_type: c5.xlarge
+    server_instance_type: c5.2xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 80
     block_device:
-      volume_size: 4200
+      volume_size: 5300
     group: "couchdb2:main"
   - server_name: "couch5-production"
-    server_instance_type: c5.xlarge
+    server_instance_type: c5.2xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 80
     block_device:
-      volume_size: 4200
+      volume_size: 5300
     group: "couchdb2:main"
   - server_name: "couch6-production"
-    server_instance_type: c5.xlarge
+    server_instance_type: c5.2xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 80
     block_device:
-      volume_size: 4200
+      volume_size: 5300
     group: "couchdb2:main"
   - server_name: "couch7-production"
-    server_instance_type: c5.xlarge
+    server_instance_type: c5.2xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 80
     block_device:
-      volume_size: 4200
+      volume_size: 5300
     group: "couchdb2:main"
   - server_name: "couch8-production"
-    server_instance_type: c5.xlarge
+    server_instance_type: c5.2xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 80
     block_device:
-      volume_size: 4200
+      volume_size: 5300
     group: "couchdb2:main"
   - server_name: "couch9-production"
-    server_instance_type: c5.xlarge
+    server_instance_type: c5.2xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 80
     block_device:
-      volume_size: 4200
+      volume_size: 5300
     group: "couchdb2:main"
   - server_name: "couch10-production"
-    server_instance_type: c5.xlarge
+    server_instance_type: c5.2xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 80
     block_device:
-      volume_size: 4200
+      volume_size: 5300
     group: "couchdb2:main"
 
   - server_name: "rabbit0-production"


### PR DESCRIPTION
Final couchdb cluster will be 8 x (c5.2xlarge, 5.3TB disk). After migration, will terminate couch[0-2].