### PR TITLE
Finalize production couch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ DimagiKeyStore
 /dist
 couchdb@*_files
 **/fab/config.py
+**/migrations/*/migration_build_*/
+**/migrations/*/copy_file_scripts_*/

--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -196,16 +196,6 @@ elasticsearch_node_zone=aws
 es_master
 es_data
 
-
-[couch0]
-10.202.40.211 hostname=couch0-production ec2=yes
-
-[couch1]
-10.202.41.83 hostname=couch1-production ec2=yes
-
-[couch2]
-10.202.42.85 hostname=couch2-production ec2=yes
-
 [couch3]
 10.202.40.135 hostname=couch3-production ec2=yes
 [couch4]
@@ -224,9 +214,6 @@ es_data
 10.202.40.133 hostname=couch10-production ec2=yes
 
 [couchdb2:children]
-couch0
-couch1
-couch2
 couch3
 couch4
 couch5

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -196,16 +196,6 @@ elasticsearch_node_zone=aws
 es_master
 es_data
 
-
-[couch0]
-{{ couch0-production }} hostname=couch0-production ec2=yes
-
-[couch1]
-{{ couch1-production }} hostname=couch1-production ec2=yes
-
-[couch2]
-{{ couch2-production }} hostname=couch2-production ec2=yes
-
 [couch3]
 {{ couch3-production }} hostname=couch3-production ec2=yes
 [couch4]
@@ -224,9 +214,6 @@ es_data
 {{ couch10-production }} hostname=couch10-production ec2=yes
 
 [couchdb2:children]
-couch0
-couch1
-couch2
 couch3
 couch4
 couch5

--- a/environments/production/migrations/0004-migrate-non-main-dbs/couchdb-step-1.yml
+++ b/environments/production/migrations/0004-migrate-non-main-dbs/couchdb-step-1.yml
@@ -1,0 +1,3 @@
+target_allocation:
+  - couch3,couch4,couch5,couch6,couch7,couch8,couch9,couch10:3:commcarehq
+  - couch3,couch4,couch5,couch6,couch7,couch8,couch9,couch10,couch0,couch1:3

--- a/environments/production/migrations/0004-migrate-non-main-dbs/couchdb-step-2.yml
+++ b/environments/production/migrations/0004-migrate-non-main-dbs/couchdb-step-2.yml
@@ -1,0 +1,3 @@
+target_allocation:
+  - couch3,couch4,couch5,couch6,couch7,couch8,couch9,couch10:3:commcarehq
+  - couch3,couch4,couch5,couch6,couch7,couch8,couch9,couch10,couch0:3

--- a/environments/production/migrations/0004-migrate-non-main-dbs/couchdb-step-3.yml
+++ b/environments/production/migrations/0004-migrate-non-main-dbs/couchdb-step-3.yml
@@ -1,0 +1,2 @@
+target_allocation:
+  - couch3,couch4,couch5,couch6,couch7,couch8,couch9,couch10:3

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -127,32 +127,7 @@ servers:
     az: "a"
     volume_size: 80
     group: "couchdb2_proxy"
-  - server_name: "couch0-production"
-    server_instance_type: c5.4xlarge
-    network_tier: "db-private"
-    az: "a"
-    volume_size: 4000
-    block_device:
-      volume_size: 7500
-    group: "couchdb2"
-  - server_name: "couch1-production"
-    server_instance_type: c5.4xlarge
-    network_tier: "db-private"
-    az: "b"
-    volume_size: 6000  # this was a mistake, but it's harder to reduce the size of disk
-    block_device:
-      volume_size: 7500
-    group: "couchdb2"
-  - server_name: "couch2-production"
-    server_instance_type: c5.4xlarge
-    network_tier: "db-private"
-    az: "c"
-    volume_size: 4000
-    block_device:
-      volume_size: 7500
-    group: "couchdb2"
 
-  # couch main-db cluster: 8 nodes, one per shard
   - server_name: "couch3-production"
     server_instance_type: c5.2xlarge
     network_tier: "db-private"

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -134,7 +134,7 @@ servers:
     az: "a"
     volume_size: 80
     block_device:
-      volume_size: 5300
+      volume_size: 5500
     group: "couchdb2"
   - server_name: "couch4-production"
     server_instance_type: c5.2xlarge
@@ -142,7 +142,7 @@ servers:
     az: "a"
     volume_size: 80
     block_device:
-      volume_size: 5300
+      volume_size: 5500
     group: "couchdb2"
   - server_name: "couch5-production"
     server_instance_type: c5.2xlarge
@@ -150,7 +150,7 @@ servers:
     az: "a"
     volume_size: 80
     block_device:
-      volume_size: 5300
+      volume_size: 5500
     group: "couchdb2"
   - server_name: "couch6-production"
     server_instance_type: c5.2xlarge
@@ -158,7 +158,7 @@ servers:
     az: "a"
     volume_size: 80
     block_device:
-      volume_size: 5300
+      volume_size: 5500
     group: "couchdb2"
   - server_name: "couch7-production"
     server_instance_type: c5.2xlarge
@@ -166,7 +166,7 @@ servers:
     az: "a"
     volume_size: 80
     block_device:
-      volume_size: 5300
+      volume_size: 5500
     group: "couchdb2"
   - server_name: "couch8-production"
     server_instance_type: c5.2xlarge
@@ -174,7 +174,7 @@ servers:
     az: "a"
     volume_size: 80
     block_device:
-      volume_size: 5300
+      volume_size: 5500
     group: "couchdb2"
   - server_name: "couch9-production"
     server_instance_type: c5.2xlarge
@@ -182,7 +182,7 @@ servers:
     az: "a"
     volume_size: 80
     block_device:
-      volume_size: 5300
+      volume_size: 5500
     group: "couchdb2"
   - server_name: "couch10-production"
     server_instance_type: c5.2xlarge
@@ -190,7 +190,7 @@ servers:
     az: "a"
     volume_size: 80
     block_device:
-      volume_size: 5300
+      volume_size: 5500
     group: "couchdb2"
 
   - server_name: "rabbit0-production"

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -135,7 +135,7 @@ servers:
     volume_size: 80
     block_device:
       volume_size: 5300
-    group: "couchdb2:main"
+    group: "couchdb2"
   - server_name: "couch4-production"
     server_instance_type: c5.2xlarge
     network_tier: "db-private"
@@ -143,7 +143,7 @@ servers:
     volume_size: 80
     block_device:
       volume_size: 5300
-    group: "couchdb2:main"
+    group: "couchdb2"
   - server_name: "couch5-production"
     server_instance_type: c5.2xlarge
     network_tier: "db-private"
@@ -151,7 +151,7 @@ servers:
     volume_size: 80
     block_device:
       volume_size: 5300
-    group: "couchdb2:main"
+    group: "couchdb2"
   - server_name: "couch6-production"
     server_instance_type: c5.2xlarge
     network_tier: "db-private"
@@ -159,7 +159,7 @@ servers:
     volume_size: 80
     block_device:
       volume_size: 5300
-    group: "couchdb2:main"
+    group: "couchdb2"
   - server_name: "couch7-production"
     server_instance_type: c5.2xlarge
     network_tier: "db-private"
@@ -167,7 +167,7 @@ servers:
     volume_size: 80
     block_device:
       volume_size: 5300
-    group: "couchdb2:main"
+    group: "couchdb2"
   - server_name: "couch8-production"
     server_instance_type: c5.2xlarge
     network_tier: "db-private"
@@ -175,7 +175,7 @@ servers:
     volume_size: 80
     block_device:
       volume_size: 5300
-    group: "couchdb2:main"
+    group: "couchdb2"
   - server_name: "couch9-production"
     server_instance_type: c5.2xlarge
     network_tier: "db-private"
@@ -183,7 +183,7 @@ servers:
     volume_size: 80
     block_device:
       volume_size: 5300
-    group: "couchdb2:main"
+    group: "couchdb2"
   - server_name: "couch10-production"
     server_instance_type: c5.2xlarge
     network_tier: "db-private"
@@ -191,7 +191,7 @@ servers:
     volume_size: 80
     block_device:
       volume_size: 5300
-    group: "couchdb2:main"
+    group: "couchdb2"
 
   - server_name: "rabbit0-production"
     server_instance_type: t3.large


### PR DESCRIPTION
These changes have already been applied. Our new allocation is

```
target_allocation:
  - couch3,couch4,couch5,couch6,couch7,couch8,couch9,couch10:3
```

i.e. 3 copies evenly distributed across the eight new nodes, couch[3-10]. The data has been migrated and the old nodes couch[0-2] have been terminated. (I took a snapshot of their data volumes just in case before deleting, but I don't expect we'll need those.)