### PR TITLE
Start production backups at 11AM EST

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -33,6 +33,7 @@ backup_couch: True
 postgres_s3: True
 postgresql_backup_days: 1
 postgresql_backup_weeks: 1
+nadir_hour: 16
 
 aws_region: 'us-east-1'
 


### PR DESCRIPTION
Previously they started at 7PM EST and would run all night and into the late morning,
which is our peak load time.