### PR TITLE
Make COUCH_REINDEX_SCHEDULE less frequent on production

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -91,7 +91,7 @@ localsettings:
   BIGCOUCH_QUORUM_COUNT: 2
   COUCH_CACHE_DOCS: True
   COUCH_CACHE_VIEWS: True
-  COUCH_REINDEX_SCHEDULE: {'timedelta': {'minutes': 3}}
+  COUCH_REINDEX_SCHEDULE: {'timedelta': {'minutes': 20}}
   CUSTOM_SYNCLOGS_DB: "synclogs_2017-11-01"
   DEPLOY_MACHINE_NAME: "{{ ansible_hostname }}"
   EULA_COMPLIANCE: True


### PR DESCRIPTION
I decreased this yesterday and things were _worse_ not better last night.
Though it may be unrelated, I am going to try taking this in the opposite direction.
It's possible such frequent reindexing caused unnecesary churn
and CPU spent on rarely accessed views when it was needed to process real requests.