### PR TITLE
Fix COUCH_REINDEX_SCHEDULE assignment in localsettings.py

### DIFF
--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -158,7 +158,7 @@ COUCH_CACHE_DOCS = '{{ localsettings.COUCH_CACHE_DOCS }}'
 COUCH_CACHE_VIEWS = '{{ localsettings.COUCH_CACHE_VIEWS }}'
 {% endif %}
 {% if 'COUCH_REINDEX_SCHEDULE' in localsettings %}
-COUCH_REINDEX_SCHEDULE = '{{ localsettings.COUCH_REINDEX_SCHEDULE }}'
+COUCH_REINDEX_SCHEDULE = {{ localsettings.COUCH_REINDEX_SCHEDULE }}
 {% endif %}
 
 {% if 'STAGING_DOMAINS' in localsettings %}


### PR DESCRIPTION
I had fixed this yesterday, but forgot to PR it