### PR TITLE
Use built in AWS snapshots to backup production couchdb2 volumes

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -29,7 +29,7 @@ supervisor_http_enabled: True
 backup_blobdb: False
 backup_postgres: plain
 backup_es_s3: True
-backup_couch: True
+backup_couch: False
 postgres_s3: True
 postgresql_backup_days: 1
 postgresql_backup_weeks: 1

--- a/src/commcare_cloud/ansible/roles/couchdb2/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/couchdb2/tasks/main.yml
@@ -128,7 +128,7 @@
     weekday: "1,2,3,4,5,6"
     user: couchdb
     cron_file: backup_couch
-  when: backup_couch
+    state: '{{ "present" if backup_couch else "absent"}}'
   tags:
     - cron
     - backups
@@ -143,7 +143,7 @@
     weekday: 0
     user: couchdb
     cron_file: backup_couch
-  when: backup_couch
+    state: '{{ "present" if backup_couch else "absent"}}'
   tags:
     - cron
     - backups

--- a/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
@@ -75,8 +75,7 @@ resource "aws_dlm_lifecycle_policy" "data_volume_backups" {
     }
 
     target_tags = {
-      Group = "couchdb2"
-      VolumeType = "data"
+      GroupDetail = "couchdb2:data"
     }
   }
 }

--- a/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
@@ -43,6 +43,44 @@ locals {
   }
 }
 
+
+data "aws_iam_role" "data_lifecycle_role" {
+  name = "AWSDataLifecycleManagerDefaultRole"
+}
+
+resource "aws_dlm_lifecycle_policy" "data_volume_backups" {
+  description        = "Data Volume Backup Policy"
+  execution_role_arn = "${data.aws_iam_role.data_lifecycle_role.arn}"
+  state              = "ENABLED"
+
+  policy_details {
+    resource_types = ["VOLUME"]
+
+    schedule {
+      name = "Default Schedule"
+
+      create_rule {
+        interval      = 24
+        interval_unit = "HOURS"
+        times         = ["22:00"]
+      }
+
+      retain_rule {
+        count = 7
+      }
+
+      tags_to_add = {
+        VolumeType = "backup"
+      }
+    }
+
+    target_tags = {
+      Group = "couchdb2"
+      VolumeType = "data"
+    }
+  }
+}
+
 {% for server in servers + proxy_servers %}
 module "server__{{ server.server_name }}" {
   source = "./modules/server"

--- a/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
@@ -72,6 +72,8 @@ resource "aws_dlm_lifecycle_policy" "data_volume_backups" {
       tags_to_add = {
         VolumeType = "backup"
       }
+
+      copy_tags = true
     }
 
     target_tags = {

--- a/src/commcare_cloud/commands/terraform/templates/terraform.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/terraform.tf.j2
@@ -8,6 +8,7 @@ terraform {
 }
 
 provider "aws" {
+  version = "~> 1.44"
   region  = {{ region|tojson }}
 }
 

--- a/src/commcare_cloud/terraform/modules/server/main.tf
+++ b/src/commcare_cloud/terraform/modules/server/main.tf
@@ -19,7 +19,8 @@ resource aws_instance "server" {
     delete_on_termination = true
   }
   lifecycle {
-    ignore_changes = ["user_data", "key_name", "root_block_device.0.delete_on_termination", "ebs_optimized", "ami"]
+    ignore_changes = ["user_data", "key_name", "root_block_device.0.delete_on_termination",
+      "ebs_optimized", "ami", "volume_tags"]
   }
   tags {
     Name        = "${var.server_name}"

--- a/src/commcare_cloud/terraform/modules/server/main.tf
+++ b/src/commcare_cloud/terraform/modules/server/main.tf
@@ -41,10 +41,11 @@ resource "aws_ebs_volume" "ebs_volume" {
   type = "${var.secondary_volume_type}"
 
   tags {
-    Name = "vol-${var.server_name}"
+    Name = "data-vol-${var.server_name}"
     ServerName = "${var.server_name}"
     Environment = "${var.environment}"
     Group = "${var.group_tag}"
+    VolumeType = "data"
   }
 }
 

--- a/src/commcare_cloud/terraform/modules/server/main.tf
+++ b/src/commcare_cloud/terraform/modules/server/main.tf
@@ -47,6 +47,7 @@ resource "aws_ebs_volume" "ebs_volume" {
     Environment = "${var.environment}"
     Group = "${var.group_tag}"
     VolumeType = "data"
+    GroupDetail = "${var.group_tag}:data"
   }
 }
 


### PR DESCRIPTION
The tar/gzip-style backups we do are taking longer than 24h to run on production and take a _lot_ of space on the pricey SSDs. This turns off our manual backup strategy and replaces it with a policy of taking volume snapshots of couchdb2 data volumes. Currently set to once a day, saving the last 7.