### PR TITLE
default icds-ucr-non-dashboard for softlayer and icds-new

### DIFF
--- a/environments/icds-new/postgresql.yml
+++ b/environments/icds-new/postgresql.yml
@@ -1,6 +1,7 @@
 DEFAULT_POSTGRESQL_HOST: pgmain1
 REPORTING_DATABASES:
   ucr: ucr
+  icds-ucr-non-dashboard: icds-ucr
   icds-ucr:
     WRITE: icds-ucr
     READ:

--- a/environments/softlayer/postgresql.yml
+++ b/environments/softlayer/postgresql.yml
@@ -2,6 +2,7 @@ REPORTING_DATABASES:
   ucr: ucr
   icds-ucr: icds-ucr
   icds-test-ucr: icds-ucr
+  icds-ucr-non-dashboard: icds-ucr
 
 override:
   pgbouncer_default_pool: 290


### PR DESCRIPTION
Without this [this other PR](https://github.com/dimagi/commcare-hq/pull/23199/files) would break ICDS UCRs on softlayer.