### PR TITLE
Temporarily double all production couch nodes to c5.4xlarge

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -135,7 +135,7 @@ servers:
     group: "couchdb2_proxy"
 
   - server_name: "couch3-production"
-    server_instance_type: c5.2xlarge
+    server_instance_type: c5.4xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 80
@@ -143,7 +143,7 @@ servers:
       volume_size: 5500
     group: "couchdb2"
   - server_name: "couch4-production"
-    server_instance_type: c5.2xlarge
+    server_instance_type: c5.4xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 80
@@ -151,7 +151,7 @@ servers:
       volume_size: 5500
     group: "couchdb2"
   - server_name: "couch5-production"
-    server_instance_type: c5.2xlarge
+    server_instance_type: c5.4xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 80
@@ -159,7 +159,7 @@ servers:
       volume_size: 5500
     group: "couchdb2"
   - server_name: "couch6-production"
-    server_instance_type: c5.2xlarge
+    server_instance_type: c5.4xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 80
@@ -167,7 +167,7 @@ servers:
       volume_size: 6500
     group: "couchdb2"
   - server_name: "couch7-production"
-    server_instance_type: c5.2xlarge
+    server_instance_type: c5.4xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 80
@@ -175,7 +175,7 @@ servers:
       volume_size: 5500
     group: "couchdb2"
   - server_name: "couch8-production"
-    server_instance_type: c5.2xlarge
+    server_instance_type: c5.4xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 80
@@ -183,7 +183,7 @@ servers:
       volume_size: 5500
     group: "couchdb2"
   - server_name: "couch9-production"
-    server_instance_type: c5.2xlarge
+    server_instance_type: c5.4xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 80
@@ -191,7 +191,7 @@ servers:
       volume_size: 5500
     group: "couchdb2"
   - server_name: "couch10-production"
-    server_instance_type: c5.2xlarge
+    server_instance_type: c5.4xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 80

--- a/scripts/example-apply-terraform-to-single-server-and-bring-back-up.sh
+++ b/scripts/example-apply-terraform-to-single-server-and-bring-back-up.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+bash example-apply-terraform-to-single-server-and-bring-back-up.sh production couch3 master
+
+env=$1
+host=$2
+branch=$3
+
+read -sp "Vault Password for '${env}': " vault_password
+
+cchq ${env} terraform apply --skip-secrets -target module.server__${host}-${env}.aws_instance.server &&
+until cchq production ping ${host}
+do
+    sleep 5
+done &&
+ANSIBLE_VAULT_PASSWORD="${vault_password}" cchq ${env} after-reboot ${host} --branch=${branch} --quiet

--- a/src/commcare_cloud/environment/main.py
+++ b/src/commcare_cloud/environment/main.py
@@ -45,7 +45,10 @@ class Environment(object):
 
     @memoized
     def get_ansible_vault_password(self):
-        return getpass.getpass("Vault Password for '{}': ".format(self.paths.env_name))
+        return (
+            os.environ.get('ANSIBLE_VAULT_PASSWORD') or
+            getpass.getpass("Vault Password for '{}': ".format(self.paths.env_name))
+        )
 
     @memoized
     def get_vault_variables(self):


### PR DESCRIPTION
##### SUMMARY

We've been getting http errors on CouchDB on production during IST ever since we got off Cloudant, and I want to do a conclusive test that will narrow the cause down to a CPU/RAM bottleneck. This PR doubles the CPU and RAM on all nodes. Then using the data I get from this, I will rearrange the couch nodes back down to a more cost-optimized node configuration (e.g. maybe fewer larger nodes, less total disk, etc).

I also included a little script I made while doing this that strings together the multiple steps involved in restarting nodes one by one. It's nothing fancy, and it may be better suited to be a `cchq` command in the future, but I wanted to jot down the quick and dirty version so I had something to iterate on as I continue to do similar operations.

##### ENVIRONMENTS AFFECTED

production

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
Production CouchDB nodes

##### ADDITIONAL INFORMATION

I cleared my terminal history before making the PR but the output was something like

* After
```paste below
$ host=couch10 && cchq production terraform apply --skip-secrets -target module.server__${host}-production.aws_instance.server
...
  ~ module.server__couch10-production.aws_instance.server
      instance_type:           "c5.2xlarge" => "c5.4xlarge"
```

for each of the couch nodes couch3 through couch10