### PR TITLE
Update proxy_read_timeout for the receiver|phone endpoint to Oct 2018 value

### DIFF
--- a/src/commcare_cloud/ansible/roles/nginx/vars/cchq_ssl.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/cchq_ssl.yml
@@ -41,6 +41,7 @@ nginx_sites:
       balancer: "{{ deploy_env }}_commcare_submissions"
       proxy_redirect: "http://{{ SITE_HOST }} https://{{ SITE_HOST }}"
       proxy_next_upstream_tries: 1
+      proxy_read_timeout: 900s
       proxy_buffers: 8 64k
       proxy_buffer_size: 64k
       client_body_buffer_size: 512k


### PR DESCRIPTION
##### SUMMARY

I inadvertently changed this setting in https://github.com/dimagi/commcare-cloud/pull/2324.
This PR changes it back to the pre-Oct 23 2018 value of 900s (https://github.com/dimagi/commcare-cloud/pull/2300)

##### ENVIRONMENTS AFFECTED

All environments but mainly production

##### ISSUE TYPE

- Bugfix Pull Request

I'm not certain this will fix it, but this is attempting to fix an ongoing issue we've discovered that we've had since ~Oct 29, 2018 where form submissions have only a 50% (daily) success rate.

##### COMPONENT NAME

Mobile webworkers / form submissions
