### PR TITLE
remove TCL object storage

### DIFF
--- a/environments/icds-cas/public.yml
+++ b/environments/icds-cas/public.yml
@@ -253,7 +253,7 @@ localsettings:
             - 'static-dashboard_growth_monitoring_forms'
             - 'dashboard_child_health_daily_feeding_forms'
             - 'static-dashboard_birth_preparedness_forms'
-  BLOB_DB_MIGRATING_FROM_S3_TO_S3: True
+  BLOB_DB_MIGRATING_FROM_S3_TO_S3: False
   OBFUSCATE_PASSWORD_FOR_NIC_COMPLIANCE: True
   PILLOWTOP_MACHINE_ID: pil0
   PILLOW_RETRY_QUEUE_ENABLED: True

--- a/environments/icds-cas/public.yml
+++ b/environments/icds-cas/public.yml
@@ -138,12 +138,13 @@ couch_dbs:
 TWO_FACTOR_GATEWAY_ENABLED: True
 
 s3_blob_db_enabled: yes
-old_s3_blob_db_url: "https://mowcdmum.ipstorage.tatacommunications.com"
-old_s3_blob_db_s3_bucket: 'mowcdmum-c1'
-old_s3_bulk_delete_chunksize: 200
-
 s3_blob_db_url: "http://{{ groups['proxy'][0] }}:{{ riakcs_proxy_port }}"
 s3_blob_db_s3_bucket: 'blobdb'
+
+# removed after migrating data to riak
+#old_s3_blob_db_url: "https://mowcdmum.ipstorage.tatacommunications.com"
+#old_s3_blob_db_s3_bucket: 'mowcdmum-c1'
+#old_s3_bulk_delete_chunksize: 200
 
 localsettings:
   ALLOWED_HOSTS:

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -193,7 +193,7 @@ S3_BLOB_DB_SETTINGS = {
     'bulk_delete_chunksize': {{ s3_bulk_delete_chunksize }},
     'config': {'signature_version': 's3'},
 }
-{% if 'BLOB_DB_MIGRATING_FROM_S3_TO_S3' in localsettings %}
+{% if localsettings.get('BLOB_DB_MIGRATING_FROM_S3_TO_S3', False) %}
 OLD_S3_BLOB_DB_SETTINGS = {
     'url': '{{ old_s3_blob_db_url }}',
     'access_key': '{{ old_s3_blob_db_access_key }}',


### PR DESCRIPTION
##### SUMMARY
Update localsettings to remove old blobdb now that all data has been migrated to back to Riak.

##### ENVIRONMENTS AFFECTED
* icds

##### ISSUE TYPE
- Change Pull Request

##### ADDITIONAL INFORMATION
```
cchq icds update-config
```

* Before
```diff
--- before: /home/cchq/www/icds/current/localsettings.py
+++ after: /tmp/ansible-local-22176_hIY2P/tmpZ27tq1/localsettings.py.j2
@@ -388,15 +388,6 @@
     'bulk_delete_chunksize': 1000,
     'config': {'signature_version': 's3'},
 }
-OLD_S3_BLOB_DB_SETTINGS = {
-    'url': 'https://mowcdmum.ipstorage.tatacommunications.com',
-    'access_key': 'mowcdmumusr',
-    'secret_key': '316dfae92a322c17ea41eb1dee20c2d4',
-    's3_bucket': 'mowcdmum-c1',
-    'bulk_delete_chunksize': 200,
-    'config': {'signature_version': 's3'},
-}
-BLOB_DB_MIGRATING_FROM_S3_TO_S3 = True
```