### PR TITLE
Reduce production couchdb to 6 nodes

### DIFF
--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -206,26 +206,20 @@ es_data
 10.202.40.97 hostname=couch4-production ec2=yes
 [couch5]
 10.202.40.5 hostname=couch5-production ec2=yes
-[couch6]
-10.202.40.100 hostname=couch6-production ec2=yes
 [couch7]
 10.202.40.120 hostname=couch7-production ec2=yes
 [couch8]
 10.202.40.57 hostname=couch8-production ec2=yes
 [couch9]
 10.202.40.134 hostname=couch9-production ec2=yes
-[couch10]
-10.202.40.133 hostname=couch10-production ec2=yes
 
 [couchdb2:children]
 couch3
 couch4
 couch5
-couch6
 couch7
 couch8
 couch9
-couch10
 
 [couchdb2:vars]
 swap_size=8G

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -206,26 +206,20 @@ es_data
 {{ couch4-production }} hostname=couch4-production ec2=yes
 [couch5]
 {{ couch5-production }} hostname=couch5-production ec2=yes
-[couch6]
-{{ couch6-production }} hostname=couch6-production ec2=yes
 [couch7]
 {{ couch7-production }} hostname=couch7-production ec2=yes
 [couch8]
 {{ couch8-production }} hostname=couch8-production ec2=yes
 [couch9]
 {{ couch9-production }} hostname=couch9-production ec2=yes
-[couch10]
-{{ couch10-production }} hostname=couch10-production ec2=yes
 
 [couchdb2:children]
 couch3
 couch4
 couch5
-couch6
 couch7
 couch8
 couch9
-couch10
 
 [couchdb2:vars]
 swap_size=8G

--- a/environments/production/migrations/0005-reduce-couchdb-to-6-nodes/couchdb-step-1.yml
+++ b/environments/production/migrations/0005-reduce-couchdb-to-6-nodes/couchdb-step-1.yml
@@ -1,0 +1,2 @@
+target_allocation:
+  - couch3,couch4,couch5,couch7,couch8,couch9:3

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -158,14 +158,6 @@ servers:
     block_device:
       volume_size: 5500
     group: "couchdb2"
-  - server_name: "couch6-production"
-    server_instance_type: c5.4xlarge
-    network_tier: "db-private"
-    az: "a"
-    volume_size: 80
-    block_device:
-      volume_size: 6500
-    group: "couchdb2"
   - server_name: "couch7-production"
     server_instance_type: c5.4xlarge
     network_tier: "db-private"
@@ -183,14 +175,6 @@ servers:
       volume_size: 5500
     group: "couchdb2"
   - server_name: "couch9-production"
-    server_instance_type: c5.4xlarge
-    network_tier: "db-private"
-    az: "a"
-    volume_size: 80
-    block_device:
-      volume_size: 5500
-    group: "couchdb2"
-  - server_name: "couch10-production"
     server_instance_type: c5.4xlarge
     network_tier: "db-private"
     az: "a"


### PR DESCRIPTION
##### SUMMARY

CouchDB for the last couple weeks was 8 x (8 CPU, 16GB RAM) nodes, and we were getting a lot of http errors from couch during IST work hours. Yesterday we doubled node sizes to 8 x (16 CPU, 32GB RAM), and the errors went away almost entirely. But that seems like an absurd amount of power to need. In addition, I was able to reclaim many terrabytes of space in the last week, we're now paying for too much disk as well. Because of these two things together, I'm estimating that 6 nodes with the same disk and node size is a good compromise position that balances cost and performance. (I'm still surprised at the CPU and RAM we need on this cluster to keep it running smooth at peak hours, but I don't have a good way to gauge what those number should be.)

Somewhat fortuitously, the current disk size of 5500 per node is almost exactly what I'm estimating we need (but on 6 nodes instead of 8) to host our data at around 70% disk usage, to leave room for compacting, growth, and a margin of error, so I'm not modifying the volume sizes.

##### ENVIRONMENTS AFFECTED

- production

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME

production CouchDB

##### ADDITIONAL INFORMATION

In terms of the details of the couch shard reallocation, the new allocation still manages to split each db evenly across all nodes, with every node having 4 shards (6 * 4 = 24) instead of 3 shards (8 * 3 = 24). I picked couch6 and couch10 to remove because couch6 had too much disk and I specifically wanted to get rid of it, and couch10 didn't share any shards with couch6, meaning that I could migrate off both of them at once while only moving at most one copy of each shard, allowing for a maximally safe no-downtime migration.
