### PR TITLE
Double production nginx_max_worker_connection to 2048

### DIFF
--- a/environments/production/proxy.yml
+++ b/environments/production/proxy.yml
@@ -7,7 +7,7 @@ primary_ssl_env: "production"
 
 nginx_hsts_max_age: 300 # 5 minutes
 
-nginx_max_worker_connection: 1024
+nginx_max_worker_connection: 2048
 # commcarehq.org of certs
 nginx_combined_cert_value: "{{ ssl_secrets.certs.commcarehq_org }}"
 nginx_key_value: "{{ ssl_secrets.private_keys.commcarehq_org }}"


### PR DESCRIPTION
##### SUMMARY

This was recently doubled from 512, which helped but wasn't quite enough.
This is motivated by couchdb2_proxy (not the main site proxy, which it also affects).

##### ENVIRONMENTS AFFECTED

production

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME

CouchDB proxy (production)


##### ADDITIONAL INFORMATION

```diff
TASK [nginx : Copy the nginx configuration file] ***********************************************************************************************************************************************************
--- before: /etc/nginx/nginx.conf
+++ after: /Users/droberts/.ansible/tmp/ansible-local-48309lH9bnS/tmp5GnJ_G/nginx.conf.j2
@@ -6,7 +6,7 @@
 worker_rlimit_nofile 65536;

 events {
-    worker_connections  1024;
+    worker_connections  2048;
 }
```
