### PR TITLE
Add AAA database

### DIFF
--- a/environments/softlayer/postgresql.yml
+++ b/environments/softlayer/postgresql.yml
@@ -3,6 +3,7 @@ REPORTING_DATABASES:
   icds-ucr: icds-ucr
   icds-test-ucr: icds-ucr
   icds-ucr-non-dashboard: icds-ucr
+  aaa-data: aaa-data
 
 override:
   pgbouncer_default_pool: 290
@@ -29,5 +30,8 @@ dbs:
     - django_alias: icds-ucr
       name: icds-ucr
       django_migrate: True  # ICDS dashboard models are stored here
+    - django_alias: aaa-data
+      name: aaa-data
+      django_migrate: True  # AAA dashboard models are stored here
     - name: airflow
       django_migrate: False


### PR DESCRIPTION
##### SUMMARY
Adds AAA database used for the new dashboard

##### ENVIRONMENTS AFFECTED
softlayer

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
postgresql

##### ADDITIONAL INFORMATION
```bash
# creates the database and updates pgbouncer
cchq softlayer ap deploy_db.yml --branch=je/add-aaa-db --tags=postgresql --limit=db1

# add's aaa-data to localsettings.py
cchq softlayer ap update-config --branch=je/add-aaa-db 
```

@NitigyaS I noticed that softlayer has a lot of diffs with the pgbouncer hba confs that I believe you've been working on. Can you look into resolving those? I was able to work around it today