### PR TITLE
specify redis pickle version in localsettings

### DIFF
--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -383,6 +383,7 @@ redis_cache = {
 {% endif %}
     'OPTIONS': {
         'PARSER_CLASS': 'redis.connection.HiredisParser',
+        'PICKLE_VERSION': 2,  # After PY3 migration: remove
 {% if is_redis_cluster %}
         'REDIS_CLIENT_CLASS': 'rediscluster.RedisCluster',
         'CONNECTION_POOL_CLASS': 'rediscluster.connection.ClusterConnectionPool',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

This hardcodes the version of pickle used by ```django_redis```, which enables backwards/forwards compatibility between python 2 and 3.

See https://github.com/dimagi/commcare-hq/pull/23284 for more information.

##### ENVIRONMENTS AFFECTED

All

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
localsettings

##### ADDITIONAL INFORMATION
Without this addition, the highest available pickle version is used in python 3, which then can't be used with python 2.

@dimagi/py3 
