### PR TITLE
Add confirmation_email_queue

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -25,8 +25,6 @@ celery_processes:
     async_restore_queue:
       concurrency: 2
       max_tasks_per_child: 5
-    confirmation_email_queue:
-      concurrency: 1
   celery1:
     flower: {}
     reminder_queue:
@@ -91,6 +89,8 @@ celery_processes:
     export_download_queue:
       concurrency: 6
       max_tasks_per_child: 5
+    confirmation_email_queue:
+      concurrency: 1
 pillows:
   pillow0:
     CaseToElasticsearchPillow:

--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -25,6 +25,8 @@ celery_processes:
     async_restore_queue:
       concurrency: 2
       max_tasks_per_child: 5
+    confirmation_email_queue:
+      concurrency: 1
   celery1:
     flower: {}
     reminder_queue:


### PR DESCRIPTION
##### SUMMARY
Adds `confirmation_email_queue` to `celery4`, to be used _only when sending the new domain confirmation email_.

##### ENVIRONMENTS AFFECTED
Production

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
N/A

##### ADDITIONAL INFORMATION
After parallel-izing loading of the template apps for Appcues v3 [here](https://github.com/dimagi/commcare-hq/pull/23261), we are worried that the confirmation email still takes a while to reach the user's inbox and that backups in the `email_queue` will result in a poor UX for new users. Adding `confirmation_email_queue` should speed up the process even more.