### PR TITLE
add tasks to optionally include a python 3.6 virtualenv

### DIFF
--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/main.yml
@@ -74,6 +74,19 @@
         - slow
       when: not testing|default(False)
 
+    - name: py3 install pip requirements
+      become: true
+      with_items: "{{ commcarehq_requirements }}"
+      pip:
+        requirements: "{{ code_home }}/requirements-python3_6/{{ item }}"
+        virtualenv: "{{ py3_virtualenv_home }}"
+        virtualenv_python: "python3.6"
+        chdir: "{{ code_home }}"
+      tags:
+        - slow
+        - py3
+      when: (py3_include_venv is defined and py3_include_venv)
+
     - name: chown clone
       become: true
       file:
@@ -106,6 +119,18 @@
     owner: "{{ cchq_user }}"
     group: "{{ cchq_user }}"
     recurse: yes
+
+- name: py3 chown virtualenv
+  become: true
+  file:
+    path: "{{ py3_virtualenv_home }}"
+    state: directory
+    owner: "{{ cchq_user }}"
+    group: "{{ cchq_user }}"
+    recurse: yes
+  tags:
+    - py3
+  when: (py3_include_venv is defined and py3_include_venv)
 
 - name: copy localsettings
   become: true

--- a/src/commcare_cloud/ansible/roles/commcarehq/vars/main.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/vars/main.yml
@@ -2,4 +2,5 @@ code_releases: "{{ www_home }}/releases"
 code_source: "{{ code_releases }}/{{ ansible_date_time.date }}_{{ ansible_date_time.hour }}.{{ ansible_date_time.minute }}"
 virtualenv_source: "{{ code_source }}/python_env"
 virtualenv_home: "{{ code_home }}/python_env"
+py3_virtualenv_home: "{{ code_home }}/python_env-3_6"
 BROKER_URL: 'amqp://{{ AMQP_USER }}:{{ AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Creates a new virtualenv for python 3.6 and adds requirements.  Coexists with the python 2 virtualenv.
Currently is only run if the variable ```py3_include_venv``` is set to true, since python 3.6 does not come by default with Ubuntu 14.04.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
No environments are affected for now.  After the Ubuntu 18.04 migration is complete I will make these tasks standard for all environments.
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

@dimagi/py3 