### PR TITLE
Increase concurrency on prod email_queue

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -12,7 +12,9 @@ celery_processes:
     submission_reprocessing_queue:
       concurrency: 1
     email_queue:
-      concurrency: 2
+      pooling: gevent
+      concurrency: 100
+      num_workers: 2
     repeat_record_queue,sumologic_logs_queue:
       pooling: gevent
       concurrency: 50


### PR DESCRIPTION
##### SUMMARY
Increase the concurrency and number of workers on `email_queue`

##### ENVIRONMENTS AFFECTED
Production

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
N/A

##### ADDITIONAL INFORMATION
I'm increasing the capacity of `email_queue`, to avoid a lag in user's receiving the confirmation email (instead of creating a new queue entirely, detailed https://github.com/dimagi/commcare-hq/pull/23291 and https://github.com/dimagi/commcare-cloud/pull/2661)
