### PR TITLE
add settings for python 3 deploy

### DIFF
--- a/environments/staging/fab-settings.yml
+++ b/environments/staging/fab-settings.yml
@@ -1,2 +1,4 @@
 ignore_kafka_checkpoint_warning: True
 default_branch: autostaging
+py3_include_venv: False
+py3_run_deploy: False

--- a/src/commcare_cloud/environment/schemas/fab_settings.py
+++ b/src/commcare_cloud/environment/schemas/fab_settings.py
@@ -16,6 +16,15 @@ class FabSettingsConfig(jsonobject.JsonObject):
     ignore_kafka_checkpoint_warning = jsonobject.BooleanProperty()
     acceptable_maintenance_window = jsonobject.ObjectProperty(lambda: AcceptableMaintenanceWindow)
     email_enabled = jsonobject.BooleanProperty()
+    py3_include_venv = jsonobject.BooleanProperty()
+    py3_run_deploy = jsonobject.BooleanProperty()
+
+    @classmethod
+    def wrap(cls, data):
+        obj = super(FabSettingsConfig, cls).wrap(data)
+        if obj.py3_run_deploy:
+            assert obj.py3_include_venv, "Must include Python 3 virtualenv to run Python 3 code."
+        return obj
 
 
 class AcceptableMaintenanceWindow(jsonobject.JsonObject):

--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -124,8 +124,19 @@ def _setup_path():
     env.code_root = posixpath.join(env.releases, env.deploy_metadata.timestamp)
     env.project_root = posixpath.join(env.code_root, env.project)
     env.project_media = posixpath.join(env.code_root, 'media')
-    env.virtualenv_current = posixpath.join(env.code_current, 'python_env')
-    env.virtualenv_root = posixpath.join(env.code_root, 'python_env')
+
+    env.py2_virtualenv_current = posixpath.join(env.code_current, 'python_env')
+    env.py2_virtualenv_root = posixpath.join(env.code_root, 'python_env')
+    env.py3_virtualenv_current = posixpath.join(env.code_current, 'python_env-3_6')
+    env.py3_virtualenv_root = posixpath.join(env.code_root, 'python_env-3_6')
+
+    if env.py3_run_deploy:
+        env.virtualenv_current = env.py3_virtualenv_current
+        env.virtualenv_root = env.py3_virtualenv_root
+    else:
+        env.virtualenv_current = env.py2_virtualenv_current
+        env.virtualenv_root = env.py2_virtualenv_root
+
     env.services = posixpath.join(env.code_root, 'services')
     env.jython_home = '/usr/local/lib/jython'
     env.db = '%s_%s' % (env.project, env.deploy_env)
@@ -137,8 +148,19 @@ def _override_code_root_to_current():
     env.code_root = env.code_current
     env.project_root = posixpath.join(env.code_root, env.project)
     env.project_media = posixpath.join(env.code_root, 'media')
-    env.virtualenv_current = posixpath.join(env.code_current, 'python_env')
-    env.virtualenv_root = posixpath.join(env.code_root, 'python_env')
+
+    env.py2_virtualenv_current = posixpath.join(env.code_current, 'python_env')
+    env.py2_virtualenv_root = posixpath.join(env.code_root, 'python_env')
+    env.py3_virtualenv_current = posixpath.join(env.code_current, 'python_env-3_6')
+    env.py3_virtualenv_root = posixpath.join(env.code_root, 'python_env-3_6')
+
+    if env.py3_run_deploy:
+        env.virtualenv_current = env.py3_virtualenv_current
+        env.virtualenv_root = env.py3_virtualenv_root
+    else:
+        env.virtualenv_current = env.py2_virtualenv_current
+        env.virtualenv_root = env.py2_virtualenv_root
+
     env.services = posixpath.join(env.code_root, 'services')
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add two settings:
```py3_include_venv``` - whether or not to clone and update the python 3 virtualenv.
```py3_run_deploy``` - whether or not to invoke the management commands used for deploy in python 3.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request



##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
For now, none of these settings will be set to true, so there will be no effect on deploys.

@dimagi/py3 