### PR TITLE
Add example snippet for a couchdb2 rolling restart

### DIFF
--- a/scripts/example-rolling-restart-couchdb2.sh
+++ b/scripts/example-rolling-restart-couchdb2.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+branch=$1
+
+# Restart each couch node with 15 seconds in between
+cchq $branch run-shell-command couchdb2 'sleep {{ groups["couchdb2"].index(inventory_hostname) * 15 }}; service couchdb2 restart' -b


### PR DESCRIPTION
##### SUMMARY

This is just an example snippet, something I used earlier to day that was effective. Like the other example snippet in this directory, I wasn't ready to turn this into a tool, but didn't want to lose the little tinkering I'd done to figure it out entirely.

##### ENVIRONMENTS AFFECTED

none

