### PR TITLE
Store Password Encrypted Require above PostgreSQL 10

### DIFF
--- a/src/commcare_cloud/ansible/roles/postgresql/tasks/set_up_dbs.yml
+++ b/src/commcare_cloud/ansible/roles/postgresql/tasks/set_up_dbs.yml
@@ -43,6 +43,7 @@
     login_user: "{{ db_is_remote and postgres_users.root.username or omit }}"
     login_password: "{{ db_is_remote and postgres_users.root.password or omit }}"
     db: 'postgres'
+    encrypted: True
   when: not is_pg_standby
   with_items: "{{ postgres_users.values() }}"
   tags:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Addding Encryption Flag. https://github.com/ansible/ansible/issues/33753
Require in Postgresql >= 10
Will be required by CitusDB too. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
all
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the script, playbook, task or feature below -->
Ansible : PostgreSQL
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

