### PR TITLE
Open RDS to traffic form proxy for websockets features

### DIFF
--- a/src/commcare_cloud/terraform/modules/network/main.tf
+++ b/src/commcare_cloud/terraform/modules/network/main.tf
@@ -369,7 +369,12 @@ resource "aws_security_group" "rds" {
     from_port = "5432"
     to_port = "5432"
     protocol = "tcp"
-    cidr_blocks = ["${aws_subnet.subnet-app-private.*.cidr_block}", "${aws_subnet.subnet-db-private.*.cidr_block}"]
+    cidr_blocks = [
+      "${aws_subnet.subnet-app-private.*.cidr_block}",
+      "${aws_subnet.subnet-db-private.*.cidr_block}",
+      # proxy needs access for websockets
+      "${aws_subnet.subnet-public.*.cidr_block}"
+    ]
     ipv6_cidr_blocks = ["::/0"]
   }
 


### PR DESCRIPTION
##### SUMMARY

Security groups allow you to block or allow traffic from specific IP ranges. Previously traffic from proxy to RDS (postgresql) was _not_ allowed, simply because I thought it was unnecessary. It turns out that I was wrong, that the proxy _does_ make requests directly to RDS, for our websockets feature.

As an aside, I'm not totally sure, but I'm wondering whether the proxy directly making requests to postgres is the right setup. Still I think first reenabling this to potentially fix broken websockets features ("some else is editing this form" in form builder, for example) is worth it.

##### ENVIRONMENTS AFFECTED
AWS envs: production, staging

##### ISSUE TYPE
- Bugfix Pull Request

(Not sure if this fully fixes a specific user-facing bug, but is definitely a necessary step.)
##### COMPONENT NAME

Websockets