### PR TITLE
Separate celery check

### DIFF
--- a/changelog/0015-separate-celery-datadog-http-check.yml
+++ b/changelog/0015-separate-celery-datadog-http-check.yml
@@ -1,0 +1,22 @@
+title: Separate celery datadog http check
+key: separate-celery-datadog-http-check.yml
+date: 2019-02-22
+optional_per_env: yes
+min_commcare_version:
+max_commcare_version: 81325fbd9e3131c710179f7246dbe9caccb45154
+context: |
+  This adds a specific http check for the celery check (serverup.txt?only=celery)
+  to datadog.
+  Environments that are not relying on datadog for monitoring can ignore this change.
+
+details: |
+  This will result in three distinct http checks:
+    - "serverup" endpoint (high severity)
+    - "celery" endpoint (usually lower severity)
+    - "heartbeat" endpoint (usually lower severity)
+
+update_steps: |
+  1. Update datadog integrations on the proxy machine:
+  ```bash
+  commcare-cloud <env> deploy-stack --limit=proxy --tags=datadog_integrations
+  ```

--- a/docs/changelog/0015-separate-celery-datadog-http-check.md
+++ b/docs/changelog/0015-separate-celery-datadog-http-check.md
@@ -1,0 +1,28 @@
+# 15. Separate celery datadog http check
+
+**Date:** 2019-02-22
+
+**Optional per env:** _only required on some environments_
+
+
+## CommCare Version Dependency
+CommCare versions beyond this commit require this change to function correctly:
+[81325fbd](https://github.com/dimagi/commcare-hq/commit/81325fbd9e3131c710179f7246dbe9caccb45154)
+
+
+## Change Context
+This adds a specific http check for the celery check (serverup.txt?only=celery)
+to datadog.
+Environments that are not relying on datadog for monitoring can ignore this change.
+
+## Details
+This will result in three distinct http checks:
+  - "serverup" endpoint (high severity)
+  - "celery" endpoint (usually lower severity)
+  - "heartbeat" endpoint (usually lower severity)
+
+## Steps to update
+1. Update datadog integrations on the proxy machine:
+```bash
+commcare-cloud <env> deploy-stack --limit=proxy --tags=datadog_integrations
+```

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -5,6 +5,11 @@ newest first.
 
 ## Changelog
 
+### **2019-02-22** [Separate celery datadog http check](0015-separate-celery-datadog-http-check.md)
+This adds a specific http check for the celery check (serverup.txt?only=celery)
+to datadog.
+Environments that are not relying on datadog for monitoring can ignore this change.
+
 ### **2019-02-11** [Add tag to datadog http checks](0014-add-tag-to-datadog-http-checks.md)
 This change adds "check_type" tag to the http_check datadog integration.
 This change applies only to envs using datadog for monitoring.

--- a/src/commcare_cloud/ansible/roles/datadog/templates/http_check.yaml.j2
+++ b/src/commcare_cloud/ansible/roles/datadog/templates/http_check.yaml.j2
@@ -11,6 +11,12 @@ instances:
     include_content: true
     tags:
       - check_type:serverup
+  - name: {{ env_monitoring_id }} Celery
+    url: https://{{ SITE_HOST }}/serverup.txt?only=celery
+    check_certificate_expiration: false
+    timeout: 30
+    tags:
+      - check_type:celery
 {% if monitor_celery_heartbeat|default(True) %}
   - name: {{ env_monitoring_id }} Heartbeat
     url: https://{{ SITE_HOST }}/serverup.txt?only=heartbeat


### PR DESCRIPTION
##### SUMMARY
This adds a specific http check for the celery check (serverup.txt?only=celery) to datadog.

##### ENVIRONMENTS AFFECTED
Environments that are not relying on datadog for monitoring can ignore this change.

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME

Datadog monitoring 

##### ADDITIONAL INFORMATION
Example ansible diff:
```
--- before: /etc/dd-agent/conf.d/http_check.yaml
+++ after: /Users/droberts/.ansible/tmp/ansible-local-97263sd5Pmr/tmpygx_Im/http_check.yaml.j2
@@ -11,6 +11,12 @@
     include_content: true
     tags:
       - check_type:serverup
+  - name: production Celery
+    url: https://www.commcarehq.org/serverup.txt?only=celery
+    check_certificate_expiration: false
+    timeout: 30
+    tags:
+      - check_type:celery
   - name: production Heartbeat
     url: https://www.commcarehq.org/serverup.txt?only=heartbeat
     check_certificate_expiration: false

changed: [10.202.20.138] => (item={u'enabled': True, u'name': u'http_check'})
```