### PR TITLE
Give proxy access to pgbouncer port in AWS envs

### DIFF
--- a/src/commcare_cloud/terraform/modules/network/main.tf
+++ b/src/commcare_cloud/terraform/modules/network/main.tf
@@ -277,6 +277,16 @@ resource "aws_security_group" "db-private" {
   }
 
   ingress {
+    from_port   = 6432
+    to_port     = 6432
+    protocol    = "tcp"
+    cidr_blocks = [
+      // Allow proxy access to pgbouncer
+      "${aws_subnet.subnet-public.*.cidr_block}",
+    ]
+  }
+
+  ingress {
     from_port   = 2049
     to_port     = 2049
     protocol    = "tcp"


### PR DESCRIPTION
##### SUMMARY
Try number two of https://github.com/dimagi/commcare-cloud/pull/2677.
This should fix at least some of the low but consistent rate of postgres errors
we've been seeing.

##### ENVIRONMENTS AFFECTED
production, staging

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
websockets
