### PR TITLE
Only restart formplayer when the jar has changed

### DIFF
--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -399,7 +399,6 @@ def kill_stale_celery_workers():
 def deploy_formplayer():
     execute(announce_formplayer_deploy_start)
     execute(formplayer.build_formplayer, True)
-    execute(supervisor.restart_formplayer)
 
 
 @task

--- a/src/commcare_cloud/fab/operations/formplayer.py
+++ b/src/commcare_cloud/fab/operations/formplayer.py
@@ -3,12 +3,27 @@ import datetime
 import os
 
 from fabric import utils
-from fabric.api import roles, env, sudo
+from fabric.api import roles, env, sudo, settings
 from fabric.context_managers import cd
 from fabric.contrib import console
 from fabric.contrib import files
 
+from commcare_cloud.fab.operations import supervisor
 from ..const import ROLES_FORMPLAYER, FORMPLAYER_BUILD_DIR, DATE_FMT
+
+
+def get_formplayer_build_url(env):
+    if env.deploy_env == 'staging':
+        return 'https://s3.amazonaws.com/dimagi-formplayer-jars/staging/latest-successful/formplayer.jar'
+    else:
+        return 'https://s3.amazonaws.com/dimagi-formplayer-jars/latest-successful/formplayer.jar'
+
+
+def _formplayer_jars_differ(build_dir, release_1, release_2):
+    with cd(build_dir):
+        with settings(warn_only=True):
+            result = sudo("diff {}/libs/formplayer.jar {}/libs/formplayer.jar".format(release_1, release_2))
+    return result.return_code == 1
 
 
 @roles(ROLES_FORMPLAYER)
@@ -29,18 +44,21 @@ def build_formplayer(use_current_release=False):
     if not files.exists(build_dir):
         sudo('mkdir {}'.format(build_dir))
 
-    if env.deploy_env == 'staging':
-        jenkins_formplayer_build_url = 'https://s3.amazonaws.com/dimagi-formplayer-jars/staging/latest-successful/formplayer.jar'
-    else:
-        jenkins_formplayer_build_url = 'https://s3.amazonaws.com/dimagi-formplayer-jars/latest-successful/formplayer.jar'
+    jenkins_formplayer_build_url = get_formplayer_build_url(env)
 
     release_name = 'formplayer__{}'.format(datetime.datetime.utcnow().strftime(DATE_FMT))
     release_name_libs = os.path.join(release_name, 'libs')
     with cd(build_dir):
         sudo('mkdir -p {}'.format(release_name_libs))
         sudo("wget -nv '{}' -O {}/formplayer.jar".format(jenkins_formplayer_build_url, release_name_libs))
-        sudo('ln -sfn {} current'.format(release_name))
-        sudo('ln -sf current/libs/formplayer.jar formplayer.jar')
+
+    # since restarting formplayer currently causes Web Apps downtime
+    # only relink current and restart if the jar actually differs
+    if _formplayer_jars_differ(build_dir, 'current', release_name):
+        with cd(build_dir):
+            sudo('ln -sfn {} current'.format(release_name))
+            sudo('ln -sf current/libs/formplayer.jar formplayer.jar')
+        supervisor.restart_formplayer()
 
 
 @roles(ROLES_FORMPLAYER)


### PR DESCRIPTION

##### SUMMARY
Previously, formplayer restarts during every deploy. Now it only restarts when the jar changes,
because for the time being restarting formplayer causes meaningful Web Apps downtime.

##### ENVIRONMENTS AFFECTED
All that use Web Apps

##### ISSUE TYPE

- Change Pull Request

This is mostly a hack to fix the 80% case. The "real" issue is that we don't have a way to restart formplayer without causing a service interruption.

##### COMPONENT NAME

Web Apps (formplayer)
