### PR TITLE
Fix formplayer deploy after recent change

### DIFF
--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -819,6 +819,8 @@ def silent_services_restart(use_current_release=False):
     """
     execute(db.set_in_progress_flag, use_current_release)
     if not env.is_monolith:
+        if getattr(env, 'NEEDS_FORMPLAYER_RESTART', False):
+            execute(supervisor.restart_formplayer)
         execute(supervisor.restart_all_except_webworkers)
     execute(supervisor.restart_webworkers)
 

--- a/src/commcare_cloud/fab/operations/formplayer.py
+++ b/src/commcare_cloud/fab/operations/formplayer.py
@@ -23,7 +23,8 @@ def _formplayer_jars_differ(build_dir, release_1, release_2):
     with cd(build_dir):
         with settings(warn_only=True):
             result = sudo("diff {}/libs/formplayer.jar {}/libs/formplayer.jar".format(release_1, release_2))
-    return result.return_code == 1
+    # 1 means there's a diff, 2 means one of the files doesn't exist
+    return result.return_code in (1, 2)
 
 
 @roles(ROLES_FORMPLAYER)
@@ -58,7 +59,8 @@ def build_formplayer(use_current_release=False):
         with cd(build_dir):
             sudo('ln -sfn {} current'.format(release_name))
             sudo('ln -sf current/libs/formplayer.jar formplayer.jar')
-        supervisor.restart_formplayer()
+        env.NEEDS_FORMPLAYER_RESTART = True
+
 
 
 @roles(ROLES_FORMPLAYER)

--- a/src/commcare_cloud/fab/operations/release.py
+++ b/src/commcare_cloud/fab/operations/release.py
@@ -412,13 +412,11 @@ def copy_localsettings(full_cluster=True):
 @parallel
 @roles(ROLES_FORMPLAYER)
 def copy_formplayer_properties():
-    sudo('mkdir -p {}'.format(os.path.join(env.code_root, FORMPLAYER_BUILD_DIR)))
-    for filename in ['application.properties', 'sentry.properties']:
-        sudo(
-            'cp {} {}'.format(
-                os.path.join(env.code_current, FORMPLAYER_BUILD_DIR, filename),
-                os.path.join(env.code_root, FORMPLAYER_BUILD_DIR)
-            ))
+    sudo(
+        'cp -r {} {}'.format(
+            os.path.join(env.code_current, FORMPLAYER_BUILD_DIR),
+            os.path.join(env.code_root, FORMPLAYER_BUILD_DIR)
+        ))
 
 
 @parallel

--- a/src/commcare_cloud/fab/operations/supervisor.py
+++ b/src/commcare_cloud/fab/operations/supervisor.py
@@ -49,7 +49,7 @@ def start_celery_tasks(current=False):
         sudo('scripts/supervisor-group-ctl start celery')
 
 
-@roles(set(ROLES_ALL_SERVICES) - set(ROLES_DJANGO))
+@roles(set(ROLES_ALL_SERVICES) - set(ROLES_DJANGO) - set(ROLES_FORMPLAYER))
 @parallel
 def restart_all_except_webworkers():
     _services_restart()


### PR DESCRIPTION
##### SUMMARY
fixes https://github.com/dimagi/commcare-cloud/pull/2682

In addition, I found that another assumption from when I made that PR weren't correct. I found that since possibly forever, formplayer has been restarted _twice_ on every deploy: once unnecessarily before we've re-linked the current commcare-hq release (thus not picking up any changes) and once again afterwards when we restart services. In this PR I remove the first time entirely, and make the second time only happen if we detect an actual change in the formplayer jar

##### ENVIRONMENTS AFFECTED
All
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Formplayer deploy

