### PR TITLE
Clean up solo_queues declaration in app_processes.py

### DIFF
--- a/src/commcare_cloud/environment/schemas/app_processes.py
+++ b/src/commcare_cloud/environment/schemas/app_processes.py
@@ -98,18 +98,23 @@ CELERY_PROCESS_NAMES = [process.name for process in CELERY_PROCESSES]
 OPTIONAL_CELERY_PROCESSES = [process.name for process in CELERY_PROCESSES
                              if not process.required]
 
+# queues specified in solo_queues cannot be combined with other queues in the same process
+SOLO_QUEUES = [
+    # because these don't actually run normal celery processes
+    'flower', 'beat',
+    # because these run management commands in addition to normal celery processes
+    # (see commcare_cloud/ansible/roles/commcarehq/tasks/celery.yml)
+    'reminder_queue', 'submission_reprocessing_queue', 'sms_queue',
+]
+
 
 def validate_app_processes_config(app_processes_config):
-    # queues specified in solo_queues cannot be combined with other queues in the same processes, otherwise tasks
-    # specific to those queues in celery.yml will get skipped
-    solo_queues = ['flower', 'beat', 'reminder_queue', 'submission_reprocessing_queue',
-                   'sms_queue', 'queue_schedule_instances', 'handle_survey_actions']
     all_queues_mentioned = Counter({queue_name: 0 for queue_name in CELERY_PROCESS_NAMES})
     for machine, queues_config in app_processes_config.celery_processes.items():
         for comma_separated_queue_names, celery_options in queues_config.items():
             queue_names = comma_separated_queue_names.split(',')
             for queue_name in queue_names:
-                if queue_name in solo_queues:
+                if queue_name in SOLO_QUEUES:
                     assert len(queue_names) == 1, \
                         "The special process {} may not be grouped with other processes".format(queue_name)
                 assert queue_name in CELERY_PROCESS_NAMES, \


### PR DESCRIPTION
##### SUMMARY

Just a little thing I come across sometimes. The comment here wasn't quite right for all queues there and I thought I could break it down a little more clearly. Also removed some things that weren't defined as a `CeleryProcess` and thus didn't need to be in the list.

##### ENVIRONMENTS AFFECTED
It's a no-op change.

##### ISSUE TYPE
- Comment Pull Request

##### COMPONENT NAME
Celery config
