### PR TITLE
use redis as celery results backend

### DIFF
--- a/changelog/0017-use-redis-celery-results-backend.yml
+++ b/changelog/0017-use-redis-celery-results-backend.yml
@@ -1,0 +1,22 @@
+title: Update supervisor confs to invoke celery directly
+key: invoke-celery-directly
+date: 2019-02-26
+optional_per_env: no
+min_commcare_version:
+max_commcare_version:
+context: |
+  Upgrading to celery 4.x requires removing the dependency on
+  django-celery, which means that the results backend provided
+  by django-celery has to be replaced.  This change configures
+  celery to use the redis results backend instead.
+
+details: |
+  This change must be applied before the django-celery dependency
+  is removed from the commcare-hq library, otherwise celery
+  will not be able to store task results.
+
+update_steps: |
+  Update supervisor confs:
+  ```bash
+  commcare-cloud <env> update-config
+  ```

--- a/docs/changelog/0017-use-redis-celery-results-backend.md
+++ b/docs/changelog/0017-use-redis-celery-results-backend.md
@@ -1,0 +1,27 @@
+# 17. Update supervisor confs to invoke celery directly
+
+**Date:** 2019-02-26
+
+**Optional per env:** _required on all environments_
+
+
+## CommCare Version Dependency
+This change is not known to be dependent on any particular version of CommCare.
+
+
+## Change Context
+Upgrading to celery 4.x requires removing the dependency on
+django-celery, which means that the results backend provided
+by django-celery has to be replaced.  This change configures
+celery to use the redis results backend instead.
+
+## Details
+This change must be applied before the django-celery dependency
+is removed from the commcare-hq library, otherwise celery
+will not be able to store task results.
+
+## Steps to update
+Update supervisor confs:
+```bash
+commcare-cloud <env> update-config
+```

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -5,6 +5,12 @@ newest first.
 
 ## Changelog
 
+### **2019-02-26** [Update supervisor confs to invoke celery directly](0017-use-redis-celery-results-backend.md)
+Upgrading to celery 4.x requires removing the dependency on
+django-celery, which means that the results backend provided
+by django-celery has to be replaced.  This change configures
+celery to use the redis results backend instead.
+
 ### **2019-02-22** [Update supervisor confs to invoke celery directly](0016-invoke-celery-directly.md)
 Upgrading to celery 4.x requires removing the dependency on
 django-celery, which means that the celery management command

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -350,7 +350,6 @@ CUSTOM_REPORT_MAP = {
     ]
 }
 
-CELERY_RESULT_BACKEND = '{{ CELERY_RESULT_BACKEND }}'
 CELERY_FLOWER_URL = '{{ CELERY_FLOWER_URL }}'
 {% if 'CELERY_TIMEZONE' in localsettings and localsettings.CELERY_TIMEZONE %}
 CELERY_TIMEZONE = '{{ localsettings.CELERY_TIMEZONE }}'
@@ -398,6 +397,8 @@ CACHES = {
     'default': redis_cache,
     'redis': redis_cache,
 }
+
+CELERY_RESULT_BACKEND = redis_cache['LOCATION']
 
 ELASTICSEARCH_HOSTS = [
     {% for es_host in groups.elasticsearch -%}

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -350,16 +350,9 @@ CUSTOM_REPORT_MAP = {
     ]
 }
 
-CELERY_FLOWER_URL = '{{ CELERY_FLOWER_URL }}'
-{% if 'CELERY_TIMEZONE' in localsettings and localsettings.CELERY_TIMEZONE %}
-CELERY_TIMEZONE = '{{ localsettings.CELERY_TIMEZONE }}'
-{% endif %}
-
 PREVIEWER_RE = r'^(.*@dimagi\.com|.*@valuelabs\.in)$'
 GMAPS_API_KEY = '{{ GMAPS_API_KEY }}'
 FORMTRANSLATE_TIMEOUT = 5
-
-CELERY_BROKER_URL = BROKER_URL = '{{ BROKER_URL }}'
 
 FORMPLAYER_URL = "/formplayer"
 
@@ -398,7 +391,12 @@ CACHES = {
     'redis': redis_cache,
 }
 
+CELERY_BROKER_URL = BROKER_URL = '{{ BROKER_URL }}'
+CELERY_FLOWER_URL = '{{ CELERY_FLOWER_URL }}'
 CELERY_RESULT_BACKEND = redis_cache['LOCATION']
+{% if 'CELERY_TIMEZONE' in localsettings and localsettings.CELERY_TIMEZONE %}
+CELERY_TIMEZONE = '{{ localsettings.CELERY_TIMEZONE }}'
+{% endif %}
 
 ELASTICSEARCH_HOSTS = [
     {% for es_host in groups.elasticsearch -%}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently we use a postgres table defined by ```django-celery``` as the celery results backend.  We are removing this library in order to upgrade to celery 4.x, so we have to replace the results backend.  I choose redis since this is the recommended best practice, since it reduces pressure on postgres.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Change Pull Request

##### COMPONENT NAME
<!--- Write the short name of the script, playbook, task or feature below -->
```commcare-cloud <env> update-config```

Recommend reviewing commit by commit 🐡 

