### PR TITLE
only monitor primary rabbitmq queues 

### DIFF
--- a/changelog/0017-monitor-specific-rabbitmq-queues.yml
+++ b/changelog/0017-monitor-specific-rabbitmq-queues.yml
@@ -1,0 +1,19 @@
+title: Only monitor specific RabbitMQ queues
+key: monitor-specific-rabbitmq-queues
+date: 2019-02-27
+optional_per_env: yes
+min_commcare_version:
+max_commcare_version:
+context: |
+  Datadog RabbitMQ monitoring restricts the number of queues it
+  can monitor to 200. To avoid hitting this limit on large
+  scale deployments we limit the queues being monitored to only
+  the primary queues.
+details: |
+  This will result in only the queues listed in the config file
+  being monitored by Datadog.
+update_steps: |
+  1. Update datadog integrations on the RabbitMQ machine:
+  ```bash
+  commcare-cloud <env> deploy-stack --limit=rabbitmq --tags=datadog_integrations
+  ```

--- a/docs/changelog/0017-monitor-specific-rabbitmq-queues.md
+++ b/docs/changelog/0017-monitor-specific-rabbitmq-queues.md
@@ -1,0 +1,26 @@
+# 17. Only monitor specific RabbitMQ queues
+
+**Date:** 2019-02-27
+
+**Optional per env:** _only required on some environments_
+
+
+## CommCare Version Dependency
+This change is not known to be dependent on any particular version of CommCare.
+
+
+## Change Context
+Datadog RabbitMQ monitoring restricts the number of queues it
+can monitor to 200. To avoid hitting this limit on large
+scale deployments we limit the queues being monitored to only
+the primary queues.
+
+## Details
+This will result in only the queues listed in the config file
+being monitored by Datadog.
+
+## Steps to update
+1. Update datadog integrations on the RabbitMQ machine:
+```bash
+commcare-cloud <env> deploy-stack --limit=rabbitmq --tags=datadog_integrations
+```

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -5,6 +5,12 @@ newest first.
 
 ## Changelog
 
+### **2019-02-27** [Only monitor specific RabbitMQ queues](0017-monitor-specific-rabbitmq-queues.md)
+Datadog RabbitMQ monitoring restricts the number of queues it
+can monitor to 200. To avoid hitting this limit on large
+scale deployments we limit the queues being monitored to only
+the primary queues.
+
 ### **2019-02-22** [Update supervisor confs to invoke celery directly](0016-invoke-celery-directly.md)
 Upgrading to celery 4.x requires removing the dependency on
 django-celery, which means that the celery management command

--- a/src/commcare_cloud/ansible/roles/datadog/templates/rabbitmq.yaml.j2
+++ b/src/commcare_cloud/ansible/roles/datadog/templates/rabbitmq.yaml.j2
@@ -12,3 +12,7 @@ instances:
     vhosts:
       - {{ AMQP_NAME }}
     skip_proxy: True
+    queues:
+      {% for queue in celery_queues -%}
+      - {{ queue }}
+      {% endfor -%}

--- a/src/commcare_cloud/environment/schemas/app_processes.py
+++ b/src/commcare_cloud/environment/schemas/app_processes.py
@@ -55,6 +55,7 @@ class AppProcessesConfig(jsonobject.JsonObject):
         return {
             'CELERY_FLOWER_URL': "http://{flower_host}:5555".format(flower_host=flower_host),
             'app_processes_config': self.to_json(),
+            'celery_queues': CELERY_PROCESS_NAMES
         }
 
 


### PR DESCRIPTION
##### SUMMARY
Datadog has a 200 queue limit for RabbitMQ monitoring. Most of the queues are individual worker queues and not of great interest to us.

This changes the datadog configuration to only record metrics for the primary queues.

##### ENVIRONMENTS AFFECTED
All

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
RabbitMQ Datadog integration