### PR TITLE
Add comment on swiss DATADOG_INTEGRATIONS_ENABLED

### DIFF
--- a/environments/swiss/public.yml
+++ b/environments/swiss/public.yml
@@ -1,6 +1,12 @@
 msp_users: "{{ secrets.MSP_USERS }}"
 
 DATADOG_ENABLED: True
+# Simon 2019-02-28
+# on why DATADOG_INTEGRATIONS_ENABLED is False and whether it could be enabled:
+# > no real reason except that we didn't think it was necessary -
+# > given our current bill I don't think adding it would have much impact
+# > so if you think it would be useful please go ahead
+# So if you have a reason to, feel free to enable
 DATADOG_INTEGRATIONS_ENABLED: False
 
 elasticsearch_endpoint: '{{ groups.elasticsearch.0 }}'


### PR DESCRIPTION
##### SUMMARY
Add comment on swiss DATADOG_INTEGRATIONS_ENABLED
so that if someone comes along who would like to enable integrations
they know they have the go-ahead

Taken from a slack coversation:

> Danny Roberts [12:10 PM]
>  Hey I just wanted to confirm we’re okay with swiss not having datadog integrations enabled, including the basic endpoint checks: https://github.com/dimagi/commcare-cloud/blob/cfc4c794f1a36c2e935a9ed69fea206c778c7efa/environments/swiss/public.yml#L4
> GitHub
> dimagi/commcare-cloud
> Tools for standing up and managing a CommCare HQ server environment - dimagi/commcare-cloud
> If anyone knows anything specific about the decision not to enable datadog integrations there, I can add it as a comment to that file
> @snopoke looks like it was a matter of just not needing it? https://github.com/dimagi/commcare-cloud/pull/743. Do you remember if it was a cost thing?
> GitHub
> exclude integrations from swiss by snopoke · Pull Request #743 · dimagi/commcare-cloud
> I don't think we're using this data at all so removing it.
> No particular pushback from my side, I just noticed it and want to document the decision if we’re still onboard with it
> Simon Kelly [1:06 PM]
>  no real reason except that we didn't think it was necessary - given our current bill I don't think adding it would have much impact so if you think it would be useful please go ahead
