### PR TITLE
add delivery death list report back to UCR_COMPARISONS

### DIFF
--- a/environments/icds-cas/public.yml
+++ b/environments/icds-cas/public.yml
@@ -286,6 +286,7 @@ localsettings:
     'static-icds-cas-static-mpr_3i_person_cases': 'static-icds-cas-static-mpr_3i_person_cases-optimized'
     'static-icds-cas-static-mpr_2a_deaths': 'static-icds-cas-static-mpr_2a_deaths-optimized'
     'static-icds-cas-static-mpr_2a_person_cases': 'static-icds-cas-static-mpr_2a_person_cases-optimized'
+    'static-icds-cas-static-mpr_2bi_preg_delivery_death_list': 'static-icds-cas-static-mpr_2bi_preg_delivery_death_list-optimized'
     # new UCR format from LS app
     'static-icds-cas-static-mpr_10a_children_referred': 'static-icds-cas-static-mpr_10a_children_referred-optimized'
     'static-icds-cas-static-mpr_10b_pregnancies_referred': 'static-icds-cas-static-mpr_10b_pregnancies_referred-optimized'


### PR DESCRIPTION
##### SUMMARY

Add back previously broken UCR comparison test due to issues

##### ENVIRONMENTS AFFECTED

icds

##### ISSUE TYPE

- Change Pull Request

##### COMPONENT NAME

UCR comparison

##### ADDITIONAL INFORMATION

hopefully the reports are working again and we can retest these.

@emord seem right?