### PR TITLE
Throw more resources at the repeat record queue

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -18,9 +18,9 @@ celery_processes:
     sumologic_logs_queue:
       pooling: gevent
       concurrency: 50
-      num_workers: 8
     repeat_record_queue:
       pooling: gevent
+      num_workers: 3
       concurrency: 100
     ucr_queue:
       concurrency: 4
@@ -77,6 +77,7 @@ celery_processes:
       concurrency: 10
     repeat_record_queue:
       pooling: gevent
+      num_workers: 5
       concurrency: 100
   celery3:
     async_restore_queue:
@@ -92,6 +93,7 @@ celery_processes:
       max_tasks_per_child: 5
     repeat_record_queue:
       pooling: gevent
+      num_workers: 4
       concurrency: 100
   celery4:
     celery,case_import_queue:

--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -21,7 +21,7 @@ celery_processes:
     repeat_record_queue:
       pooling: gevent
       num_workers: 3
-      concurrency: 100
+      concurrency: 50
     ucr_queue:
       concurrency: 4
       max_tasks_per_child: 5
@@ -78,7 +78,7 @@ celery_processes:
     repeat_record_queue:
       pooling: gevent
       num_workers: 5
-      concurrency: 100
+      concurrency: 50
   celery3:
     async_restore_queue:
       concurrency: 8
@@ -94,7 +94,7 @@ celery_processes:
     repeat_record_queue:
       pooling: gevent
       num_workers: 4
-      concurrency: 100
+      concurrency: 50
   celery4:
     celery,case_import_queue:
       concurrency: 6

--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -15,10 +15,13 @@ celery_processes:
       pooling: gevent
       concurrency: 100
       num_workers: 2
-    repeat_record_queue,sumologic_logs_queue:
+    sumologic_logs_queue:
       pooling: gevent
       concurrency: 50
       num_workers: 8
+    repeat_record_queue:
+      pooling: gevent
+      concurrency: 100
     ucr_queue:
       concurrency: 4
       max_tasks_per_child: 5
@@ -72,6 +75,9 @@ celery_processes:
     analytics_queue:
       pooling: gevent
       concurrency: 10
+    repeat_record_queue:
+      pooling: gevent
+      concurrency: 100
   celery3:
     async_restore_queue:
       concurrency: 8
@@ -84,6 +90,9 @@ celery_processes:
     export_download_queue:
       concurrency: 4
       max_tasks_per_child: 5
+    repeat_record_queue:
+      pooling: gevent
+      concurrency: 100
   celery4:
     celery,case_import_queue:
       concurrency: 6


### PR DESCRIPTION
##### SUMMARY

Adds more Celery resources to deal with the repeat record queue.

Fixes (improves?) [HI-451: Delay in Data Forwarding](https://dimagi-dev.atlassian.net/browse/HI-451).

##### ENVIRONMENTS AFFECTED

production

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

production app-processes.yml

##### ADDITIONAL INFORMATION

This is the result of some wild guesswork on my part. I haven't absorbed enough from the Celery docs to understand our Celery config. I'm sure this change will add more resources to deal with the problem, but I don't know if this is the best way to do it.

Here are some things I'd like to understand so I can know whether this change is "right", or even "good".

- **workers vs processes:** This [SO answer](https://stackoverflow.com/a/32046332) distinguishes between Celery workers (`num_workers`) and worker processes (`concurrency` and `autoscale`). The [Celery Workers Guide](http://docs.celeryproject.org/en/latest/userguide/workers.html#concurrency) bears this out. The SO answer says you don't need more than one worker **per machine**, but the Guide says sometimes it helps to have more than one. Either way, my understanding is that the number of processes is independent of the number of workers. 
  - How do we determine that a particular queue needs more than one worker? How do we know how many it needs?

- **processes vs threads:** The [Celery User Guide](http://docs.celeryproject.org/en/latest/userguide/concurrency/eventlet.html#concurrency-eventlet) says, 

  > The prefork pool can take use of multiple processes, but how many is often limited to a few processes per CPU. With Eventlet you can efficiently spawn hundreds, or thousands of green threads.

  I am assuming that gevent works exactly the same in Celery as Eventlet. I couldn't find any Celery docs to back that up, but the [code](http://docs.celeryproject.org/en/latest/_modules/celery/concurrency/gevent.html) looks very [similar](http://docs.celeryproject.org/en/latest/_modules/celery/concurrency/eventlet.html) and the [gevent blog](https://blog.gevent.org/2010/02/27/why-gevent/) supports the idea.

  Does this mean that (regardless of `num_workers`) the repeat record queue is running in multiple threads in just one process (i.e. on a single core/vCPU)?
  - If so, does Celery have its own a mechanism of specifying how many processes to run, and how many threads per process? Or (as this [SO question](https://stackoverflow.com/questions/48630026/celery-workers-utilization-decreases-with-more-workers) suggests) if we want both, do we need to use a Celery prefork pool for processes and use a threaded pool in our code for threads (i.e. what the closed PR did)?
  - If Celery's gevent pool is running in multiple threads across multiple processes, is there a way we can see how many processes it is running in?

I'm guessing here, but from all of the above, it sounds likely that up until now, the repeat record queue has been running 50 threads (shared with the sumologic logs queue) in a single process. 

Maybe what we need is to run 100 threads (I just made that number up with no data to support it), and run the queue on three machines in order to have 3 processes.

The usual suspects by now: @czue @orangejenny @snopoke @millerdev @dannyroberts 