### PR TITLE
Add cost tags for openvpn and network

### DIFF
--- a/src/commcare_cloud/terraform/modules/network/main.tf
+++ b/src/commcare_cloud/terraform/modules/network/main.tf
@@ -146,6 +146,8 @@ resource "aws_eip" "nat_gateway" {
   vpc = true
   tags {
     Name = "nat-gateway-ip-${var.env}"
+    Environment = "production"
+    Group = "Network"
   }
 }
 
@@ -154,11 +156,21 @@ resource "aws_nat_gateway" "main" {
   allocation_id = "${aws_eip.nat_gateway.id}"
   subnet_id     = "${aws_subnet.subnet-public.*.id[0]}"
   depends_on    = ["aws_internet_gateway.main", "aws_eip.nat_gateway"]
+  tags {
+    Name = "nat-gateway-${var.env}"
+    Environment = "production"
+    Group = "Network"
+  }
 }
 
 # Create an Internet Gateway
 resource "aws_internet_gateway" "main" {
   vpc_id = "${aws_vpc.main.id}"
+  tags {
+    Name = "internet-gateway-${var.env}"
+    Environment = "production"
+    Group = "Network"
+  }
 }
 
 locals {

--- a/src/commcare_cloud/terraform/modules/openvpn/main.tf
+++ b/src/commcare_cloud/terraform/modules/openvpn/main.tf
@@ -29,6 +29,7 @@ resource aws_instance "vpn_host" {
   tags {
     Name        = "vpn-${var.environment}"
     Environment = "${var.environment}"
+    Group = "openvpn"
   }
 }
 
@@ -39,6 +40,7 @@ resource aws_eip "vpn_ip" {
   tags {
     Name        = "vpn-public-ip-${var.environment}"
     Environment = "${var.environment}"
+    Group = "openvpn"
   }
 }
 


### PR DESCRIPTION
##### SUMMARY

We use the Group tag to classify AWS costs, and I found a few more sources for untagged costs