### PR TITLE
Fix india celery queues

### DIFF
--- a/environments/india/app-processes.yml
+++ b/environments/india/app-processes.yml
@@ -12,10 +12,10 @@ celery_processes:
     sms_queue:
       pooling: gevent
       concurrency: 10
-    async_restore_queue,celery_periodic,email_queue,repeat_record_queue,sumologic_logs_queue,reminder_case_update_queue,icds_aggregation_queue:
+    email_queue,repeat_record_queue,sumologic_logs_queue,reminder_case_update_queue,icds_aggregation_queue,analytics_queue:
       pooling: gevent
       concurrency: 200
-    ucr_queue,ucr_indicator_queue,celery,export_download_queue,reminder_rule_queue,case_import_queue,case_rule_queue,icds_dashboard_reports_queue,analytics_queue:
+    ucr_queue,ucr_indicator_queue,celery,export_download_queue,reminder_rule_queue,case_import_queue,case_rule_queue,icds_dashboard_reports_queue,async_restore_queue,celery_periodic:
       concurrency: 3
       max_tasks_per_child: 5
     saved_exports_queue:


### PR DESCRIPTION
##### SUMMARY
Fixes https://dimagi-dev.atlassian.net/browse/ICDS-405

Better allocates resources for india's celery.

##### ENVIRONMENTS AFFECTED
india
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
celery

##### ADDITIONAL INFORMATION

gevent queues should be used for tasks which are I/O bound. These are things like  external requests to other services (analytics, email, repeats,etc).

Previously the analytics queue was in a non-gevent queue which clogged the queue with tons of events (and would have caused a lot of process restarting). async_restore_queue and celery_periodic have non-I/O bound tasks which would clog the gevent queue (resulting in large backups of emails/analytics)

@dannyroberts I think a long term outcome of this should be enforcing a queue is always/never gevent in the celery process schema. How does that work into platform reliability's current work on celery?