### PR TITLE
Use ddtrace-run with celery

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -2,6 +2,7 @@ newrelic_djangoagent: False
 newrelic_javaagent: True
 datadog_pythonagent: True
 django_command_prefix: '{{ virtualenv_home }}/bin/ddtrace-run '
+celery_command_prefix: '{{ virtualenv_home }}/bin/ddtrace-run '
 gunicorn_workers_static_factor: 0
 gunicorn_workers_factor: 2
 celery_processes:

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/celery_bash_runner.sh.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/celery_bash_runner.sh.j2
@@ -44,7 +44,7 @@ HOSTNAME_ARG+=".${TIMESTAMP}_timestamp"
 HOSTNAME_PARTS=(${HOSTNAME_ARG//=/ })
 HOSTNAME=${HOSTNAME_PARTS[1]}
 
-{% if PY3_RUN_CELERY_WORKER %}{{ py3_virtualenv_home }}{% else %}{{ virtualenv_home }}{% endif %}/bin/celery -A corehq worker ${HOSTNAME_ARG} ${ARGS}  &
+{{ app_processes_config.celery_command_prefix }}{% if PY3_RUN_CELERY_WORKER %}{{ py3_virtualenv_home }}{% else %}{{ virtualenv_home }}{% endif %}/bin/celery -A corehq worker ${HOSTNAME_ARG} ${ARGS}  &
 PID=$!
 BASH_PID=$$
 echo "Started ${HOSTNAME} on PID: ${PID}"

--- a/src/commcare_cloud/environment/schemas/app_processes.py
+++ b/src/commcare_cloud/environment/schemas/app_processes.py
@@ -34,6 +34,7 @@ class AppProcessesConfig(jsonobject.JsonObject):
     newrelic_djangoagent = jsonobject.BooleanProperty()
     newrelic_javaagent = jsonobject.BooleanProperty()
     django_command_prefix = jsonobject.StringProperty()
+    celery_command_prefix = jsonobject.StringProperty()
     datadog_pythonagent = jsonobject.BooleanProperty()
     additional_no_proxy_hosts = CommaSeparatedStrings()
 

--- a/src/commcare_cloud/environmental-defaults/app-processes.yml
+++ b/src/commcare_cloud/environmental-defaults/app-processes.yml
@@ -31,3 +31,4 @@ http_proxy: null
 newrelic_djangoagent: False
 newrelic_javaagent: False
 django_command_prefix: ''
+celery_command_prefix: ''


### PR DESCRIPTION
##### SUMMARY
Run celery processes with [`ddtrace-run`](https://docs.datadoghq.com/tracing/languages/python/)

Probable fix for https://sentry.io/organizations/dimagi/issues/918618547, based on absence of errors in trace-agent.log after deploying to celery0-production.

Will deploy to other celery machines after review/approval.

##### ENVIRONMENTS AFFECTED

production

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the script, playbook, task or feature below -->
commcarehq ansible role

@snopoke @dannyroberts 