### PR TITLE
fix WorkerLostError in production background_queue

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -58,8 +58,8 @@ celery_processes:
       max_tasks_per_child: 5
   celery2:
     background_queue:
+      pooling: gevent
       concurrency: 8
-      max_tasks_per_child: 1
     send_report_throttled:
       concurrency: 2
       max_tasks_per_child: 1


### PR DESCRIPTION
This issue was observed in the background_queue on production: https://github.com/celery/celery/issues/5120

Using gevent avoids the bug.  These changes are currently running on production.

I'd recommend applying similar changes to other workers on an as-needed basis until a bugfix becomes available.  background_queue was chosen because the workers would never recover from this issue.  Other queues sometimes are going down but are recovering on their own.