### PR TITLE
improvements for production celery stability

### DIFF
--- a/docs/commcare-cloud/env/index.md
+++ b/docs/commcare-cloud/env/index.md
@@ -112,7 +112,7 @@ celery_processes:
     <queue-name>:
       pooling: [gevent|prefork]  # default prefork
       concurrency: <int>  # Required
-      max_tasks_per_child: <int>  # default 50
+      max_tasks_per_child: <int>
   <host>:
     ...
   ...

--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -2,7 +2,7 @@ newrelic_djangoagent: False
 newrelic_javaagent: True
 datadog_pythonagent: True
 django_command_prefix: '{{ virtualenv_home }}/bin/ddtrace-run '
-celery_command_prefix: '{{ virtualenv_home }}/bin/ddtrace-run '
+celery_command_prefix: ''
 gunicorn_workers_static_factor: 0
 gunicorn_workers_factor: 2
 celery_processes:

--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -18,12 +18,10 @@ celery_processes:
       concurrency: 50
     ucr_queue:
       concurrency: 4
-      max_tasks_per_child: 5
     ucr_indicator_queue:
       concurrency: 2
     async_restore_queue:
       concurrency: 2
-      max_tasks_per_child: 5
   celery1:
     flower: {}
     reminder_queue:
@@ -36,14 +34,12 @@ celery_processes:
       num_workers: 3
     case_rule_queue:
       concurrency: 4
-      max_tasks_per_child: 1
     reminder_case_update_queue:
       pooling: gevent
       concurrency: 5
       num_workers: 2
     reminder_rule_queue:
       concurrency: 3
-      max_tasks_per_child: 1
     ils_gateway_sms_queue:
       # Use 1 worker with concurrency 8 in order to enforce the
       # restriction of having 8 max simultaneous connections with
@@ -52,19 +48,15 @@ celery_processes:
       concurrency: 8
     logistics_reminder_queue:
       concurrency: 2
-      max_tasks_per_child: 5
     logistics_background_queue:
       concurrency: 2
-      max_tasks_per_child: 5
   celery2:
     background_queue:
       concurrency: 8
     send_report_throttled:
       concurrency: 2
-      max_tasks_per_child: 1
     async_restore_queue:
       concurrency: 2
-      max_tasks_per_child: 5
     analytics_queue:
       pooling: gevent
       concurrency: 10
@@ -75,15 +67,12 @@ celery_processes:
   celery3:
     async_restore_queue:
       concurrency: 8
-      max_tasks_per_child: 5
     saved_exports_queue:
       num_workers: 3
       concurrency: 2
-      max_tasks_per_child: 1
       optimize: True
     export_download_queue:
       concurrency: 4
-      max_tasks_per_child: 5
     repeat_record_queue:
       pooling: gevent
       num_workers: 4
@@ -91,10 +80,8 @@ celery_processes:
   celery4:
     celery,case_import_queue:
       concurrency: 6
-      max_tasks_per_child: 5
     export_download_queue:
       concurrency: 6
-      max_tasks_per_child: 5
   celery5:
     beat: {}
     celery_periodic:

--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -58,7 +58,6 @@ celery_processes:
       max_tasks_per_child: 5
   celery2:
     background_queue:
-      pooling: gevent
       concurrency: 8
     send_report_throttled:
       concurrency: 2

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_celery_workers.conf.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_celery_workers.conf.j2
@@ -5,7 +5,11 @@
 [program:{{ project }}-{{ deploy_env }}-celery_{{ queue_names }}_{{worker_num}}]
 environment={% for name, value in item.env_vars.items() %}{% if value %}{{ name }}="{{ value }}",{% endif %}{% endfor %}
 
-command=/bin/bash {{ service_home }}/{{ deploy_env }}_celery_bash_runner{% if celery_params.optimize %}_optimized{% endif %}.sh --queues={{ queue_names }} --events --loglevel=INFO --hostname={{ inventory_hostname }}_{{ queue_names }}_{{ worker_num }} {% if celery_params.pooling == 'prefork' %} --autoscale={{ celery_params.concurrency }},0 -Ofair --maxtasksperchild={{ celery_params.max_tasks_per_child }}{% endif %}{% if celery_params.pooling == 'gevent' %} -P gevent --concurrency={{ celery_params.concurrency }}{% endif %} --without-gossip
+command=/bin/bash {{ service_home }}/{{ deploy_env }}_celery_bash_runner{% if celery_params.optimize %}_optimized{% endif %}.sh
+    --events --loglevel=INFO --without-gossip
+    --queues={{ queue_names }}
+    --hostname={{ inventory_hostname }}_{{ queue_names }}_{{ worker_num }} {% if celery_params.pooling == 'prefork' %} --autoscale={{ celery_params.concurrency }},0 -Ofair {% if celery_params.max_tasks_per_child %}--maxtasksperchild={{ celery_params.max_tasks_per_child }}{% endif %}{% endif %}{% if celery_params.pooling == 'gevent' %} -P gevent --concurrency={{ celery_params.concurrency }}{% endif %}
+
 directory={{ code_home }}
 user={{ cchq_user }}
 numprocs=1

--- a/src/commcare_cloud/environment/schemas/app_processes.py
+++ b/src/commcare_cloud/environment/schemas/app_processes.py
@@ -16,7 +16,7 @@ class CeleryOptions(jsonobject.JsonObject):
     _allow_dynamic_properties = False
     concurrency = jsonobject.IntegerProperty(default=1)
     pooling = jsonobject.StringProperty(choices=['gevent', 'prefork'], default='prefork')
-    max_tasks_per_child = jsonobject.IntegerProperty(default=50)
+    max_tasks_per_child = jsonobject.IntegerProperty(default=None)
     num_workers = jsonobject.IntegerProperty(default=1)
     optimize = jsonobject.BooleanProperty(default=False)
 

--- a/src/commcare_cloud/environmental-defaults/app-processes.yml
+++ b/src/commcare_cloud/environmental-defaults/app-processes.yml
@@ -8,7 +8,7 @@
 #     queue_name:               # Required; the comma-separated names of the queue from which each worker configured in this section will consume
 #       concurrency: 4          # Required; the concurrency configured on each worker
 #       pooling: prefork        # Optional, default prefork; specify prefork or gevent for the process pool type used on each worker in this section
-#       max_tasks_per_child: 5  # Optional, default 50; only applicable for prefork pooling (corresponds to maxtasksperchild worker command line arg)
+#       max_tasks_per_child: 5  # Optional, only applicable for prefork pooling (corresponds to maxtasksperchild worker command line arg)
 #       num_workers: 2          # Optional, default 1; the number of workers to create consuming from this queue on this host
 #
 # The above celery configuration would create 2 celery workers with max concurrency of 4


### PR DESCRIPTION
Updates include:

1) Remove ```dd-trace``` from production.  Memory issues are reproduced when ```dd-trace``` is running and you run:
```
from corehq.apps.export.tasks import saved_exports
saved_exports.delay()
```
2) Remove ```maxtasksperchild``` from all workers in prefork.  This addresses https://github.com/celery/celery/issues/5120.  This has a risk of causing memory leaks if there are many tasks in the queue and the child process is never stopped.  However, I think this is more of a theoretical risk than a practical risk and, if it were to appear, could be addressed by adding more workers so queues don't get backlogged.

3) Runs ```background_queue``` in prefork.  I switched it to run in gevent to avoid https://github.com/celery/celery/issues/5120, but this caused the bug: https://github.com/celery/celery/issues/3377.  

🐡 

After letting these changes run in production for 24 hours and if no new issues are observed, I'll remove ```maxtasksperchild``` from other environments as well.