### PR TITLE
Revert "Undo split prod webworkers"

### DIFF
--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -22,13 +22,20 @@ proxy0
 [web9]
 10.202.10.37 hostname=web9-production ec2=yes
 
-[webworkers:children]
+
+[hq_webworkers:children]
 web0
 web1
+
+[mobile_webworkers:children]
 web6
 web7
 web8
 web9
+
+[webworkers:children]
+hq_webworkers
+mobile_webworkers
 
 [pgproxy1]
 10.202.40.54 hostname=pgproxy1-production ec2=yes

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -22,13 +22,20 @@ proxy0
 [web9]
 {{ web9-production }} hostname=web9-production ec2=yes
 
-[webworkers:children]
+
+[hq_webworkers:children]
 web0
 web1
+
+[mobile_webworkers:children]
 web6
 web7
 web8
 web9
+
+[webworkers:children]
+hq_webworkers
+mobile_webworkers
 
 [pgproxy1]
 {{ pgproxy1-production }} hostname=pgproxy1-production ec2=yes


### PR DESCRIPTION
Revert dimagi/commcare-cloud#2713 after reviewing the [Mobile Request Success dashboard](https://app.datadoghq.com/dashboard/a4u-nfz-gex/mobile-request-success) and concluding that this change made no difference in submission success rates on prod.