### PR TITLE
double number of async_restore_queue workers on celery0 and celery2

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -21,6 +21,7 @@ celery_processes:
     ucr_indicator_queue:
       concurrency: 2
     async_restore_queue:
+      num_workers: 2
       concurrency: 2
   celery1:
     flower: {}
@@ -56,6 +57,7 @@ celery_processes:
     send_report_throttled:
       concurrency: 2
     async_restore_queue:
+      num_workers: 2
       concurrency: 2
     analytics_queue:
       pooling: gevent


### PR DESCRIPTION
```async_restore_queue``` gets backed up during high load times.  celery0 and celery2 are underutilized in both CPU and memory, so I'm increasing the number of workers from 1 to 2.  I expect to revisit this later in the week and possibly continue to increase the number of workers.