### PR TITLE
discontinue using max_tasks_per_child

### DIFF
--- a/environments/echis/app-processes.yml
+++ b/environments/echis/app-processes.yml
@@ -11,16 +11,13 @@ celery_processes:
   echis_server0:
     celery,export_download_queue,email_queue,case_import_queue:
       concurrency: 1
-      max_tasks_per_child: 5
     background_queue,case_rule_queue,analytics_queue:
       concurrency: 1
-      max_tasks_per_child: 1
     beat: {}
     celery_periodic:
       concurrency: 1
     saved_exports_queue:
       concurrency: 1
-      max_tasks_per_child: 1
       optimize: True
     submission_reprocessing_queue:
       concurrency: 1
@@ -32,7 +29,6 @@ celery_processes:
       concurrency: 5
     reminder_rule_queue,ucr_indicator_queue,ucr_queue:
       concurrency: 1
-      max_tasks_per_child: 1
     sms_queue:
       pooling: gevent
       concurrency: 10

--- a/environments/icds-cas/app-processes.yml
+++ b/environments/icds-cas/app-processes.yml
@@ -14,7 +14,6 @@ celery_processes:
     beat: {}
     celery,export_download_queue,case_import_queue:
       concurrency: 8
-      max_tasks_per_child: 5
     celery_periodic:
        concurrency: 4
     submission_reprocessing_queue:
@@ -23,27 +22,22 @@ celery_processes:
       concurrency: 2
     reminder_rule_queue:
       concurrency: 2
-      max_tasks_per_child: 1
     saved_exports_queue:
       concurrency: 3
-      max_tasks_per_child: 1
       optimize: True
     background_queue,analytics_queue:
       concurrency: 6
-      max_tasks_per_child: 1
     icds_aggregation_queue:
       pooling: gevent
       concurrency: 10
     case_rule_queue:
       concurrency: 2
-      max_tasks_per_child: 1
     sumologic_logs_queue:
       pooling: gevent
       concurrency: 8
   'celery1':
     ucr_queue:
       concurrency: 4
-      max_tasks_per_child: 1
     reminder_case_update_queue:
       pooling: gevent
       concurrency: 5

--- a/environments/india/app-processes.yml
+++ b/environments/india/app-processes.yml
@@ -17,14 +17,11 @@ celery_processes:
       concurrency: 200
     ucr_queue,ucr_indicator_queue,celery,export_download_queue,reminder_rule_queue,case_import_queue,case_rule_queue,icds_dashboard_reports_queue,async_restore_queue,celery_periodic:
       concurrency: 3
-      max_tasks_per_child: 5
     saved_exports_queue:
       concurrency: 2
-      max_tasks_per_child: 1
       optimize: True
     background_queue:
       concurrency: 5
-      max_tasks_per_child: 1
 pillows:
   'pillow1':
     AppDbChangeFeedPillow:

--- a/environments/pna/app-processes.yml
+++ b/environments/pna/app-processes.yml
@@ -5,22 +5,17 @@ celery_processes:
   'pnaserver1':
     repeat_record_queue:
       concurrency: 2
-      max_tasks_per_child: 1
     celery,case_import_queue:
       concurrency: 2
-      max_tasks_per_child: 1
     background_queue,export_download_queue,saved_exports_queue,analytics_queue:
       concurrency: 4
-      max_tasks_per_child: 1
 # wait until background_queue,export_download_queue have been verified to work with optimize
 #      optimize: True
     ucr_queue,async_restore_queue,email_queue,case_rule_queue:
       concurrency: 1
-      max_tasks_per_child: 1
     beat: {}
     celery_periodic:
       concurrency: 2
-      max_tasks_per_child: 1
     flower: {}
   None:
     # todo: create these queues?

--- a/environments/staging/app-processes.yml
+++ b/environments/staging/app-processes.yml
@@ -7,17 +7,13 @@ celery_processes:
   'celery1':
     repeat_record_queue,reminder_case_update_queue,reminder_rule_queue,celery,export_download_queue,case_import_queue:
       concurrency: 4
-      max_tasks_per_child: 5
     background_queue,case_rule_queue,analytics_queue:
       concurrency: 2
-      max_tasks_per_child: 1
     saved_exports_queue:
       concurrency: 3
-      max_tasks_per_child: 1
       optimize: True
     ucr_queue:
       concurrency: 1
-      max_tasks_per_child: 5
     email_queue:
       concurrency: 1
     async_restore_queue:

--- a/environments/swiss/app-processes.yml
+++ b/environments/swiss/app-processes.yml
@@ -5,10 +5,8 @@ celery_processes:
   'swiss.commcarehq.org':
     repeat_record_queue,celery,export_download_queue,case_import_queue:
       concurrency: 1
-      max_tasks_per_child: 5
     background_queue,case_rule_queue,analytics_queue:
       concurrency: 1
-      max_tasks_per_child: 1
     beat: {}
     celery_periodic,email_queue:
       concurrency: 1
@@ -16,13 +14,11 @@ celery_processes:
       concurrency: 1
     saved_exports_queue:
       concurrency: 1
-      max_tasks_per_child: 1
       optimize: True
     reminder_case_update_queue:
       concurrency: 1
     reminder_rule_queue:
       concurrency: 1
-      max_tasks_per_child: 1
     flower: {}
 pillows:
   'swiss.commcarehq.org':


### PR DESCRIPTION
Removing ```max_tasks_per_child``` from production worked well (https://github.com/dimagi/commcare-cloud/pull/2719) so I'm applying these changes to all environments.