### PR TITLE
Minimally increase couch{7,8} disk to keep them under 88%

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -166,7 +166,7 @@ servers:
     az: "a"
     volume_size: 80
     block_device:
-      volume_size: 5500
+      volume_size: 6100
     group: "couchdb2"
   - server_name: "couch8-production"
     server_instance_type: c5.4xlarge
@@ -174,7 +174,7 @@ servers:
     az: "a"
     volume_size: 80
     block_device:
-      volume_size: 5500
+      volume_size: 5800
     group: "couchdb2"
   - server_name: "couch9-production"
     server_instance_type: c5.4xlarge


### PR DESCRIPTION
##### SUMMARY
The fullest two couchdb disks, couch7 and couch8, are at 95% and 91% during their daily peak. This aims to get them down to around 86%. I will be deleting some large views next week which should get the usage down a little more. The total increase will cost +$90/mo (+900GB @ $.10/GB/mo).

##### ENVIRONMENTS AFFECTED
production

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
production couchdb disk
