### PR TITLE
Set the accepted lag to 0

### DIFF
--- a/environments/icds-cas/postgresql.yml
+++ b/environments/icds-cas/postgresql.yml
@@ -133,16 +133,16 @@ dbs:
       host: pgmainstandby0
       create: False
       django_migrate: False
-      hq_acceptable_standby_delay: 5
+      hq_acceptable_standby_delay: 0
     - django_alias: pgmainstandby1
       name: commcarehq
       host: pgmainstandby1
       create: False
       django_migrate: False
-      hq_acceptable_standby_delay: 5
+      hq_acceptable_standby_delay: 0
     - django_alias: pgmainstandby2
       name: commcarehq
       host: pgmainstandby2
       create: False
       django_migrate: False
-      hq_acceptable_standby_delay: 5
+      hq_acceptable_standby_delay: 0


### PR DESCRIPTION
This sets the acceptable lag to 0 this was specifically changed to allow the bulk user upload to go smoothly without error. Else it was causing this error: 
```
Traceback (most recent call last):
  File "/home/cchq/www/icds/releases/2019-03-19_22.04/python_env/local/lib/python2.7/site-packages/celery/app/trace.py", line 375, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/home/cchq/www/icds/releases/2019-03-19_22.04/python_env/local/lib/python2.7/site-packages/celery/app/trace.py", line 632, in __protected_call__
    return self.run(*args, **kwargs)
  File "/home/cchq/www/icds/releases/2019-03-19_22.04/corehq/apps/users/tasks.py", line 43, in bulk_upload_async
    task=task,
  File "/home/cchq/www/icds/releases/2019-03-19_22.04/corehq/apps/users/bulkupload.py", line 547, in create_or_update_users_and_groups
    user.get_django_user().check_password(password)
  File "/home/cchq/www/icds/releases/2019-03-19_22.04/corehq/apps/users/models.py", line 1198, in get_django_user
    return User.objects.get(username__iexact=self.username)
  File "/home/cchq/www/icds/releases/2019-03-19_22.04/python_env/local/lib/python2.7/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/home/cchq/www/icds/releases/2019-03-19_22.04/python_env/local/lib/python2.7/site-packages/django/db/models/query.py", line 380, in get
    self.model._meta.object_name
Exception: User matching query does not exist.
```

@millerdev 