### PR TITLE
use prefork for icds_aggregation_queue

### DIFF
--- a/environments/icds-cas/app-processes.yml
+++ b/environments/icds-cas/app-processes.yml
@@ -28,7 +28,6 @@ celery_processes:
     background_queue,analytics_queue:
       concurrency: 6
     icds_aggregation_queue:
-      pooling: gevent
       concurrency: 10
     case_rule_queue:
       concurrency: 2


### PR DESCRIPTION
The ```icds_aggregation_queue``` worker was suffering from the same issue as ```background_queue``` on production: https://github.com/dimagi/commcare-cloud/pull/2719

Changing to prefork avoids https://github.com/celery/celery/issues/3377

I applied these changes and ```icds_aggregation_queue``` is now processing successfully: https://app.datadoghq.com/dashboard/bdu-k5b-bz5/celery-overview?tile_size=m&page=0&is_auto=false&from_ts=1552914000000&to_ts=1553086800000&live=true&tpl_var_environment=icds&fullscreen_widget=185712938