### PR TITLE
double num_workers for async_restore_queue on celery0 and celery2

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -21,7 +21,7 @@ celery_processes:
     ucr_indicator_queue:
       concurrency: 2
     async_restore_queue:
-      num_workers: 2
+      num_workers: 4
       concurrency: 2
   celery1:
     flower: {}
@@ -57,7 +57,7 @@ celery_processes:
     send_report_throttled:
       concurrency: 2
     async_restore_queue:
-      num_workers: 2
+      num_workers: 4
       concurrency: 2
     analytics_queue:
       pooling: gevent

--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -87,6 +87,7 @@ celery_processes:
   celery5:
     beat: {}
     celery_periodic:
+      num_workers: 2
       concurrency: 4
     email_queue:
       pooling: gevent


### PR DESCRIPTION
https://github.com/dimagi/commcare-cloud/pull/2724 helped prevent ```async_restore_queue``` from getting backlogged.  I'm making this change to provide a little more buffer, and because these two machines are still underutilized.

code buddy @mkangia 