### PR TITLE
Remove UCR comparisons from icds

### DIFF
--- a/environments/icds-cas/public.yml
+++ b/environments/icds-cas/public.yml
@@ -277,22 +277,7 @@ localsettings:
   ENTERPRISE_MODE: True
   ENABLE_DRACONIAN_SECURITY_FEATURES: yes
   ICDS_DOMAIN: "{{ localsettings_private.ICDS_DOMAIN }}"
-  UCR_COMPARISONS:
-    'static-icds-cas-static-mpr_10a_person_cases': 'static-icds-cas-static-mpr_10a_person_cases-optimized'
-    'static-icds-cas-static-mpr_10b_person_cases': 'static-icds-cas-static-mpr_10b_person_cases-optimized'
-    'static-icds-cas-static-mpr_1_person_cases': 'static-icds-cas-static-mpr_1_person_cases-optimized'
-    'static-icds-cas-static-mpr_3ii_person_cases': 'static-icds-cas-static-mpr_3ii_person_cases-optimized'
-    'static-icds-cas-static-asr_2_3_person_cases': 'static-icds-cas-static-asr_2_3_person_cases-optimized'
-    'static-icds-cas-static-mpr_3i_person_cases': 'static-icds-cas-static-mpr_3i_person_cases-optimized'
-    'static-icds-cas-static-mpr_2a_deaths': 'static-icds-cas-static-mpr_2a_deaths-optimized'
-    'static-icds-cas-static-mpr_2a_person_cases': 'static-icds-cas-static-mpr_2a_person_cases-optimized'
-    'static-icds-cas-static-mpr_2bi_preg_delivery_death_list': 'static-icds-cas-static-mpr_2bi_preg_delivery_death_list-optimized'
-    # new UCR format from LS app
-    'static-icds-cas-static-mpr_10a_children_referred': 'static-icds-cas-static-mpr_10a_children_referred-optimized'
-    'static-icds-cas-static-mpr_10b_pregnancies_referred': 'static-icds-cas-static-mpr_10b_pregnancies_referred-optimized'
-    'static-icds-cas-static-mpr_3_children_registered': 'static-icds-cas-static-mpr_3_children_registered-optimized'
-    'static-icds-cas-static-asr_2_3_beneficiaries': 'static-icds-cas-static-asr_2_3_beneficiaries-optimized'
-    'static-icds-cas-static-mpr_3i_pregnancies': 'static-icds-cas-static-mpr_3i_pregnancies-optimized'
+  UCR_COMPARISONS: {}
   USER_REPORTING_METADATA_UPDATE_FREQUENCY_HOURS: 6
   WAREHOUSE_DATABASE_ALIAS: 'warehouse'
 


### PR DESCRIPTION
##### SUMMARY
Removing UCR comparisons from ICDS

##### ENVIRONMENTS AFFECTED
ICDS

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
UCR

##### ADDITIONAL INFORMATION

Most of these aren't being used since @czue completed the person case UCR work and they are causing (harmless) [sentry errors](https://sentry.io/organizations/dimagi/issues/944647902/?project=136860&referrer=slack). The rest of them have known discrepancies as part of the MPR, meaning that comparisons aren't particularly useful going forward.