### PR TITLE
Record commcare-cloud command events in datadog

### DIFF
--- a/commcare-cloud-bootstrap/commcare_cloud_bootstrap.py
+++ b/commcare-cloud-bootstrap/commcare_cloud_bootstrap.py
@@ -384,7 +384,7 @@ def save_vault_yml(environment):
         return str(uuid.uuid4())
     j2.globals.update(generate_uuid=generate_uuid)
     template = j2.get_template('private.yml.j2')
-    vault_file_contents = template.render(deploy_env=environment.paths.env_name)
+    vault_file_contents = template.render(deploy_env=environment.name)
     vault_file = environment.paths.vault_yml
     with open(vault_file, 'w') as f:
         f.write(vault_file_contents)

--- a/src/commcare_cloud/commands/ansible/ansible_playbook.py
+++ b/src/commcare_cloud/commands/ansible/ansible_playbook.py
@@ -137,7 +137,8 @@ def run_ansible_playbook(
         return subprocess.call(cmd_parts, env=env_vars)
 
     def run_check():
-        return ansible_playbook(environment, playbook, '--check', *unknown_args)
+        with environment.suppress_vault_loaded_event():
+            return ansible_playbook(environment, playbook, '--check', *unknown_args)
 
     def run_apply():
         return ansible_playbook(environment, playbook, *unknown_args)

--- a/src/commcare_cloud/commands/ansible/helpers.py
+++ b/src/commcare_cloud/commands/ansible/helpers.py
@@ -6,7 +6,6 @@ from contextlib import contextmanager
 from clint.textui import puts, colored
 
 from commcare_cloud.cli_utils import has_arg, ask
-from commcare_cloud.environment.main import get_environment
 from commcare_cloud.environment.paths import ANSIBLE_DIR, ANSIBLE_ROLES_PATH
 from six.moves import shlex_quote
 

--- a/src/commcare_cloud/commands/ansible/run_module.py
+++ b/src/commcare_cloud/commands/ansible/run_module.py
@@ -91,7 +91,8 @@ class RunAnsibleModule(CommandBase):
             )
 
         def run_check():
-            return _run_ansible(args, '--check', *unknown_args)
+            with environment.suppress_vault_loaded_event():
+                return _run_ansible(args, '--check', *unknown_args)
 
         def run_apply():
             return _run_ansible(args, *unknown_args)

--- a/src/commcare_cloud/commands/ansible/service.py
+++ b/src/commcare_cloud/commands/ansible/service.py
@@ -65,7 +65,7 @@ class ServiceBase(six.with_metaclass(ABCMeta)):
             self.print_help()
             return 0
         elif action == 'logs':
-            print("Logs can be found at:\n{}".format(self.log_location.format(env=self.environment.paths.env_name)))
+            print("Logs can be found at:\n{}".format(self.log_location.format(env=self.environment.name)))
             return 0
         try:
             return self.execute_action(action, host_pattern, process_pattern)

--- a/src/commcare_cloud/commands/terraform/terraform_migrate_state.py
+++ b/src/commcare_cloud/commands/terraform/terraform_migrate_state.py
@@ -281,7 +281,7 @@ def apply_migration_plans(environment, migration_plans, remote_migration_state_m
         log('  [{:0>4} {}]'.format(migration.number, migration.slug))
         for start_address, end_address in migration_plan.moves:
             log('    {} => {}'.format(start_address, end_address))
-            commcare_cloud(environment.paths.env_name, 'terraform', 'state', 'mv',
+            commcare_cloud(environment.name, 'terraform', 'state', 'mv',
                            start_address, end_address)
         remote_migration_state_manager.push(
             RemoteMigrationState(number=migration.number, slug=migration.slug))

--- a/src/commcare_cloud/commcare_cloud.py
+++ b/src/commcare_cloud/commcare_cloud.py
@@ -32,7 +32,6 @@ from .commands.fab import Fab
 from .commands.inventory_lookup.inventory_lookup import Lookup, Ssh, Mosh, DjangoManage, Tmux
 from .commands.ansible.ops_tool import ListDatabases
 from commcare_cloud.commands.command_base import CommandBase, Argument, CommandError
-from .environment.main import setup_environment
 from .environment.paths import (
     get_available_envs,
     put_virtualenv_bin_on_the_path,
@@ -154,7 +153,6 @@ def call_commcare_cloud(input_argv=sys.argv):
 
     if args.control:
         run_on_control_instead(args, input_argv)
-    setup_environment(args.env_name, input_argv)
     try:
         exit_code = commands[args.command].run(args, unknown_args)
     except CommandError as e:

--- a/src/commcare_cloud/commcare_cloud.py
+++ b/src/commcare_cloud/commcare_cloud.py
@@ -32,6 +32,7 @@ from .commands.fab import Fab
 from .commands.inventory_lookup.inventory_lookup import Lookup, Ssh, Mosh, DjangoManage, Tmux
 from .commands.ansible.ops_tool import ListDatabases
 from commcare_cloud.commands.command_base import CommandBase, Argument, CommandError
+from .environment.main import setup_environment
 from .environment.paths import (
     get_available_envs,
     put_virtualenv_bin_on_the_path,
@@ -153,6 +154,7 @@ def call_commcare_cloud(input_argv=sys.argv):
 
     if args.control:
         run_on_control_instead(args, input_argv)
+    setup_environment(args.env_name, input_argv)
     try:
         exit_code = commands[args.command].run(args, unknown_args)
     except CommandError as e:

--- a/src/commcare_cloud/environment/main.py
+++ b/src/commcare_cloud/environment/main.py
@@ -68,6 +68,8 @@ class Environment(object):
                 with open(self.paths.vault_yml, 'r') as vf:
                     return vault.load(vf.read())
             except AnsibleVaultError:
+                if os.environ.get('ANSIBLE_VAULT_PASSWORD'):
+                    raise
                 print('incorrect password')
                 self.get_ansible_vault_password.reset_cache(self)
 

--- a/src/commcare_cloud/environment/main.py
+++ b/src/commcare_cloud/environment/main.py
@@ -28,6 +28,10 @@ class Environment(object):
     def __init__(self, paths):
         self.paths = paths
 
+    @property
+    def name(self):
+        return self.paths.env_name
+
     def check(self):
 
         included_disallowed_public_variables = set(self.public_vars.keys()) & self._disallowed_public_variables
@@ -47,7 +51,7 @@ class Environment(object):
     def get_ansible_vault_password(self):
         return (
             os.environ.get('ANSIBLE_VAULT_PASSWORD') or
-            getpass.getpass("Vault Password for '{}': ".format(self.paths.env_name))
+            getpass.getpass("Vault Password for '{}': ".format(self.name))
         )
 
     @memoized

--- a/src/commcare_cloud/environment/main.py
+++ b/src/commcare_cloud/environment/main.py
@@ -1,21 +1,19 @@
 import getpass
 import os
+from collections import Counter
 
 import yaml
+from ansible.inventory.manager import InventoryManager
+from ansible.parsing.dataloader import DataLoader
 from ansible.parsing.vault import AnsibleVaultError
+from ansible.vars.manager import VariableManager
 from ansible_vault import Vault
 from memoized import memoized, memoized_property
-from collections import Counter
 
 from commcare_cloud.environment.constants import constants
 from commcare_cloud.environment.exceptions import EnvironmentException
 from commcare_cloud.environment.paths import DefaultPaths, get_role_defaults
 from commcare_cloud.environment.schemas.app_processes import AppProcessesConfig
-
-from ansible.inventory.manager import InventoryManager
-from ansible.parsing.dataloader import DataLoader
-from ansible.vars.manager import VariableManager
-
 from commcare_cloud.environment.schemas.fab_settings import FabSettingsConfig
 from commcare_cloud.environment.schemas.meta import MetaConfig
 from commcare_cloud.environment.schemas.postgresql import PostgresqlConfig


### PR DESCRIPTION
##### SUMMARY

Send an event to datadog when a commcare-cloud command is run (if it loads the ansible vault). This will provide a basic audit trail of commcare-cloud changes applied to environments with datadog monitoring.

##### ENVIRONMENTS AFFECTED

All environments with datadog enabled and having proper datadog credentials in the `secrets` section of the corresponding ansible vault.

The following have `DATADOG_ENABLED: True` in *public.yml*:

- production
- icds
- india/softlayer
- swiss
- pna
- staging
- 64-test?

##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Events are only sent when ansible vault variables are loaded since some of those variables are needed to send the event. It would be possible to always prompt for the vault password for every commcare-cloud command, and we may want to consider that for some additional commands in the future, but I opted not to impose any extra inconvenience at this time for commands that do not load the vault.

In most cases the event will not be sent during the "check" phase of a two-phase ansible run. In this case it will not be sent until the second "apply" phase is initiated. However, there are a couple commands (couchdb migrations and the `copy-files` command) that have a check phase where this does not apply—the event will be sent immediately the first time the vault is loaded for these commands.

Note that this mechanism provides an audit trail based on trust in the person running the command. It is trivially simple to disable the code that sends the event before running a command. It is also possible to cancel the command before it has any effect, so the presence of an event in datadog is not a guarantee that the command ran to successful completion. Secure verification of commcare-cloud command execution is not the intent nor in scope for this change.

Review by commit 🐟 

@dannyroberts @snopoke 