### PR TITLE
Use new timezone setting

### DIFF
--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -352,7 +352,7 @@ CUSTOM_REPORT_MAP = {
 
 CELERY_FLOWER_URL = '{{ CELERY_FLOWER_URL }}'
 {% if 'CELERY_TIMEZONE' in localsettings and localsettings.CELERY_TIMEZONE %}
-CELERY_TIMEZONE = '{{ localsettings.CELERY_TIMEZONE }}'
+timezone = '{{ localsettings.CELERY_TIMEZONE }}'
 {% endif %}
 
 PREVIEWER_RE = r'^(.*@dimagi\.com|.*@valuelabs\.in)$'


### PR DESCRIPTION
##### SUMMARY

They removed (accidentally?) their support form CELERY_TIMEZONE because software is hard and we all make mistakes

code: https://github.com/celery/celery/blob/4.1/celery/app/utils.py#L122
(wrong) documentation: http://docs.celeryproject.org/en/latest/userguide/configuration.html?highlight=timezone#new-lowercase-settings

##### ENVIRONMENTS AFFECTED
icds

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
celery
