### PR TITLE
add saved_exports_queue workers to celery2

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -66,6 +66,10 @@ celery_processes:
       pooling: gevent
       num_workers: 5
       concurrency: 50
+    saved_exports_queue:
+      num_workers: 3
+      concurrency: 2
+      optimize: True
   celery3:
     async_restore_queue:
       concurrency: 8


### PR DESCRIPTION
celery2 is quite underutilized, so let's double the capacity to process saved_export_queue tasks.