### PR TITLE
double concurrency of saved_export_queue workers in production

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -68,14 +68,14 @@ celery_processes:
       concurrency: 50
     saved_exports_queue:
       num_workers: 3
-      concurrency: 2
+      concurrency: 4
       optimize: True
   celery3:
     async_restore_queue:
       concurrency: 8
     saved_exports_queue:
       num_workers: 3
-      concurrency: 2
+      concurrency: 4
       optimize: True
     export_download_queue:
       concurrency: 4


### PR DESCRIPTION
Continuing to increase resources for saved_export_queue.  Ideally I would like this task to be scheduled for completion by midnight EST so if there are issues, I'll be awake to debug them.


Current machine utilization:

https://app.datadoghq.com/dash/host/665473534?live=false&tile_size=m&page=0&is_auto=false&from_ts=1553557381993&to_ts=1553606775000

https://app.datadoghq.com/dash/host/665473537?live=false&tile_size=m&page=0&is_auto=false&from_ts=1553557866139&to_ts=1553606806000