### PR TITLE
Resize prod couch disks to target 65% full

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -142,7 +142,7 @@ servers:
     az: "a"
     volume_size: 80
     block_device:
-      volume_size: 5500
+      volume_size: 5857
     group: "couchdb2"
   - server_name: "couch4-production"
     server_instance_type: c5.4xlarge
@@ -150,7 +150,7 @@ servers:
     az: "a"
     volume_size: 80
     block_device:
-      volume_size: 5500
+      volume_size: 5714
     group: "couchdb2"
   - server_name: "couch5-production"
     server_instance_type: c5.4xlarge
@@ -158,7 +158,7 @@ servers:
     az: "a"
     volume_size: 80
     block_device:
-      volume_size: 5500
+      volume_size: 5929
     group: "couchdb2"
   - server_name: "couch7-production"
     server_instance_type: c5.4xlarge
@@ -174,7 +174,7 @@ servers:
     az: "a"
     volume_size: 80
     block_device:
-      volume_size: 5800
+      volume_size: 6478
     group: "couchdb2"
   - server_name: "couch9-production"
     server_instance_type: c5.4xlarge
@@ -182,7 +182,7 @@ servers:
     az: "a"
     volume_size: 80
     block_device:
-      volume_size: 5500
+      volume_size: 6357
     group: "couchdb2"
 
   - server_name: "rabbit0-production"

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -142,7 +142,7 @@ servers:
     az: "a"
     volume_size: 80
     block_device:
-      volume_size: 5857
+      volume_size: 6938
     group: "couchdb2"
   - server_name: "couch4-production"
     server_instance_type: c5.4xlarge
@@ -150,7 +150,7 @@ servers:
     az: "a"
     volume_size: 80
     block_device:
-      volume_size: 5714
+      volume_size: 6769
     group: "couchdb2"
   - server_name: "couch5-production"
     server_instance_type: c5.4xlarge
@@ -158,7 +158,7 @@ servers:
     az: "a"
     volume_size: 80
     block_device:
-      volume_size: 5929
+      volume_size: 7023
     group: "couchdb2"
   - server_name: "couch7-production"
     server_instance_type: c5.4xlarge
@@ -166,7 +166,7 @@ servers:
     az: "a"
     volume_size: 80
     block_device:
-      volume_size: 6100
+      volume_size: 7226
     group: "couchdb2"
   - server_name: "couch8-production"
     server_instance_type: c5.4xlarge
@@ -174,7 +174,7 @@ servers:
     az: "a"
     volume_size: 80
     block_device:
-      volume_size: 6478
+      volume_size: 7674
     group: "couchdb2"
   - server_name: "couch9-production"
     server_instance_type: c5.4xlarge
@@ -182,7 +182,7 @@ servers:
     az: "a"
     volume_size: 80
     block_device:
-      volume_size: 6357
+      volume_size: 7531
     group: "couchdb2"
 
   - server_name: "rabbit0-production"


### PR DESCRIPTION
##### SUMMARY

We've been getting oscillating disk usage warnings for about a month now, and some of the disks really are uncomfortably full. I did out what it would take for each disk to get down to 65% full (at their daily peak) and came up with these numbers. Will cost an extra $930/mo or so, but it puts us in a safer place and will make the disk warnings a stronger signal.



  | current max (%) | current disk (GB) | target max (%) | new disk (GB) | increase (GB)
-- | -- | -- | -- | -- | --
couch3 | 82 | 5500 | 65 | 6938 | 1438
couch4 | 80 | 5500 | 65 | 6769 | 1269
couch5 | 83 | 5500 | 65 | 7023 | 1523
couch7 | 77 | 6100 | 65 | 7226 | 1126
couch8 | 86 | 5800 | 65 | 7674 | 1874
couch9 | 89 | 5500 | 65 | 7531 | 2031
  | **current spend** | $3,390/mo |   | **increase spend** | $926/mo

##### ENVIRONMENTS AFFECTED
production