### PR TITLE
increase number of UpdateUserSyncHistoryPillow processes

### DIFF
--- a/environments/icds-cas/app-processes.yml
+++ b/environments/icds-cas/app-processes.yml
@@ -258,7 +258,7 @@ pillows:
     UserPillow:
       num_processes: 1
     UpdateUserSyncHistoryPillow:
-      num_processes: 1
+      num_processes: 16
     kafka-ucr-main:
       num_processes: 1
       processor_chunk_size: 100


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-414

```UpdateUserSyncHistoryPillow``` has a low CPU load, so I'm not worried about adding load to ```pillow0```.  I've increased the number of kafka partitions for ```synclog-sql``` to 16.