### PR TITLE
accounting should never use standby DBs

### DIFF
--- a/environments/icds-cas/postgresql.yml
+++ b/environments/icds-cas/postgresql.yml
@@ -18,8 +18,6 @@ LOAD_BALANCED_APPS:
     - [pgmainstandby0, 4]
     - [pgmainstandby1, 4]
     - [pgmainstandby2, 4]
-  accounting:
-    - [default, 1]
   locations:
     - [default, 1]
     - [pgmainstandby0, 4]

--- a/environments/icds-cas/postgresql.yml
+++ b/environments/icds-cas/postgresql.yml
@@ -20,9 +20,6 @@ LOAD_BALANCED_APPS:
     - [pgmainstandby2, 4]
   accounting:
     - [default, 1]
-    - [pgmainstandby0, 4]
-    - [pgmainstandby1, 4]
-    - [pgmainstandby2, 4]
   locations:
     - [default, 1]
     - [pgmainstandby0, 4]


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-125

Accounting should never use the standby servers, since accounting often assumes a ```.save()``` operation to have effect immediately after it is called.

We now cache the current subscription, which used to be the largest source of accounting load by a lot.