### PR TITLE
add rabbitmq config with warning level logging

### DIFF
--- a/changelog/0019-update-rabbitmq-logging.yml
+++ b/changelog/0019-update-rabbitmq-logging.yml
@@ -1,0 +1,29 @@
+title: Update RabbitMQ logging configuration
+key: update-rabbitmq-logging
+date: 2019-04-05
+optional_per_env: yes
+min_commcare_version:
+max_commcare_version:
+context: |
+  This change updates the RabbitMQ logging configuration to change the
+  log level from `info` to `warning`.
+
+details: |
+  With the upgrade of Celery to v4 the RabbitMQ connection logs have
+  increased greatly. The logging configuration is being changed to
+  prevent the logs from growing beyond 10GB in size.
+
+
+update_steps: |
+  1. Stop all CommCare services
+  ```bash
+  commcare-cloud <env> downtime start
+  ```
+  2. Update the RabbitMQ logs
+  ```bash
+  commcare-cloud <env> ap deploy_rabbitmq.yml
+  ```
+  3. Start all CommCare services
+  ```bash
+  commcare-cloud <env> downtime end
+  ```

--- a/docs/changelog/0019-update-rabbitmq-logging.md
+++ b/docs/changelog/0019-update-rabbitmq-logging.md
@@ -1,0 +1,33 @@
+# 19. Update RabbitMQ logging configuration
+
+**Date:** 2019-04-05
+
+**Optional per env:** _only required on some environments_
+
+
+## CommCare Version Dependency
+This change is not known to be dependent on any particular version of CommCare.
+
+
+## Change Context
+This change updates the RabbitMQ logging configuration to change the
+log level from `info` to `warning`.
+
+## Details
+With the upgrade of Celery to v4 the RabbitMQ connection logs have
+increased greatly. The logging configuration is being changed to
+prevent the logs from growing beyond 10GB in size.
+
+## Steps to update
+1. Stop all CommCare services
+```bash
+commcare-cloud <env> downtime start
+```
+2. Update the RabbitMQ logs
+```bash
+commcare-cloud <env> ap deploy_rabbitmq.yml
+```
+3. Start all CommCare services
+```bash
+commcare-cloud <env> downtime end
+```

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -12,6 +12,10 @@ longer be available.  This removes the django-celery backend
 as the default from localsettings, so the results backend can
 be specified by commcare-hq settings instead.
 
+### **2019-04-05** [Update RabbitMQ logging configuration](0019-update-rabbitmq-logging.md)
+This change updates the RabbitMQ logging configuration to change the
+log level from `info` to `warning`.
+
 ### **2019-02-26** [Split pgbouncer vars from postgresql vars](0018-split_pgbouncer_postgresql_vars.md)
 This change extracts a new role from the existing postgresql role for installing
 and configuring pgbouncer.

--- a/src/commcare_cloud/ansible/deploy_db.yml
+++ b/src/commcare_cloud/ansible/deploy_db.yml
@@ -69,11 +69,9 @@
   roles:
     - redis_monitoring
 
-- name: RabbitMQ
-  hosts: rabbitmq
-  become: true
-  roles:
-    - {role: rabbitmq, tags: 'rabbitmq'}
+- import_playbook: deploy_rabbitmq.yml
+  tags:
+    - rabbitmq
 
 - import_playbook: deploy_kafka.yml
   tags:

--- a/src/commcare_cloud/ansible/deploy_rabbitmq.yml
+++ b/src/commcare_cloud/ansible/deploy_rabbitmq.yml
@@ -1,0 +1,35 @@
+---
+- name: Common Database Machine Setup
+  hosts:
+    - rabbitmq
+  become: true
+  roles:
+    - {role: ecryptfs, tags: 'ecryptfs'}
+    - {role: backups, tags: 'backups'}
+
+- name: RabbitMQ
+  hosts: rabbitmq
+  become: true
+  roles:
+    - {role: rabbitmq, tags: 'rabbitmq'}
+
+- name: RabbitMQ log rolling configurations
+  hosts: rabbitmq
+  become: true
+  roles:
+    - role: ansible-logrotate
+      tags: rabbitmq
+      logrotate_scripts:
+        - name: "rabbitmq-server"
+          path: "/var/log/rabbitmq/*.log"
+          options:
+            - weekly
+            - size 1G
+            - rotate 10
+            - missingok
+            - compress
+            - delaycompress
+            - notifempty
+            - sharedscripts
+          scripts:
+            postrotate: "/etc/init.d/rabbitmq-server rotate-logs > /dev/null"

--- a/src/commcare_cloud/ansible/deploy_rabbitmq.yml
+++ b/src/commcare_cloud/ansible/deploy_rabbitmq.yml
@@ -18,7 +18,9 @@
   become: true
   roles:
     - role: ansible-logrotate
-      tags: rabbitmq
+      tags:
+      - rabbitmq
+      - logging
       logrotate_scripts:
         - name: "rabbitmq-server"
           path: "/var/log/rabbitmq/*.log"

--- a/src/commcare_cloud/ansible/roles/rabbitmq/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/rabbitmq/tasks/main.yml
@@ -9,6 +9,14 @@
   notify:
   - restart rabbitmq
 
+- name: Place config file
+  template:
+    src: "rabbitmq.config.j2"
+    dest: "/etc/rabbitmq/rabbitmq.config"
+    group: root
+    owner: rabbitmq
+    mode: 0644
+
 - include: config-cluster.yml
   when: rabbitmq_create_cluster
 

--- a/src/commcare_cloud/ansible/roles/rabbitmq/templates/rabbitmq.config.j2
+++ b/src/commcare_cloud/ansible/roles/rabbitmq/templates/rabbitmq.config.j2
@@ -1,0 +1,6 @@
+[
+ {rabbit,
+  [
+     {log_levels, [{channel, warning}, {connection, warning}, {federation, warning}, {mirroring, warning}]},
+  ]},
+].


### PR DESCRIPTION
##### SUMMARY
I think upgrading to Celery4 has increased the number of connections and disconnections occurring on RabbitMQ which has greatly increased the logging and is filling up the disks.

##### ENVIRONMENTS AFFECTED
all (optional)