### PR TITLE
Remove celery112 from app processes

### DIFF
--- a/environments/icds-cas/app-processes.yml
+++ b/environments/icds-cas/app-processes.yml
@@ -153,15 +153,6 @@ celery_processes:
       num_workers: 6
     icds_dashboard_reports_queue:
       concurrency: 2
-  'celery112':
-    ucr_indicator_queue:
-      concurrency: 4
-    reminder_case_update_queue:
-      pooling: gevent
-      concurrency: 5
-      num_workers: 6
-    icds_dashboard_reports_queue:
-      concurrency: 2
   'celery13':
     ucr_indicator_queue:
       concurrency: 4


### PR DESCRIPTION
Followup to https://github.com/dimagi/commcare-cloud/pull/2758

@calellowitz 
@gbova 