### PR TITLE
Have update-datadog-monitors print out list of untracked monitors

### DIFF
--- a/src/commcare_cloud/manage_commcare_cloud/datadog_monitors.py
+++ b/src/commcare_cloud/manage_commcare_cloud/datadog_monitors.py
@@ -130,10 +130,11 @@ def write_monitor_definition(monitor_id, monitor_definition):
             if env_key in monitor_definition['message']:
                 monitor_definition['env_key'] = env_key
                 break
-        if 'by {environment}' in monitor_definition['query']:
-            monitor_definition['env_key'] = 'environment.name'
         else:
-            monitor_definition['env_key'] = 'host.environment'
+            if 'by {environment}' in monitor_definition['query']:
+                monitor_definition['env_key'] = 'environment.name'
+            else:
+                monitor_definition['env_key'] = 'host.environment'
 
     filename = 'autogen_{}.yml'.format(monitor_id)
     with open(os.path.join(CONFIG_ROOT, filename), 'w') as f:

--- a/src/commcare_cloud/manage_commcare_cloud/datadog_monitors.py
+++ b/src/commcare_cloud/manage_commcare_cloud/datadog_monitors.py
@@ -119,6 +119,10 @@ def get_monitor_definitions(config):
     return monitors
 
 
+def dump_monitor_yaml(monitor_definition):
+    return yaml.safe_dump(monitor_definition, allow_unicode=True)
+
+
 def write_monitor_definition(monitor_id, monitor_definition):
     if 'env_key' not in monitor_definition:
         # try to guess it
@@ -133,7 +137,7 @@ def write_monitor_definition(monitor_id, monitor_definition):
 
     filename = 'autogen_{}.yml'.format(monitor_id)
     with open(os.path.join(CONFIG_ROOT, filename), 'w') as f:
-        f.write(yaml.safe_dump(monitor_definition, allow_unicode=True))
+        f.write(dump_monitor_yaml(monitor_definition))
 
 
 def render_messages(config, monitor):
@@ -258,8 +262,8 @@ class DatadogMonitors(CommandBase):
 
         for id, (expected, actual) in shared_local_remote_monitors.items():
             diff = list(_unidiff_output(
-                yaml.safe_dump(get_data_to_update(actual, keys_to_update)),
-                yaml.safe_dump(get_data_to_update(expected, keys_to_update))))
+                dump_monitor_yaml(get_data_to_update(actual, keys_to_update)),
+                dump_monitor_yaml(get_data_to_update(expected, keys_to_update))))
             any_diffs |= bool(diff)
             if diff:
                 puts(colored.magenta("\nDiff for '{}'\n".format(expected['name'])))


### PR DESCRIPTION
##### SUMMARY

After all the diffs, have `manage-commcare-cloud update-datadog-monitors` print out the full list of untracked monitors. This is will be a useful part of helping us keep config files in sync with datadog. A next step will be to have a tool to ease the bootstrapping process to make configs out of these untracked monitors.

##### COMPONENT NAME
Datadog Monitoring

##### ADDITIONAL INFORMATION
Current output:
```
FYI you also have some untracked monitors. No change will be applied for these:
  - Untracked monitor 309189 'Django response times high' (no change will be applied)
  - Untracked monitor 582119 'Datadog can't connect to pgbouncer' (no change will be applied)
  - Untracked monitor 598865 'Riak service on {{host.name}}' (no change will be applied)
  - Untracked monitor 654754 'ES Cluster Status ALERT' (no change will be applied)
  - Untracked monitor 822202 'Cloudant disk usage alert' (no change will be applied)
  - Untracked monitor 1278009 'Disk space running low on Riak Node {{host.name}}' (no change will be applied)
  - Untracked monitor 1278022 'Disk IO high on {{host.name}}' (no change will be applied)
  - Untracked monitor 1278050 'Django error rate high' (no change will be applied)
  - Untracked monitor 1291358 'Memory usage (RAM + swap) high on {{host.name}}' (no change will be applied)
  - Untracked monitor 1300873 'Disk IO high on {{host.name}} (pg_standby)' (no change will be applied)
  - Untracked monitor 1320983 'CPU high on Pillowtop: {{host.name}}' (no change will be applied)
  - Untracked monitor 1400710 'Case Importer upload files total size high' (no change will be applied)
  - Untracked monitor 1704065 'Number of Queued Tasks is High in queue "{{celery_queue}}"' (no change will be applied)
  - Untracked monitor 1716697 'The number of overdue repeaters is high' (no change will be applied)
  - Untracked monitor 1945144 'Disk space running low on {{host.name}} ({{device.name}})' (no change will be applied)
  - Untracked monitor 2195274 'CouchDB node is down on {{instance}}' (no change will be applied)
  - Untracked monitor 2498362 'Above 15% error rate on ICDS' (no change will be applied)
  - Untracked monitor 2742482 'Riak process alert' (no change will be applied)
  - Untracked monitor 3220612 'PostgreSQL replication delay is high' (no change will be applied)
  - Untracked monitor 4013126 'Pillow {{pillow_name.name}} on {{environment.name}} is not able to keep up with changes' (no change will be applied)
  - Untracked monitor 4314745 'ElasticSearch JVM Heap Usage' (no change will be applied)
  - Untracked monitor 4765265 '[Scale] Normalised Load Average more than 1 on {{host.name}} for 24 hours' (no change will be applied)
  - Untracked monitor 4765671 '[Scale] Disk space will reach {{threshold}} on {{host.name}} in 2 weeks' (no change will be applied)
  - Untracked monitor 4848178 'HQ 500 errors (as % or requests) {{environment.name}}' (no change will be applied)
  - Untracked monitor 4961588 'Elasticsearch is returning partial results' (no change will be applied)
  - Untracked monitor 5091620 '{{service.name}} giving high number of error in {{environment.name}}' (no change will be applied)
  - Untracked monitor 5511193 'Backlog high on export_download_queue on {{environment.name}}' (no change will be applied)
  - Untracked monitor 5848034 '[Scale] RAM usable Left {{host.name}}' (no change will be applied)
  - Untracked monitor 5895341 'PgBouncer Connection Above {{threshold}}% on Production {{host.name}}' (no change will be applied)
  - Untracked monitor 5895436 'PgBouncer Connection Above 30% on ICDS {{host.name}}' (no change will be applied)
  - Untracked monitor 6901846 'Support Alert: Tasks backed up on celery queue:{{celery_queue.name}}' (no change will be applied)
  - Untracked monitor 6904929 'Support Alert: Tasks backed up on saved_exports_queue on {{environment.name}}' (no change will be applied)
  - Untracked monitor 8131184 'Support Alert: RabbitMQ is down! Environment: {{host.environment}}' (no change will be applied)
  - Untracked monitor 8131399 'Support Alert: Kafka is down! Environment: {{host.environment}}' (no change will be applied)
  - Untracked monitor 8265469 'Support Alert: Postgres is down! Environment: {{host.environment}}' (no change will be applied)
  - Untracked monitor 8362409 'Couch Pillow Rewind? Couch Pillow {{pillow_name.name}} on {{environment.name}} is very high' (no change will be applied)
  - Untracked monitor 8548590 '[Synthetics] Test on www.commcarehq.org/serverup.txt' (no change will be applied)
  - Untracked monitor 8797655 '[ICDS] Disk space will reach {{threshold}}% in 2 weeks' (no change will be applied)
  - Untracked monitor 9455671 '[Synthetics] Test on www.icds-cas.gov.in/serverup.txt' (no change will be applied)
```
