### PR TITLE
Clean up datadog monitors diff

### DIFF
--- a/src/commcare_cloud/manage_commcare_cloud/datadog_monitors.py
+++ b/src/commcare_cloud/manage_commcare_cloud/datadog_monitors.py
@@ -196,8 +196,7 @@ def get_config(config_path):
 
 
 class MonitorError(Exception):
-    def __init__(self, errors):
-        self.errors = errors
+    pass
 
 
 class RemoteMonitorAPI(object):
@@ -208,7 +207,7 @@ class RemoteMonitorAPI(object):
         if raw_mon['type'] == 'synthetics alert':
             raw_mon = api.Monitor.get(raw_mon['id'])
         if raw_mon.get('errors'):
-            raise MonitorError(raw_mon['errors'])
+            raise MonitorError('\n'.join(raw_mon['errors']))
         else:
             return clean_raw_monitor(raw_mon)
 
@@ -217,7 +216,9 @@ class RemoteMonitorAPI(object):
                 if raw_mon['id'] not in get_ignored_mointor_ids()}
 
     def update(self, monitor_id, wrapped_monitor):
-        api.Monitor.update(monitor_id, **wrapped_monitor)
+        result = api.Monitor.update(monitor_id, **wrapped_monitor)
+        if result.get('errors'):
+            raise MonitorError('\n'.join(result['errors']))
 
 
 class LocalMonitorAPI(object):
@@ -263,6 +264,8 @@ class DatadogMonitors(CommandBase):
             for id in set(local_monitors) & set(remote_monitors)
         }
 
+        monitors_with_diffs = {}
+
         any_diffs = False
         if only_local:
             for id, monitor in only_local.items():
@@ -279,10 +282,12 @@ class DatadogMonitors(CommandBase):
                 puts(colored.magenta("\nDiff for '{}'\n".format(expected['name'])))
                 with indent():
                     print_diff(diff)
+                monitors_with_diffs[id] = expected
 
         if any_diffs:
             if ask("Do you want to push these changes to Datadog?"):
-                for id, expected in local_monitors.items():
+                for id, expected in monitors_with_diffs.items():
+                    print("Updating '{}'".format(expected['name']))
                     remote_monitor_api.update(id, get_data_to_update(expected, keys_to_update))
 
         if only_remote:

--- a/src/commcare_cloud/manage_commcare_cloud/datadog_monitors.py
+++ b/src/commcare_cloud/manage_commcare_cloud/datadog_monitors.py
@@ -154,6 +154,8 @@ def render_messages(config, monitor):
     if escal_msg:
         elcal_rendered = render_message(config, escal_msg, monitor['env_key'])
         monitor['options'][ESCAL_MSG] = LiteralUnicode(elcal_rendered.strip())
+    if 'include_tags' not in monitor['options']:
+        monitor['options']['include_tags'] = True
     return monitor
 
 

--- a/src/commcare_cloud/manage_commcare_cloud/monitors/es_cluster_status.yml
+++ b/src/commcare_cloud/manage_commcare_cloud/monitors/es_cluster_status.yml
@@ -21,7 +21,7 @@ options:
   notify_no_data: false
   renotify_interval: 60
   silenced: {}
-  thresholds: {critical: 10, warning: 80}
+  thresholds: {critical: 80.0, warning: 10.0}
   timeout_h: 0
 query: '"elasticsearch.cluster_health".over("*").exclude("environment:icds-new").by("environment").last(1).pct_by_status()'
 tags: [opsgenie]

--- a/src/commcare_cloud/manage_commcare_cloud/monitors/riak_process_up.yml
+++ b/src/commcare_cloud/manage_commcare_cloud/monitors/riak_process_up.yml
@@ -11,7 +11,7 @@ options:
   notify_no_data: false
   renotify_interval: 0
   silenced: {}
-  thresholds: {critical: 20, warning: 10}
+  thresholds: {critical: 20.0, warning: 10.0}
   timeout_h: 0
 query: '"process.up".over("process:riak").by("environment").last(1).pct_by_status()'
 tags: []


### PR DESCRIPTION
Applied diff to datadog and then ran again and found there were spurious diffs, as well as one alert that wasn't updating. I cleaned up the diff until there were no diffs on subsequent runs, and made the tool louder when there's an error updating.