### PR TITLE
Send india to #alerts-india and softlayer to #alerts-softlayer

### DIFF
--- a/environments/datadog_envs.yml
+++ b/environments/datadog_envs.yml
@@ -2,8 +2,8 @@ env_with_datadog_auth: production
 catchall_alert_channel: '@slack-hq-ops-priority'
 env_notifications:
   icds: '@slack-alerts-icds'
-  india: '@slack-alerts-softlayer @slack-alerts-india'
-  softlayer: '@slack-alerts-softlayer @slack-alerts-india'
+  india: '@slack-alerts-india'
+  softlayer: '@slack-alerts-softlayer'
   production: '@slack-alerts-production @opsgenie-commcarehq'
   pna: '@slack-alerts-pna'
   swiss: '@slack-alerts-swiss'


### PR DESCRIPTION
##### SUMMARY
Send india to #alerts-india and softlayer to #alerts-softlayer
to confirm the hypothesis that #alerts-softlayer will be empty.
After that we can remove softlayer from datadog_envs.yml altogether.

##### ENVIRONMENTS AFFECTED
India

##### COMPONENT NAME
Datadog Monitoring

##### ADDITIONAL INFORMATION
This will change the << notification_block >> portion of each monitor