### PR TITLE
 Give terraform server spec an `os` (trusty/bionic)

### DIFF
--- a/environments/india/terraform.yml
+++ b/environments/india/terraform.yml
@@ -34,6 +34,7 @@ proxy_servers:
     network_tier: "public"
     az: "a"
     volume_size: 80
-    group: "proxy:bionic"
+    group: proxy
+    os: bionic
 
 rds_instances: []

--- a/environments/staging/terraform.yml
+++ b/environments/staging/terraform.yml
@@ -52,13 +52,15 @@ servers:
     network_tier: "app-private"
     az: "a"
     volume_size: 80
-    group: "webworkers:bionic"
+    group: webworkers
+    os: bionic
   - server_name: "web3-staging"
     server_instance_type: "t3.medium"
     network_tier: "app-private"
     az: "b"
     volume_size: 80
-    group: "webworkers:bionic"
+    group: webworkers
+    os: bionic
 
   - server_name: "es0-staging"
     server_instance_type: "t3.medium"
@@ -76,7 +78,8 @@ servers:
     network_tier: "app-private"
     az: "a"
     volume_size: 80
-    group: "pillowtop:bionic"
+    group: pillowtop
+    os: bionic
   - server_name: "celery0-staging"
     server_instance_type: "t3.large"
     network_tier: "app-private"
@@ -88,7 +91,8 @@ servers:
     network_tier: "app-private"
     az: "a"
     volume_size: 80
-    group: "celery:bionic"
+    group: celery
+    os: bionic
   - server_name: "airflow0-staging"
     server_instance_type: "t3.small"
     network_tier: "app-private"
@@ -101,7 +105,8 @@ servers:
     network_tier: "app-private"
     az: "a"
     volume_size: 40
-    group: "airflow:bionic"
+    group: airflow
+    os: bionic
 
   - server_name: "formplayer0-staging"
     server_instance_type: "t3.large"
@@ -115,7 +120,8 @@ servers:
     network_tier: "app-private"
     az: "a"
     volume_size: 80
-    group: "formplayer:bionic"
+    group: formplayer
+    os: bionic
 
   - server_name: "couch0-staging"
     server_instance_type: "t2.large"
@@ -155,7 +161,8 @@ servers:
     network_tier: "db-private"
     az: "a"
     volume_size: 80
-    group: "postgresql:bionic"
+    group: postgresql
+    os: bionic
 
   - server_name: "redis0-staging"
     server_instance_type: t3.medium
@@ -169,7 +176,8 @@ servers:
     network_tier: "app-private"
     az: "a"
     volume_size: 200
-    group: "hwarehouse:bionic"
+    group: hwarehouse
+    os: bionic
 
 
 proxy_servers:

--- a/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
@@ -90,7 +90,7 @@ module "server__{{ server.server_name }}" {
   secondary_volume_size = {{ server.block_device.volume_size|default(0)|tojson }}
   secondary_volume_type = {{ server.block_device.volume_type|default("")|tojson }}
 
-{% if ':bionic' in server.group %}
+{% if server.os == 'bionic' or ':bionic' in server.group %}
   server_image = "${var.bionic_server_image}"
 {% else %}
   server_image = "${var.server_image}"

--- a/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
@@ -90,6 +90,8 @@ module "server__{{ server.server_name }}" {
   secondary_volume_size = {{ server.block_device.volume_size|default(0)|tojson }}
   secondary_volume_type = {{ server.block_device.volume_type|default("")|tojson }}
 
+{# Remove the :bionic in group option once this has been rolled out -#}
+{# and any open PRs have had a chance to adopt the new convention -#}
 {% if server.os == 'bionic' or ':bionic' in server.group %}
   server_image = "${var.bionic_server_image}"
 {% else %}

--- a/src/commcare_cloud/environment/schemas/terraform.py
+++ b/src/commcare_cloud/environment/schemas/terraform.py
@@ -53,6 +53,7 @@ class ServerConfig(jsonobject.JsonObject):
     volume_size = jsonobject.IntegerProperty(default=20)
     block_device = jsonobject.ObjectProperty(lambda: BlockDevice, default=None)
     group = jsonobject.StringProperty()
+    os = jsonobject.StringProperty(default='trusty')
 
 
 class BlockDevice(jsonobject.JsonObject):

--- a/src/commcare_cloud/environment/schemas/terraform.py
+++ b/src/commcare_cloud/environment/schemas/terraform.py
@@ -53,6 +53,7 @@ class ServerConfig(jsonobject.JsonObject):
     volume_size = jsonobject.IntegerProperty(default=20)
     block_device = jsonobject.ObjectProperty(lambda: BlockDevice, default=None)
     group = jsonobject.StringProperty()
+    # todo: invert this so that all new machines are bionic unless otherwise specified
     os = jsonobject.StringProperty(default='trusty')
 
 


### PR DESCRIPTION
##### SUMMARY
Adding ":bionic" to the `group` tag was always sort of a hack, and has small annoying downstream effects. This cleans it up by specifying bionic in a separate `os: bionic` property.

##### ENVIRONMENTS AFFECTED
Just staging for now. (The india aws env is not yet in use.)

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME

Terraform, Bionic upgrade

##### ADDITIONAL INFORMATION

The diff on staging only changes the servers' group tag (e.g. from 'webworkers:bionic' to just 'webworkers'). This is part of the point, since we use that tag for e.g. analyzing costs and it's annoying to have them split into groups like that.

Staging diff:

```
  ~ module.server__airflow1-staging.aws_instance.server
      tags.%:           "3" => "3"
      tags.Environment: "staging" => "staging"
      tags.Group:       "airflow:bionic" => "airflow"
      tags.Name:        "airflow1-staging" => "airflow1-staging"

  ~ module.server__celery1-staging.aws_instance.server
      tags.%:           "3" => "3"
      tags.Environment: "staging" => "staging"
      tags.Group:       "celery:bionic" => "celery"
      tags.Name:        "celery1-staging" => "celery1-staging"

  ~ module.server__formplayer1-staging.aws_instance.server
      tags.%:           "3" => "3"
      tags.Environment: "staging" => "staging"
      tags.Group:       "formplayer:bionic" => "formplayer"
      tags.Name:        "formplayer1-staging" => "formplayer1-staging"

  ~ module.server__hwarehouse0-staging.aws_instance.server
      tags.Group:       "hwarehouse:bionic" => "hwarehouse"

  ~ module.server__pgproxy1-staging.aws_instance.server
      tags.%:           "3" => "3"
      tags.Environment: "staging" => "staging"
      tags.Group:       "postgresql:bionic" => "postgresql"
      tags.Name:        "pgproxy1-staging" => "pgproxy1-staging"

  ~ module.server__pillow1-staging.aws_instance.server
      tags.%:           "3" => "3"
      tags.Environment: "staging" => "staging"
      tags.Group:       "pillowtop:bionic" => "pillowtop"
      tags.Name:        "pillow1-staging" => "pillow1-staging"

  ~ module.server__web2-staging.aws_instance.server
      tags.%:           "3" => "3"
      tags.Environment: "staging" => "staging"
      tags.Group:       "webworkers:bionic" => "webworkers"
      tags.Name:        "web2-staging" => "web2-staging"

  ~ module.server__web3-staging.aws_instance.server
      tags.%:           "3" => "3"
      tags.Environment: "staging" => "staging"
      tags.Group:       "webworkers:bionic" => "webworkers"
      tags.Name:        "web3-staging" => "web3-staging"
```
