### PR TITLE
add packages for weasyprint

### DIFF
--- a/src/commcare_cloud/ansible/roles/common_installs/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/common_installs/tasks/main.yml
@@ -50,6 +50,8 @@
     - iotop
     - ncdu # 'du' improved
     - monit # service restarter
+    - libcairo2
+    - libpango1.0-0
 
 - include: trusty_apt_installs.yml
   when: ansible_distribution_version == '14.04'


### PR DESCRIPTION
@Rohit25negi @biyeun @emord 
This adds two libraries needed for weasyprint, which is added in https://github.com/dimagi/commcare-hq/pull/23707/files