### PR TITLE
Set india to use google nameservers

### DIFF
--- a/environments/india/public.yml
+++ b/environments/india/public.yml
@@ -32,6 +32,9 @@ redis_appendonly: 'yes'
 
 KSPLICE_ACTIVE: yes
 
+nameservers:
+  - 8.8.8.8
+  - 8.8.4.4
 
 kafka_broker_id: 0
 kafka_log_dir: "{{ encrypted_root }}/kafka"


### PR DESCRIPTION
##### SUMMARY

Softlayer support suggested I do this as part of fixing some network issues that come up when I try to set up the tunnel to AWS. This would only fix part of it (access to the public internet).

##### ENVIRONMENTS AFFECTED
India

##### COMPONENT NAME
India softlayer-aws tunnel
