### PR TITLE
Add more "blip" queues to celery6

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -76,7 +76,7 @@ celery_processes:
       concurrency: 4
       optimize: True
     export_download_queue:
-      concurrency: 4
+      concurrency: 5
     repeat_record_queue:
       pooling: gevent
       num_workers: 4
@@ -87,7 +87,7 @@ celery_processes:
     case_import_queue:
       concurrency: 4
     export_download_queue:
-      concurrency: 6
+      concurrency: 5
   celery5:
     beat: {}
     celery_periodic:
@@ -104,6 +104,8 @@ celery_processes:
       concurrency: 4
     case_rule_queue:
       concurrency: 4
+    export_download_queue:
+      concurrency: 5
 
 
 pillows:

--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -104,6 +104,10 @@ celery_processes:
       concurrency: 4
     case_rule_queue:
       concurrency: 4
+    email_queue:
+      pooling: gevent
+      concurrency: 100
+      num_workers: 2
     export_download_queue:
       concurrency: 5
 


### PR DESCRIPTION
##### SUMMARY

Distribute some of `export_download_queue` and `email_queue` onto new celery6, overall increasing processing allocated to those queues.

I identified these queues by looking at this graph: https://app.datadoghq.com/dashboard/bdu-k5b-bz5/celery-overview?tile_size=m&page=0&is_auto=false&from_ts=1555432200000&to_ts=1555518600000&live=false&tpl_var_celery_queue=*&tpl_var_celery_task=*&tpl_var_environment=production&fullscreen_widget=1447409977947274

<img width="1358" alt="Screen Shot 2019-04-17 at 12 11 35 PM" src="https://user-images.githubusercontent.com/137212/56303515-11efb480-610a-11e9-943a-d39ad8a1bab1.png">




##### ENVIRONMENTS AFFECTED
production

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME

Celery
