### PR TITLE
Fix private interface for enhanced network enabled AWS instances

### DIFF
--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -122,7 +122,7 @@ kafka0
 10.202.12.120 hostname=celery5-production ec2=yes
 
 [celery6]
-10.202.12.126 hostname=celery6-production ec2=yes
+10.202.12.126 hostname=celery6-production ec2=ena
 
 
 [celery:children]

--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -122,7 +122,7 @@ kafka0
 10.202.12.120 hostname=celery5-production ec2=yes
 
 [celery6]
-10.202.12.126 hostname=celery6-production ec2=ena
+10.202.12.126 hostname=celery6-production ec2=ena ansible_python_interpreter=/usr/bin/python3
 
 
 [celery:children]

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -122,7 +122,7 @@ kafka0
 {{ celery5-production }} hostname=celery5-production ec2=yes
 
 [celery6]
-{{ celery6-production }} hostname=celery6-production ec2=ena
+{{ celery6-production }} hostname=celery6-production ec2=ena ansible_python_interpreter=/usr/bin/python3
 
 
 [celery:children]

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -122,7 +122,7 @@ kafka0
 {{ celery5-production }} hostname=celery5-production ec2=yes
 
 [celery6]
-{{ celery6-production }} hostname=celery6-production ec2=yes
+{{ celery6-production }} hostname=celery6-production ec2=ena
 
 
 [celery:children]

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -43,7 +43,7 @@ formplayer_purge_time_spec: '8d'
 KSPLICE_ACTIVE: yes
 
 
-ufw_private_interface: "{{ 'eth0' if ec2|default(false) else 'eth1' }}"
+ufw_private_interface: "{{ 'ens5' if ec2 == 'ena' else 'eth0' if ec2|default(false) else 'eth1' }}"
 
 run_websockets_wsgi: True
 

--- a/environments/staging/inventory.ini
+++ b/environments/staging/inventory.ini
@@ -11,10 +11,10 @@
 proxy1
 
 [web2]
-10.201.10.182 swap_size=1G hostname=web2-staging ec2=yes ansible_python_interpreter=/usr/bin/python3
+10.201.10.182 swap_size=1G hostname=web2-staging ec2=ena ansible_python_interpreter=/usr/bin/python3
 
 [web3]
-10.201.11.246 swap_size=1G hostname=web3-staging ec2=yes ansible_python_interpreter=/usr/bin/python3
+10.201.11.246 swap_size=1G hostname=web3-staging ec2=ena ansible_python_interpreter=/usr/bin/python3
 
 [webworkers:children]
 # Amazon EC2
@@ -22,7 +22,7 @@ web2
 web3
 
 [pgproxy1]
-10.201.40.187 hostname=pgproxy1-staging ec2=yes ansible_python_interpreter=/usr/bin/python3
+10.201.40.187 hostname=pgproxy1-staging ec2=ena ansible_python_interpreter=/usr/bin/python3
 
 [rds_pg0]
 # RDS
@@ -75,21 +75,21 @@ kafka0
 kafka0
 
 [celery1]
-10.201.10.108 hostname=celery1-staging ec2=yes ansible_python_interpreter=/usr/bin/python3
+10.201.10.108 hostname=celery1-staging ec2=ena ansible_python_interpreter=/usr/bin/python3
 
 [celery:children]
 # Amazon EC2
 celery1
 
 [pillow1]
-10.201.10.103 hostname=pillow1-staging ec2=yes ansible_python_interpreter=/usr/bin/python3
+10.201.10.103 hostname=pillow1-staging ec2=ena ansible_python_interpreter=/usr/bin/python3
 
 [pillowtop:children]
 # Amazon EC2
 pillow1
 
 [formplayer1]
-10.201.10.234 hostname=formplayer1-staging ec2=yes ansible_python_interpreter=/usr/bin/python3
+10.201.10.234 hostname=formplayer1-staging ec2=ena ansible_python_interpreter=/usr/bin/python3
 
 [formplayer:children]
 # Amazon EC2
@@ -116,7 +116,7 @@ es1
 redis0
 
 [airflow1]
-10.201.10.147 hostname=airflow1-staging ec2=yes ansible_python_interpreter=/usr/bin/python3
+10.201.10.147 hostname=airflow1-staging ec2=ena ansible_python_interpreter=/usr/bin/python3
 
 [airflow:children]
 # Amazon EC2
@@ -136,7 +136,7 @@ web2
 web3
 
 [hwarehouse0]
-10.201.10.192 hostname=hwarehouse0-staging ec2=yes
+10.201.10.192 hostname=hwarehouse0-staging ec2=ena
 
 [openvpn]
 10.201.20.112  # ansible_host=54.227.170.89

--- a/environments/staging/inventory.ini.j2
+++ b/environments/staging/inventory.ini.j2
@@ -11,10 +11,10 @@
 proxy1
 
 [web2]
-{{ web2-staging }} swap_size=1G hostname=web2-staging ec2=yes ansible_python_interpreter=/usr/bin/python3
+{{ web2-staging }} swap_size=1G hostname=web2-staging ec2=ena ansible_python_interpreter=/usr/bin/python3
 
 [web3]
-{{ web3-staging }} swap_size=1G hostname=web3-staging ec2=yes ansible_python_interpreter=/usr/bin/python3
+{{ web3-staging }} swap_size=1G hostname=web3-staging ec2=ena ansible_python_interpreter=/usr/bin/python3
 
 [webworkers:children]
 # Amazon EC2
@@ -22,7 +22,7 @@ web2
 web3
 
 [pgproxy1]
-{{ pgproxy1-staging }} hostname=pgproxy1-staging ec2=yes ansible_python_interpreter=/usr/bin/python3
+{{ pgproxy1-staging }} hostname=pgproxy1-staging ec2=ena ansible_python_interpreter=/usr/bin/python3
 
 [rds_pg0]
 # RDS
@@ -75,21 +75,21 @@ kafka0
 kafka0
 
 [celery1]
-{{ celery1-staging }} hostname=celery1-staging ec2=yes ansible_python_interpreter=/usr/bin/python3
+{{ celery1-staging }} hostname=celery1-staging ec2=ena ansible_python_interpreter=/usr/bin/python3
 
 [celery:children]
 # Amazon EC2
 celery1
 
 [pillow1]
-{{ pillow1-staging }} hostname=pillow1-staging ec2=yes ansible_python_interpreter=/usr/bin/python3
+{{ pillow1-staging }} hostname=pillow1-staging ec2=ena ansible_python_interpreter=/usr/bin/python3
 
 [pillowtop:children]
 # Amazon EC2
 pillow1
 
 [formplayer1]
-{{ formplayer1-staging }} hostname=formplayer1-staging ec2=yes ansible_python_interpreter=/usr/bin/python3
+{{ formplayer1-staging }} hostname=formplayer1-staging ec2=ena ansible_python_interpreter=/usr/bin/python3
 
 [formplayer:children]
 # Amazon EC2
@@ -116,7 +116,7 @@ es1
 redis0
 
 [airflow1]
-{{ airflow1-staging }} hostname=airflow1-staging ec2=yes ansible_python_interpreter=/usr/bin/python3
+{{ airflow1-staging }} hostname=airflow1-staging ec2=ena ansible_python_interpreter=/usr/bin/python3
 
 [airflow:children]
 # Amazon EC2
@@ -136,4 +136,4 @@ web2
 web3
 
 [hwarehouse0]
-{{ hwarehouse0-staging }} hostname=hwarehouse0-staging ec2=yes
+{{ hwarehouse0-staging }} hostname=hwarehouse0-staging ec2=ena

--- a/src/commcare_cloud/ansible/roles/ufw/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/ufw/tasks/main.yml
@@ -1,4 +1,4 @@
-- name: "make sure the specified public interface actually exists"
+- name: "make sure the specified private interface actually exists"
   # a bit of a hack, but just hopefully prevents turning off access on all interfaces!
   shell: "ifconfig | grep {{ ufw_private_interface }}"
   changed_when: no

--- a/src/commcare_cloud/ansible/roles/ufw/tasks/proxy_ufw.yml
+++ b/src/commcare_cloud/ansible/roles/ufw/tasks/proxy_ufw.yml
@@ -1,4 +1,4 @@
-- name: "make sure the specified public interface actually exists"
+- name: "make sure the specified private interface actually exists"
   # a bit of a hack, but just hopefully prevents turning off access on all interfaces!
   shell: "ifconfig | grep {{ ufw_private_interface }}"
   changed_when: no


### PR DESCRIPTION
##### SUMMARY

The bionic image on AWS has AWS Enhanced Networking enabled, which means among other things it calls the private interface `ens5` instead of `eth0`

##### ENVIRONMENTS AFFECTED
AWS envs using bionic (staging, production)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Bionic
