### PR TITLE
Fix s3transfer version conflict by setting a lower bound to boto3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,8 +11,8 @@ args==0.1.0               # via clint
 asn1crypto==0.24.0        # via cryptography
 attrs==18.2.0
 bcrypt==3.1.4             # via paramiko
-boto3==1.9.38
-botocore==1.12.38         # via boto3, s3transfer
+boto3==1.9.131
+botocore==1.12.131        # via boto3, s3transfer
 certifi==2018.10.15       # via requests
 cffi==1.11.5              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via requests
@@ -52,7 +52,7 @@ python-dateutil==2.7.5    # via botocore
 pytz==2017.2
 pyyaml==3.13              # via ansible, couchdb-cluster-admin
 requests==2.19.1          # via couchdb-cluster-admin, datadog, pygithub
-s3transfer==0.1.13        # via boto3
+s3transfer==0.2.0         # via boto3
 simplejson==3.16.0        # via datadog
 six==1.11.0
 urllib3==1.23             # via botocore, requests

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'ansible==2.5.0',
         'argparse>=1.4',
         'attrs>=18.1.0',
-        'boto3',
+        'boto3>=1.9.131',
         'clint',
         'couchdb-cluster-admin>=0.4.1',
         'cryptography>=2.3',  # security update


### PR DESCRIPTION
##### SUMMARY
I noticed this was causing a version conflict locally, including on a fresh install.
