### PR TITLE
Fix submodule fetch during deploy

### DIFF
--- a/src/commcare_cloud/fab/operations/release.py
+++ b/src/commcare_cloud/fab/operations/release.py
@@ -178,6 +178,8 @@ def _upload_and_extract(zippath, strip_components=0):
 
 def _update_code_from_previous_release():
     if files.exists(env.code_current):
+        with cd(env.code_current):
+            sudo('git submodule foreach "git fetch origin"')
         _clone_code_from_local_path(env.code_current, env.code_root)
         with cd(env.code_root):
             sudo('git remote set-url origin {}'.format(env.code_repo))


### PR DESCRIPTION
##### SUMMARY
Fix submodule fetch during deploy by running `git fetch orgin` in each submodule of the `current` directory before cloning it.

##### ENVIRONMENTS AFFECTED
potentially all, in this case I was seeing the issue on production, and we've seen it before.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Deploy