### PR TITLE
Apply pg_stat_statement settings from other environments to pgmain0-production

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -308,6 +308,11 @@ rds_instances:
     instance_type: "db.t2.xlarge"
     storage: 500
     multi_az: true
+    params:
+      pg_stat_statements.track: all
+      pg_stat_statements.max: 10000
+      track_activity_query_size: 2048
+
   - identifier: "pgucr0-production"  # replaces old hqdb3
     instance_type: "db.t2.xlarge"
     storage: 500


### PR DESCRIPTION
##### SUMMARY

Since RDS is managed through terraform, we have to set these settings separately there. For now just setting on the main db, but we can of course turn it on for others as well.

This is already applied.

##### ENVIRONMENTS AFFECTED
production

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME

RDS
