### PR TITLE
Add redundancy to production ucr_queue

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -110,6 +110,8 @@ celery_processes:
       num_workers: 2
     export_download_queue:
       concurrency: 5
+    ucr_queue:
+      concurrency: 4
 
 
 pillows:


### PR DESCRIPTION
##### SUMMARY

In response to yesterday's downtime on the UCR queue, I'm doubling the capacity, spread across two machines.

I haven't dug into what caused the downtime, but we do know that in this case as many others simply restarting the processor for the `ucr_queue` fixed it. My prediction is that simply adding enough redundancy to hold us over to the next deploy (which will restart all services) will go a long way towards preventing issues with a single processor leading to service disruption.

<img width="1238" alt="Screen Shot 2019-04-19 at 10 34 56 AM" src="https://user-images.githubusercontent.com/137212/56428890-fb269a80-628e-11e9-806d-fbcdd18bf3e6.png">


In this case though it looks like the queue being blocked was somehow triggered by the deploy, as it starts immediately after deploy.

##### ENVIRONMENTS AFFECTED
production

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
Celery
