### PR TITLE
Streamline reloading supervisor in update-supervisor-confs

### DIFF
--- a/src/commcare_cloud/commands/ansible/ansible_playbook.py
+++ b/src/commcare_cloud/commands/ansible/ansible_playbook.py
@@ -301,8 +301,13 @@ class UpdateSupervisorConfs(_AnsiblePlaybookAlias):
         unknown_args += ('--tags=services',)
         rc = AnsiblePlaybook(self.parser).run(args, unknown_args)
         if ask("Would you like to update supervisor to use the new configurations?"):
-            exec_fab_command(args.env_name, 'supervisorctl:"reread"')
-            exec_fab_command(args.env_name, 'supervisorctl:"update"')
+            carryover_args = []
+            if args.limit:
+                carryover_args.extend(['--limit', args.limit])
+            commcare_cloud(
+                args.env_name, 'run-shell-command', 'webworkers:celery:pillowtop:formplayer',
+                'supervisorctl reread; supervisorctl update', '-b', *carryover_args
+            )
         else:
             return rc
 


### PR DESCRIPTION
##### SUMMARY
run commands through ansible shell instead of through fab

Also now the reload also respects the `--limit` arg

Fixes https://github.com/dimagi/commcare-cloud/issues/2571

##### ENVIRONMENTS AFFECTED
None

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
`update-supervisor-confs` command
