### PR TITLE
Disable elasticsearch console logging

### DIFF
--- a/src/commcare_cloud/ansible/roles/elasticsearch/templates/config/logging.yml.j2
+++ b/src/commcare_cloud/ansible/roles/elasticsearch/templates/config/logging.yml.j2
@@ -1,4 +1,4 @@
-rootLogger: INFO, console, file
+rootLogger: INFO, file
 logger:
   # log action execution errors for easier debugging
   action: DEBUG
@@ -23,12 +23,6 @@ additivity:
   index.indexing.slowlog: false
 
 appender:
-  console:
-    type: console
-    layout:
-      type: consolePattern
-      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
-
   file:
     type: dailyRollingFile
     file: ${path.logs}/${cluster.name}.log


### PR DESCRIPTION
##### SUMMARY
This is a different attempt at fixing the same problem https://github.com/dimagi/commcare-cloud/pull/2533 was intended to fix, and which it didn't seem to fix. The symptom is an es machine occasionally become unresponsive, due to too high a rate of writing to "the console" and overloading "the serial port". I do not have a clear mental model of what those things mean. This potential fix is @calellowitz brainchild.

##### ENVIRONMENTS AFFECTED
production