### PR TITLE
Set DEPLOY_ENV env var for settings.py to use

### DIFF
--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/webworkers.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/webworkers.yml
@@ -24,6 +24,7 @@
         DATADOG_ENV: "{% if app_processes_config.datadog_pythonagent %}{{ env_monitoring_id }}{% endif %}"
         DD_REQUESTS_SERVICE_NAME: "{% if app_processes_config.datadog_pythonagent %}requests{% endif %}"
         DD_REQUESTS_SPLIT_BY_DOMAIN: "{% if app_processes_config.datadog_pythonagent %}True{% endif %}"
+        DEPLOY_ENV: {{ deploy_env }}
       gunicorn_workers: "{{ app_processes_config.gunicorn_workers_static_factor + (ansible_processor_vcpus * app_processes_config.gunicorn_workers_factor)|int }}"
   tags:
     - services


### PR DESCRIPTION
##### SUMMARY

[Concept note](https://docs.google.com/document/d/1WTCmE8MGXNXCtztJWoQUR8alQ9HzWRRnaTFsAJrlkZE/edit#).

Allows settings.py to select custom modules based on its deployment environment.

**NOTE**: I am not certain that this is the correct place to set environment variables that will be visible in gunicorn, but it is my best guess. This is currently untested!

##### ENVIRONMENTS AFFECTED

Webworkers will have a DEPLOY_ENV environment variable available. But this change does not affect behaviour.

##### ISSUE TYPE

- Change Pull Request

##### COMPONENT NAME

Django worker service definition (roles/commcarehq/tasks/webworkers.yml)

##### ADDITIONAL INFORMATION

This is related to corresponding [HQ PR #24128](https://github.com/dimagi/commcare-hq/pull/24128).
