### PR TITLE
Fix certbot renew hook 

### DIFF
--- a/src/commcare_cloud/ansible/letsencrypt_cert.yml
+++ b/src/commcare_cloud/ansible/letsencrypt_cert.yml
@@ -64,7 +64,7 @@
     - name: Add custom_certbot cron
       cron:
         name: "Certbot Renew"
-        job: "test -x /usr/bin/certbot && perl -e 'sleep int(rand(3600))' && certbot -q renew --renew-hook '/etc/init.d/nginx reload'"
+        job: "test -x /usr/bin/certbot && perl -e 'sleep int(rand(3600))' && certbot -q renew --post-hook '/etc/init.d/nginx reload'"
         minute: "0"
         hour: "*/12"
         user: root


### PR DESCRIPTION
HTTPS for swiss wasn't working today, I didn't have to renew but just reload nginx to make it work. Presumably the certs renewed but nginx didn't get reloaded (perhaps because there was no deploy on swiss in a while.). 

I think if the `--renew-hook` worked correctly this would have been prevented. I think we should probably use `--post-hook`

```
root@commcarealmanach:~# certbot  --help renew | grep hook
                        changes. It also calls --pre-hook and --post-hook
                        hook commands are not called. (default: False)
  --pre-hook PRE_HOOK   Command to be run in a shell before obtaining any
                        that have identical pre-hooks, only the first will be
  --post-hook POST_HOOK
                        were stopped by --pre-hook. This is only run if an
                        hooks, only one will be run. (default: None)
  --deploy-hook DEPLOY_HOOK
  --disable-hook-validation
                        Ordinarily the commands specified for --pre-hook
                        /--post-hook/--deploy-hook will be checked for
                        the hooks aren't being run just yet. The validation is
  --no-directory-hooks  Disable running executables found in Certbot's hook
```