### PR TITLE
Make os (bionic|trusty) in terraform spec required with no default

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -34,6 +34,7 @@ servers:
     az: "a"
     volume_size: 40
     group: "control"
+    os: trusty
 
   - server_name: "djangomanage0-production"
     server_instance_type: c5.xlarge
@@ -41,6 +42,7 @@ servers:
     az: "a"
     volume_size: 80
     group: "django_manage"
+    os: trusty
 
   - server_name: "web0-production"
     server_instance_type: m5.2xlarge
@@ -48,12 +50,14 @@ servers:
     az: "a"
     volume_size: 40
     group: "hq_webworkers"
+    os: trusty
   - server_name: "web1-production"
     server_instance_type: m5.2xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 40
     group: "hq_webworkers"
+    os: trusty
 
   - server_name: "web6-production"
     server_instance_type: m5.2xlarge
@@ -61,24 +65,28 @@ servers:
     az: "b"
     volume_size: 40
     group: "mobile_webworkers"
+    os: trusty
   - server_name: "web7-production"
     server_instance_type: m5.2xlarge
     network_tier: "app-private"
     az: "b"
     volume_size: 40
     group: "mobile_webworkers"
+    os: trusty
   - server_name: "web8-production"
     server_instance_type: m5.2xlarge
     network_tier: "app-private"
     az: "b"
     volume_size: 40
     group: "mobile_webworkers"
+    os: trusty
   - server_name: "web9-production"
     server_instance_type: m5.2xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 40
     group: "mobile_webworkers"
+    os: trusty
 
   - server_name: "esmaster0-production"
     server_instance_type: t3.large
@@ -86,17 +94,20 @@ servers:
     az: "b"
     volume_size: 40
     group: "elasticsearch"
+    os: trusty
   - server_name: "esmaster1-production"
     server_instance_type: t3.large
     network_tier: "db-private"
     az: "b"
     volume_size: 40
     group: "elasticsearch"
+    os: trusty
   - server_name: "esmaster2-production"
     server_instance_type: t3.large
     network_tier: "db-private"
     az: "a"
     group: "elasticsearch"
+    os: trusty
 
   - server_name: "es10-production"
     server_instance_type: m5.2xlarge
@@ -104,30 +115,35 @@ servers:
     az: "a"
     volume_size: 600
     group: "elasticsearch"
+    os: trusty
   - server_name: "es11-production"
     server_instance_type: m5.2xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 600
     group: "elasticsearch"
+    os: trusty
   - server_name: "es12-production"
     server_instance_type: m5.2xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 600
     group: "elasticsearch"
+    os: trusty
   - server_name: "es13-production"
     server_instance_type: m5.2xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 600
     group: "elasticsearch"
+    os: trusty
   - server_name: "es14-production"
     server_instance_type: m5.2xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 600
     group: "elasticsearch"
+    os: trusty
 
   - server_name: "couchproxy0-production"
     server_instance_type: "t3.medium"
@@ -135,6 +151,7 @@ servers:
     az: "a"
     volume_size: 80
     group: "couchdb2_proxy"
+    os: trusty
 
   - server_name: "couch3-production"
     server_instance_type: c5.4xlarge
@@ -144,6 +161,7 @@ servers:
     block_device:
       volume_size: 6938
     group: "couchdb2"
+    os: trusty
   - server_name: "couch4-production"
     server_instance_type: c5.4xlarge
     network_tier: "db-private"
@@ -152,6 +170,7 @@ servers:
     block_device:
       volume_size: 6769
     group: "couchdb2"
+    os: trusty
   - server_name: "couch5-production"
     server_instance_type: c5.4xlarge
     network_tier: "db-private"
@@ -160,6 +179,7 @@ servers:
     block_device:
       volume_size: 7023
     group: "couchdb2"
+    os: trusty
   - server_name: "couch7-production"
     server_instance_type: c5.4xlarge
     network_tier: "db-private"
@@ -168,6 +188,7 @@ servers:
     block_device:
       volume_size: 7226
     group: "couchdb2"
+    os: trusty
   - server_name: "couch8-production"
     server_instance_type: c5.4xlarge
     network_tier: "db-private"
@@ -176,6 +197,7 @@ servers:
     block_device:
       volume_size: 7674
     group: "couchdb2"
+    os: trusty
   - server_name: "couch9-production"
     server_instance_type: c5.4xlarge
     network_tier: "db-private"
@@ -184,6 +206,7 @@ servers:
     block_device:
       volume_size: 7531
     group: "couchdb2"
+    os: trusty
 
   - server_name: "rabbit0-production"
     server_instance_type: t3.large
@@ -191,6 +214,7 @@ servers:
     az: "c"
     volume_size: 80
     group: "rabbitmq"
+    os: trusty
 
   - server_name: "celery0-production"
     server_instance_type: t3.2xlarge
@@ -198,36 +222,42 @@ servers:
     az: "c"
     volume_size: 150
     group: "celery"
+    os: trusty
   - server_name: "celery1-production"
     server_instance_type: t3.2xlarge
     network_tier: "app-private"
     az: "c"
     volume_size: 150
     group: "celery"
+    os: trusty
   - server_name: "celery2-production"
     server_instance_type: t3.2xlarge
     network_tier: "app-private"
     az: "c"
     volume_size: 150
     group: "celery"
+    os: trusty
   - server_name: "celery3-production"
     server_instance_type: t3.2xlarge
     network_tier: "app-private"
     az: "c"
     volume_size: 150
     group: "celery"
+    os: trusty
   - server_name: "celery4-production"
     server_instance_type: t3.xlarge
     network_tier: "app-private"
     az: "c"
     volume_size: 150
     group: "celery"
+    os: trusty
   - server_name: "celery5-production"
     server_instance_type: t3.xlarge
     network_tier: "app-private"
     az: "c"
     volume_size: 80
     group: "celery"
+    os: trusty
   - server_name: "celery6-production"
     server_instance_type: t3.xlarge
     network_tier: "app-private"
@@ -242,6 +272,7 @@ servers:
     az: "c"
     volume_size: 150
     group: "pillowtop"
+    os: trusty
 
   - server_name: "formplayer0-production"
     server_instance_type: t3.large
@@ -249,13 +280,15 @@ servers:
     az: "a"
     volume_size: 50
     group: "formplayer"
-  
+    os: trusty
+
   - server_name: "formplayer1-production"
     server_instance_type: t3.large
     network_tier: "app-private"
     az: "a"
     volume_size: 50
     group: "formplayer"
+    os: trusty
 
   - server_name: "redis1-production"
     server_instance_type: r5.xlarge
@@ -263,6 +296,7 @@ servers:
     az: "a"
     volume_size: 60
     group: "redis"
+    os: trusty
 
   - server_name: "shareddir0-production"
     server_instance_type: t3.micro
@@ -270,6 +304,7 @@ servers:
     az: "a"
     volume_size: 40
     group: "shared_dir_host"
+    os: trusty
 
   - server_name: "kafka0-production"
     server_instance_type: t3.medium
@@ -277,6 +312,7 @@ servers:
     az: "a"
     volume_size: 160
     group: "kafka"
+    os: trusty
 
   - server_name: "pgproxy1-production"
     server_instance_type: t3.large
@@ -284,6 +320,7 @@ servers:
     az: "a"
     volume_size: 80
     group: "postgresql"
+    os: trusty
 
   - server_name: "pgbouncer0-production"
     server_instance_type: t3.medium
@@ -291,6 +328,7 @@ servers:
     az: "a"
     volume_size: 80
     group: "postgresql"
+    os: trusty
 
 
 
@@ -301,6 +339,7 @@ proxy_servers:
     az: "a"
     volume_size: 80
     group: "proxy"
+    os: trusty
 
 
 rds_instances:

--- a/environments/staging/terraform.yml
+++ b/environments/staging/terraform.yml
@@ -34,6 +34,7 @@ servers:
     az: "a"
     volume_size: 50
     group: "control"
+    os: trusty
   - server_name: "control0-staging"
     server_instance_type: "t3.medium"
     network_tier: "app-private"
@@ -47,12 +48,14 @@ servers:
     az: "a"
     volume_size: 80
     group: "webworkers"
+    os: trusty
   - server_name: "web1-staging"
     server_instance_type: "t3.medium"
     network_tier: "app-private"
     az: "b"
     volume_size: 80
     group: "webworkers"
+    os: trusty
 
   - server_name: "web3-staging"
     server_instance_type: "t3.medium"
@@ -74,12 +77,14 @@ servers:
     network_tier: "db-private"
     az: "a"
     group: "elasticsearch"
+    os: trusty
   - server_name: "es1-staging"
     server_instance_type: "t3.medium"
     network_tier: "db-private"
     az: "a"
     volume_size: 80
     group: "elasticsearch"
+    os: trusty
   - server_name: "es2-staging"
     server_instance_type: "t3.medium"
     network_tier: "db-private"
@@ -107,6 +112,7 @@ servers:
     az: "a"
     volume_size: 80
     group: "celery"
+    os: trusty
   - server_name: "celery1-staging"
     server_instance_type: "t3.large"
     network_tier: "app-private"
@@ -120,6 +126,7 @@ servers:
     az: "a"
     volume_size: 40
     group: "airflow"
+    os: trusty
 
   - server_name: "airflow1-staging"
     server_instance_type: "t3.small"
@@ -135,6 +142,7 @@ servers:
     az: "a"
     volume_size: 80
     group: "formplayer"
+    os: trusty
 
   - server_name: "formplayer1-staging"
     server_instance_type: "t3.large"
@@ -150,24 +158,28 @@ servers:
     az: "a"
     volume_size: 400
     group: "couchdb2"
+    os: trusty
   - server_name: "couch1-staging"
     server_instance_type: "t2.large"
     network_tier: "db-private"
     az: "a"
     volume_size: 400
     group: "couchdb2"
+    os: trusty
   - server_name: "couch2-staging"
     server_instance_type: "t2.large"
     network_tier: "db-private"
     az: "a"
     volume_size: 400
     group: "couchdb2"
+    os: trusty
   - server_name: "rabbit0-staging"
     server_instance_type: "t3.large"
     network_tier: "app-private"
     az: "a"
     volume_size: 80
     group: "rabbitmq"
+    os: trusty
   - server_name: "rabbit1-staging"
     server_instance_type: "t3.large"
     network_tier: "app-private"
@@ -182,6 +194,7 @@ servers:
     az: "a"
     volume_size: 80
     group: "kafka"
+    os: trusty
 
 
   - server_name: "pgproxy1-staging"
@@ -198,7 +211,8 @@ servers:
     az: "a"
     volume_size: 60
     group: "redis"
-    
+    os: trusty
+
   - server_name: "redis1-staging"
     server_instance_type: t3.medium
     network_tier: "db-private"
@@ -223,6 +237,7 @@ proxy_servers:
     az: "a"
     volume_size: 80
     group: "proxy"
+    os: trusty
 
 
 rds_instances:

--- a/src/commcare_cloud/environment/schemas/terraform.py
+++ b/src/commcare_cloud/environment/schemas/terraform.py
@@ -54,7 +54,7 @@ class ServerConfig(jsonobject.JsonObject):
     block_device = jsonobject.ObjectProperty(lambda: BlockDevice, default=None)
     group = jsonobject.StringProperty()
     # todo: invert this so that all new machines are bionic unless otherwise specified
-    os = jsonobject.StringProperty(default='trusty')
+    os = jsonobject.StringProperty(required=True)
 
 
 class BlockDevice(jsonobject.JsonObject):


### PR DESCRIPTION
##### SUMMARY
The goal is to make it difficult to create a new "trusty" machine by mistake

##### ENVIRONMENTS AFFECTED
staging, production

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
Ubuntu upgrade

##### ADDITIONAL INFORMATION
This change produces no diff (terraform or otherwise)