### PR TITLE
Install ufw on bionic

### DIFF
--- a/src/commcare_cloud/ansible/roles/common_installs/tasks/bionic_apt_installs.yml
+++ b/src/commcare_cloud/ansible/roles/common_installs/tasks/bionic_apt_installs.yml
@@ -6,3 +6,4 @@
     - npm
     - python-minimal
     - python3-pip
+    - ufw


### PR DESCRIPTION
##### SUMMARY
Friday when I was adding web4-staging I also had issues with `ufw` giving an opaque error on the first few passes, then I added this and run common_installs.yml and then the `ufw` commands worked. Not sure if it was this change or the re-running of some other part that made the difference, but I don't think this could hurt.
