### PR TITLE
Fix staging inventory template and render it

### DIFF
--- a/environments/staging/aws-resources.yml
+++ b/environments/staging/aws-resources.yml
@@ -17,6 +17,7 @@ pillow1-staging: 10.201.10.103
 proxy1-staging: 10.201.20.21
 proxy1-staging.public_ip: 107.20.83.77
 rabbit0-staging: 10.201.10.73
+rabbit1-staging: 10.201.10.129
 redis1-staging: 10.201.40.219
 vpn-staging: 10.201.20.112
 vpn-staging.public_ip: 54.227.170.89

--- a/environments/staging/inventory.ini
+++ b/environments/staging/inventory.ini
@@ -59,9 +59,13 @@ couch0
 [rabbit0]
 10.201.10.73 hostname=rabbit0-staging ec2=yes
 
+[rabbit1]
+10.201.10.129 hostname=rabbit1-staging ec2=ena ansible_python_interpreter=/usr/bin/python3
+
 [rabbitmq:children]
 # Amazon EC2
 rabbit0
+rabbit1
 
 [kafka0]
 10.201.40.189 hostname=kafka0-staging ec2=yes kafka_broker_id=0

--- a/environments/staging/inventory.ini.j2
+++ b/environments/staging/inventory.ini.j2
@@ -50,8 +50,7 @@ couch0
 
 {{ __rabbit0__ }}
 
-[rabbit1]
-{{ rabbit1-staging }} hostname=rabbit1-staging ec2=ena ansible_python_interpreter=/usr/bin/python3
+{{ __rabbit1__ }}
 
 [rabbitmq:children]
 # Amazon EC2

--- a/src/commcare_cloud/commands/terraform/aws.py
+++ b/src/commcare_cloud/commands/terraform/aws.py
@@ -13,8 +13,6 @@ import jinja2
 import six
 import yaml
 from clint.textui import puts, colored
-from jinja2 import nodes
-from jinja2.ext import Extension
 from memoized import memoized
 from six.moves import shlex_quote
 from six.moves import configparser
@@ -143,9 +141,12 @@ class AwsFillInventory(CommandBase):
         with open(environment.paths.inventory_ini_j2) as f:
             inventory_ini_j2 = f.read()
 
-        out_string = AwsFillInventoryHelper(environment, inventory_ini_j2, resources).render()
-
         with open(environment.paths.inventory_ini, 'w') as f:
+            # by putting this inside the with
+            # we make sure that if the it fails, inventory.ini is made empty
+            # reflecting that we were unable to create it
+            out_string = AwsFillInventoryHelper(environment, inventory_ini_j2,
+                                                resources).render()
             f.write(out_string)
 
 


### PR DESCRIPTION
##### SUMMARY

Build wasn't failing when `aws-fill-inventory` fails because of a poorly formatted `inventory.ini.j2`; now it will. I also then fixed the staging inventory template and rendered it.
