### PR TITLE
Print loud warning instead of auto replacing a py3 virtualenv

### DIFF
--- a/control/init.sh
+++ b/control/init.sh
@@ -51,12 +51,18 @@ if [ -z ${TRAVIS_TEST} ]; then
     if [ ! -d ~/.virtualenvs/ansible ]; then
         echo "Creating ansible virtualenv..."
         mkvirtualenv ansible --python $(which python2)
-    # If we by mistake are using a py3 env (unsupported), then replace with a py2 env
     elif ~/.virtualenvs/ansible/bin/python -c 'print ""' 2> /dev/null; [ "$?" -ne "0" ]; then
-        echo "Replacing ansible py3 virtualenv with py2 virtualenv..."
-        deactivate 2> /dev/null || :  # deactivate if in a virtualenv, else ignore error
-        rmvirtualenv ansible
-        mkvirtualenv ansible --python $(which python2)
+        echo "######################################################"
+        echo "#                                                    #"
+        echo "#  You're working from a python3 virtualenv,         #"
+        echo "#  but commcare-cloud doesn't yet support Python 3.  #"
+        echo "#  To reset your virtualenv, run the following:      #"
+        echo "#                                                    #"
+        echo "#    deactivate                                      #"
+        echo "#    rmvirtualenv ansible                            #"
+        echo "#    mkvirtualenv ansible --python $(which python2)  #"
+        echo "#                                                    #"
+        echo "######################################################"
     else
         workon ansible
     fi


### PR DESCRIPTION
##### SUMMARY

Since after this we won't auto-replace py3 virtualenvs on the control machine, I ran manual cleanup on staging to remove all py3 envs. (Since I know that they were all created in error, rolled out by mistake and then discovered, while working on https://github.com/dimagi/commcare-cloud/pull/2822.)

To clean up I ran
```
cchq staging run-shell-command control 'ls /home/*/.virtualenvs/ansible/bin/python3 | sed "s|/bin/python3||" | xargs rm -rf' -b
```

and then I also ran

```
cchq staging run-shell-command control 'rm -rf /home/droberts/.virtualenvs/ansible' -b
cchq --control staging ping all
```

just to test the experience, and as I predicted and hoped, the script properly recreates the missing virtualenv with no complaint, so it's a seamless experience.