### PR TITLE
Make terraform skip attempt to fetch rds password when no rds_instances are configured

### DIFF
--- a/src/commcare_cloud/commands/terraform/terraform.py
+++ b/src/commcare_cloud/commands/terraform/terraform.py
@@ -71,7 +71,12 @@ class Terraform(CommandBase):
             return -1
 
         if not args.skip_secrets and unknown_args and unknown_args[0] in ('plan', 'apply'):
-            rds_password = environment.get_vault_variables()['secrets']['POSTGRES_USERS']['root']['password']
+            rds_password = (
+                environment.get_vault_variables()['secrets']['POSTGRES_USERS']['root']['password']
+                if environment.terraform_config.rds_instances
+                else ''
+            )
+
             with open(os.path.join(run_dir, 'secrets.auto.tfvars'), 'w') as f:
                 print('rds_password = {}'.format(json.dumps(rds_password)), file=f)
 


### PR DESCRIPTION
##### SUMMARY

Previously, it would error if the password wasn't in vault, even if it didn't need it. E.g.

```
$ cchq india terraform plan
[WARNING]: log file at /var/log/ansible.log is not writeable and we cannot create it, aborting

Vault Password for 'india':
Traceback (most recent call last):
  File "/Users/droberts/.virtualenvs/ccc/bin/cchq", line 11, in <module>
    load_entry_point('commcare-cloud', 'console_scripts', 'cchq')()
  File "/Users/droberts/dimagi/commcare-cloud/src/commcare_cloud/commcare_cloud.py", line 166, in main
    exit_code = call_commcare_cloud()
  File "/Users/droberts/dimagi/commcare-cloud/src/commcare_cloud/commcare_cloud.py", line 157, in call_commcare_cloud
    exit_code = commands[args.command].run(args, unknown_args)
  File "/Users/droberts/dimagi/commcare-cloud/src/commcare_cloud/commands/terraform/terraform.py", line 74, in run
    rds_password = environment.get_vault_variables()['secrets']['POSTGRES_USERS']['root']['password']
KeyError: 'root'
```

##### ENVIRONMENTS AFFECTED
india

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
terraform
