### PR TITLE
Do not add india.commcarehq.org to AWS india hosts

### DIFF
--- a/environments/india/inventory.ini
+++ b/environments/india/inventory.ini
@@ -1,5 +1,5 @@
 [celery0]
-10.162.36.233 hostname="celery0" encrypted_root=/opt/tmp
+10.162.36.233 hostname="celery0.india.commcarehq.org" encrypted_root=/opt/tmp
 
 [celery0:vars]
 devices='["/dev/xvdc"]'
@@ -7,10 +7,10 @@ partitions=["/dev/xvdc1"]
 datavol_device='/dev/mapper/consolidated-data'
 
 [django0]
-10.162.36.250 hostname="django0"
+10.162.36.250 hostname="django0.india.commcarehq.org"
 
 [django1]
-10.162.36.231 hostname="django1"
+10.162.36.231 hostname="django1.india.commcarehq.org"
 
 [web0]
 10.203.10.48 hostname=web0-india ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3
@@ -21,19 +21,19 @@ datavol_device='/dev/mapper/consolidated-data'
 10.162.36.194
 
 [citusdb0:vars]
-hostname="citusdb0"
+hostname="citusdb0.india.commcarehq.org"
 
 [citusdb1]
 10.162.36.212
 
 [citusdb1:vars]
-hostname="citusdb1"
+hostname="citusdb1.india.commcarehq.org"
 
 [citusdb2]
 10.162.36.195
 
 [citusdb2:vars]
-hostname="citusdb2"
+hostname="citusdb2.india.commcarehq.org"
 
 [citusdb_worker:children]
 citusdb1
@@ -54,21 +54,21 @@ datavol_device=/dev/xvdc
 10.162.36.238
 
 [db1:vars]
-hostname="db1"
+hostname="db1.india.commcarehq.org"
 datavol_device=/dev/xvdc
 
 [es2]
 10.162.36.221 encrypted_root=/opt/data/ecrypt
 
 [es2:vars]
-hostname="es2"
+hostname="es2.india.commcarehq.org"
 elasticsearch_node_name=es2
 
 [es3]
 10.162.36.200 encrypted_root=/opt/data/ecrypt
 
 [es3:vars]
-hostname="es3"
+hostname="es3.india.commcarehq.org"
 elasticsearch_node_name=es3
 datavol_device=/dev/xvdc
 
@@ -76,40 +76,40 @@ datavol_device=/dev/xvdc
 10.162.36.207 hostname=kafka0 datavol_device=/dev/xvdc encrypted_root=/opt/data/ecrypt
 
 [pillow1]
-10.162.36.253 hostname="pillow1"
+10.162.36.253 hostname="pillow1.india.commcarehq.org"
 
 [proxy0]
-10.162.36.203 hostname="proxy0"
+10.162.36.203 hostname="proxy0.india.commcarehq.org"
 
 [proxy1]
 10.203.20.59 hostname=proxy1-india ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 public_ip=13.234.163.136
 
 [formplayer0]
-10.162.36.248 hostname="formplayer0" encrypted_root=/opt/data/ecrypt
+10.162.36.248 hostname="formplayer0.india.commcarehq.org" encrypted_root=/opt/data/ecrypt
 
 [riak15]
-10.162.36.235 hostname="riak15" encrypted_root=/opt/data/ecrypt
+10.162.36.235 hostname="riak15.india.commcarehq.org" encrypted_root=/opt/data/ecrypt
 
 [riak16]
-10.162.36.225 hostname="riak16" encrypted_root=/opt/data/ecrypt
+10.162.36.225 hostname="riak16.india.commcarehq.org" encrypted_root=/opt/data/ecrypt
 
 [riak17]
-10.162.36.244 hostname="riak17" encrypted_root=/opt/data/ecrypt
+10.162.36.244 hostname="riak17.india.commcarehq.org" encrypted_root=/opt/data/ecrypt
 
 [riak18]
-10.162.36.211 hostname="riak18" encrypted_root=/opt/data/ecrypt
+10.162.36.211 hostname="riak18.india.commcarehq.org" encrypted_root=/opt/data/ecrypt
 
 [riak19]
-10.162.36.202 hostname="riak19" encrypted_root=/opt/data/ecrypt
+10.162.36.202 hostname="riak19.india.commcarehq.org" encrypted_root=/opt/data/ecrypt
 
 [couch1]
-10.162.36.218 hostname="couch1" encrypted_root=/opt/data/ecrypt
+10.162.36.218 hostname="couch1.india.commcarehq.org" encrypted_root=/opt/data/ecrypt
 
 [couch5]
-10.162.36.208 hostname="couch5" encrypted_root=/opt/data/ecrypt
+10.162.36.208 hostname="couch5.india.commcarehq.org" encrypted_root=/opt/data/ecrypt
 
 [couch6]
-10.162.36.234 hostname="couch6" encrypted_root=/opt/data/ecrypt
+10.162.36.234 hostname="couch6.india.commcarehq.org" encrypted_root=/opt/data/ecrypt
 
 [couch_big_nodes:children]
 couch1
@@ -122,7 +122,7 @@ partitions=["/dev/xvde1","/dev/xvdc1"]
 datavol_device='/dev/mapper/consolidated-data'
 
 [airflow0]
-10.162.36.205 hostname="airflow0"
+10.162.36.205 hostname="airflow0.india.commcarehq.org"
 
 [proxy:children]
 proxy1
@@ -192,7 +192,7 @@ celery0
 10.203.10.246 hostname=control0-india ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3
 
 [control_sl]
-10.162.36.196 hostname="control"
+10.162.36.196 hostname="control.india.commcarehq.org"
 
 [control:children]
 control0

--- a/environments/india/inventory.ini.j2
+++ b/environments/india/inventory.ini.j2
@@ -1,5 +1,5 @@
 [celery0]
-10.162.36.233 hostname="celery0" encrypted_root=/opt/tmp
+10.162.36.233 hostname="celery0.india.commcarehq.org" encrypted_root=/opt/tmp
 
 [celery0:vars]
 devices='["/dev/xvdc"]'
@@ -7,10 +7,10 @@ partitions=["/dev/xvdc1"]
 datavol_device='/dev/mapper/consolidated-data'
 
 [django0]
-10.162.36.250 hostname="django0"
+10.162.36.250 hostname="django0.india.commcarehq.org"
 
 [django1]
-10.162.36.231 hostname="django1"
+10.162.36.231 hostname="django1.india.commcarehq.org"
 
 {{ __web0__ }}
 {{ __web1__ }}
@@ -19,19 +19,19 @@ datavol_device='/dev/mapper/consolidated-data'
 10.162.36.194
 
 [citusdb0:vars]
-hostname="citusdb0"
+hostname="citusdb0.india.commcarehq.org"
 
 [citusdb1]
 10.162.36.212
 
 [citusdb1:vars]
-hostname="citusdb1"
+hostname="citusdb1.india.commcarehq.org"
 
 [citusdb2]
 10.162.36.195
 
 [citusdb2:vars]
-hostname="citusdb2"
+hostname="citusdb2.india.commcarehq.org"
 
 [citusdb_worker:children]
 citusdb1
@@ -52,21 +52,21 @@ datavol_device=/dev/xvdc
 10.162.36.238
 
 [db1:vars]
-hostname="db1"
+hostname="db1.india.commcarehq.org"
 datavol_device=/dev/xvdc
 
 [es2]
 10.162.36.221 encrypted_root=/opt/data/ecrypt
 
 [es2:vars]
-hostname="es2"
+hostname="es2.india.commcarehq.org"
 elasticsearch_node_name=es2
 
 [es3]
 10.162.36.200 encrypted_root=/opt/data/ecrypt
 
 [es3:vars]
-hostname="es3"
+hostname="es3.india.commcarehq.org"
 elasticsearch_node_name=es3
 datavol_device=/dev/xvdc
 
@@ -74,39 +74,39 @@ datavol_device=/dev/xvdc
 10.162.36.207 hostname=kafka0 datavol_device=/dev/xvdc encrypted_root=/opt/data/ecrypt
 
 [pillow1]
-10.162.36.253 hostname="pillow1"
+10.162.36.253 hostname="pillow1.india.commcarehq.org"
 
 [proxy0]
-10.162.36.203 hostname="proxy0"
+10.162.36.203 hostname="proxy0.india.commcarehq.org"
 
 {{ __proxy1__ }} public_ip={{ aws_resources['proxy1-india.public_ip'] }}
 
 [formplayer0]
-10.162.36.248 hostname="formplayer0" encrypted_root=/opt/data/ecrypt
+10.162.36.248 hostname="formplayer0.india.commcarehq.org" encrypted_root=/opt/data/ecrypt
 
 [riak15]
-10.162.36.235 hostname="riak15" encrypted_root=/opt/data/ecrypt
+10.162.36.235 hostname="riak15.india.commcarehq.org" encrypted_root=/opt/data/ecrypt
 
 [riak16]
-10.162.36.225 hostname="riak16" encrypted_root=/opt/data/ecrypt
+10.162.36.225 hostname="riak16.india.commcarehq.org" encrypted_root=/opt/data/ecrypt
 
 [riak17]
-10.162.36.244 hostname="riak17" encrypted_root=/opt/data/ecrypt
+10.162.36.244 hostname="riak17.india.commcarehq.org" encrypted_root=/opt/data/ecrypt
 
 [riak18]
-10.162.36.211 hostname="riak18" encrypted_root=/opt/data/ecrypt
+10.162.36.211 hostname="riak18.india.commcarehq.org" encrypted_root=/opt/data/ecrypt
 
 [riak19]
-10.162.36.202 hostname="riak19" encrypted_root=/opt/data/ecrypt
+10.162.36.202 hostname="riak19.india.commcarehq.org" encrypted_root=/opt/data/ecrypt
 
 [couch1]
-10.162.36.218 hostname="couch1" encrypted_root=/opt/data/ecrypt
+10.162.36.218 hostname="couch1.india.commcarehq.org" encrypted_root=/opt/data/ecrypt
 
 [couch5]
-10.162.36.208 hostname="couch5" encrypted_root=/opt/data/ecrypt
+10.162.36.208 hostname="couch5.india.commcarehq.org" encrypted_root=/opt/data/ecrypt
 
 [couch6]
-10.162.36.234 hostname="couch6" encrypted_root=/opt/data/ecrypt
+10.162.36.234 hostname="couch6.india.commcarehq.org" encrypted_root=/opt/data/ecrypt
 
 [couch_big_nodes:children]
 couch1
@@ -119,7 +119,7 @@ partitions=["/dev/xvde1","/dev/xvdc1"]
 datavol_device='/dev/mapper/consolidated-data'
 
 [airflow0]
-10.162.36.205 hostname="airflow0"
+10.162.36.205 hostname="airflow0.india.commcarehq.org"
 
 [proxy:children]
 proxy1
@@ -188,7 +188,7 @@ celery0
 {{ __control0__ }}
 
 [control_sl]
-10.162.36.196 hostname="control"
+10.162.36.196 hostname="control.india.commcarehq.org"
 
 [control:children]
 control0

--- a/environments/india/public.yml
+++ b/environments/india/public.yml
@@ -1,4 +1,3 @@
-internal_domain_name: "india.commcarehq.org"
 couchdb2:
   username: "{{ localsettings_private.COUCH_USERNAME }}"
   password: "{{ localsettings_private.COUCH_PASSWORD }}"


### PR DESCRIPTION
##### SUMMARY
I noticed we were getting e.g. web0-india.india.commcarehq.org in
datadog. I'd like to use the same convention we have on staging and
production, which would be just web0-india. In order to keep existing
softlayer machines' hostnames the same, I also manually change their
hostnames to *.india.commcarehq.org.
