### PR TITLE
Temporarily remove web[0-1]-india from webworkers list

### DIFF
--- a/environments/india/inventory.ini
+++ b/environments/india/inventory.ini
@@ -131,8 +131,8 @@ proxy0
 [webworkers:children]
 django0
 django1
-web0
-web1
+#web0
+#web1
 
 [postgresql:children]
 db1

--- a/environments/india/inventory.ini.j2
+++ b/environments/india/inventory.ini.j2
@@ -128,8 +128,8 @@ proxy0
 [webworkers:children]
 django0
 django1
-web0
-web1
+#web0
+#web1
 
 [postgresql:children]
 db1


### PR DESCRIPTION
##### SUMMARY
The hundreds of round trips to backing services in softlayer are adding many seconds to longer requests: https://app.datadoghq.com/dashboard/g9s-pw6-tpg/hq-vitals?tile_size=s&page=0&is_auto=false&from_ts=1556215200000&to_ts=1556820000000&live=false&tpl_var_environment=india&fullscreen_widget=406795560566138.
Until there is a better rollout plan, I will revert to removing these.
