### PR TITLE
Kill "heartbeat" http check, supplanted by "celery" check

### DIFF
--- a/src/commcare_cloud/ansible/roles/datadog/templates/http_check.yaml.j2
+++ b/src/commcare_cloud/ansible/roles/datadog/templates/http_check.yaml.j2
@@ -11,19 +11,13 @@ instances:
     include_content: true
     tags:
       - check_type:serverup
+{% if monitor_celery_heartbeat|default(True) %}
   - name: {{ env_monitoring_id }} Celery
     url: https://{{ SITE_HOST }}/serverup.txt?only=celery
     check_certificate_expiration: false
     timeout: 30
     tags:
       - check_type:celery
-{% if monitor_celery_heartbeat|default(True) %}
-  - name: {{ env_monitoring_id }} Heartbeat
-    url: https://{{ SITE_HOST }}/serverup.txt?only=heartbeat
-    check_certificate_expiration: false
-    timeout: 30
-    tags:
-      - check_type:heartbeat
 {% endif %}
 {% for host in datadog_extra_host_checks %}
   - name: {{ host.url|urlsplit('hostname') }}


### PR DESCRIPTION
##### SUMMARY
Make datadog not check the "heartbeat" endpoint anymore. Also, apply the same skip logic on staging to celery as we did to heartbeat

##### ENVIRONMENTS AFFECTED
all (but it's largely invisible/cleanup)