### PR TITLE
Fix "Install Kafka systemd script" for bionic

### DIFF
--- a/src/commcare_cloud/ansible/roles/kafka/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/kafka/tasks/main.yml
@@ -56,7 +56,7 @@
   when: ansible_distribution_version == '14.04'
 
 - name: Install Kafka systemd script
-  template: src=kafka-server.j2 dest=/etc/systemd/system/kafka.service mode=0755
+  template: src=kafka.service.j2 dest=/etc/systemd/system/kafka.service mode=0755
   when: ansible_distribution_version == '18.04'
 
 - name: Enable and start Kafka service

--- a/src/commcare_cloud/ansible/roles/kafka/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/kafka/tasks/main.yml
@@ -56,7 +56,7 @@
   when: ansible_distribution_version == '14.04'
 
 - name: Install Kafka systemd script
-  template: src=kafka.server.j2 dest=/etc/systemd/system/kafka.service mode=0755
+  template: src=kafka-server.j2 dest=/etc/systemd/system/kafka.service mode=0755
   when: ansible_distribution_version == '18.04'
 
 - name: Enable and start Kafka service


### PR DESCRIPTION
##### SUMMARY
@sanjay2916 I ran this again and noticed installing the systemd script was failing.

After deploying (`cchq staging ansible-playbook deploy_kafka.yml`) with this change, we stopped receiving this error: https://sentry.io/organizations/dimagi/issues/1004425291/?environment=staging&project=136860&query=is%3Aunresolved&statsPeriod=14d, though I'm not sure that this change is what caused that. There were other changes, notably that both kafka0 and kafka1's IP addresses were listed in the kafka and zookeeper settings, and deploying removed kafka0's IP address