### PR TITLE
don't store downtime locally

### DIFF
--- a/docs/commcare-cloud/commands/index.md
+++ b/docs/commcare-cloud/commands/index.md
@@ -1012,7 +1012,7 @@ then it's acceptable to do live.
 Manage downtime for the selected environment.
 
 ```
-commcare-cloud <env> downtime [-m MESSAGE] {start,end}
+commcare-cloud <env> downtime [-m MESSAGE] [-d DURATION] {start,end}
 ```
 
 This notifies Datadog of the planned downtime so that is is recorded
@@ -1027,6 +1027,12 @@ in the history, and so that during it service alerts are silenced.
 ###### `-m MESSAGE, --message MESSAGE`
 
 Optional message to set on Datadog.
+
+###### `-d DURATION, --duration DURATION`
+
+Max duration for the Datadog downtime after which it will be auto-cancelled.
+This is a safeguard against downtime remaining active and preventing future
+alerts.
 
 ---
 

--- a/docs/commcare-cloud/commands/index.md
+++ b/docs/commcare-cloud/commands/index.md
@@ -1030,9 +1030,10 @@ Optional message to set on Datadog.
 
 ###### `-d DURATION, --duration DURATION`
 
-Max duration for the Datadog downtime after which it will be auto-cancelled.
+Max duration in hours for the Datadog downtime after which it will be auto-cancelled.
 This is a safeguard against downtime remaining active and preventing future
 alerts.
+Default: 24 hours
 
 ---
 

--- a/src/commcare_cloud/commands/ansible/downtime.py
+++ b/src/commcare_cloud/commands/ansible/downtime.py
@@ -32,9 +32,10 @@ class Downtime(CommandBase):
             Optional message to set on Datadog.
         """),
         Argument('-d', '--duration', default=24, help="""
-            Max duration for the Datadog downtime after which it will be auto-cancelled.
+            Max duration in hours for the Datadog downtime after which it will be auto-cancelled.
             This is a safeguard against downtime remaining active and preventing future
             alerts.
+            Default: 24 hours
         """),
     )
 

--- a/src/commcare_cloud/environment/paths.py
+++ b/src/commcare_cloud/environment/paths.py
@@ -130,10 +130,6 @@ class DefaultPaths(object):
         return self.get_env_file_path('.generated.yml')
 
     @lazy_immutable_property
-    def downtime_yml(self):
-        return self.get_env_file_path('.downtime.yml')
-
-    @lazy_immutable_property
     def terraform_yml(self):
         return self.get_env_file_path('terraform.yml')
 


### PR DESCRIPTION
Query datadog for downtime record instead of storing it locally so that if the user ending the downtime is not the same as the user who started the downtime it will still get ended correctly on Datadog.

Also added an end time for the downtime to safeguard against it not being cancelled.