### PR TITLE
Changing Elastic IP for proxy server in staging environment

### DIFF
--- a/environments/staging/aws-resources.yml
+++ b/environments/staging/aws-resources.yml
@@ -16,9 +16,9 @@ pg0-staging-replica: pg0-staging-replica.czkracjslrn2.us-east-1.rds.amazonaws.co
 pgproxy1-staging: 10.201.40.187
 pillow1-staging: 10.201.10.103
 proxy0-staging: 10.201.20.89
-proxy0-staging.public_ip: 107.20.83.77
+proxy0-staging.public_ip: 3.216.37.252
 proxy1-staging: 10.201.20.21 
-proxy1-staging.public_ip: 3.216.37.252
+proxy1-staging.public_ip: 107.20.83.77
 rabbit0-staging: 10.201.10.73
 rabbit1-staging: 10.201.10.129
 redis1-staging: 10.201.40.219

--- a/environments/staging/inventory.ini
+++ b/environments/staging/inventory.ini
@@ -4,7 +4,7 @@
 # using the aws-fill-inventory command.
 
 [proxy0]
-10.201.20.89 hostname=proxy0-staging ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 public_ip=107.20.83.77
+10.201.20.89 hostname=proxy0-staging ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 public_ip=3.216.37.252
 
 [proxy:children]
 # Amazon EC2


### PR DESCRIPTION
when we run terraform plan after Swapping of elastic IP's manually, it's reverting back and if we edit terraform scripts, we will miss naming conversion and we will update the new IP in DNS 