### PR TITLE
swap pgshard8 and pgshard8standby

### DIFF
--- a/environments/icds-cas/inventory/postgresql.csv
+++ b/environments/icds-cas/inventory/postgresql.csv
@@ -18,7 +18,7 @@ pgshard4,100.71.184.32,postgresql,shard_dbs,MUMGCCWCDPRDPS04,pgshard4standby,,"[
 pgshard5,100.71.184.20,postgresql,shard_dbs,MUMGCCWCDPRDPS05,pgshard5standby,,"[""standby0"",""spare""]",
 pgshard6,100.71.184.30,postgresql,shard_dbs,MUMGCCWCDPRDPS06,pgshard6standby,,"[""standby0"",""spare""]",
 pgshard7,100.71.184.31,postgresql,shard_dbs,MUMGCCWCDPRDPS07,pgshard7standby,,"[""standby0"",""spare""]",
-pgshard8,100.71.184.34,postgresql,shard_dbs,MUMGCCWCDPRDPS08,pgshard8standby,,"[""standby0"",""spare""]",
+pgshard8,100.71.184.34,pg_standby,shard_dbs,MUMGCCWCDPRDPS08,,pgshard8standby,,standby0
 pgshard9,100.71.184.26,postgresql,shard_dbs,MUMGCCWCDPRDPS09,pgshard9standby,,"[""standby0"",""spare""]",
 pgshard0standby,100.71.184.47,pg_standby,shard_dbs,MUMGCCWCDPRDSS00,,pgshard0,,standby0
 pgshard1standby,100.71.184.51,pg_standby,shard_dbs,MUMGCCWCDPRDSS01,,pgshard1,,standby0
@@ -28,7 +28,7 @@ pgshard4standby,100.71.184.60,pg_standby,shard_dbs,MUMGCCWCDPRDSS04,,pgshard4,,s
 pgshard5standby,100.71.184.52,pg_standby,shard_dbs,MUMGCCWCDPRDSS05,,pgshard5,,standby0
 pgshard6standby,100.71.184.58,pg_standby,shard_dbs,MUMGCCWCDPRDSS06,,pgshard6,,standby0
 pgshard7standby,100.71.184.61,pg_standby,shard_dbs,MUMGCCWCDPRDSS07,,pgshard7,,standby0
-pgshard8standby,100.71.184.56,pg_standby,shard_dbs,MUMGCCWCDPRDSS08,,pgshard8,,standby0
+pgshard8standby,100.71.184.56,postgresql,shard_dbs,MUMGCCWCDPRDSS08,pgshard8,,"[""standby0"",""spare""]",
 pgshard9standby,100.71.184.59,pg_standby,shard_dbs,MUMGCCWCDPRDSS09,,pgshard9,,standby0
 plproxy0,100.71.184.18,postgresql,,MUMGCCWCDPRDPLP0,,,,
 pgsynclog0,100.71.184.39,postgresql,synclog_dbs,MUMGCCWCDPRDPSL0,,,"[""spare""]",

--- a/environments/icds-cas/postgresql.yml
+++ b/environments/icds-cas/postgresql.yml
@@ -77,7 +77,7 @@ dbs:
         host: pgshard7
       p9:
         shards: [824, 926]
-        host: pgshard8
+        host: pgshard8standby
       p10:
         shards: [927, 1023]
         host: pgshard9


### PR DESCRIPTION
Since we have seen high CPU on pgshard8 we are going to try promote pgshard8standby to see if it has the same issues.