### PR TITLE
Merge swiss celery into fewer processes

### DIFF
--- a/environments/swiss/app-processes.yml
+++ b/environments/swiss/app-processes.yml
@@ -3,22 +3,12 @@ formplayer_memory: "1024m"
 
 celery_processes:
   'swiss.commcarehq.org':
-    repeat_record_queue,celery,export_download_queue,case_import_queue:
-      concurrency: 1
-    background_queue,case_rule_queue,analytics_queue:
-      concurrency: 1
+    repeat_record_queue,celery,export_download_queue,case_import_queue,reminder_case_update_queue,background_queue,case_rule_queue,analytics_queue,celery_periodic,email_queue,reminder_rule_queue:
+      concurrency: 3
     beat: {}
-    celery_periodic,email_queue:
-      concurrency: 1
-    email_queue:
-      concurrency: 1
     saved_exports_queue:
       concurrency: 1
       optimize: True
-    reminder_case_update_queue:
-      concurrency: 1
-    reminder_rule_queue:
-      concurrency: 1
     flower: {}
 pillows:
   'swiss.commcarehq.org':


### PR DESCRIPTION
##### SUMMARY
Swiss doesn't tend to have long backlogs, and is having issues with too much memory being used, so this seems like a reasonable way to reclaim some memory.

##### ENVIRONMENTS AFFECTED
swiss
