### PR TITLE
Fix yaml.load deprecation warnings

### DIFF
--- a/commcare-cloud-bootstrap/commcare_cloud_bootstrap.py
+++ b/commcare-cloud-bootstrap/commcare_cloud_bootstrap.py
@@ -447,7 +447,7 @@ class Provision(object):
     @staticmethod
     def run(args):
         with open(args.spec) as f:
-            spec = yaml.load(f)
+            spec = yaml.safe_load(f)
 
         spec = Spec.wrap(spec)
         provision_machines(spec, args.env, create_machines=args.create_machines)

--- a/src/commcare_cloud/commands/migrations/config.py
+++ b/src/commcare_cloud/commands/migrations/config.py
@@ -24,7 +24,7 @@ class CouchMigration(object):
     @memoized_property
     def plan(self):
         with open(self.plan_path) as f:
-            plan = yaml.load(f)
+            plan = yaml.safe_load(f)
 
         return CouchMigrationPlan.wrap(plan)
 
@@ -96,7 +96,7 @@ class CouchMigration(object):
     @memoized_property
     def shard_plan(self):
         with open(self.shard_plan_path) as f:
-            plan = yaml.load(f)
+            plan = yaml.safe_load(f)
 
         return [
             ShardAllocationDoc.from_plan_json(db_name, plan_json)

--- a/src/commcare_cloud/commands/migrations/copy_files.py
+++ b/src/commcare_cloud/commands/migrations/copy_files.py
@@ -126,7 +126,7 @@ class CopyFiles(CommandBase):
 
 def read_plan(plan_path, target_env, limit=None):
     with open(plan_path, 'r') as f:
-        plan_dict = yaml.load(f)
+        plan_dict = yaml.safe_load(f)
 
     source_env = None
     if 'source_env' in plan_dict:

--- a/src/commcare_cloud/commands/terraform/aws.py
+++ b/src/commcare_cloud/commands/terraform/aws.py
@@ -136,7 +136,7 @@ class AwsFillInventory(CommandBase):
                 f.write(yaml.safe_dump(resources, default_flow_style=False))
         else:
             with open(environment.paths.aws_resources_yml, 'r') as f:
-                resources = yaml.load(f.read())
+                resources = yaml.safe_load(f.read())
 
         with open(environment.paths.inventory_ini_j2) as f:
             inventory_ini_j2 = f.read()

--- a/src/commcare_cloud/environment/main.py
+++ b/src/commcare_cloud/environment/main.py
@@ -115,7 +115,7 @@ class Environment(object):
     def _get_vault_variables(self):
         # try unencrypted first for tests
         with open(self.paths.vault_yml, 'r') as f:
-            vault_vars = yaml.load(f)
+            vault_vars = yaml.safe_load(f)
         if isinstance(vault_vars, dict):
             return vault_vars
 
@@ -176,7 +176,7 @@ class Environment(object):
     def public_vars(self):
         """contents of public.yml, as a dict"""
         with open(self.paths.public_yml) as f:
-            return yaml.load(f)
+            return yaml.safe_load(f)
 
     @memoized_property
     def _disallowed_public_variables(self):
@@ -187,13 +187,13 @@ class Environment(object):
     @memoized_property
     def meta_config(self):
         with open(self.paths.meta_yml) as f:
-            meta_json = yaml.load(f)
+            meta_json = yaml.safe_load(f)
         return MetaConfig.wrap(meta_json)
 
     @memoized_property
     def postgresql_config(self):
         with open(self.paths.postgresql_yml) as f:
-            postgresql_json = yaml.load(f)
+            postgresql_json = yaml.safe_load(f)
         postgresql_config = PostgresqlConfig.wrap(postgresql_json)
         postgresql_config.replace_hosts(self)
         postgresql_config.check()
@@ -203,7 +203,7 @@ class Environment(object):
     def elasticsearch_config(self):
         try:
             with open(self.paths.elasticsearch_yml) as f:
-                elasticsearch_json = yaml.load(f)
+                elasticsearch_json = yaml.safe_load(f)
         except IOError:
             # It's fine to omit this file
             elasticsearch_json = {}
@@ -216,7 +216,7 @@ class Environment(object):
     @memoized_property
     def proxy_config(self):
         with open(self.paths.proxy_yml) as f:
-            proxy_json = yaml.load(f)
+            proxy_json = yaml.safe_load(f)
         proxy_config = ProxyConfig.wrap(proxy_json)
         proxy_config.check()
         return proxy_config
@@ -228,7 +228,7 @@ class Environment(object):
         present_users = []
         for user_group_from_yml in user_groups_from_yml:
             with open(self.paths.get_users_yml(user_group_from_yml)) as f:
-                user_group_json = yaml.load(f)
+                user_group_json = yaml.safe_load(f)
             present_users += user_group_json['dev_users']['present']
             absent_users += user_group_json['dev_users']['absent']
         self.check_user_group_absent_present_overlaps(absent_users, present_users)
@@ -239,7 +239,7 @@ class Environment(object):
     def terraform_config(self):
         try:
             with open(self.paths.terraform_yml) as f:
-                config_yml = yaml.load(f)
+                config_yml = yaml.safe_load(f)
         except IOError:
             return None
         config_yml['environment'] = config_yml.get('environment', self.meta_config.env_monitoring_id)
@@ -264,9 +264,9 @@ class Environment(object):
         includes environmental-defaults/app-processes.yml as well as <env>/app-processes.yml
         """
         with open(self.paths.app_processes_yml_default) as f:
-            app_processes_json = yaml.load(f)
+            app_processes_json = yaml.safe_load(f)
         with open(self.paths.app_processes_yml) as f:
-            app_processes_json.update(yaml.load(f))
+            app_processes_json.update(yaml.safe_load(f))
 
         raw_app_processes_config = AppProcessesConfig.wrap(app_processes_json)
         raw_app_processes_config.check()
@@ -287,9 +287,9 @@ class Environment(object):
         includes environmental-defaults/fab-settings.yml as well as <env>/fab-settings.yml
         """
         with open(self.paths.fab_settings_yml_default) as f:
-            fab_settings_json = yaml.load(f)
+            fab_settings_json = yaml.safe_load(f)
         with open(self.paths.fab_settings_yml) as f:
-            fab_settings_json.update(yaml.load(f) or {})
+            fab_settings_json.update(yaml.safe_load(f) or {})
 
         fab_settings_config = FabSettingsConfig.wrap(fab_settings_json)
         return fab_settings_config

--- a/src/commcare_cloud/environment/paths.py
+++ b/src/commcare_cloud/environment/paths.py
@@ -153,7 +153,7 @@ def get_role_defaults_yml(role):
 def get_role_defaults(role):
     """contents of a role's defaults/main.yml, as a dict"""
     with open(get_role_defaults_yml(role)) as f:
-        return yaml.load(f)
+        return yaml.safe_load(f)
 
 
 def get_available_envs(exclude_symlinks=False):

--- a/src/commcare_cloud/manage_commcare_cloud/datadog_monitors.py
+++ b/src/commcare_cloud/manage_commcare_cloud/datadog_monitors.py
@@ -116,7 +116,7 @@ def get_monitor_definitions(config):
             file_path = os.path.join(CONFIG_ROOT, file)
             with open(file_path, 'r') as mon:
                 data = mon.read()
-            monitor_def = render_messages(config, yaml.load(data))
+            monitor_def = render_messages(config, yaml.safe_load(data))
             monitors[monitor_def['id']] = monitor_def
             monitor_file_names_by_id[monitor_def['id']] = file_path
     return monitors, monitor_file_names_by_id
@@ -193,7 +193,7 @@ def initialize_datadog(config):
 
 def get_config(config_path):
     with open(config_path, 'r') as config_file:
-        config = Config(yaml.load(config_file))
+        config = Config(yaml.safe_load(config_file))
         config.env_notifications = OrderedDict(sorted(config.env_notifications.items()))
     return config
 

--- a/src/commcare_cloud/manage_commcare_cloud/make_changelog.py
+++ b/src/commcare_cloud/manage_commcare_cloud/make_changelog.py
@@ -63,9 +63,9 @@ def compile_changelog():
 def load_changelog_entry(path):
     try:
         with open(path, encoding='utf-8') as f:
-            change_yaml = yaml.load(f)
+            change_yaml = yaml.safe_load(f)
             change_yaml['filename'] = re.sub(r'\.yml$', '.md', path.split('/')[-1])
-            # yaml.load already parses dates, using this instead of ChangelogEntry.wrap
+            # yaml.safe_load already parses dates, using this instead of ChangelogEntry.wrap
             return ChangelogEntry(**change_yaml)
     except Exception:
         print("Error parsing the file {}.".format(path), file=sys.stderr)

--- a/tests/test_couch_migration.py
+++ b/tests/test_couch_migration.py
@@ -127,7 +127,7 @@ def _get_expected_yml(plan_name, filename):
 
 def _get_yml(path):
     with open(path, 'r') as exp:
-        return yaml.load(exp)
+        return yaml.safe_load(exp)
 
 
 def _get_test_file(plan_name, filename):

--- a/tests/test_postgresql_config.py
+++ b/tests/test_postgresql_config.py
@@ -19,7 +19,7 @@ def test_postgresql_config(env_name):
     env = Environment(DefaultPaths(env_name, environments_dir=TEST_ENVIRONMENTS_DIR))
 
     with open(env.paths.generated_yml) as f:
-        generated = yaml.load(f)
+        generated = yaml.safe_load(f)
         assert generated.keys() == ['postgresql_dbs']
 
     expected_json = generated['postgresql_dbs']


### PR DESCRIPTION
##### SUMMARY
Replace yaml.load => yaml.safe_load throughout
to get rid of this message when running commands:

```
YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  meta_json = yaml.load(f)
```