### PR TITLE
fix apt deprecation warnings

### DIFF
--- a/src/commcare_cloud/ansible/deploy_postgres.yml
+++ b/src/commcare_cloud/ansible/deploy_postgres.yml
@@ -28,12 +28,8 @@
     - name: Install python-psycopg2 to be able to set up remote postgresql
       become: yes
       block:
-        - apt: name={{ item }} state=latest
-          with_items:
-            - libpq-dev
-        - pip: name={{ item }} state=present
-          with_items:
-            - psycopg2
+        - apt: name=libpq-dev state=latest
+        - pip: name=psycopg2
     - name: Remote PostgreSQL
       include_role:
         name: postgresql_base

--- a/src/commcare_cloud/ansible/letsencrypt_cert.yml
+++ b/src/commcare_cloud/ansible/letsencrypt_cert.yml
@@ -13,7 +13,7 @@
 
     - name: Install Certbot
       apt:
-        name: "{{item}}"
+        name:
           - software-properties-common
           - certbot
       ignore_errors: '{{ ansible_check_mode }}'

--- a/src/commcare_cloud/ansible/letsencrypt_cert.yml
+++ b/src/commcare_cloud/ansible/letsencrypt_cert.yml
@@ -14,10 +14,8 @@
     - name: Install Certbot
       apt:
         name: "{{item}}"
-        state: present
-      with_items:
-        - software-properties-common
-        - certbot
+          - software-properties-common
+          - certbot
       ignore_errors: '{{ ansible_check_mode }}'
 
     - name: Create Challenge Directory

--- a/src/commcare_cloud/ansible/roles/bootstrap-machine/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/bootstrap-machine/tasks/main.yml
@@ -1,5 +1,6 @@
 - name: Install packages we would want on any machine ever
-  apt: name="{{ item }}" state=present
+  apt:
+    name:
+      - htop
+    state: present
   become: yes
-  with_items:
-    - htop

--- a/src/commcare_cloud/ansible/roles/common_installs/tasks/bionic_apt_installs.yml
+++ b/src/commcare_cloud/ansible/roles/common_installs/tasks/bionic_apt_installs.yml
@@ -1,9 +1,9 @@
 - name: Install common packages (bionic)
-  apt: name="{{ item }}" state=present
   become: yes
-  with_items:
-    - software-properties-common
-    - npm
-    - python-minimal
-    - python3-pip
-    - ufw
+  apt:
+    name:
+      - software-properties-common
+      - npm
+      - python-minimal
+      - python3-pip
+      - ufw

--- a/src/commcare_cloud/ansible/roles/common_installs/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/common_installs/tasks/main.yml
@@ -26,43 +26,43 @@
 
 # Install base packages, common to all servers
 - name: Install common packages
-  apt: name="{{ item }}" state=present
   become: yes
-  with_items:
-    - build-essential
-    - python-psycopg2
-    - postgresql-client-common
-    - postgresql-client-{{ postgresql_version }}
-    - libxml2-dev
-    - libxslt1-dev
-    - tig # git browser
-    - libpq-dev
-    - curl
-    - htop
-    - tmpreaper # remove files older than x days
-    - mailutils
-    - ntp
-    - at
-    - screen
-    - sysstat
-    - gettext
-    - mosh
-    - libjpeg-dev
-    - libfreetype6-dev
-    - ranger  # cmdline file browser
-    - libffi-dev  # Required for installing github3py
-    - libssl-dev  # Required for pip setup tools
-    - tmux
-    - reptyr # move process into tmux session
-    - unzip
-    - zip
-    - iotop
-    - ncdu # 'du' improved
-    - monit # service restarter
-    - libcairo2
-    - libpango1.0-0
-    - python3.7
-    - python3.7-dev
+  apt:
+    name:
+      - build-essential
+      - python-psycopg2
+      - postgresql-client-common
+      - postgresql-client-{{ postgresql_version }}
+      - libxml2-dev
+      - libxslt1-dev
+      - tig # git browser
+      - libpq-dev
+      - curl
+      - htop
+      - tmpreaper # remove files older than x days
+      - mailutils
+      - ntp
+      - at
+      - screen
+      - sysstat
+      - gettext
+      - mosh
+      - libjpeg-dev
+      - libfreetype6-dev
+      - ranger  # cmdline file browser
+      - libffi-dev  # Required for installing github3py
+      - libssl-dev  # Required for pip setup tools
+      - tmux
+      - reptyr # move process into tmux session
+      - unzip
+      - zip
+      - iotop
+      - ncdu # 'du' improved
+      - monit # service restarter
+      - libcairo2
+      - libpango1.0-0
+      - python3.7
+      - python3.7-dev
 
 - include: trusty_apt_installs.yml
   when: ansible_distribution_version == '14.04'

--- a/src/commcare_cloud/ansible/roles/common_installs/tasks/trusty_apt_installs.yml
+++ b/src/commcare_cloud/ansible/roles/common_installs/tasks/trusty_apt_installs.yml
@@ -1,5 +1,5 @@
 - name: Install common packages (trusty)
-  apt: name="{{ item }}" state=present
   become: yes
-  with_items:
-    - python-software-properties
+  apt:
+    name:
+      - python-software-properties

--- a/src/commcare_cloud/ansible/roles/couchdb/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/couchdb/tasks/main.yml
@@ -1,17 +1,17 @@
 # CouchDB
 - name: Install prequisites
-  apt: name="{{ item }}" state=present
-  with_items:
-    - build-essential
-    - g++
-    - erlang-base
-    - erlang-dev
-    - erlang-eunit
-    - erlang-nox
-    - libmozjs185-dev
-    - libicu-dev
-    - libcurl4-gnutls-dev
-    - libtool
+  apt:
+    name:
+      - build-essential
+      - g++
+      - erlang-base
+      - erlang-dev
+      - erlang-eunit
+      - erlang-nox
+      - libmozjs185-dev
+      - libicu-dev
+      - libcurl4-gnutls-dev
+      - libtool
 
 - name: Check CouchDB existence
   stat: path="{{ couchdb_install_path }}"

--- a/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
@@ -1,9 +1,9 @@
 - name: Install formplayer packages
-  apt: name="{{ item }}" state=present
   become: yes
-  with_items:
-    - sqlite3
-    - libsqlite3-dev
+  apt:
+    name:
+      - sqlite3
+      - libsqlite3-dev
 
 - name: Create purging cron jobs
   become: yes

--- a/src/commcare_cloud/ansible/roles/git/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/git/tasks/main.yml
@@ -7,7 +7,7 @@
   when: add_git_repo is changed
 
 - name: Install git packages
-  apt: name="{{ item }}" state=present
   become: yes
-  with_items:
-    - git
+  apt:
+    name:
+      - git

--- a/src/commcare_cloud/ansible/roles/java/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/java/tasks/main.yml
@@ -6,7 +6,6 @@
   become: yes
   apt:
     name: "{{ java_packages }}"
-    state: present
 
 - name: Correct java version selected
   alternatives:

--- a/src/commcare_cloud/ansible/roles/nginx/tasks/install.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/tasks/install.yml
@@ -11,8 +11,7 @@
 
 - name: Install nginx
   become: yes
-  apt: name="{{ item }}" state=latest update_cache=yes cache_valid_time=3600
-  with_items: "{{ nginx_ubuntu_pkg }}"
+  apt: name="{{ nginx_ubuntu_pkg }}" state=latest update_cache=yes cache_valid_time=3600
   when: nginx_install == True
 
 - name: Make sure nofile ulimit is high

--- a/src/commcare_cloud/ansible/roles/nodejs/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/nodejs/tasks/main.yml
@@ -6,17 +6,13 @@
   when: add_nodejs_repo is changed
 
 - name: Install nodejs packages
-  apt: name="{{ item }}" state=present
+  apt: name="nodejs" state=present
   become: yes
-  with_items:
-    - nodejs
 
 - name: Install nodejs packages
-  apt: name="{{ item }}" state=present
+  apt: name="npm" state=present
   become: yes
   when: ansible_distribution_version == '18.04'
-  with_items:
-    - npm
 
 - name: Set NPM registry
   command: 'npm config set registry http://registry.npmjs.org/'

--- a/src/commcare_cloud/ansible/roles/pg_backup/tasks/backup_pgbackrest.yml
+++ b/src/commcare_cloud/ansible/roles/pg_backup/tasks/backup_pgbackrest.yml
@@ -1,6 +1,7 @@
 - name: Install pgBackRest and requirements
-  apt: name={{item}} state=installed
-  with_items:
+  apt:
+    state: installed
+    name:
      - pgbackrest
      - libio-socket-ssl-perl
      - libxml-libxml-perl

--- a/src/commcare_cloud/ansible/roles/postgresql_base/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/postgresql_base/tasks/main.yml
@@ -19,21 +19,21 @@
   apt: name="{{postgresql_binary}}" state=present
 
 - name: Install dependencies
-  apt: name="{{ item }}" state=present
-  with_items:
-    - "postgresql-{{ postgresql_version }}-plproxy"
-    - "postgresql-contrib-{{ postgresql_version }}"
-    - "postgresql-server-dev-{{ postgresql_version }}"
-    - python-docutils  # required for building pghashlib
-    - libpq-dev
-    - python-psycopg2
-    - unzip
+  apt:
+    name:
+      - "postgresql-{{ postgresql_version }}-plproxy"
+      - "postgresql-contrib-{{ postgresql_version }}"
+      - "postgresql-server-dev-{{ postgresql_version }}"
+      - python-docutils  # required for building pghashlib
+      - libpq-dev
+      - python-psycopg2
+      - unzip
 
 - name: Install PostgreSQL & dependencies (bionic)
-  apt: name="{{ item }}" state=present
-  with_items:
-    - python3-docutils  # required for building pghashlib
-    - python3-psycopg2
+  apt:
+    name:
+      - python3-docutils  # required for building pghashlib
+      - python3-psycopg2
   when: ansible_distribution_version == '18.04'
 
 - name: Check for original postgresql directory

--- a/src/commcare_cloud/ansible/roles/python/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/python/tasks/main.yml
@@ -1,7 +1,7 @@
 - name: Install Python packages
-  apt: name="{{ item }}" state=present
   become: yes
-  with_items:
-    - python-pip
-    - python-dev
-    - python-setuptools
+  apt:
+    name:
+      - python-pip
+      - python-dev
+      - python-setuptools

--- a/src/commcare_cloud/ansible/roles/ruby_install/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/ruby_install/tasks/main.yml
@@ -8,9 +8,9 @@
   when: add_ruby_ppa is changed
 
 - name: Install ruby
-  apt: name="{{ item }}" state=present
   become: yes
-  with_items:
-    - ruby2.3
-    - ruby2.3-dev
+  apt:
+    name:
+      - ruby2.3
+      - ruby2.3-dev
   ignore_errors: '{{ ansible_check_mode }}'

--- a/src/commcare_cloud/ansible/roles/shared_dir/tasks/install.yml
+++ b/src/commcare_cloud/ansible/roles/shared_dir/tasks/install.yml
@@ -9,10 +9,10 @@
 - name: Install NFS packages
   become: yes
   when: shared_drive_enabled
-  apt: name="{{ item }}" state=present
-  with_items:
-    - nfs-kernel-server
-    - portmap
+  apt:
+    name:
+      - nfs-kernel-server
+      - portmap
   tags:
     - nfs
 

--- a/src/commcare_cloud/ansible/roles/zookeeper/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/zookeeper/tasks/main.yml
@@ -2,8 +2,8 @@
 # https://github.com/glynnbird/ansible-install-kafka/blob/master/tasks/install-zookeeper.yml
 # https://github.com/rackerlabs/ansible-kafka/blob/master/playbooks/roles/zookeeper/tasks/main.yml
 - name: install zookeeper
-  apt: name="{{ item }}" state=present
   become: yes
-  with_items:
-    - zookeeper
-    - zookeeperd
+  apt:
+    name:
+      - zookeeper
+      - zookeeperd


### PR DESCRIPTION
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying `name: "{{ item }}"`, please use `name:
['postgresql-{{ postgresql_version }}-plproxy', 'postgresql-contrib-{{ postgresql_version }}', 'postgresql-server-dev-{{ postgresql_version }}', 'python-docutils', 'libpq-dev', 'python-psycopg2', 'unzip']` and remove
the loop. This feature will be removed in version 2.11.