### PR TITLE
Update pg wal archive cron

### DIFF
--- a/src/commcare_cloud/ansible/roles/postgresql_base/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/postgresql_base/tasks/main.yml
@@ -88,7 +88,7 @@
   become: yes
   cron:
     name: "Clean PG WAL Archive"
-    job: "find {{ postgresql_archive_path }} -mmin +60 -delete"
+    job: "find {{ postgresql_archive_path }} -mmin +720 -delete"
     user: root
     special_time: hourly
     cron_file: clean_pg_archive


### PR DESCRIPTION
##### SUMMARY
Change pg wal archive to 12 hours

##### ENVIRONMENTS AFFECTED
icds

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
postgres

##### ADDITIONAL INFORMATION
@snopoke We found this was 2160 minutes on the ICDS server and the server was almost out of space. Is there a reason that deviates from the 60 minutes in the codebase? We removed all logs from greater than six hours ago (720 min) manually. The cron task still has 2160 minutes