### PR TITLE
rename citus_cordinator to citus_master

### DIFF
--- a/environments/development/inventory.ini
+++ b/environments/development/inventory.ini
@@ -30,10 +30,10 @@ hostname='citusdb3'
 [citusdb_worker:vars]
 ansible_python_interpreter = '/usr/bin/python3'
 
-[citusdb_cordinator]
+[citus_master]
 192.168.33.31
 
-[citusdb_cordinator:vars]
+[citus_master:vars]
 ansible_python_interpreter = '/usr/bin/python3'
 
 [db1]

--- a/environments/india/inventory.ini
+++ b/environments/india/inventory.ini
@@ -45,7 +45,7 @@ pgmain0-india.ccqpd1xrju8m.ap-south-1.rds.amazonaws.com
 citus1
 citus2
 
-[citusdb_cordinator:children]
+[citus_master:children]
 citus0
 
 [proxy:children]

--- a/environments/india/inventory.ini.j2
+++ b/environments/india/inventory.ini.j2
@@ -24,7 +24,7 @@
 citus1
 citus2
 
-[citusdb_cordinator:children]
+[citus_master:children]
 citus0
 
 [proxy:children]

--- a/environments/india/terraform.yml
+++ b/environments/india/terraform.yml
@@ -60,7 +60,7 @@ servers:
     network_tier: "app-private"
     az: "a"
     volume_size: 150
-    group: citusdb_cordinator
+    group: citus_master
     os: bionic
   - server_name: "citus1-india"
     server_instance_type: "c5.xlarge"

--- a/src/commcare_cloud/ansible/deploy_citusdb.yml
+++ b/src/commcare_cloud/ansible/deploy_citusdb.yml
@@ -4,7 +4,7 @@
 - name: CitusDB Machine Setup
   hosts:
     - citusdb_worker
-    - citusdb_cordinator
+    - citus_master
   become: true
   roles:
     - {role: ecryptfs, tags: 'ecryptfs'}
@@ -12,13 +12,13 @@
 - name: CitusDB
   hosts: 
     - citusdb_worker
-    - citusdb_cordinator
+    - citus_master
   become: true
   roles:
     - {role: citusdb, tags: 'citusdb'}
 
 - name: pgbouncer
-  hosts: citusdb_cordinator
+  hosts: citus_master
   become: true
   roles:
     - {role: pgbouncer, tags: 'pgbouncer'}
@@ -29,7 +29,7 @@
   become: true
   hosts:
     - citusdb_worker
-    - citusdb_cordinator
+    - citus_master
   tags: 'kernel_tuning'
   roles:
     - role: thp

--- a/src/commcare_cloud/ansible/roles/citusdb/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/citusdb/tasks/main.yml
@@ -38,7 +38,7 @@
    tags:
      - configure
 
- - name: Setup citusdb_cordinator
+ - name: Setup citus_master
    import_tasks: setup_cordinator.yml 
    tags:
     - configure

--- a/src/commcare_cloud/ansible/roles/citusdb/tasks/setup_cordinator.yml
+++ b/src/commcare_cloud/ansible/roles/citusdb/tasks/setup_cordinator.yml
@@ -6,4 +6,4 @@
    with_nested: 
     - "{{ postgresql_dbs.all }}"
     - "{{groups['citusdb_worker']}}"
-   when: inventory_hostname in groups["citusdb_cordinator"]  and (item.0.host in groups["citusdb_cordinator"])
+   when: inventory_hostname in groups["citus_master"]  and (item.0.host in groups["citus_master"])

--- a/src/commcare_cloud/ansible/roles/citusdb/tasks/setup_worker.yml
+++ b/src/commcare_cloud/ansible/roles/citusdb/tasks/setup_worker.yml
@@ -12,7 +12,7 @@
     lc_collate: 'en_US.UTF-8'
     lc_ctype: 'en_US.UTF-8'
     template: 'template0'
-  when: item.create and ((item.host in groups.citusdb_cordinator) and (inventory_hostname in groups.citusdb_worker ))
+  when: item.create and ((item.host in groups.citus_master) and (inventory_hostname in groups.citusdb_worker ))
   with_items: "{{ postgresql_dbs.all }}"
 
 - name: Add Citus Extension on Worker Database
@@ -22,4 +22,4 @@
     name: citus
     db: "{{ item.name }}"
   with_items: "{{ postgresql_dbs.all }}"
-  when: (item.host in groups.citusdb_cordinator) and (inventory_hostname in groups.citusdb_worker)
+  when: (item.host in groups.citus_master) and (inventory_hostname in groups.citusdb_worker)

--- a/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer_hba.conf.j2
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer_hba.conf.j2
@@ -33,7 +33,7 @@ host   {{ db.name }}	{{ db.user }}	{{ lookup('dig', host, wantlist=True)[0] }}/3
 {% endfor %}
 {% endif %}
 
-{% set citus_host_list = groups.get('citusdb_worker', []) + groups.get('citusdb_cordinator', []) | unique %}
+{% set citus_host_list = groups.get('citusdb_worker', []) + groups.get('citus_master', []) | unique %}
 {% if inventory_hostname in citus_host_list %}
 {% for host in citus_host_list %}
 # Allow Trus Access from Citus DB

--- a/src/commcare_cloud/ansible/roles/postgresql_base/templates/pg_hba.conf.j2
+++ b/src/commcare_cloud/ansible/roles/postgresql_base/templates/pg_hba.conf.j2
@@ -43,11 +43,11 @@ host   {{ db.name }}	{{ db.user }}	{{ lookup('dig', host, wantlist=True)[0] }}/3
 
 {% if allow_direct_citusdb_access %}
 # trus access for CitusDB connections only
-{% for host in (  groups.get('citusdb_worker', []) + groups.get('citusdb_cordinator', [])) | unique %}
+{% for host in (  groups.get('citusdb_worker', []) + groups.get('citus_master', [])) | unique %}
 # {{ host }}
 {% for db_name, db_list in postgresql_dbs.all|groupby('name') %}
 {% set db = db_list[0] %}
-{% if db.host in groups.get('citusdb_cordinator', []) %}
+{% if db.host in groups.get('citus_master', []) %}
 {% if host | ipaddr %}
 host   {{ db.name }}	{{ db.user }}	{{ host }}/32   trust
 {% else %}


### PR DESCRIPTION
`citus_cordinator` is misspelt and it's long
and harder to type than `citus_master`
