### PR TITLE
remove rabbitmq requirement

### DIFF
--- a/src/commcare_cloud/ansible/roles/rabbitmq/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/rabbitmq/tasks/main.yml
@@ -9,7 +9,7 @@
 
 - name: Install rabbitmq
   become: true
-  apt: pkg=rabbitmq-server state=installed
+  apt: name=rabbitmq-server state=present
   notify:
   - restart rabbitmq
 

--- a/src/commcare_cloud/environment/main.py
+++ b/src/commcare_cloud/environment/main.py
@@ -374,7 +374,6 @@ class Environment(object):
             mapping[self.format_sshable_host(ansible_host, ansible_port)] = host.name
         return mapping
 
-
     @memoized_property
     def hostname_map(self):
         """Mapping of inventory hostname (IP) to assigned hostname"""
@@ -388,12 +387,7 @@ class Environment(object):
 
         return mapping
 
-    def _run_last_minute_checks(self):
-        assert len(self.groups.get('rabbitmq', [])) > 0, \
-            "You need at least one rabbitmq host in the [rabbitmq] group"
-
     def create_generated_yml(self):
-        self._run_last_minute_checks()
         generated_variables = {
             'deploy_env': self.meta_config.deploy_env,
             'env_monitoring_id': self.meta_config.env_monitoring_id,


### PR DESCRIPTION
##### SUMMARY
Removes rabbitmq as a hard requirement

##### ENVIRONMENTS AFFECTED
none

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
rabbitmq/couchdb

##### ADDITIONAL INFORMATION
As noted in https://dimagi-dev.atlassian.net/browse/SLTNS-192 the [erlang dependencies for couchdb2](https://github.com/dimagi/commcare-cloud/pull/2886/commits/24f83b6bca5aa08720c6d89c2a30ea97af41615c#diff-3402d5d869f77f376e1694a0fffa614aR8) are in conflict with the erlang versions needed to run rabbitmq on bionic, which means rabbitmq and couchdb cannot be run on the same server. 

My solution to this is to remove the requirement to have rabbitmq at all and instead use redis as the broker. This is our [default in commcare-hq](https://github.com/dimagi/commcare-hq/blob/master/settings.py#L512), though it does mean you can lose tasks if your tasks take too long and redis begins evicting keys. This should be fine on small, monolith deployments