### PR TITLE
Remove kafkat

### DIFF
--- a/src/commcare_cloud/ansible/roles/kafka/meta/main.yml
+++ b/src/commcare_cloud/ansible/roles/kafka/meta/main.yml
@@ -1,5 +1,4 @@
 ---
 dependencies:
   - role: java
-  - role: ruby_install
   - role: zookeeper

--- a/src/commcare_cloud/ansible/roles/kafka/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/kafka/tasks/main.yml
@@ -77,15 +77,3 @@
 
 - name: Add Kafka binaries to PATH
   copy: src=kafka.sh dest=/etc/profile.d/ owner=root group=root mode=644
-
-- name: Install kafkat
-  command: 'gem install kafkat'
-  become: yes
-  tags:
-    - kafkat
-
-- name: Create kafkat config file
-  template: src=kafkatcfg.j2 dest="/etc/kafkatcfg"
-  become: yes
-  tags:
-    - kafkat


### PR DESCRIPTION
##### SUMMARY
Removes kafkat

##### ENVIRONMENTS AFFECTED
none
##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
kafka

##### ADDITIONAL INFORMATION
I brought this up on #devops but I don't think that anyone actually uses this. Ethan linked to a [kafka migration confluence page](https://confluence.dimagi.com/pages/viewpage.action?spaceKey=internal&title=Migrating+a+Kafka+cluster) from 2 years ago, but that is not how we've been migrating kafka recently (really haven't been migrating at all, just wiping it and installing a new server with no data)

I'm inclined to remove programs that aren't standard or documented in some workflow. If we want to document that migration in the commcare-cloud docs I'm happy to keep it, but it seems unnecessary for now