### PR TITLE
fix npm issues in bionic

### DIFF
--- a/src/commcare_cloud/ansible/roles/common_installs/tasks/bionic_apt_installs.yml
+++ b/src/commcare_cloud/ansible/roles/common_installs/tasks/bionic_apt_installs.yml
@@ -3,7 +3,6 @@
   apt:
     name:
       - software-properties-common
-      - npm
       - python-minimal
       - python3-pip
       - ufw

--- a/src/commcare_cloud/ansible/roles/common_installs/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/common_installs/tasks/main.yml
@@ -51,7 +51,7 @@
       - libfreetype6-dev
       - ranger  # cmdline file browser
       - libffi-dev  # Required for installing github3py
-      - libssl-dev  # Required for pip setup tools
+      - libssl-dev  # Required for pip setup tools and libcurl4-openssl-dev
       - tmux
       - reptyr # move process into tmux session
       - unzip

--- a/src/commcare_cloud/ansible/roles/nodejs/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/nodejs/tasks/main.yml
@@ -1,6 +1,17 @@
 - include: trusty_apt_repos.yml
   when: ansible_distribution_version == '14.04'
 
+- name: Add nodejs apt key
+  apt_key:
+    url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
+  when: ansible_distribution_version == '18.04'
+
+- name: Add git nodejs repo
+  apt_repository:
+    repo: 'deb https://deb.nodesource.com/node_8.x bionic main'
+    state: present
+  when: ansible_distribution_version == '18.04'
+
 - name: Update package list
   apt: update_cache=yes
   when: add_nodejs_repo is changed
@@ -8,11 +19,6 @@
 - name: Install nodejs packages
   apt: name="nodejs" state=present
   become: yes
-
-- name: Install npm packages (Bionic)
-  apt: name="npm" state=present
-  become: yes
-  when: ansible_distribution_version == '18.04'
 
 - name: Set NPM registry
   command: 'npm config set registry http://registry.npmjs.org/'

--- a/src/commcare_cloud/ansible/roles/nodejs/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/nodejs/tasks/main.yml
@@ -9,7 +9,7 @@
   apt: name="nodejs" state=present
   become: yes
 
-- name: Install nodejs packages
+- name: Install npm packages (Bionic)
   apt: name="npm" state=present
   become: yes
   when: ansible_distribution_version == '18.04'


### PR DESCRIPTION
##### SUMMARY
Node and NPM can't be co-installed with couchdb on bionic

##### ENVIRONMENTS AFFECTED
none (future bionic monoliths)

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME

##### ADDITIONAL INFORMATION
couchdb2 requires libcurl4-openssl-dev which requires libssl-dev (happens to be version 1.1.0 in bioinic)

npm (through node-gyp and I think one other dependency) requires libssl1.0.0-dev which is incompatible with libssl-dev

installing npm forces libcurl4 to uninstall and I have no idea what effect that would have on couch. So as a resolution, I'm doing something similar to what we've been doing in trusty. Install from the official node source repository. When installing from that repository, it also includes npm so we don't need to install it separately package information: https://deb.nodesource.com/node_8.x/dists/bionic/main/binary-amd64/Packages
