### PR TITLE
Remove letsencrypt cert when fake_ssl_certs are used

### DIFF
--- a/src/commcare_cloud/ansible/deploy_proxy.yml
+++ b/src/commcare_cloud/ansible/deploy_proxy.yml
@@ -176,3 +176,4 @@
 - name: Setup Letsencrypt
   import_playbook: letsencrypt_cert.yml
   tags: setup_letsencrypt
+  when: not fake_ssl_cert


### PR DESCRIPTION
##### SUMMARY
Remove letsencrypt cert when fake_ssl_certs are used

##### ENVIRONMENTS AFFECTED
none

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
proxy

##### ADDITIONAL INFORMATION
this seemed unnecessary if letsencrypt isn't being used. I think that this could be further filtered for sites that have their ssl certs defined, though I'm not sure if we have any manually defined ssl certs anymore