### PR TITLE
Don't create staticfiles

### DIFF
--- a/src/commcare_cloud/ansible/roles/nginx/tasks/install.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/tasks/install.yml
@@ -25,9 +25,19 @@
   become: yes
   user: name="{{ nginx_user }}" createhome=no password=no state=present groups="{{ cchq_user }}"
 
+- stat:
+    path: "{{ code_home }}"
+  register: code_home_folder
+
 - name: Create static files home
   become: yes
-  file: path="{{ nginx_static_home }}" owner="{{ cchq_user }}" group="{{ cchq_user }}" mode=0755 state=directory
+  file:
+    path: "{{ nginx_static_home }}"
+    owner: "{{ cchq_user }}"
+    group: "{{ cchq_user }}"
+    mode: 0755
+    state: directory
+  when: code_home_folder.stat.exists
 
 - name: Copy the nginx configuration file
   become: yes


### PR DESCRIPTION
Opening this up to try to figure out what to do about this.

Right now this attempts to create a `/home/cchq/www/env/current/staticfiles`. This causes linking current to relelases/release_date to fail later on when commcare gets deployed https://github.com/dimagi/commcare-cloud/blob/2bade44f6382e0b6bfd4295822ceae68580c6b05/src/commcare_cloud/ansible/roles/commcarehq/tasks/main.yml#L58-L65

Removing this may cause nginx to fail to start if there's no staticfiles until there's a real deploy. At the moment I'm considering moving this into the commcarehq role after linking. I'm not sure if that would cause any other issues though. thoughts on taht approach?