### PR TITLE
Close india softlayer-to-AWS VPN tunnel

### DIFF
--- a/environments/india/terraform.yml
+++ b/environments/india/terraform.yml
@@ -13,18 +13,9 @@ vpc_begin_range: "10.203"
 
 openvpn_image: ami-085d67fbfe42a25e7
 
-vpn_connections:
-  - name: softlayer
-    cidr_blocks:
-      - "10.162.0.0/16"
-    ip_address: "169.38.81.12"
-    type: "ipsec.1"
-    bgp_asn: 65000
-    amazon_side_asn: 7224
+vpn_connections: []
 
-external_routes:
-  - cidr_block: "10.162.0.0/16"
-    gateway_id: "vgw-0ea47c14639c0bf48"
+external_routes: []
 
 servers:
   - server_name: "control0-india"

--- a/src/commcare_cloud/terraform/modules/network/main.tf
+++ b/src/commcare_cloud/terraform/modules/network/main.tf
@@ -97,10 +97,17 @@ resource "aws_security_group" "vpn_connections" {
 resource "aws_route_table" "private" {
   vpc_id = "${aws_vpc.main.id}"
 
-  route = [{
-    cidr_block = "0.0.0.0/0"
-    nat_gateway_id = "${aws_nat_gateway.main.id}"
-  }, "${var.external_routes}"]
+  route = ["${
+    concat(
+      list(
+        map(
+          "cidr_block", "0.0.0.0/0",
+          "nat_gateway_id", aws_nat_gateway.main.id
+        )
+      ),
+      var.external_routes
+    )
+  }"]
 
   tags {
     Name = "private-${var.env}"
@@ -110,10 +117,17 @@ resource "aws_route_table" "private" {
 resource "aws_route_table" "public" {
   vpc_id = "${aws_vpc.main.id}"
 
-  route = [{
-    cidr_block = "0.0.0.0/0"
-    gateway_id = "${aws_internet_gateway.main.id}"
-  }, "${var.external_routes}"]
+  route = ["${
+    concat(
+      list(
+        map(
+          "cidr_block", "0.0.0.0/0",
+          "gateway_id", aws_internet_gateway.main.id
+        )
+      ),
+      var.external_routes
+    )
+  }"]
 
   tags {
     Name = "public-${var.env}"


### PR DESCRIPTION
##### SUMMARY
Now that the migration is over, I rolled this out to shut down the AWS side of the VPN, and I manually powered off the gateway device in softlayer.

In order to apply the changes, I had to make a small change in the some .tf files for it to treat `external_routes  = []` properly, which previously errored. I made sure to test that there's no change before changing the value of `external_routes` here.

(It also occurred to me that the VPN is still up on production even though I think we're now finally not using it. For some period there were questions about whether some site were still getting routed through the proxy so I will double check before doing anything.)

##### ENVIRONMENTS AFFECTED
india
