### PR TITLE
Increase disk size on es10 (prod) from 600 to 660

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -120,7 +120,7 @@ servers:
     server_instance_type: m5.2xlarge
     network_tier: "db-private"
     az: "a"
-    volume_size: 600
+    volume_size: 660
     group: "elasticsearch"
     os: trusty
   - server_name: "es11-production"


### PR DESCRIPTION
##### SUMMARY
Eventually I will add 60 extra GB on all the es machines, but I wanted to test out increasing `es10` from `600 GB` to `660 GB`. I will merge this commit only once I make the changes on AWS. 

##### ENVIRONMENTS AFFECTED
production

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
Updating `volume_size` in `terraform.yml`
