### PR TITLE
Fix redis monit

### DIFF
--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/main.yml
@@ -103,23 +103,21 @@
 
 - name: Upgrade python packages
   pip:
-    name: "{{ item }}"
+    name:
+      - six
+      - pip
+      - setuptools
     state: latest
     virtualenv: "{{ virtualenv_home }}"
-  with_items:
-    - six
-    - pip
-    - setuptools
 
 - name: py3 Upgrade python packages
   pip:
-    name: "{{ item }}"
+    name:
+      - six
+      - pip
+      - setuptools
     state: latest
     virtualenv: "{{ py3_virtualenv_home }}"
-  with_items:
-    - six
-    - pip
-    - setuptools
   tags:
     - py3
 

--- a/src/commcare_cloud/ansible/roles/redis/templates/monit.redis.j2
+++ b/src/commcare_cloud/ansible/roles/redis/templates/monit.redis.j2
@@ -1,6 +1,11 @@
  check process redis with pidfile {{ redis_pidfile }}
    group database
    group redis
+{% if ansible_service_mgr|default() != "systemd" %}
    start program = "/etc/init.d/{{ redis_service_name }} start"
    stop program = "/etc/init.d/{{ redis_service_name }} stop"
+{% else %}
+   start program = "/bin/systemctl start {{ redis_service_name }}"
+   stop program = "/bin/systemctl stop {{ redis_service_name }}"
+{% endif %}
    if failed host {{ inventory_hostname }} port {{ redis_port }} then restart

--- a/src/commcare_cloud/ansible/roles/shared_dir/tasks/cleanup_client.yml
+++ b/src/commcare_cloud/ansible/roles/shared_dir/tasks/cleanup_client.yml
@@ -1,6 +1,6 @@
 - name: Unmount directory from /etc/fstab
   become: yes
-  when: shared_drive_enabled
+  when: shared_drive_enabled|bool
   mount:
     name: "{{ old_shared_mount_dir }}"
     src: "{{ groups.shared_dir_host[0] }}:{{ old_shared_data_dir }}"

--- a/src/commcare_cloud/ansible/roles/shared_dir/tasks/install.yml
+++ b/src/commcare_cloud/ansible/roles/shared_dir/tasks/install.yml
@@ -1,14 +1,14 @@
 ---
 
 - name: Update the apt cache
-  when: shared_drive_enabled
+  when: shared_drive_enabled|bool
   apt:
     update_cache: yes
     cache_valid_time: 7200
 
 - name: Install NFS packages
   become: yes
-  when: shared_drive_enabled
+  when: shared_drive_enabled|bool
   apt:
     name:
       - nfs-kernel-server
@@ -17,7 +17,7 @@
     - nfs
 
 - name: ensure nfs service is running
-  when: shared_drive_enabled
+  when: shared_drive_enabled|bool
   service:
     name: nfs-kernel-server
     state: started

--- a/src/commcare_cloud/ansible/roles/shared_dir/tasks/setup_client.yml
+++ b/src/commcare_cloud/ansible/roles/shared_dir/tasks/setup_client.yml
@@ -2,7 +2,7 @@
 
 - name: Create shared mount dir
   become: yes
-  when: shared_drive_enabled
+  when: shared_drive_enabled|bool
   file:
     path: "{{ shared_mount_dir }}"
     owner: "nobody"
@@ -14,7 +14,7 @@
 
 - name: Mount directory in /etc/fstab
   become: yes
-  when: shared_drive_enabled
+  when: shared_drive_enabled|bool
   mount:
     name: "{{ shared_mount_dir }}"
     src: "{{ groups.shared_dir_host[0] }}:{{ shared_data_dir }}"

--- a/src/commcare_cloud/ansible/roles/shared_dir/tasks/setup_host.yml
+++ b/src/commcare_cloud/ansible/roles/shared_dir/tasks/setup_host.yml
@@ -58,7 +58,7 @@
 
 - name: Add shared dir to exports
   become: yes
-  when: shared_drive_enabled
+  when: shared_drive_enabled|bool
   lineinfile:
     dest: /etc/exports
     line: "{{ shared_data_dir }} {{ item }}(rw,sync,all_squash,no_subtree_check,anongid={{ shared_dir_gid }})"
@@ -76,7 +76,7 @@
 
 - name: Export directories
   become: yes
-  when: shared_drive_enabled
+  when: shared_drive_enabled|bool
   command: "exportfs -a"
   tags:
     - nfs


### PR DESCRIPTION
##### SUMMARY
Use systemctl to start/stop redis

##### ENVIRONMENTS AFFECTED
staging & india

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
redis

##### ADDITIONAL INFORMATION
the monit config for redis is currently broken as bionic uses systemd as a process manager and our redis library only installs /etc/init.d if systemd is not the process manager https://github.com/DavidWittman/ansible-redis/blob/cfe5d92a721b5b137bbbff20c57e038c5691c463/tasks/server.yml#L9-L22

monit status is currently green on staging and india because it uses the same pid file to check for status. if anyone tries monit start/stop on either of those environments it will fail

A follow up to this may be "do we need monit in a world where we have systemd?" or "how do we simplify our process managemnt?" @dannyroberts I think you'll have the most context on answering that question as part of plat-reliability