### PR TITLE
Add swap to celery1-india to avoid OOMs

### DIFF
--- a/environments/india/inventory.ini
+++ b/environments/india/inventory.ini
@@ -15,7 +15,7 @@
 [airflow1]
 10.203.10.63 hostname=airflow1-india ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3
 [celery1]
-10.203.10.13 hostname=celery1-india ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3
+10.203.10.13 hostname=celery1-india ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 swap_size=4G
 [couch2]
 10.203.40.187 hostname=couch2-india ufw_private_interface=eth0
 [couch3]

--- a/environments/india/inventory.ini.j2
+++ b/environments/india/inventory.ini.j2
@@ -6,7 +6,7 @@
 {{ __citus1__ }}
 {{ __citus2__ }}
 {{ __airflow1__ }}
-{{ __celery1__ }}
+{{ __celery1__ }} swap_size=4G
 {{ __couch2__ }}
 {{ __couch3__ }}
 {{ __couch4__ }}


### PR DESCRIPTION
##### SUMMARY
Celery is mostly powered just find on india, but experiences problems that it does not gracefully recover from when memory occasionally spikes and causes a process to be killed by the OOM killer. The last couple day's it's been causing the background_queue to get blocked until someone restarts it

##### ENVIRONMENTS AFFECTED
india
