### PR TITLE
Increase production redis_maxmemory to 16G (of 32G machine)

### DIFF
--- a/environments/echis/public.yml
+++ b/environments/echis/public.yml
@@ -10,6 +10,7 @@ elastcsearch_backup_days: 3
 elasticsearch_version: 1.7.6
 elasticsearch_download_sha256: 78affc30353730ec245dad1f17de242a4ad12cf808eaa87dd878e1ca10ed77df.
 
+redis_maxmemory: 4gb
 
 default_from_email: echismoh@moh.gov.et
 server_email: echismoh@moh.gov.et

--- a/environments/icds-cas/public.yml
+++ b/environments/icds-cas/public.yml
@@ -27,7 +27,6 @@ swift_url: https://mowcdmum.ipstorage.tatacommunications.com/auth/v1.0/
 
 nofile_limit: 65536
 
-redis_appendonly: 'yes'
 redis_maxmemory: 6gb
 redis_maxmemory_policy: allkeys-lru
 redis_auto_aof_rewrite_percentage: "50"

--- a/environments/icds-new/public.yml
+++ b/environments/icds-new/public.yml
@@ -22,7 +22,6 @@ nadir_hour: 16
 
 nofile_limit: 65536
 
-redis_appendonly: 'yes'
 redis_maxmemory: 5gb
 
 kafka_log_dir: '{{ encrypted_root }}/kafka'

--- a/environments/india/public.yml
+++ b/environments/india/public.yml
@@ -27,8 +27,6 @@ aws_region: 'ap-south-1'
 
 nofile_limit: 65536
 
-redis_appendonly: 'yes'
-
 KSPLICE_ACTIVE: yes
 
 nameservers:

--- a/environments/pna/public.yml
+++ b/environments/pna/public.yml
@@ -12,6 +12,8 @@ elasticsearch_version: 1.7.6
 elasticsearch_download_sha256: 78affc30353730ec245dad1f17de242a4ad12cf808eaa87dd878e1ca10ed77df.
 #elasticsearch_node_name: '??'
 
+redis_maxmemory: 4gb
+
 backup_blobdb: True
 backup_postgres: dump
 backup_es_s3: True

--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -158,7 +158,7 @@ formplayer0
 formplayer1
 
 [redis1]
-10.202.40.34 hostname=redis1-production ufw_private_interface=eth0
+10.202.40.34 hostname=redis1-production ufw_private_interface=eth0 swap_size=1G
 
 [redis:children]
 redis1

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -127,7 +127,7 @@ pillow0
 formplayer0
 formplayer1
 
-{{ __redis1__ }}
+{{ __redis1__ }} swap_size=1G
 
 [redis:children]
 redis1

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -20,7 +20,7 @@ elasticsearch_cluster_name: 'prodhqes-1.x'
 #elasticsearch_node_name: '???'
 elasticsearch_fielddata_cache_size: "40%"
 
-redis_maxmemory: 8gb
+redis_maxmemory: 24gb
 
 nofile_limit: 65536
 

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -20,8 +20,6 @@ elasticsearch_cluster_name: 'prodhqes-1.x'
 #elasticsearch_node_name: '???'
 elasticsearch_fielddata_cache_size: "40%"
 
-redis_maxmemory: 16gb
-
 nofile_limit: 65536
 
 supervisor_http_enabled: True

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -20,7 +20,7 @@ elasticsearch_cluster_name: 'prodhqes-1.x'
 #elasticsearch_node_name: '???'
 elasticsearch_fielddata_cache_size: "40%"
 
-redis_maxmemory: 24gb
+redis_maxmemory: 16gb
 
 nofile_limit: 65536
 

--- a/environments/swiss/public.yml
+++ b/environments/swiss/public.yml
@@ -12,7 +12,7 @@ elasticsearch_download_sha256: 78affc30353730ec245dad1f17de242a4ad12cf808eaa87dd
 #elasticsearch_node_name: '??'
 elastcsearch_backup_days: 2
 
-
+redis_maxmemory: 4gb
 
 ssh_allow_password: True
 

--- a/src/commcare_cloud/ansible/group_vars/redis.yml
+++ b/src/commcare_cloud/ansible/group_vars/redis.yml
@@ -6,9 +6,9 @@ redis_local_facts: false
 redis_logfile: "{{ redis_dir }}/redis.log"
 redis_service_name: redis-server
 redis_syslog_enabled: "yes"
-# Best practice: set redis_maxmemory to half of the RAM on redis
+# This implements the best practice of setting redis_maxmemory to half the RAM
 # Discussion: https://github.com/dimagi/commcare-cloud/pull/2929#issuecomment-499970466
-redis_maxmemory: 4gb
+redis_maxmemory: "{{ ansible_memory_mb.real.total // 2 }}m"
 redis_maxmemory_policy: volatile-lru
 redis_save: []
 redis_appendonly: "yes"

--- a/src/commcare_cloud/ansible/group_vars/redis.yml
+++ b/src/commcare_cloud/ansible/group_vars/redis.yml
@@ -6,6 +6,8 @@ redis_local_facts: false
 redis_logfile: "{{ redis_dir }}/redis.log"
 redis_service_name: redis-server
 redis_syslog_enabled: "yes"
+# Best practice: set redis_maxmemory to half of the RAM on redis
+# Discussion: https://github.com/dimagi/commcare-cloud/pull/2929#issuecomment-499970466
 redis_maxmemory: 4gb
 redis_maxmemory_policy: volatile-lru
 redis_save: []


### PR DESCRIPTION
##### SUMMARY

I'm having trouble finding what the benefits of setting this at all are over setting to 0 (which means as much memory as the underlying OS allows), but it's currently set very low and that seems like a plausible explanation for occasional evictions and generally low % of unfreeable memory (https://app.datadoghq.com/dashboard/nbz-bie-nip/host-groups?screenId=nbz-bie-nip&screenName=host-groups&abstraction_level=1&aggregate_up=false&display_timeline=false&from_ts=1546365120000&is_auto=false&live=false&page=0&per_page=30&tile_size=m&to_ts=1559926320000&tpl_var_environment=production&tpl_var_host_group=redis&use_date_happened=true).

##### ENVIRONMENTS AFFECTED
production

### To roll out ###
It will require restarting the redis service, which may cause 500s while it blocks to restore the AOF into memory
- [x] `cchq production deploy-stack --limit redis --tags=swap`
- [ ] `cchq production ansible-playbook deploy_db.yml --limit redis --branch=dmr/production-redis-maxmemory --start-at-task='create redis config file'` <--- 500s