### PR TITLE
Add ddtrace to hq_webworkers only (not mobile_webworkers)

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -12,7 +12,7 @@ DATADOG_TRACE:
     env: production
 
 LOCAL_APPS:
-  - {name: 'ddtrace.contrib.django', host: webworkers}
+  - {name: 'ddtrace.contrib.django', host: hq_webworkers}
 
 elasticsearch_endpoint: '{{ groups.elasticsearch.0 }}'
 elasticsearch_cluster_name: 'prodhqes-1.x'


### PR DESCRIPTION
##### SUMMARY
I want to see if this affects submission and restore response times and success rates. The timing of originally introducing it isn't a smoking gun but doesn't put it out of the question either, and I've been itching to put the suspicion to rest. If after a few days there's no detectable change (and assuming we find the data we get from ddtrace useful!) I'll add it back.

##### ENVIRONMENTS AFFECTED
production


### To roll out ###

- [x] `cchq production update-config`
- [x] deploy or run `cchq production fab restart_webworkers`