### PR TITLE
Set datavol_device automatically on AWS envs

### DIFF
--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -217,17 +217,17 @@ es_master
 es_data
 
 [couch3]
-10.202.40.135 hostname=couch3-production ufw_private_interface=eth0
+10.202.40.135 hostname=couch3-production ufw_private_interface=eth0 datavol_device=/dev/nvme1n
 [couch4]
-10.202.40.97 hostname=couch4-production ufw_private_interface=eth0
+10.202.40.97 hostname=couch4-production ufw_private_interface=eth0 datavol_device=/dev/nvme1n
 [couch5]
-10.202.40.5 hostname=couch5-production ufw_private_interface=eth0
+10.202.40.5 hostname=couch5-production ufw_private_interface=eth0 datavol_device=/dev/nvme1n
 [couch7]
-10.202.40.120 hostname=couch7-production ufw_private_interface=eth0
+10.202.40.120 hostname=couch7-production ufw_private_interface=eth0 datavol_device=/dev/nvme1n
 [couch8]
-10.202.40.57 hostname=couch8-production ufw_private_interface=eth0
+10.202.40.57 hostname=couch8-production ufw_private_interface=eth0 datavol_device=/dev/nvme1n
 [couch9]
-10.202.40.134 hostname=couch9-production ufw_private_interface=eth0
+10.202.40.134 hostname=couch9-production ufw_private_interface=eth0 datavol_device=/dev/nvme1n
 
 [couchdb2:children]
 couch3
@@ -239,7 +239,6 @@ couch9
 
 [couchdb2:vars]
 swap_size=8G
-datavol_device=/dev/nvme1n
 
 [couchproxy0]
 10.202.40.162 hostname=couchproxy0-production ufw_private_interface=eth0

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -193,7 +193,6 @@ couch9
 
 [couchdb2:vars]
 swap_size=8G
-datavol_device=/dev/nvme1n
 
 {{ __couchproxy0__ }}
 

--- a/src/commcare_cloud/commands/terraform/aws.py
+++ b/src/commcare_cloud/commands/terraform/aws.py
@@ -176,12 +176,16 @@ class AwsFillInventoryHelper(object):
         servers = self.environment.terraform_config.servers + self.environment.terraform_config.proxy_servers
         for server in servers:
             is_bionic = server.os == 'bionic'
+            inventory_vars = [
+                ('hostname', server.server_name),
+                ('ufw_private_interface', ('ens5' if is_bionic else 'eth0')),
+                ('ansible_python_interpreter', ('/usr/bin/python3' if is_bionic else None)),
+            ]
+            if server.block_device:
+                inventory_vars.append(('datavol_device', '/dev/nvme1n'))
+
             context.update(
-                self.get_host_group_definition(resource_name=server.server_name, vars=(
-                    ('hostname', server.server_name),
-                    ('ufw_private_interface', ('ens5' if is_bionic else 'eth0')),
-                    ('ansible_python_interpreter', ('/usr/bin/python3' if is_bionic else None)),
-                ))
+                self.get_host_group_definition(resource_name=server.server_name, vars=inventory_vars)
             )
 
         for rds_instance in self.environment.terraform_config.rds_instances:


### PR DESCRIPTION
##### SUMMARY
Set `datavol_device` automatically on AWS envs based on `block_device` for the server in `terraform.yml`. This makes it so you just have to say in `terraform.yml` that a server should have a block device, and then it'll automatically be given the inventory variable it needs to make use of it.

##### ENVIRONMENTS AFFECTED
Just aws envs
