### PR TITLE
upgrade remaining ES nodes to 660 GB

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -127,28 +127,28 @@ servers:
     server_instance_type: m5.2xlarge
     network_tier: "db-private"
     az: "a"
-    volume_size: 600
+    volume_size: 660
     group: "elasticsearch"
     os: trusty
   - server_name: "es12-production"
     server_instance_type: m5.2xlarge
     network_tier: "db-private"
     az: "a"
-    volume_size: 600
+    volume_size: 660
     group: "elasticsearch"
     os: trusty
   - server_name: "es13-production"
     server_instance_type: m5.2xlarge
     network_tier: "db-private"
     az: "a"
-    volume_size: 600
+    volume_size: 660
     group: "elasticsearch"
     os: trusty
   - server_name: "es14-production"
     server_instance_type: m5.2xlarge
     network_tier: "db-private"
     az: "a"
-    volume_size: 600
+    volume_size: 660
     group: "elasticsearch"
     os: trusty
 


### PR DESCRIPTION
##### SUMMARY
Upgrading the remaining elastic search nodes to 660 GB in preparation for enabling Case Search index on pro + domains

##### ENVIRONMENTS AFFECTED
production

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
`terraform.yml`
