### PR TITLE
Fix check_s3_backup.py script and change its check

### DIFF
--- a/src/commcare_cloud/ansible/deploy_db.yml
+++ b/src/commcare_cloud/ansible/deploy_db.yml
@@ -11,7 +11,7 @@
   become: true
   roles:
     - {role: ecryptfs, tags: 'ecryptfs'}
-    - {role: backups, tags: 'backups'}
+    - {role: backups, tags: 'backups,backups-only'}
 
 - name : PostgreSQL
   import_playbook: deploy_postgres.yml

--- a/src/commcare_cloud/ansible/roles/backups/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/backups/tasks/main.yml
@@ -82,8 +82,8 @@
   tags:
     - cron
     - backups
-  
-- name: Copy check_s3_backup script to /usr/local/sbin
+
+- name: Copy check_s3_backup script to /usr/local/bin
   template:
     src: check_s3_backup.py.j2
     dest: /usr/local/bin/check_s3_backup.py

--- a/src/commcare_cloud/ansible/roles/backups/templates/check_s3_backup.py.j2
+++ b/src/commcare_cloud/ansible/roles/backups/templates/check_s3_backup.py.j2
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 import argparse
 import boto3
+import botocore
 import datetime
 
 parser = argparse.ArgumentParser(description="S3 Backup Status.")
@@ -34,7 +35,13 @@ s3 = session.resource(service_name='s3',endpoint_url=endpoint,region_name='{{ aw
 s3 = session.resource(service_name='s3',endpoint_url=endpoint)
 {% endif %}
 
-bucket = s3.Bucket(BUCKET_NAME)
+def file_exists_in_s3(object_key):
+  try:
+    s3.Object(BUCKET_NAME, object_key).load()
+  except botocore.exceptions.ClientError:
+    return False
+  else:
+    return True
 
 today = datetime.datetime.today()
 
@@ -56,28 +63,26 @@ weekly_options = [
     for n in [0, 1, 2, 3, 4, 5, 6]
 ]
 
+# up to one match will be stored in these
 daily_matches = []
 weekly_matches = []
-# Shows Alert if backup is not uploaded since 2 days.
-for obj in bucket.objects.all():
-    if obj.key in daily_options:
-        daily_matches.append(obj)
-    if obj.key in weekly_options:
-        weekly_matches.append(obj)
+
+for options, matches in [(daily_options, daily_matches),
+                         (weekly_options, weekly_matches)]:
+    for filename in options:
+        if file_exists_in_s3(filename):
+            matches.append(filename)
+            break
 
 if daily_matches:
-    daily_matches.sort(key=lambda obj: obj.last_modified)
     match = daily_matches[-1]
-    print('[OK] Last daily {} backup is {}, uploaded @ {}'.format(
-        args.service, match.key, match.last_modified))
+    print('[OK] Last daily {} backup is {}'.format(args.service, match))
 else:
     print('[ALERT] No daily {} backup in last two days'.format(args.service))
 
 if weekly_matches:
-    weekly_matches.sort(key=lambda obj: obj.last_modified)
     match = weekly_matches[-1]
-    print('[OK] Last weekly {} backup is {}, uploaded @ {}'.format(
-        args.service, match.key, match.last_modified))
+    print('[OK] Last weekly {} backup is {}'.format(args.service, match))
 else:
     print('[ALERT] No weekly {} backup in last seven days'.format(args.service))
 

--- a/src/commcare_cloud/ansible/roles/backups/templates/check_s3_backup.py.j2
+++ b/src/commcare_cloud/ansible/roles/backups/templates/check_s3_backup.py.j2
@@ -39,8 +39,22 @@ bucket = s3.Bucket(BUCKET_NAME)
 today = datetime.datetime.today()
 
 backup_filename_format = '{prefix}_{backup_type}_{date}.tar.gz'
-daily_options = [backup_filename_format.format(prefix=PREFIX, backup_type='daily', date=(today - datetime.timedelta(days=n)).strftime('%Y_%m_%d')) for n in [0, 1]]
-weekly_options = [backup_filename_format.format(prefix=PREFIX, backup_type='weekly', date=(today - datetime.timedelta(days=n)).strftime('%Y_%m_%d')) for n in [0, 1, 2, 3, 4, 5, 6]]
+daily_options = [
+    backup_filename_format.format(
+        prefix=PREFIX,
+        backup_type='daily',
+        date=(today - datetime.timedelta(days=n)).strftime('%Y_%m_%d')
+    )
+    for n in [0, 1]
+]
+weekly_options = [
+    backup_filename_format.format(
+        prefix=PREFIX,
+        backup_type='weekly',
+        date=(today - datetime.timedelta(days=n)).strftime('%Y_%m_%d')
+    )
+    for n in [0, 1, 2, 3, 4, 5, 6]
+]
 
 daily_matches = []
 weekly_matches = []
@@ -54,14 +68,16 @@ for obj in bucket.objects.all():
 if daily_matches:
     daily_matches.sort(key=lambda obj: obj.last_modified)
     match = daily_matches[-1]
-    print('[OK] Last daily {} backup is {}, uploaded @ {}'.format(args.service, match.key, match.last_modified))
+    print('[OK] Last daily {} backup is {}, uploaded @ {}'.format(
+        args.service, match.key, match.last_modified))
 else:
     print('[ALERT] No daily {} backup in last two days'.format(args.service))
 
 if weekly_matches:
     weekly_matches.sort(key=lambda obj: obj.last_modified)
     match = weekly_matches[-1]
-    print('[OK] Last weekly {} backup is {}, uploaded @ {}'.format(args.service, match.key, match.last_modified))
+    print('[OK] Last weekly {} backup is {}, uploaded @ {}'.format(
+        args.service, match.key, match.last_modified))
 else:
     print('[ALERT] No weekly {} backup in last seven days'.format(args.service))
 

--- a/src/commcare_cloud/ansible/roles/backups/templates/check_s3_backup.py.j2
+++ b/src/commcare_cloud/ansible/roles/backups/templates/check_s3_backup.py.j2
@@ -36,12 +36,12 @@ s3 = session.resource(service_name='s3',endpoint_url=endpoint)
 {% endif %}
 
 def file_exists_in_s3(object_key):
-  try:
-    s3.Object(BUCKET_NAME, object_key).load()
-  except botocore.exceptions.ClientError:
-    return False
-  else:
-    return True
+    try:
+        s3.Object(BUCKET_NAME, object_key).load()
+    except botocore.exceptions.ClientError:
+        return False
+    else:
+        return True
 
 today = datetime.datetime.today()
 

--- a/src/commcare_cloud/ansible/roles/backups/templates/check_s3_backup.py.j2
+++ b/src/commcare_cloud/ansible/roles/backups/templates/check_s3_backup.py.j2
@@ -65,5 +65,5 @@ if weekly_matches:
 else:
     print('[ALERT] No weekly {} backup in last seven days'.format(args.service))
 
-if not weekly_matches and not daily_matches:
+if not weekly_matches or not daily_matches:
     exit(-1)

--- a/src/commcare_cloud/ansible/roles/backups/templates/check_s3_backup.py.j2
+++ b/src/commcare_cloud/ansible/roles/backups/templates/check_s3_backup.py.j2
@@ -3,24 +3,67 @@ import argparse
 import boto3
 import datetime
 
-#input environement and service from users
-
 parser = argparse.ArgumentParser(description="S3 Backup Status.")
-parser.add_argument('env', choices=['pna','softlayer','production','staging'] ,help='Environment Name')
 parser.add_argument('service', choices=['couch','blobdb','postgres'] ,help='Service Name')
 args = parser.parse_args()
 
-BUCKET_NAME = 'dimagi-'+args.env+'-'+args.service+'-backups'
+BUCKET_MAP = {
+  'couch': {{ couchdb_snapshot_bucket|tojson }},
+  'postgres': {{ postgres_snapshot_bucket|tojson }},
+  'blobdb': {{ blobdb_snapshot_bucket|tojson }},
+}
 
-s3 = boto3.resource('s3')
+PREFIX_MAP = {
+  'couch': "couchdb",
+  'postgres': "postgres_{{ deploy_env }}",
+  'blobdb': "blobdb",
+}
+
+BUCKET_NAME = BUCKET_MAP[args.service]
+PREFIX = PREFIX_MAP[args.service]
+
+endpoint = {{ aws_endpoint|tojson }}
+
+if not endpoint.startswith("http"):
+    endpoint = 'https://' + endpoint
+
+session = boto3.session.Session()
+{% if aws_region is defined %}
+s3 = session.resource(service_name='s3',endpoint_url=endpoint,region_name='{{ aws_region }}')
+{% else %}
+s3 = session.resource(service_name='s3',endpoint_url=endpoint)
+{% endif %}
 
 bucket = s3.Bucket(BUCKET_NAME)
 
 today = datetime.datetime.today()
 
-# Shows Alert if backup is not uploaded since 2 days. 
-for key in bucket.objects.all():
-    if today.day - key.last_modified.day > 2:
-        print "[ALERT]" , key.key , key.last_modified
-    else:
-        print "[OK]", key.key , key.last_modified
+backup_filename_format = '{prefix}_{backup_type}_{date}.tar.gz'
+daily_options = [backup_filename_format.format(prefix=PREFIX, backup_type='daily', date=(today - datetime.timedelta(days=n)).strftime('%Y_%m_%d')) for n in [0, 1]]
+weekly_options = [backup_filename_format.format(prefix=PREFIX, backup_type='weekly', date=(today - datetime.timedelta(days=n)).strftime('%Y_%m_%d')) for n in [0, 1, 2, 3, 4, 5, 6]]
+
+daily_matches = []
+weekly_matches = []
+# Shows Alert if backup is not uploaded since 2 days.
+for obj in bucket.objects.all():
+    if obj.key in daily_options:
+        daily_matches.append(obj)
+    if obj.key in weekly_options:
+        weekly_matches.append(obj)
+
+if daily_matches:
+    daily_matches.sort(key=lambda obj: obj.last_modified)
+    match = daily_matches[-1]
+    print('[OK] Last daily {} backup is {}, uploaded @ {}'.format(args.service, match.key, match.last_modified))
+else:
+    print('[ALERT] No daily {} backup in last two days'.format(args.service))
+
+if weekly_matches:
+    weekly_matches.sort(key=lambda obj: obj.last_modified)
+    match = weekly_matches[-1]
+    print('[OK] Last weekly {} backup is {}, uploaded @ {}'.format(args.service, match.key, match.last_modified))
+else:
+    print('[ALERT] No weekly {} backup in last seven days'.format(args.service))
+
+if not weekly_matches and not daily_matches:
+    exit(-1)


### PR DESCRIPTION
it now checks for a recent daily and weekly backup, prints out whether
it found them, and exits with -1 if there isn't a recent daily backup or
there isn't a recent weekly backup

I'm not sure what the most sensical way to hook this check up to a datadog monitor is, but I figured I'd start by fixing the broken script that was clearly meant to do something like what I'm trying to do