### PR TITLE
Pin terraform cli version and rds module version

### DIFF
--- a/src/commcare_cloud/commands/terraform/templates/terraform.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/terraform.tf.j2
@@ -5,6 +5,7 @@ terraform {
     region  = {{ state_bucket_region|tojson }}
     encrypt = true
   }
+  required_version = "~> 0.11.0"
 }
 
 provider "aws" {

--- a/src/commcare_cloud/terraform/modules/postgresql/main.tf
+++ b/src/commcare_cloud/terraform/modules/postgresql/main.tf
@@ -3,6 +3,7 @@ locals {
 }
 module "postgresql" {
   source = "terraform-aws-modules/rds/aws"
+  version = "1.28.0"
 
   create_db_instance = "${local.create}"
   create_db_option_group = "${local.create}"


### PR DESCRIPTION
##### SUMMARY
A new version of `terraform-aws-modules/rds/aws` causes problems on a clean install, and the latest version of `terraform` cli is not compatible with our code currently. This encodes those two issues and keeps any errors more helpful.
