### PR TITLE
Start supervisor on boot

### DIFF
--- a/src/commcare_cloud/ansible/roles/supervisor/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/supervisor/tasks/main.yml
@@ -79,7 +79,7 @@
   failed_when: result.rc > 1
   changed_when: result.rc == 0
 
-- name: start supervisord
+- name: start and enable supervisord
   become: yes
-  service: name=supervisord enabled=yes
+  service: name=supervisord enabled=yes state=started
   when: which_supervisord.stdout

--- a/src/commcare_cloud/ansible/roles/supervisor/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/supervisor/tasks/main.yml
@@ -81,5 +81,5 @@
 
 - name: start supervisord
   become: yes
-  service: name=supervisord state=started
+  service: name=supervisord enabled=yes
   when: which_supervisord.stdout


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When using systemd, on ubuntu 18.04 we need to enable supervisor to start on boot. 
I think this wasn't happening on 14.04 because upstart allows you to specify this directly: https://github.com/dimagi/commcare-cloud/blob/97b5ff49992e137131bca2dd66782f40574805fe/src/commcare_cloud/ansible/roles/supervisor/templates/supervisord.upstart.conf.j2#L3
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

