### PR TITLE
Fix meaningless terraform diffs

### DIFF
--- a/src/commcare_cloud/terraform/modules/network/main.tf
+++ b/src/commcare_cloud/terraform/modules/network/main.tf
@@ -79,6 +79,7 @@ resource "aws_vpn_connection_route" "vpn_connections" {
 }
 
 resource "aws_security_group" "vpn_connections" {
+  count = "${length(var.vpn_connections) == 0 ? 0 : 1}"
   name = "vpn-connections-sg-${var.env}"
   vpc_id = "${aws_vpc.main.id}"
   ingress {

--- a/src/commcare_cloud/terraform/modules/network/outputs.tf
+++ b/src/commcare_cloud/terraform/modules/network/outputs.tf
@@ -43,5 +43,5 @@ output "ssh-sg" {
 }
 
 output "vpn-connections-sg" {
-  value = "${aws_security_group.vpn_connections.id}"
+  value = "${aws_security_group.vpn_connections.*.id}"
 }

--- a/src/commcare_cloud/terraform/modules/server/main.tf
+++ b/src/commcare_cloud/terraform/modules/server/main.tf
@@ -7,9 +7,6 @@ resource aws_instance "server" {
   key_name                = "${var.key_name}"
   vpc_security_group_ids  = ["${var.security_group_options[var.network_tier]}"]
   source_dest_check       = false
-  credit_specification {
-    cpu_credits = "unlimited"
-  }
 
   disable_api_termination = true
   ebs_optimized = true


### PR DESCRIPTION
##### SUMMARY

These two otherwise unrelated issues both were causing meaningless terraform diffs—diffs that showed up again even immediately after cleanly applying. This PR gets rid of those diffs, and other than removing unneeded resources/settings doesn't make any meaningful changes to our environments.

##### ENVIRONMENTS AFFECTED
production, india, staging
