### PR TITLE
celery resource report

### DIFF
--- a/src/commcare_cloud/commcare_cloud.py
+++ b/src/commcare_cloud/commcare_cloud.py
@@ -30,7 +30,7 @@ from commcare_cloud.commands.ansible.service import Service
 from .commands.ansible.run_module import RunAnsibleModule, RunShellCommand, Ping, SendDatadogEvent
 from .commands.fab import Fab
 from .commands.inventory_lookup.inventory_lookup import Lookup, Ssh, Mosh, DjangoManage, Tmux
-from .commands.ansible.ops_tool import ListDatabases
+from .commands.ansible.ops_tool import ListDatabases, CeleryResourceReport
 from commcare_cloud.commands.command_base import CommandBase, Argument, CommandError
 from .environment.paths import (
     get_available_envs,
@@ -68,6 +68,7 @@ COMMAND_GROUPS = OrderedDict([
         Downtime,
         CopyFiles,
         ListDatabases,
+        CeleryResourceReport,
         Terraform,
         TerraformMigrateState,
         AwsSignIn,


### PR DESCRIPTION
I've written this temporarily a few times - decided to make it permanent.

Could probably use more work but it's all I need for now.

For ICDS this outputs:
```
Pooling  | Worker Queues                                    | Processes    | Concurrency  | Avg Concurrency per worker
-------  | -------------                                    | ---------    | -----------  | --------------------------
prefork  | background_queue,analytics_queue                 | 1            | 6            | 6           
prefork  | beat                                             | 1            | 1            | 1           
prefork  | case_rule_queue                                  | 1            | 2            | 2           
prefork  | celery,export_download_queue,case_import_queue   | 1            | 8            | 8           
prefork  | celery_periodic                                  | 1            | 4            | 4           
prefork  | email_queue                                      | 1            | 2            | 2           
prefork  | flower                                           | 1            | 1            | 1           
prefork  | icds_aggregation_queue                           | 1            | 10           | 10          
prefork  | icds_dashboard_reports_queue                     | 13           | 26           | 2           
gevent   | reminder_case_update_queue                       | 118          | 590          | 5           
gevent   | reminder_queue                                   | 6            | 30           | 5           
prefork  | reminder_rule_queue                              | 1            | 2            | 2           
prefork  | repeat_record_queue                              | 1            | 1            | 1           
prefork  | saved_exports_queue                              | 1            | 3            | 3           
gevent   | sms_queue                                        | 8            | 80           | 10          
prefork  | submission_reprocessing_queue                    | 1            | 2            | 2           
gevent   | sumologic_logs_queue                             | 1            | 8            | 8           
prefork  | ucr_indicator_queue                              | 28           | 119          | 4           
prefork  | ucr_queue                                        | 1            | 4            | 4  
```