### PR TITLE
Fix supervisor service management & Remove run_reminder_queue

### DIFF
--- a/src/commcare_cloud/ansible/deploy_commcarehq.yml
+++ b/src/commcare_cloud/ansible/deploy_commcarehq.yml
@@ -81,14 +81,16 @@
     - set_fact:
         supervisor_files: "{{ celery_managed_files|default([]) + pillowtop_managed_files|default([]) + proxy_managed_files|default([]) + webworker_managed_files|default([]) + airflow_managed_files|default([]) + formplayer_managed_files|default([]) }}"
       tags: services
-    - shell: ls -1 {{ service_home|quote }}
+    - shell: find {{ service_home|quote }} -type f
       register: contents
       tags: services
+      check_mode: no
+      changed_when: no
     - name: "Remove supervisor configs that are no longer needed"
       file:
-        path: "{{ service_home }}/{{ item }}"
+        path: "{{ item }}"
         state: absent
-      with_items: contents.stdout_lines
+      with_items: "{{ contents.stdout_lines }}"
       when: item not in supervisor_files
       tags: services
 

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/celery.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/celery.yml
@@ -47,15 +47,6 @@
     - services
   register: celery_sms_files
 
-- name: define errand boy services
-  become: cchq
-  template:
-    src: "../templates/supervisor_errand_boy.conf"
-    dest: "{{ service_home }}/{{ deploy_env }}_supervisor_errand_boy.conf"
-  tags:
-    - services
-  register: celery_errand_boy_files
-
 - name: Add celery_bash_runner files
   template:
     src: "../templates/celery_bash_runner.sh.j2"
@@ -68,34 +59,25 @@
     - services
   register: celery_bash_runner_files
 
-- name: define celery_flower services
+- name: define speical celery services
   become: cchq
   template:
-    src: "../templates/supervisor_celery_flower.conf.j2"
-    dest: "{{ service_home }}/{{ deploy_env }}_supervisor_celery_flower.conf"
-  when: app_processes_config.celery_processes.get(inventory_hostname).flower is defined
+    src: "{{ item.template }}"
+    dest: "{{ service_home }}/{{ deploy_env }}_{{ item.file_name }}"
+  when: item.should_apply
+  with_items:
+    - template: ../templates/supervisor_celery_flower.conf.j2
+      file_name: supervisor_celery_flower.conf
+      should_apply: "{{ app_processes_config.celery_processes.get(inventory_hostname).flower is defined }}"
+    - template: ../templates/supervisor_celery_beat.conf.j2
+      file_name: supervisor_celery_beat.conf
+      should_apply: "{{ app_processes_config.celery_processes.get(inventory_hostname).beat is defined }}"
+    - template: ../templates/supervisor_errand_boy.conf
+      file_name: supervisor_errand_boy.conf
+      should_apply: yes
   tags:
     - services
-  register: celery_flower_files
-
-- name: define celery beat service
-  become: cchq
-  template:
-    src: "../templates/supervisor_celery_beat.conf.j2"
-    dest: "{{ service_home }}/{{ deploy_env }}_supervisor_celery_beat.conf"
-  when: app_processes_config.celery_processes.get(inventory_hostname).beat is defined
-  tags:
-    - services
-  register: celery_beat_files
-
-- name: remove celery beat service
-  become: cchq
-  file:
-    path: "{{ service_home }}/{{ deploy_env }}_supervisor_celery_beat.conf"
-    state: absent
-  when: app_processes_config.celery_processes.get(inventory_hostname).beat is not defined
-  tags:
-    - services
+  register: celery_special_service_files
 
 - name: define celery workers
   become: cchq
@@ -114,7 +96,11 @@
   register: celery_worker_files
 
 - set_fact:
-    celery_supervisor_files: "{{ celery_reminder_queue_files.get('results', []) + celery_submission_reprocessing_files.get('results', []) + celery_sms_files.get('results', []) + celery_errand_boy_files.get('results', []) }} + celery_bash_runner_files.get('results', []) + celery_flower_files.get('results', []) + celery_beat_files.get('results', []) + celery_worker_files.get('results', [])"
+    celery_supervisor_files: "{{ celery_reminder_queue_files.get('results', []) + celery_submission_reprocessing_files.get('results', []) + celery_sms_files.get('results', []) + celery_bash_runner_files.get('results', []) + celery_special_service_files.get('results', []) + celery_worker_files.get('results', []) }}"
+  tags:
+    - services
 
 - set_fact:
     celery_managed_files: "{{ celery_supervisor_files|selectattr('dest', 'string')|map(attribute='dest')|list + celery_supervisor_files|selectattr('path', 'string')|map(attribute='path')|select|list }}"
+  tags:
+    - services

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/celery.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/celery.yml
@@ -8,9 +8,6 @@
     dest: "{{ service_home }}/{{ deploy_env }}_{{ item.dest_name }}"
   when: app_processes_config.celery_processes.get(inventory_hostname).reminder_queue is defined
   with_items:
-    - dest_name: supervisor_reminder_queue.conf
-      process_name: reminder_queue
-      management_command: run_reminder_queue
     - dest_name: supervisor_queue_schedule_instances.conf
       process_name: queue_schedule_instances
       management_command: queue_schedule_instances

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/formplayer.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/formplayer.yml
@@ -15,6 +15,10 @@
 
 - set_fact:
     formplayer_supervisor_files: "{{ formplayer_files.get('results', []) }}"
+  tags:
+    - services
 
 - set_fact:
     formplayer_managed_files: "{{ formplayer_supervisor_files|selectattr('dest', 'string')|map(attribute='dest')|list }}"
+  tags:
+    - services

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/pillowtop.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/pillowtop.yml
@@ -34,7 +34,11 @@
   register: pillowtop_pillow_retry_files
 
 - set_fact:
-    pillowtop_supervisor_files: "{{ pillowtop_conf_file.get('results', []) + pillowtop_form_feed_conf_file.get('results', []) }} + pillowtop_pillow_retry_files.get('results', []) "
+    pillowtop_supervisor_files: "{{ [pillowtop_conf_file] + pillowtop_form_feed_conf_file.get('results', []) + pillowtop_pillow_retry_files.get('results', []) }}"
+  tags:
+    - services
 
 - set_fact:
     pillowtop_managed_files: "{{ pillowtop_supervisor_files|selectattr('dest', 'string')|map(attribute='dest')|list + pillowtop_supervisor_files|selectattr('path', 'string')|map(attribute='path')|select|list }}"
+  tags:
+    - services

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/proxy_websockets.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/proxy_websockets.yml
@@ -8,7 +8,11 @@
   register: proxy_websocket_conf_file
 
 - set_fact:
-    proxy_supervisor_files: "{{ proxy_websocket_conf_file.get('results', []) }}"
+    proxy_supervisor_files: "{{ [proxy_websocket_conf_file] }}"
+  tags:
+    - services
 
 - set_fact:
     proxy_managed_files: "{{ proxy_supervisor_files|selectattr('dest', 'string')|map(attribute='dest')|list + proxy_supervisor_files|selectattr('path', 'string')|map(attribute='path')|select|list }}"
+  tags:
+    - services

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/webworkers.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/webworkers.yml
@@ -30,7 +30,11 @@
   register: webworker_django_worker_conf_file
 
 - set_fact:
-    webworker_supervisor_files: "{{ webworker_errand_boy_conf_file.get('results', []) }} + {{ webworker_django_worker_conf_file.get('results', []) }}"
+    webworker_supervisor_files: "{{ [webworker_errand_boy_conf_file] + webworker_django_worker_conf_file.get('results', []) }}"
+  tags:
+    - services
 
 - set_fact:
     webworker_managed_files: "{{ webworker_supervisor_files|selectattr('dest', 'string')|map(attribute='dest')|list + webworker_supervisor_files|selectattr('path', 'string')|map(attribute='path')|select|list }}"
+  tags:
+    - services


### PR DESCRIPTION
##### SUMMARY
I started out wanting to just remove the supervisor conf for running this noop management command (in a loop over and over for the last 9 months!) https://github.com/dimagi/commcare-hq/blob/d260492c9655bddde714aa5d81e507c757e596c2/corehq/apps/reminders/management/commands/run_reminder_queue.py

In the process, I realized the code for removing supervisor conf files we no longer need was very broken, and fixed that all up. I tested that on india production it doesn't remove any files except for the one I'm removing in this PR (which it does remove).

##### ENVIRONMENTS AFFECTED
all
