### PR TITLE
Retry until things come up

### DIFF
--- a/src/commcare_cloud/ansible/roles/couchdb2/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/couchdb2/tasks/main.yml
@@ -35,6 +35,10 @@
     status_code: 201, 412 # 412 means already set up (conflict)
     body: '{}'
   when: inventory_hostname == groups.couchdb2.0
+  register: result
+  until: not result.failed or 'Connection refused' not in result.msg
+  retries: 5
+  delay: 20
   with_items:
    - _users
    - _replicator
@@ -183,4 +187,7 @@
     state: monitored
   tags: monit
   ignore_errors: "{{ ansible_check_mode }}"
-
+  register: result
+  until: not result.failed or 'process not presently configured with monit' not in result.msg
+  retries: 5
+  delay: 20

--- a/src/commcare_cloud/ansible/roles/pgbouncer/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/tasks/main.yml
@@ -71,3 +71,7 @@
     state: monitored
   tags: monit
   ignore_errors: "{{ ansible_check_mode }}"
+  register: result
+  until: not result.failed or 'process not presently configured with monit' not in result.msg
+  retries: 5
+  delay: 20

--- a/src/commcare_cloud/ansible/roles/postgresql_base/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/postgresql_base/tasks/main.yml
@@ -237,3 +237,7 @@
     state: monitored
   tags: monit
   ignore_errors: "{{ ansible_check_mode }}"
+  register: result
+  until: not result.failed or 'process not presently configured with monit' not in result.msg
+  retries: 5
+  delay: 20

--- a/src/commcare_cloud/ansible/roles/postgresql_base/tasks/set_up_dbs.yml
+++ b/src/commcare_cloud/ansible/roles/postgresql_base/tasks/set_up_dbs.yml
@@ -48,6 +48,10 @@
   with_items: "{{ postgres_users.values() }}"
   tags:
     - postgres_users
+  register: result
+  until: not result.failed or 'starting up' not in result.msg
+  retries: 5
+  delay: 20
 
 - name: Add user privs
   become: yes

--- a/src/commcare_cloud/ansible/roles/redis/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/redis/tasks/main.yml
@@ -25,3 +25,7 @@
     state: monitored
   tags: monit
   ignore_errors: "{{ ansible_check_mode }}"
+  register: result
+  until: not result.failed or 'process not presently configured with monit' not in result.msg
+  retries: 5
+  delay: 20


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds retries to places where tasks were failing when certain services hadn't yet come up after the previous command.
