### PR TITLE
Increase production couch disk from 2.2TB to 2.6TB each

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -221,7 +221,7 @@ servers:
     az: "a"
     volume_size: 30
     block_device:
-      volume_size: 2200
+      volume_size: 2600
     group: "couchdb2"
     os: bionic
   - server_name: "couch11-production"
@@ -230,7 +230,7 @@ servers:
     az: "a"
     volume_size: 30
     block_device:
-      volume_size: 2200
+      volume_size: 2600
     group: "couchdb2"
     os: bionic
   - server_name: "couch12-production"
@@ -239,7 +239,7 @@ servers:
     az: "a"
     volume_size: 30
     block_device:
-      volume_size: 2200
+      volume_size: 2600
     group: "couchdb2"
     os: bionic
 


### PR DESCRIPTION
##### SUMMARY

Increase production couch disk from 2.2TB to 2.6TB each to be able to handle this fluctuation
https://app.datadoghq.com/dashboard/nbz-bie-nip/host-groups?screenId=nbz-bie-nip&screenName=host-groups&abstraction_level=1&aggregate_up=false&display_timeline=false&from_ts=1560648932649&is_auto=false&live=false&page=0&per_page=30&tile_size=m&to_ts=1560789235000&tpl_var_environment=production&tpl_var_host=*&tpl_var_host_group=couchdb2&use_date_happened=true&fullscreen_widget=1935918389490078&fullscreen_section=overview
at under 80% disk usage

##### ENVIRONMENTS AFFECTED
production

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
couchdb

##### ADDITIONAL INFORMATION

Overall terraform changes (though I will apply with care so as to only have one machine down at a time):
```
Terraform will perform the following actions:

  ~ module.server__couch10-production.aws_ebs_volume.ebs_volume
      size:                               "2200" => "2600"

  ~ module.server__couch11-production.aws_ebs_volume.ebs_volume
      size:                               "2200" => "2600"

  ~ module.server__couch12-production.aws_ebs_volume.ebs_volume
      size:                               "2200" => "2600"
```