### PR TITLE
Don't change nginx pid location to the same file

### DIFF
--- a/src/commcare_cloud/ansible/roles/nginx/templates/nginx.conf.j2
+++ b/src/commcare_cloud/ansible/roles/nginx/templates/nginx.conf.j2
@@ -1,7 +1,7 @@
 # {{ ansible_managed }}
 user {{ nginx_user }};
 worker_processes  {{ ansible_processor_count }};
-pid        /var/run/nginx.pid;
+pid /run/nginx.pid;
 
 worker_rlimit_nofile {{ nginx_worker_rlimit_nofile }};
 


### PR DESCRIPTION
The default location for this pid file is /run/nginx.pid
/var/run is symlinked to /run on Ubuntu.

When running the whole install playbook, we run into this bug since when nginx
is installed it has the pid file set as /run/nginx.pid;
https://trac.nginx.org/nginx/ticket/796

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
If the `deploy-proxy` playbook is run on environments where nginx is already existing, reloading nginx might fail after this change. `service nginx stop` and `service nginx start` is required to be run. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All