### PR TITLE
Update production terraform.yml to final couchdb cluster state

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -160,87 +160,13 @@ servers:
     group: "couchdb2_proxy"
     os: trusty
 
-  - server_name: "couch3-production"
-    server_instance_type: c5.4xlarge
-    network_tier: "db-private"
-    az: "a"
-    volume_size: 80
-    block_device:
-      volume_size: 6938
-    group: "couchdb2"
-    os: trusty
-  - server_name: "couch4-production"
-    server_instance_type: c5.4xlarge
-    network_tier: "db-private"
-    az: "a"
-    volume_size: 80
-    block_device:
-      volume_size: 6769
-    group: "couchdb2"
-    os: trusty
-  - server_name: "couch5-production"
-    server_instance_type: c5.4xlarge
-    network_tier: "db-private"
-    az: "a"
-    volume_size: 80
-    block_device:
-      volume_size: 7023
-    group: "couchdb2"
-    os: trusty
-  - server_name: "couch7-production"
-    server_instance_type: c5.4xlarge
-    network_tier: "db-private"
-    az: "a"
-    volume_size: 80
-    block_device:
-      volume_size: 7226
-    group: "couchdb2"
-    os: trusty
-  - server_name: "couch8-production"
-    server_instance_type: c5.4xlarge
-    network_tier: "db-private"
-    az: "a"
-    volume_size: 80
-    block_device:
-      volume_size: 7674
-    group: "couchdb2"
-    os: trusty
-  - server_name: "couch9-production"
-    server_instance_type: c5.4xlarge
-    network_tier: "db-private"
-    az: "a"
-    volume_size: 80
-    block_device:
-      volume_size: 7531
-    group: "couchdb2"
-    os: trusty
-
-  - server_name: "couch10-production"
-    server_instance_type: c5.9xlarge
-    network_tier: "db-private"
-    az: "a"
-    volume_size: 30
-    block_device:
-      volume_size: 2600
-    group: "couchdb2"
-    os: bionic
-  - server_name: "couch11-production"
-    server_instance_type: c5.9xlarge
-    network_tier: "db-private"
-    az: "a"
-    volume_size: 30
-    block_device:
-      volume_size: 2600
-    group: "couchdb2"
-    os: bionic
-
   - server_name: "couch12-production"
     server_instance_type: c5.9xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 30
     block_device:
-      volume_size: 3000
+      volume_size: 4000
     group: "couchdb2"
     os: bionic
   - server_name: "couch13-production"
@@ -249,7 +175,7 @@ servers:
     az: "a"
     volume_size: 30
     block_device:
-      volume_size: 3000
+      volume_size: 4000
     group: "couchdb2"
     os: bionic
   - server_name: "couch14-production"
@@ -258,7 +184,7 @@ servers:
     az: "a"
     volume_size: 30
     block_device:
-      volume_size: 3000
+      volume_size: 4000
     group: "couchdb2"
     os: bionic
   - server_name: "couch15-production"
@@ -267,7 +193,7 @@ servers:
     az: "a"
     volume_size: 30
     block_device:
-      volume_size: 3000
+      volume_size: 4000
     group: "couchdb2"
     os: bionic
 


### PR DESCRIPTION
##### SUMMARY

This reflects changes I made manually in the AWS console to the production couch cluster:

- remove old Trusty nodes `couch{3,4,5,7,8,9}` (were already stopped)
- remove broken Bionic nodes `couch{10,11}` (were already stopped)
- increase disk from 3T to 4T on `couch{12,13,14,15}`

Note that couch15 is currently "part of the couchdb cluster" but has no shards assigned to it and thus doesn't serve any reads or receive any writes. It is an extra free node we created during firefighting yesterday to test operations on and provide some slack in case of the unknown, but I will likely remove on Monday if there are no further issues.

##### ENVIRONMENTS AFFECTED
production
