### PR TITLE
Update deploy documentation

### DIFF
--- a/docs/commcare-cloud/deploy.md
+++ b/docs/commcare-cloud/deploy.md
@@ -1,72 +1,91 @@
 # Deploying CommCare HQ code changes
 
-1. Update your commcare-cloud environment to make sure it's on the latest version of commcare-cloud
-```
+This document will walk you through the process of updating the CommCareHQ code on your server using `commcare-cloud`.
+
+## Prerequisites
+
+Ensure that you have a working version of `commcare-cloud` which is configured to act on your monolith or fleet of servers. You can find more information on setting up `commcare-cloud` in the [installing `commcare-cloud`](../setup/installation.md) documentation. 
+
+If you don't yet have a server with CommCareHQ, you can try [setting up a monolith](../setup/new_environment.md). 
+
+All commands listed here will be run from your control machine which has `commcare-cloud` installed.
+
+## Step 1: Update `commcare-cloud`
+
+We first want to pull the latest code for `commcare-cloud` to make sure it has the latest bugfixes by running:
+
+``` bash
 $ update-code
 ```
-2. Connect to the VPN (if applicable)
-1. Use commcare-cloud to deploy the environment
 
+This command will update the `commcare-cloud` command from GitHub and apply any updates required. You can see exactly what this command does in [this file](https://github.com/dimagi/commcare-cloud/blob/master/control/update_code.sh).
+
+## Step 2: Deploy new CommCareHQ code to all machines
+
+CommCareHQ is deployed using [`fabric`](http://www.fabfile.org/), which ensures only the necessary code is deployed to each machine.
+
+Envoke the `deploy` command by running:
+
+``` bash
+$ commcare-cloud <env> fab deploy
 ```
-$ cchq <env> fab deploy
+where you will substitute `<env>` for the name of the environment you wish to deploy to.
 
-# or to run it from the control machine which usually makes it faster
-$ cchq <env> --control fab deploy
+### Preindex Command
+
+The first step in deploy is what we call a `preindex`, which updates any CouchDB views and Elasticsearch indices. This only runs when changes need to be made, and may take a while depending on the volume of data that you have in these data stores. You may need to wait for this process to complete in order to complete deploy. 
+
+If your server has email capabilities, you can look out for an email notification with the subject: `[<env>_preindex] HQAdmin preindex_everything may or may not be complete`. This will be sent to the `SERVER_EMAIL` email address defined in the Django settings file.
+
+You can also try running:
+
+``` bash
+$ commcare-cloud <env> django-manage preindex_everything --check
 ```
 
-If you had to wait for a preindex, retry deploy when the preindex completes,
-which may be hours later. To check if preindex is complete...
+If this command exits with no output, there is still a preindex ongoing. 
 
-* You can monitor email for preindex complete notification
-(subject: *\[\<env>_preindex] HQAdmin preindex_everything may or may not be complete*).
+## Step 3: Checking services once deploy is complete
 
-* Check status at Cloudant dashboard for production (or India). You may need to be whitelisted to do so, follow Cloudant Whitelisting
-* Check on production (or India) system status pages
+Once deploy has completed successfully, the script will automatically restart each service, as required. You can check that the system is in a good state by running:
 
-4. Once deploy is complete check that the system is up and running:
+``` bash
+$ commcare-cloud <env> django-manage check_services
+```
 
-  * https://<commcare url>/hq/admin/system/
-  * https://<commcare url>/hq/admin/system/check_services
+This will provide a list of all services which are running in an unexpected state.
+
+You may also wish to monitor the following pages, which provide similar information if you are logged in to CommCareHQ as a superuser:
+
+  * `https://<commcare url>/hq/admin/system/`
+  * `https://<commcare url>/hq/admin/system/check_services`
 
 # Advanced
 
-## Run a pre-index
-When there are changes that require a reindex of some database indexes
-it is possible to do that indexing prior to the deploy so that the deploy
-goes more smoothly.
+The following commands may be useful in certain circumstances.
 
-Examples of change that woud result in a reindex are changes to a
-CouchDB view, changes to an Elasticsearch index.
+## Run a pre-index
+When there are changes that require a reindex of some database indexes it is possible to do that indexing prior to the deploy so that the deploy goes more smoothly.
+
+Examples of change that woud result in a reindex are changes to a CouchDB view, or changes to an Elasticsearch index.
 
 To perform a pre-index:
 
-```
+``` bash
 $ commcare-cloud <env> fab preindex_views
 ```
 
 ## Resume failed deploy
-If something goes wrong and the deploy fails part way through you may
-be able to resume it as follows:
-```
+If something goes wrong and the deploy fails part way through you may be able to resume it as follows:
+
+``` bash
 $ commcare-cloud <env> fab deploy:"resume=yes"
 ```
 
-## Deploy hot fix
-In rare occasions it may be necessary to deploy a quick fix
-to resolve a bug that is causing issues.
+## Roll back a failed deploy
 
-**Note:** This process
-can only be used to deploy code changes and not HTML / CSS / Database
-changes.
+You may also wish to revert to a previous version of the CommCareHQ code if the version you just deployed was not working for some reason. Before reverting, you should ensure that there were no database migrations that were run during the previous deploy that would break if you revert to a previous version.
 
-1. Create a branch from the currently deployed version
-```
-$ git checkout <deployed commit>
-$ git checkout -b hotfix_deploy
-```
-
-2. Update branch with necessary changes and push changes to public repo
-3. Deploy hotfix branch
-```
-$ commcare-cloud <env> fab hotfix_deploy --set code_branch=hotfix_deploy
+``` bash
+$ commcare-cloud <env> fab rollback
 ```


### PR DESCRIPTION
Updates the deploy documentation for clarity. 
I removed the `hotfix` instructions as I think those are internal only (no one else can push to the repo), and it is documented internally here: https://confluence.dimagi.com/display/commcarehq/Deploy+Process

I'm going to self-merge this as we need to send it externally on Monday morning, but I'd still love your feedback, and will make updates in a separate PR. 