### PR TITLE
Use default kafka log retention for icds

### DIFF
--- a/environments/icds-cas/public.yml
+++ b/environments/icds-cas/public.yml
@@ -32,7 +32,6 @@ redis_maxmemory_policy: allkeys-lru
 redis_auto_aof_rewrite_percentage: "50"
 
 kafka_log_dir: '{{ encrypted_root }}/kafka'
-kafka_log_retention: 1440 # 60 days
 
 KSPLICE_ACTIVE: no
 


### PR DESCRIPTION
##### SUMMARY
Reverts https://github.com/dimagi/commcare-cloud/pull/2216 which was only intended to be for a short time

##### ENVIRONMENTS AFFECTED
icds

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
kafka

##### ADDITIONAL INFORMATION
This should result in roughly half disk space being used.

This does require brief downtime to change because it requires a kafka restart, though I am going to investigate using replicas so that it would not require dowtime