### PR TITLE
Change note about online kafka migration

### DIFF
--- a/docs/services/kafka.md
+++ b/docs/services/kafka.md
@@ -55,8 +55,7 @@ $ ./kafka-topics.sh --alter --zookeeper=<zookeeper host>:2181 --topic <topci> --
 Pillowtop process configurations as described in the [CommCare docs](https://commcare-hq.readthedocs.io/pillows.html#parallel-processors).
 
 ### Move partitions
-**NOTE**: All processes accessing Kafka should be shutdown prior to following this process to avoid
- errors publishing or consuming Kafka messages.
+**NOTE**: This can be done while all services are online
 
 1. Create the list of topics to rebalance
 


### PR DESCRIPTION
##### SUMMARY
Note that kafka migrations can occur online

##### ENVIRONMENTS AFFECTED
none

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
kafka

##### ADDITIONAL INFORMATION
I went through http://kafka.apache.org/082/documentation.html#basic_ops_cluster_expansion a few times to verify that this is the case and I've since rebalanced all of our topics (in batches) across all kafka servers while services were online and no errors came up