### PR TITLE
Compact production CouchDB more aggressively

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -55,6 +55,10 @@ couchdb2:
   username: "{{ localsettings_private.COUCH_USERNAME }}"
   password: "{{ localsettings_private.COUCH_PASSWORD }}"
 
+couchdb_compaction_settings:
+  _default: '[{db_fragmentation, "6%"}, {view_fragmentation, "6%"}, {from, "17:00"}, {to, "22:30"}]'
+
+
 couchdb2_client_max_body_size: 100M
 
 couchdb_reduce_limit: False

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -56,7 +56,7 @@ couchdb2:
   password: "{{ localsettings_private.COUCH_PASSWORD }}"
 
 couchdb_compaction_settings:
-  _default: '[{db_fragmentation, "6%"}, {view_fragmentation, "6%"}, {from, "17:00"}, {to, "22:30"}]'
+  _default: '[{db_fragmentation, "6%"}, {view_fragmentation, "6%"}, {from, "17:00"}, {to, "5:00"}]'
 
 
 couchdb2_client_max_body_size: 100M

--- a/src/commcare_cloud/ansible/roles/couchdb2/vars/main.yml
+++ b/src/commcare_cloud/ansible/roles/couchdb2/vars/main.yml
@@ -21,3 +21,4 @@ couchdb_async_io_threads: 64
 
 couchdb_require_valid_user: false
 couchdb_require_valid_user_node_local: false
+couchdb_httpd_auth_secret: "{{ couchdb2.password|hash('sha256') }}"


### PR DESCRIPTION
##### SUMMARY
Extend the time window during which compaction can happen from 1pm-5:30pm ET to 1pm-1am. In addition, compact at a lower fragmentation threshold. This will allow us to stay at an overall disk usage in steady state.

##### ENVIRONMENTS AFFECTED
production
