### PR TITLE
Default GITHUB_APIKEY=None

### DIFF
--- a/docs/setup/new_environment.md
+++ b/docs/setup/new_environment.md
@@ -218,13 +218,6 @@ $ commcare-cloud monolith deploy-stack --skip-check -e 'CCHQ_IS_FRESH_INSTALL=1'
     $ cp ~/commcare-cloud/src/commcare_cloud/fab/config.example.py ~/commcare-cloud/src/commcare_cloud/fab/config.py
     ```
 
-2. Edit this file
-
-    ``` bash
-    $ nano ~/commcare-cloud/src/commcare_cloud/fab/config.py
-    ```
-    Enter `None` for the GitHub API key, it is not needed for locally hosted deploys.
-
 ## Step 8: Deploy CommCare HQ
 
 Deploying CommcareHQ for the first time needs a few things enabled first.

--- a/src/commcare_cloud/fab/config.example.py
+++ b/src/commcare_cloud/fab/config.example.py
@@ -1,6 +1,4 @@
 # To generate a Github apikey follow these instructions: https://github.com/blog/1509-personal-api-tokens
 # Minimally you will need a key with repo -> public_repo
 
-# If you do not have write access to the repo then set this to `None`. This will disable the creation of release
-# tags.
-GITHUB_APIKEY = ''
+GITHUB_APIKEY = None


### PR DESCRIPTION
Makes local setup a bit easier. @proteusvacuum @dannyroberts Does this seem like a reasonable default?