### PR TITLE
Ansible cron module now requires user

### DIFF
--- a/src/commcare_cloud/ansible/letsencrypt_cert.yml
+++ b/src/commcare_cloud/ansible/letsencrypt_cert.yml
@@ -57,6 +57,7 @@
     - name: Remove default certbot cron
       cron:
         cron_file: certbot
+        user: root
         state: absent
 
     - name: Add custom_certbot cron
@@ -72,4 +73,5 @@
     - name: Remove "Reload Nginx to reread SSL" cron job
       cron:
         state: absent
+        user: root
         cron_file: nginx_ssl_reread


### PR DESCRIPTION
##### SUMMARY
This fixes this letsencrypt ansible playbook for new versions of ansible
