### PR TITLE
Add http referer to nginx timing logs

### DIFF
--- a/src/commcare_cloud/ansible/roles/nginx/templates/nginx.conf.j2
+++ b/src/commcare_cloud/ansible/roles/nginx/templates/nginx.conf.j2
@@ -18,7 +18,7 @@ http {
         access_log /var/log/{{ nginx_access_log_name }};
         error_log /var/log/{{ nginx_error_log_name }} warn;
 
-        log_format timing '[$time_local] $upstream_cache_status $request $status $request_time';
+        log_format timing '[$time_local] $upstream_cache_status $request $status $request_time $http_referer';
         log_format rt_cache '$remote_addr - $remote_user - $upstream_cache_status - [$time_local] '
                     '"$request" $status $request_length $body_bytes_sent '
                     '"$http_referer" "$http_user_agent"';


### PR DESCRIPTION
##### SUMMARY
Add http referer to nginx timing logs

##### ENVIRONMENTS AFFECTED
all

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
proxy

##### ADDITIONAL INFORMATION
We include this in the rt_cache logs already, but our datadog parser currently only parses the timing logs.

Companion to https://github.com/dimagi/datadog-parsers/pull/33