### PR TITLE
assign more webworkers to mobile

### DIFF
--- a/environments/icds-cas/inventory/commcare.csv
+++ b/environments/icds-cas/inventory/commcare.csv
@@ -40,10 +40,10 @@ web0,100.71.188.44,webworkers,celery,shared_dir_host,hq_webworkers,MUMGCCWCDPRDW
 web1,100.71.188.15,webworkers,celery,django_manage,hq_webworkers,MUMGCCWCDPRDW001
 web2,100.71.188.41,webworkers,celery,hq_webworkers,,MUMGCCWCDPRDW002
 web3,100.71.188.47,webworkers,celery,hq_webworkers,,MUMGCCWCDPRDW003
-web4,100.71.188.46,webworkers,celery,hq_webworkers,,MUMGCCWCDPRDW004
-web5,100.71.188.35,webworkers,celery,hq_webworkers,,MUMGCCWCDPRDW005
-web6,100.71.188.40,webworkers,celery,hq_webworkers,,MUMGCCWCDPRDW006
-web7,100.71.188.36,webworkers,celery,hq_webworkers,,MUMGCCWCDPRDW007
+web4,100.71.188.46,webworkers,celery,mobile_webworkers,,MUMGCCWCDPRDW004
+web5,100.71.188.35,webworkers,celery,mobile_webworkers,,MUMGCCWCDPRDW005
+web6,100.71.188.40,webworkers,celery,mobile_webworkers,,MUMGCCWCDPRDW006
+web7,100.71.188.36,webworkers,celery,mobile_webworkers,,MUMGCCWCDPRDW007
 web8,100.71.188.49,webworkers,celery,mobile_webworkers,,MUMGCCWCDPRDW008
 web9,100.71.188.45,webworkers,celery,mobile_webworkers,,MUMGCCWCDPRDW009
 web10,100.71.188.52,webworkers,celery,mobile_webworkers,,MUMGCCWCDPRDW010


### PR DESCRIPTION
##### SUMMARY
Convert half of the `hq_webworkers` to `mobile_webworkers`

##### ENVIRONMENTS AFFECTED
`icds`

##### ADDITIONAL INFORMATION
Based on metrics from the last day the `hq_webworkers` usage stays below 10% while the `mobile_webworkers` is up at 80-90%:

![image](https://user-images.githubusercontent.com/249606/60706876-bc59c580-9f0a-11e9-9516-17be3f8c31d1.png)
