### PR TITLE
Revert "Increase production celery resources for async_restore_queue"

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -197,7 +197,7 @@ servers:
     os: trusty
 
   - server_name: "celery0-production"
-    server_instance_type: m5.4xlarge
+    server_instance_type: t3.2xlarge
     network_tier: "app-private"
     az: "c"
     volume_size: 150
@@ -211,14 +211,14 @@ servers:
     group: "celery"
     os: trusty
   - server_name: "celery2-production"
-    server_instance_type: m5.4xlarge
+    server_instance_type: t3.2xlarge
     network_tier: "app-private"
     az: "c"
     volume_size: 150
     group: "celery"
     os: trusty
   - server_name: "celery3-production"
-    server_instance_type: m5.4xlarge
+    server_instance_type: t3.2xlarge
     network_tier: "app-private"
     az: "c"
     volume_size: 150


### PR DESCRIPTION
Reverts dimagi/commcare-cloud#2898

I'll roll this out once I get the go ahead from @esoergel (or else close in favor of something else).

The three machines `celery{0,2,3}-production` haven't had memory peaks since I think Jun 12: https://app.datadoghq.com/dashboard/nbz-bie-nip/host-groups?abstraction_level=1&aggregate_up=false&display_timeline=false&from_ts=1557154920000&is_auto=false&live=false&page=0&per_page=30&tile_size=m&to_ts=1562338920000&tpl_var_environment=production&tpl_var_host_group=celery&use_date_happened=true&fullscreen_widget=3806476073669242&fullscreen_section=overview