### PR TITLE
set umask to 022

### DIFF
--- a/src/commcare_cloud/ansible/roles/common/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/common/tasks/main.yml
@@ -132,6 +132,17 @@
   tags:
     - postfix
 
+
+- name: Set proper umask
+  lineinfile:
+    dest: /etc/login.defs
+    state: present
+    regexp: "^UMASK"
+    line: "UMASK\t\t022"
+  tags:
+    - umask
+
+
 - import_tasks: antivirus.yml
   tags:
     - antivirus


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
UMASK determines the default file permissions. New ICDS machines were being setup with stricter default permissions which was breaking deploy. This sets them back to debian defaults