### PR TITLE
remove ddtrace from prod webworkers until it is upgraded

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -1,7 +1,7 @@
 newrelic_djangoagent: False
 newrelic_javaagent: True
 datadog_pythonagent: True
-django_command_prefix: '{{ virtualenv_home }}/bin/ddtrace-run '
+django_command_prefix: ''
 celery_command_prefix: ''
 gunicorn_workers_static_factor: 0
 gunicorn_workers_factor: 2


### PR DESCRIPTION
We're running into this issue when running prod webworkers in python 3:
https://github.com/DataDog/dd-trace-py/issues/373#issuecomment-485607536