### PR TITLE
reduce factor to 1

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -4,7 +4,7 @@ datadog_pythonagent: True
 django_command_prefix: ''
 celery_command_prefix: ''
 gunicorn_workers_static_factor: 0
-gunicorn_workers_factor: 2
+gunicorn_workers_factor: 1
 celery_processes:
   celery0:
     submission_reprocessing_queue:


### PR DESCRIPTION
##### SUMMARY
High CPU usage was noted for webworkers, [choking to 100% at all times](https://app.datadoghq.com/dashboard/g9s-pw6-tpg/hq-vitals?from_ts=1562911302662&fullscreen_section=overview&fullscreen_widget=379741435&live=true&tile_size=m&to_ts=1562925702662).
A quick fix was to reduce the concurrency to half.

##### ENVIRONMENTS AFFECTED
production

##### ISSUE TYPE
- Change Pull Request

This was deployed


##### ADDITIONAL INFORMATION
This looks related to python3 migration since the CPU has been high for last 2-3 days that coincides with the migration. A better change might be to add more CPUs.