### PR TITLE
Remove ddtrace app from production LOCAL_APPS for webworkers

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -11,8 +11,7 @@ DATADOG_TRACE:
   TAGS:
     env: production
 
-LOCAL_APPS:
-  - {name: 'ddtrace.contrib.django', host: webworkers}
+LOCAL_APPS: []
 
 elasticsearch_endpoint: '{{ groups.elasticsearch.0 }}'
 elasticsearch_cluster_name: 'prodhqes-1.x'


### PR DESCRIPTION
##### SUMMARY
Because of https://github.com/dimagi/commcare-cloud/pull/2930 and https://github.com/dimagi/commcare-cloud/pull/3018, hq_webworkers have been running with the ddtrace django app but without being run by `run-ddtrace`. I think you need both for ddtrace to be effective.

There's some small chance in my mind that running without run-ddtrace but with the ddtrace django app causes some kind of issue under load resulting in what we saw earlier today—because we were seeing high CPU only on hq_webworkers—but I'm not that hopeful, seems not that likely.

##### ENVIRONMENTS AFFECTED
production


To roll out
- [ ]  cchq production update-config
- [ ]  deploy or run cchq production fab restart_webworkers