### PR TITLE
ignore inventory limits when getting hosts

### DIFF
--- a/src/commcare_cloud/environment/main.py
+++ b/src/commcare_cloud/environment/main.py
@@ -310,7 +310,7 @@ class Environment(object):
         return get_variable_manager(self._ansible_inventory_data_loader, self.inventory_manager)
 
     def get_host_vars(self, host):
-        host_object, = [h for h in self.inventory_manager.get_hosts() if h.name == host]
+        host_object, = [h for h in self.inventory_manager.get_hosts(ignore_limits=True) if h.name == host]
         return self._ansible_inventory_variable_manager.get_vars(host=host_object)
 
     @memoized_property
@@ -347,10 +347,10 @@ class Environment(object):
         # use the ip address specified by ansible_host to ssh in if it's given
         ssh_addr_map = {
             host.name: var_manager.get_vars(host=host).get('ansible_host', host.name)
-            for host in inventory.get_hosts()}
+            for host in inventory.get_hosts(ignore_limits=True)}
         # use the port specified by ansible_port to ssh in if it's given
         port_map = {host.name: var_manager.get_vars(host=host).get('ansible_port')
-                    for host in inventory.get_hosts()}
+                    for host in inventory.get_hosts(ignore_limits=True)}
         return {group: [
             self.format_sshable_host(ssh_addr_map[host], port_map[host])
             for host in hosts

--- a/src/commcare_cloud/environment/schemas/app_processes.py
+++ b/src/commcare_cloud/environment/schemas/app_processes.py
@@ -152,11 +152,11 @@ def validate_app_processes_config(app_processes_config):
 
 def _validate_all_required_machines_mentioned(environment, translated_app_process_config):
     inventory = environment.inventory_manager
-    for host in inventory.groups['pillowtop'].get_hosts():
+    for host in inventory.groups['pillowtop'].get_hosts(ignore_limits=True):
         assert host.get_name() in translated_app_process_config.pillows, \
             "pillowtop machine {} not in {}".format(host.get_name(), environment.paths.app_processes_yml)
 
-    for host in inventory.groups['celery'].get_hosts():
+    for host in inventory.groups['celery'].get_hosts(ignore_limits=True):
         assert host.get_name() in translated_app_process_config.celery_processes, \
             "celery machine {} not in {}".format(host.get_name(), environment.paths.app_processes_yml)
 

--- a/src/commcare_cloud/environment/schemas/app_processes.py
+++ b/src/commcare_cloud/environment/schemas/app_processes.py
@@ -152,11 +152,11 @@ def validate_app_processes_config(app_processes_config):
 
 def _validate_all_required_machines_mentioned(environment, translated_app_process_config):
     inventory = environment.inventory_manager
-    for host in inventory.groups['pillowtop'].get_hosts(ignore_limits=True):
+    for host in inventory.groups['pillowtop'].get_hosts():
         assert host.get_name() in translated_app_process_config.pillows, \
             "pillowtop machine {} not in {}".format(host.get_name(), environment.paths.app_processes_yml)
 
-    for host in inventory.groups['celery'].get_hosts(ignore_limits=True):
+    for host in inventory.groups['celery'].get_hosts():
         assert host.get_name() in translated_app_process_config.celery_processes, \
             "celery machine {} not in {}".format(host.get_name(), environment.paths.app_processes_yml)
 


### PR DESCRIPTION
Some commands apply limits to the inventory before calling
other commands. This change ignores those limits in places
that expect all hosts to be returned from the inventory.
