### PR TITLE
do not reuse celery workers for agg

### DIFF
--- a/environments/icds-cas/app-processes.yml
+++ b/environments/icds-cas/app-processes.yml
@@ -29,6 +29,7 @@ celery_processes:
       concurrency: 6
     icds_aggregation_queue:
       concurrency: 20
+      max_tasks_per_child: 1
     case_rule_queue:
       concurrency: 2
     sumologic_logs_queue:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I think the thread_local we are using to override db settings is persisting across tasks that share workers. This will ensure that each task gets a fresh worker. The added overheaded of spinning up a new worker should be insignificant given how long each task runs.