### PR TITLE
Limit based on mobile header for synclogs

### DIFF
--- a/src/commcare_cloud/ansible/roles/nginx/templates/site.j2
+++ b/src/commcare_cloud/ansible/roles/nginx/templates/site.j2
@@ -20,8 +20,10 @@ upstream {{ balancer.name }} {
 
 {% for var_map in item.server.get('mappings', []) %}
 map {{ var_map.variable }} {{ var_map.name }} {
-  ""     {{ var_map.value }};
-  default     "";
+  {% for map_value in var_map.var_mappings %}
+  {{ map_value.key}}     {{ map_value.value }};
+  {% endfor %}
+  default     {{ var_map.default_value}};
 }
 {% endfor %}
 

--- a/src/commcare_cloud/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/cas_ssl.yml
@@ -13,15 +13,21 @@ nginx_sites:
       port: "{{ formplayer_port }}"
       method: "hash $cookie_sessionid consistent"
    mappings:
-    - name: "$fresh_sync"
+    - name: "$sync_update"
       variable: "$http_x_commcarehq_lastsynctoken"
+      # If header is provided, rate limit on $server_name
       default_value: "$server_name"
       var_mappings:
+        # If the header is not provided, do not rate limit
         - key: '""'
           value: '""'
    limit_req_zones:
-    - name: "restore"
-      zone: "$fresh_sync"
+    - name: "restore" # Limits restores that are not new device or 412s
+      zone: "$sync_update"
+      size: "10m"
+      rate: "1r/s"
+    - name: "overall_restore" # Limits all restores
+      zone: "$server_name"
       size: "10m"
       rate: "15r/s"
     - name: "submissions"
@@ -93,7 +99,10 @@ nginx_sites:
        proxy_read_timeout: 900s
        limit_reqs:
          - zone_name: "restore"
-           burst: 100
+           burst: 50
+           nodelay: True
+         - zone_name: "overall_restore"
+           burst: 50
            nodelay: True
      - name: "/a/icds-cas/receiver"
        balancer: "{{ deploy_env }}_cas_commcare"

--- a/src/commcare_cloud/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/cas_ssl.yml
@@ -12,9 +12,13 @@ nginx_sites:
       hosts: formplayer
       port: "{{ formplayer_port }}"
       method: "hash $cookie_sessionid consistent"
+   mappings:
+    - name: "$fresh_sync"
+      variable: "$http_x_commcarehq_lastsynctoken"
+      value: "$server_name"
    limit_req_zones:
     - name: "restore"
-      zone: "$server_name"
+      zone: "$fresh_sync"
       size: "10m"
       rate: "15r/s"
     - name: "submissions"

--- a/src/commcare_cloud/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/cas_ssl.yml
@@ -99,7 +99,7 @@ nginx_sites:
        proxy_read_timeout: 900s
        limit_reqs:
          - zone_name: "restore"
-           burst: 50
+           burst: 10
            nodelay: True
          - zone_name: "overall_restore"
            burst: 50

--- a/src/commcare_cloud/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/cas_ssl.yml
@@ -33,7 +33,7 @@ nginx_sites:
     - name: "submissions"
       zone: "$server_name"
       size: "10m"
-      rate: "200r/s"
+      rate: "110r/s"
     - name: "server_name"
       zone: "$server_name"
       size: "10m"

--- a/src/commcare_cloud/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/cas_ssl.yml
@@ -15,7 +15,10 @@ nginx_sites:
    mappings:
     - name: "$fresh_sync"
       variable: "$http_x_commcarehq_lastsynctoken"
-      value: "$server_name"
+      default_value: "$server_name"
+      var_mappings:
+        - key: '""'
+          value: '""'
    limit_req_zones:
     - name: "restore"
       zone: "$fresh_sync"


### PR DESCRIPTION
##### SUMMARY
Allow first time syncs to pass through without rate limits

##### ENVIRONMENTS AFFECTED
icds

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
nginx

##### ADDITIONAL INFORMATION
based off my previous work here: https://github.com/dimagi/commcare-cloud/pull/953

As currently implemented it would not rate limit when `X-CommCareHQ-LastSyncToken` is not passed. If the header exists, it falls back to rate limiting based on `$server_name`