### PR TITLE
Better prioritization of non-incremental syncs

### DIFF
--- a/src/commcare_cloud/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/cas_ssl.yml
@@ -99,7 +99,7 @@ nginx_sites:
        proxy_read_timeout: 900s
        limit_reqs:
          - zone_name: "incremental_restore"
-           burst: 0
+           burst: 10
            nodelay: True
          - zone_name: "overall_restore"
            burst: 100

--- a/src/commcare_cloud/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/cas_ssl.yml
@@ -25,7 +25,7 @@ nginx_sites:
     - name: "restore" # Limits restores that are not new device or 412s
       zone: "$sync_update"
       size: "10m"
-      rate: "1r/s"
+      rate: "15r/s"
     - name: "overall_restore" # Limits all restores
       zone: "$server_name"
       size: "10m"
@@ -99,10 +99,10 @@ nginx_sites:
        proxy_read_timeout: 900s
        limit_reqs:
          - zone_name: "restore"
-           burst: 10
+           burst: 0
            nodelay: True
          - zone_name: "overall_restore"
-           burst: 50
+           burst: 100
            nodelay: True
      - name: "/a/icds-cas/receiver"
        balancer: "{{ deploy_env }}_cas_commcare"

--- a/src/commcare_cloud/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/cas_ssl.yml
@@ -13,7 +13,7 @@ nginx_sites:
       port: "{{ formplayer_port }}"
       method: "hash $cookie_sessionid consistent"
    mappings:
-    - name: "$sync_update"
+    - name: "$incremental_sync"
       variable: "$http_x_commcarehq_lastsynctoken"
       # If header is provided, rate limit on $server_name
       default_value: "$server_name"
@@ -22,8 +22,8 @@ nginx_sites:
         - key: '""'
           value: '""'
    limit_req_zones:
-    - name: "restore" # Limits restores that are not new device or 412s
-      zone: "$sync_update"
+    - name: "incremental_restore" # Limits restores that are not new device or 412s
+      zone: "$incremental_sync"
       size: "10m"
       rate: "15r/s"
     - name: "overall_restore" # Limits all restores
@@ -98,7 +98,7 @@ nginx_sites:
        proxy_next_upstream_tries: 1
        proxy_read_timeout: 900s
        limit_reqs:
-         - zone_name: "restore"
+         - zone_name: "incremental_restore"
            burst: 0
            nodelay: True
          - zone_name: "overall_restore"


### PR DESCRIPTION
##### SUMMARY
Following up on https://github.com/dimagi/commcare-cloud/pull/3037. Spoke with @ctsims about this method

##### ENVIRONMENTS AFFECTED
icds

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
nginx

##### ADDITIONAL INFORMATION
With this PR the behavior will be:

Incremental syncs will be limited to 15 r/s with burst of 10 requests

Non-incremental syncs will be subject to 15 r/s, but have a burst of 100 requests.

To receive a 412 (if we lost the user's synclog) they must be able to get through the first rate limiting. If they get into the 412 they should be able to get into the burst of 90 requests in the non-incremental sync queue on a retry.