### PR TITLE
fix TCL hostname for synclogdb

### DIFF
--- a/environments/icds-cas/inventory/postgresql.csv
+++ b/environments/icds-cas/inventory/postgresql.csv
@@ -31,7 +31,7 @@ pgshard7standby,100.71.184.61,pg_standby,shard_dbs,MUMGCCWCDPRDSS07,,pgshard7,,s
 pgshard8standby,100.71.184.56,postgresql,shard_dbs,MUMGCCWCDPRDSS08,pgshard8,,"[""standby0"",""spare""]",
 pgshard9standby,100.71.184.59,pg_standby,shard_dbs,MUMGCCWCDPRDSS09,,pgshard9,,standby0
 plproxy0,100.71.184.18,postgresql,,MUMGCCWCDPRDPLP0,,,,
-pgsynclog0,100.71.184.41,postgresql,synclog_dbs,MUMGCCWCDPRDPSL0,,,"[""spare""]",
+pgsynclog0,100.71.184.41,postgresql,synclog_dbs,MUMGCCWCDPRDPSL1,,,"[""spare""]",
 pgwarehouse0,100.71.184.23,postgresql,,MUMGCCWCDPRDPW00,,,,
 ,,,,,,,,
 group,var,val,type,,,,,


### PR DESCRIPTION
This was introduced when we had to [swap with standby](https://github.com/dimagi/commcare-cloud/pull/3019/files). We should make sure to update TCL hostnames correctly always

@Rohit25negi 