### PR TITLE
clear password expiry

### DIFF
--- a/src/commcare_cloud/ansible/roles/bootstrap-users/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/bootstrap-users/tasks/main.yml
@@ -69,3 +69,16 @@
   template: src=sudoers.j2 dest=/etc/sudoers.d/cchq validate='visudo -cf %s' owner=root group=root mode=0440
   tags:
     - sudoers
+
+- name: check users password valid time
+  become: yes
+  shell: getent shadow "{{ item }}" | cut -d':' -f5
+  register: users_pw_valid
+  loop: "{{ dev_users.present }} + ['ansible', '{{ cchq_user }}']"
+  changed_when: False
+
+- name: clear users password valid time
+  become: yes
+  shell: chage -M -1 "{{ item['item'] }}"
+  loop: users_pw_valid.results
+  when: item.stdout is defined and item.stdout != ''


### PR DESCRIPTION
Replacement of https://github.com/dimagi/commcare-cloud/pull/3060

Ubuntu 18 defaults to 45 days validity for passwords.

