### PR TITLE
Fix after-reboot command in basics

### DIFF
--- a/docs/commcare-cloud/basics.md
+++ b/docs/commcare-cloud/basics.md
@@ -35,10 +35,10 @@ $ commcare-cloud <env> service --help
 
 ## Handling a reboot
 When a server reboots there are a number of tasks that should be run
-to ensure that the ecyprted drive is decrupted and all systems are
+to ensure that the encyprted drive is decrypted and all systems are
 brought back up.
 ```
-$ commcare-cloud <env> after-reboot --limit <inventory name or IP>
+$ commcare-cloud <env> after-reboot --limit <inventory name or IP> all
 ```
 
 ## Update CommCare HQ local settings


### PR DESCRIPTION
##### SUMMARY
Fix after-reboot command in basics. It requires an inventory group, so I left the default to `all` since there's already a `--limit` already in the command

##### ENVIRONMENTS AFFECTED
none

##### ISSUE TYPE
- Docs Pull Request
