### PR TITLE
increase pillow stop time

### DIFF
--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_pillowtop.conf.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_pillowtop.conf.j2
@@ -21,7 +21,7 @@ stderr_logfile={{ log_home }}/pillowtop-{{ pillow_name }}-{{ num_process }}.erro
 startsecs=10
 ; Need to wait for currently executing tasks to finish at shutdown.
 ; Increase this if you have very long running tasks.
-stopwaitsecs = 10
+stopwaitsecs = 120
 ; if rabbitmq is supervised, set its priority higher
 ; so it starts first
 priority=998


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Increases supervisor stop timeout for for pillows to allow current batch to finish. I was sort of guessing on this one since our timing is done in buckets and those end at "over 10s". However, this should have no effect on anything other than UCR pillows and 2 minutes seemed long enough to be safe but short enough not to cause issues, we can fine tune as appropriate.

Relevant HQ PR
https://github.com/dimagi/commcare-hq/pull/24947