### PR TITLE
fix 'bare variable' deprecation warning

### DIFF
--- a/src/commcare_cloud/ansible/deploy_commcarehq.yml
+++ b/src/commcare_cloud/ansible/deploy_commcarehq.yml
@@ -48,7 +48,7 @@
   hosts: proxy
   tasks:
     - include_tasks: roles/commcarehq/tasks/proxy_websockets.yml
-      when: run_websockets_wsgi
+      when: run_websockets_wsgi|bool
       tags: services
 
 - name: Webworker Supervisor Config

--- a/src/commcare_cloud/ansible/roles/couchdb/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/couchdb/tasks/main.yml
@@ -134,7 +134,7 @@
     owner: couchdb
     mode: 0700
     backup: yes
-  when: backup_couch
+  when: backup_couch|bool
   tags:
     - cron
     - backups
@@ -150,7 +150,7 @@
     user: couchdb
     cron_file: backup_couch
     state: absent
-  when: backup_couch
+  when: backup_couch|bool
   tags:
     - cron
     - backups
@@ -166,7 +166,7 @@
     user: couchdb
     cron_file: backup_couch
     state: absent
-  when: backup_couch
+  when: backup_couch|bool
   tags:
     - cron
     - backups
@@ -181,7 +181,7 @@
     weekday: "1,2,3,4,5,6"
     user: couchdb
     cron_file: backup_couch
-  when: backup_couch
+  when: backup_couch|bool
   tags:
     - cron
     - backups
@@ -196,7 +196,7 @@
     weekday: 0
     user: couchdb
     cron_file: backup_couch
-  when: backup_couch
+  when: backup_couch|bool
   tags:
     - cron
     - backups
@@ -210,7 +210,7 @@
   vars:
     s3_user: "couchdb"
     s3_user_home_dir: "{{ couchdb_dir }}"
-  when: couch_s3
+  when: couch_s3|bool
   tags:
     - cron
     - backups

--- a/src/commcare_cloud/ansible/roles/datadog/tasks/add_integrations.yml
+++ b/src/commcare_cloud/ansible/roles/datadog/tasks/add_integrations.yml
@@ -26,7 +26,7 @@
     dest: /etc/dd-agent/checks.d/shell.py
     sha256sum: "{{ datadog_shell_sha256sum }}"
     force: yes
-  when: datadog_integration_vmware
+  when: datadog_integration_vmware|bool
   notify: restart datadog
   tags:
     - datadog_integrations
@@ -37,7 +37,7 @@
     dest: /etc/dd-agent/checks.d/pgbouncer_custom.py
     sha256sum: "{{ datadog_pgbouncer_custom_sha256sum }}"
     force: yes
-  when: datadog_integration_pgbouncer_custom
+  when: datadog_integration_pgbouncer_custom|bool
   notify: restart datadog
   tags:
     - datadog_integrations

--- a/src/commcare_cloud/ansible/roles/ksplice/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/ksplice/tasks/main.yml
@@ -4,7 +4,7 @@
   shell: uptrack-show
   ignore_errors: yes
   register: command_result
-  when: KSPLICE_ACTIVE
+  when: KSPLICE_ACTIVE|bool
   changed_when: no
 
 - name: Download install-uptrack

--- a/src/commcare_cloud/ansible/roles/pg_backup/tasks/backup_plain.yml
+++ b/src/commcare_cloud/ansible/roles/pg_backup/tasks/backup_plain.yml
@@ -24,7 +24,7 @@
   pip:
     name: boto3
     version: 1.4.0
-  when: postgres_s3
+  when: postgres_s3|bool
 
 - name: Set up aws credentials
   become: yes
@@ -34,7 +34,7 @@
   vars:
     s3_user: "postgres"
     s3_user_home_dir: "{{ postgresql_user_home }}"
-  when: postgres_s3
+  when: postgres_s3|bool
   tags:
     - cron
     - backups
@@ -70,7 +70,7 @@
     owner: root
     mode: 0700
     backup: yes
-  when: postgres_s3
+  when: postgres_s3|bool
 
 - name: copy restore script
   become: yes
@@ -81,4 +81,4 @@
     owner: root
     mode: 0700
     backup: yes
-  when: postgres_s3
+  when: postgres_s3|bool

--- a/src/commcare_cloud/ansible/roles/rabbitmq/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/rabbitmq/tasks/main.yml
@@ -26,7 +26,7 @@
   service: name=rabbitmq-server state=started
 
 - include: config-cluster.yml
-  when: rabbitmq_create_cluster
+  when: rabbitmq_create_cluster|bool
 
 - include: config.yml
   when: not rabbitmq_create_cluster or ( ansible_fqdn == hostvars[rabbitmq_cluster_master]['ansible_fqdn'] )


### PR DESCRIPTION
[DEPRECATION WARNING]: evaluating XXX as a bare variable, this behaviour will go away and you might need to add |bool to the expression in the future.
