### PR TITLE
Add note about running django-manage commands in python 3

### DIFF
--- a/changelog/0023-upgrade-to-python-3.yml
+++ b/changelog/0023-upgrade-to-python-3.yml
@@ -31,3 +31,5 @@ update_steps: |
   ```bash
   cchq <env> fab restart_services
   ```
+  6. [Optional] To run management commands in Python 3 when using `cchq <env> django-manage`,
+  set `py3_run_deploy` in `fab-settings.yml` to `True`.

--- a/docs/changelog/0023-upgrade-to-python-3.md
+++ b/docs/changelog/0023-upgrade-to-python-3.md
@@ -40,3 +40,5 @@ cchq <env> update-supervisor-confs
 ```bash
 cchq <env> fab restart_services
 ```
+6. [Optional] To run management commands in Python 3 when using `cchq <env> django-manage`,
+set `py3_run_deploy` in `fab-settings.yml` to `True`.


### PR DESCRIPTION
##### SUMMARY
Add note about running django-manage commands in python 3

##### ENVIRONMENTS AFFECTED
none

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
changelog

##### ADDITIONAL INFORMATION
This is optional as we're already running services in python 3 when the other command is set.