### PR TITLE
set postgresql_max_standby_delay for ICDS

### DIFF
--- a/.travis/environments/travis/postgresql.yml
+++ b/.travis/environments/travis/postgresql.yml
@@ -14,7 +14,7 @@ postgres_override:
   postgresql_shared_buffers: '128MB'
   postgresql_max_stack_depth: '6MB'
   postgresql_effective_cache_size: '4GB'
-  postgresql_max_standby_delay: -1
+  postgresql_max_standby_delay: '-1'
 
 pgbouncer_override:
   pgbouncer_max_connections: 100

--- a/commcare-cloud-bootstrap/environment/postgresql.yml
+++ b/commcare-cloud-bootstrap/environment/postgresql.yml
@@ -9,7 +9,7 @@ postgres_override:
   postgresql_shared_buffers: '128MB'
   postgresql_max_stack_depth: '6MB'
   postgresql_effective_cache_size: '4GB'
-  postgresql_max_standby_delay: -1
+  postgresql_max_standby_delay: '-1'
 
 pgbouncer_override:
   pgbouncer_max_connections: 100

--- a/environments/development/postgresql.yml
+++ b/environments/development/postgresql.yml
@@ -5,7 +5,7 @@ postgres_override:
   postgresql_effective_cache_size: 4GB
   postgresql_log_directory: '{{ encrypted_root }}/pg_log'
   postgresql_max_stack_depth: 6MB
-  postgresql_max_standby_delay: -1
+  postgresql_max_standby_delay: '-1'
   postgresql_shared_buffers: 128MB
 
 dbs:

--- a/environments/enikshay-reference/postgresql.yml
+++ b/environments/enikshay-reference/postgresql.yml
@@ -9,7 +9,7 @@ postgres_override:
   postgresql_shared_buffers: '128MB'
   postgresql_max_stack_depth: '6MB'
   postgresql_effective_cache_size: '4GB'
-  postgresql_max_standby_delay: -1
+  postgresql_max_standby_delay: '-1'
 
 pgbouncer_override:
   pgbouncer_max_connections: 100

--- a/environments/icds-cas/postgresql.yml
+++ b/environments/icds-cas/postgresql.yml
@@ -37,6 +37,7 @@ pgbouncer_override:
   pgbouncer_reserve_pool: 5
 
 postgres_override:
+  postgresql_max_standby_delay: 180s
   postgresql_max_stack_depth: 6MB
   postgresql_slow_log_threshold: 1000
   postgresql_hba_entries:

--- a/src/commcare_cloud/ansible/roles/postgresql_base/defaults/main.yml
+++ b/src/commcare_cloud/ansible/roles/postgresql_base/defaults/main.yml
@@ -31,7 +31,7 @@ postgresql_work_mem: '8MB'
 postgresql_shared_buffers: '1024MB'
 postgresql_max_stack_depth: '2MB'
 postgresql_effective_cache_size: '128MB'
-postgresql_max_standby_delay: 0  # 0 means don't set in postgresql.conf (leaving default value)
+postgresql_max_standby_delay: ''  # empty means don't set in postgresql.conf (leaving default value)
 postgresql_maintenance_work_mem: '64MB'
 postgresql_checkpoint_completion_target: '0.5'
 postgresql_wal_buffers: '-1'


### PR DESCRIPTION
This will allow queries on standby nodes to last up to 3 min before being cancelled.