### PR TITLE
set blockage_thresholds

### DIFF
--- a/environments/icds-cas/app-processes.yml
+++ b/environments/icds-cas/app-processes.yml
@@ -27,6 +27,7 @@ celery_processes:
        concurrency: 4
     submission_reprocessing_queue:
        concurrency: 2
+       blockage_threshold: 7200
     email_queue:
       concurrency: 2
     reminder_rule_queue:
@@ -39,14 +40,17 @@ celery_processes:
     icds_aggregation_queue:
       concurrency: 20
       max_tasks_per_child: 1
+      blockage_threshold: 86400
     case_rule_queue:
       concurrency: 2
+      blockage_threshold: 86400
     sumologic_logs_queue:
       pooling: gevent
       concurrency: 8
   'celery1':
     ucr_queue:
       concurrency: 4
+      blockage_threshold: 7200
     reminder_case_update_queue:
       pooling: gevent
       concurrency: 5

--- a/environments/icds-cas/app-processes.yml
+++ b/environments/icds-cas/app-processes.yml
@@ -1,6 +1,12 @@
 formplayer_memory: "8000m"
 gunicorn_workers_static_factor: 4
 
+celery_heartbeat_thresholds:
+  icds_aggregation_queue: 86400
+  case_rule_queue: 86400
+  ucr_queue: 7200
+  submission_reprocessing_queue: 7200
+
 management_commands:
   celery0:
     submission_reprocessing_queue:
@@ -27,7 +33,6 @@ celery_processes:
        concurrency: 4
     submission_reprocessing_queue:
        concurrency: 2
-       blockage_threshold: 7200
     email_queue:
       concurrency: 2
     reminder_rule_queue:
@@ -40,17 +45,14 @@ celery_processes:
     icds_aggregation_queue:
       concurrency: 20
       max_tasks_per_child: 1
-      blockage_threshold: 86400
     case_rule_queue:
       concurrency: 2
-      blockage_threshold: 86400
     sumologic_logs_queue:
       pooling: gevent
       concurrency: 8
   'celery1':
     ucr_queue:
       concurrency: 4
-      blockage_threshold: 7200
     reminder_case_update_queue:
       pooling: gevent
       concurrency: 5

--- a/environments/icds-cas/app-processes.yml
+++ b/environments/icds-cas/app-processes.yml
@@ -2,7 +2,6 @@ formplayer_memory: "8000m"
 gunicorn_workers_static_factor: 4
 
 celery_heartbeat_thresholds:
-  icds_aggregation_queue: 86400
   case_rule_queue: 86400
   ucr_queue: 7200
   submission_reprocessing_queue: 7200


### PR DESCRIPTION
Customise celery blockage thresholds for ICDS.

These get used to determine celery uptime. I'd like to configure these appropriately for ICDS so that we can get some useful uptime metrics.