### PR TITLE
Airflow config; remove quotes, escape special chars

### DIFF
--- a/src/commcare_cloud/ansible/roles/airflow/templates/airflow.cfg.j2
+++ b/src/commcare_cloud/ansible/roles/airflow/templates/airflow.cfg.j2
@@ -77,7 +77,7 @@ smtp_ssl = False
 
 {% if EMAIL_PASSWORD %}
 smtp_user = {{ EMAIL_LOGIN|replace("%", "%%") }}
-{# airflow config parser treats % as special char, that needs to be escaped with %#}
+{# airflow config parser treats % as special char, that needs to be escaped with % #}
 smtp_password = {{ EMAIL_PASSWORD|replace("%", "%%") }}
 {% endif %}
 

--- a/src/commcare_cloud/ansible/roles/airflow/templates/airflow.cfg.j2
+++ b/src/commcare_cloud/ansible/roles/airflow/templates/airflow.cfg.j2
@@ -76,8 +76,9 @@ smtp_starttls = {{ localsettings.EMAIL_USE_TLS }}
 smtp_ssl = False
 
 {% if EMAIL_PASSWORD %}
-smtp_user = "{{ EMAIL_LOGIN }}"
-smtp_password = "{{ EMAIL_PASSWORD }}"
+smtp_user = {{ EMAIL_LOGIN|replace("%", "%%") }}
+{# airflow config parser treats % as special char, that needs to be escaped with %#}
+smtp_password = {{ EMAIL_PASSWORD|replace("%", "%%") }}
 {% endif %}
 
 smtp_port = {{ localsettings.EMAIL_SMTP_PORT }}


### PR DESCRIPTION
This should fix airflow's ability to send email (which I tested using airflow's send_email method). It's not clear yet whether airflow is triggering that method at all on failure, which I am investigating.

@calellowitz @snopoke 