### PR TITLE
remove max_tasks_per_child

### DIFF
--- a/environments/icds-cas/app-processes.yml
+++ b/environments/icds-cas/app-processes.yml
@@ -38,7 +38,6 @@ celery_processes:
       concurrency: 6
     icds_aggregation_queue:
       concurrency: 20
-      max_tasks_per_child: 1
     case_rule_queue:
       concurrency: 2
     sumologic_logs_queue:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Max tasks per child and high task turnover do not play nicely together. It is also no longer necessary due to https://github.com/dimagi/commcare-hq/pull/24910