### PR TITLE
Run a rexi server on every node

### DIFF
--- a/src/commcare_cloud/ansible/roles/couchdb2/templates/extras.ini.j2
+++ b/src/commcare_cloud/ansible/roles/couchdb2/templates/extras.ini.j2
@@ -1,2 +1,5 @@
 [couch_httpd_auth]
 auth_cache_size = {{ couchdb_auth_cache_size }}
+
+[rexi]
+server_per_node = true


### PR DESCRIPTION
##### SUMMARY
Removes a known performance bottleneck in Couch 2.1. Its the default behavior in 2.3

https://github.com/apache/couchdb/pull/1627


##### ENVIRONMENTS AFFECTED
icds

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
couchdb