### PR TITLE
Fewer couch nodes on ICDS

### DIFF
--- a/environments/icds-cas/inventory/couchdb2.csv
+++ b/environments/icds-cas/inventory/couchdb2.csv
@@ -2,10 +2,3 @@ hostname,host_address,group 1,group 2,group 3,var: hostname
 couch0,100.71.184.25,couchdb2,couchdb2_proxy,,MUMGCCWCDPRDCD00
 couch1,100.71.184.8,couchdb2,,,MUMGCCWCDPRDCD01
 couch2,100.71.184.9,couchdb2,,,MUMGCCWCDPRDCD02
-couch3,100.71.184.6,couchdb2,,,MUMGCCWCDPRDCD03
-couch4,100.71.184.17,couchdb2,,,MUMGCCWCDPRDCD04
-couch5,100.71.184.62,couchdb2,,,MUMGCCWCDPRDCD05
-couch6,100.71.184.54,couchdb2,,,MUMGCCWCDPRDCD06
-couch7,100.71.184.65,couchdb2,,,MUMGCCWCDPRDCD07
-couch8,100.71.184.67,couchdb2,,,MUMGCCWCDPRDCD08
-couch9,100.71.184.95,couchdb2,,,MUMGCCWCDPRDCD09

--- a/environments/icds-cas/migrations/400k_expansion/couchdb.yml
+++ b/environments/icds-cas/migrations/400k_expansion/couchdb.yml
@@ -1,3 +1,3 @@
 target_allocation:
-  - couch0,couch1,couch2,couch3,couch4,couch5,couch6,couch7,couch8,couch9:3
+  - couch0,couch1,couch2:3
 


### PR DESCRIPTION
##### SUMMARY
We're finding that a lot of the errors in the couch logs are from the RPC between couch nodes. Reducing the number of couch nodes (thus having the data more local) should reduce need for RPC calls since all requests should be able to be served by any node.

##### ENVIRONMENTS AFFECTED
icds

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
couch
