### PR TITLE
Run s3 backup checks daily on swiss

### DIFF
--- a/docs/commcare-cloud/backup.md
+++ b/docs/commcare-cloud/backup.md
@@ -46,10 +46,9 @@ variable in public.yml:
 check_s3_backups_email: backup-alerts@example.com
 ```
 
-It's your responsibility to test that you receive these emails
-when recent backups are missing in S3 and that the emails
-don't go to you spam folder before treating the absence of
-alerts as a positive signal.
+It's your responsibility to test that you receive these emails when recent backups are missing in S3 and that the emails don't go to you spam folder before treating the absence of alerts as a positive signal.
+In addition to sending an email when there's an error, it will place a file called `s3_backup_status.txt` inside the backup dir for each service.
+You can check for the presence of that file and its last modified date when looking for evidence that the backup check is running correctly.
 
 ## PostgreSQL Backups
 

--- a/docs/commcare-cloud/backup.md
+++ b/docs/commcare-cloud/backup.md
@@ -35,6 +35,22 @@ We use [`boto3`](https://boto3.amazonaws.com/v1/documentation/api/latest/index.h
 - `aws_region`: The Amazon AWS region to send data to. (Amazon S3 only - this changes the default aws-endpoint to the region-specific endpoint).
 - `aws_versioning_enabled`: (`true` or `false`) Set this to `true` if the AWS endpoint you are using automatically stores old versions of the same file (Amazon S3 does this). If this is set to `false`, files will be uploaded to your S3-compatible bucket with a date and timestamp in the filename, creating a new file each time. (Default: `true`)
 
+### Receiving email alerts if check fails
+
+There is a script that can run to check for the presence of
+recent backups uploaded to S3, and it currently supports
+blobdb, couch, and postgres. To enable it, configure the following
+variable in public.yml:
+
+```
+check_s3_backups_email: backup-alerts@example.com
+```
+
+It's your responsibility to test that you receive these emails
+when recent backups are missing in S3 and that the emails
+don't go to you spam folder before treating the absence of
+alerts as a positive signal.
+
 ## PostgreSQL Backups
 
 PostgreSQL backups are made daily and weekly. Old backups are deleted from the local system.

--- a/environments/swiss/public.yml
+++ b/environments/swiss/public.yml
@@ -77,7 +77,7 @@ report_builder_add_on_email: sales@dimagi.com
 eula_change_email: eula-notifications@dimagi.com
 contact_email: info@dimagi.com
 soft_assert_email: commcarehq-ops+soft_asserts@dimagi.com
-check_s3_backups_email: commcarehq-ops+root@dimagi.com
+check_s3_backups_email: commcarehq-ops+root@dimagi.com,httu.admin@swisstph.ch
 
 TWO_FACTOR_GATEWAY_ENABLED: True
 

--- a/environments/swiss/public.yml
+++ b/environments/swiss/public.yml
@@ -77,7 +77,7 @@ report_builder_add_on_email: sales@dimagi.com
 eula_change_email: eula-notifications@dimagi.com
 contact_email: info@dimagi.com
 soft_assert_email: commcarehq-ops+soft_asserts@dimagi.com
-
+check_s3_backups_email: commcarehq-ops+root@dimagi.com
 
 TWO_FACTOR_GATEWAY_ENABLED: True
 

--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -123,6 +123,7 @@ eula_change_email: eula-notifications@example.com
 contact_email: info@example.com
 soft_assert_email: commcarehq-ops+soft_asserts@example.com
 daily_deploy_email: null
+check_s3_backups_email: null
 
 
 AMAZON_S3_ACCESS_KEY: "{{ localsettings_private.AMAZON_S3_ACCESS_KEY | default(None) }}"

--- a/src/commcare_cloud/ansible/roles/backups/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/backups/tasks/main.yml
@@ -89,35 +89,14 @@
     - cron
     - backups
 
-- name: Copy check_s3_backup script to /usr/local/bin
-  template:
-    src: check_s3_backup.py.j2
-    dest: /usr/local/bin/check_s3_backup.py
-    mode: "u=rwx,g=rx,o=rx"
-  when: postgres_s3 or couch_s3 or blobdb_s3
-  tags:
-    - backup_checks
 
-- name: Create Daily Check Backups Cron job
+- name: Set up check_s3_backups
   become: yes
-  cron:
-    name: "Check {{ item.service }} s3 backups"
-    job: "/usr/local/bin/check_s3_backup.py {{ item.service }} > /tmp/check_s3_backup-{{ item.service }} || { echo /tmp/check_s3_backup-{{ item.service }} | mail -s 'Recent {{ item.service }} backups missing' {{ check_s3_backups_email }}; }"
-    state: "{{ 'present' if item.condition else 'absent' }}"
-    minute: 0
-    hour: "{{ nadir_hour|default(0) }}"
-    weekday: "1,2,3,4,5,6"
-    user: "{{ item.user }}"
-    cron_file: "backup_{{ item.service }}"
-  with_items:
-    - service: 'blobdb'
-      condition: "{{ check_s3_backups_email and blobdb_s3 and backup_blobdb and 'shared_dir_host' in group_names }}"
-      user: "{{ blobdb_user }}"
-    - service: 'postgres'
-      condition: "{{ check_s3_backups_email and postgres_s3 and backup_postgres and ('postgresql' in group_names or 'pg_backup' in group_names) }}"
-      user: "postgres"
-    - service: 'couch'
-      condition: "{{ check_s3_backups_email and couch_s3 and backup_couch and ('couchdb2' in group_names) }}"
-      user: "couchdb"
-  tags:
-    - backup_checks
+  import_role:
+    name: backups
+    tasks_from: set_up_check_s3_backups.yml
+  vars:
+    service: 'blobdb'
+    condition: "{{ check_s3_backups_email and blobdb_s3 and backup_blobdb and 'shared_dir_host' in group_names }}"
+    user: "{{ blobdb_user }}"
+    service_backup_dir: "{{ blobdb_backup_dir }}"

--- a/src/commcare_cloud/ansible/roles/backups/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/backups/tasks/main.yml
@@ -1,3 +1,9 @@
+# todo:  The backups code doesn't really logically handle what happens when more than one
+# todo:  server hosts a service, because it runs the same backup code on all of them,
+# todo:  which depending on the service is either redundant (backup happens multiple times)
+# todo:  or conflicting (shards uploaded to the same place, overwrite each other)
+# todo:  I don't know the implications of this, possibly currently only used on monoliths.
+
 - name: Set up aws credentials
   become: yes
   import_role:
@@ -89,3 +95,29 @@
     dest: /usr/local/bin/check_s3_backup.py
     mode: "u=rwx,g=rx,o=rx"
   when: postgres_s3 or couch_s3 or blobdb_s3
+  tags:
+    - backup_checks
+
+- name: Create Daily Check Backups Cron job
+  become: yes
+  cron:
+    name: "Check {{ item.service }} s3 backups"
+    job: "/usr/local/bin/check_s3_backup.py {{ item.service }} > /tmp/check_s3_backup-{{ item.service }} || { echo /tmp/check_s3_backup-{{ item.service }} | mail -s 'Recent {{ item.service }} backups missing' {{ check_s3_backups_email }}; }"
+    state: "{{ 'present' if item.condition else 'absent' }}"
+    minute: 0
+    hour: "{{ nadir_hour|default(0) }}"
+    weekday: "1,2,3,4,5,6"
+    user: "{{ item.user }}"
+    cron_file: "backup_{{ item.service }}"
+  with_items:
+    - service: 'blobdb'
+      condition: "{{ check_s3_backups_email and blobdb_s3 and backup_blobdb and 'shared_dir_host' in group_names }}"
+      user: "{{ blobdb_user }}"
+    - service: 'postgres'
+      condition: "{{ check_s3_backups_email and postgres_s3 and backup_postgres and ('postgresql' in group_names or 'pg_backup' in group_names) }}"
+      user: "postgres"
+    - service: 'couch'
+      condition: "{{ check_s3_backups_email and couch_s3 and backup_couch and ('couchdb2' in group_names) }}"
+      user: "couchdb"
+  tags:
+    - backup_checks

--- a/src/commcare_cloud/ansible/roles/backups/tasks/set_up_check_s3_backups.yml
+++ b/src/commcare_cloud/ansible/roles/backups/tasks/set_up_check_s3_backups.yml
@@ -1,0 +1,23 @@
+- name: Copy check_s3_backup script to /usr/local/bin
+  template:
+    src: check_s3_backup.py.j2
+    dest: /usr/local/bin/check_s3_backup.py
+    mode: "u=rwx,g=rx,o=rx"
+  when: postgres_s3 or couch_s3 or blobdb_s3
+  tags:
+    - backup_checks
+
+
+- name: Create Daily Check Backups Cron job
+  become: yes
+  cron:
+    name: "Check {{ service }} s3 backups"
+    job: "/usr/local/bin/check_s3_backup.py {{ service }} > {{ service_backup_dir }}/s3_backup_status.txt || { echo {{ service_backup_dir }}/s3_backup_status.txt mail -s 'Recent {{ service }} backups missing' {{ check_s3_backups_email }}; }"
+    state: "{{ 'present' if condition else 'absent' }}"
+    minute: 0
+    hour: "{{ nadir_hour|default(0) }}"
+    weekday: "1,2,3,4,5,6"
+    user: "{{ user }}"
+    cron_file: "backup_{{ service }}"
+  tags:
+    - backup_checks

--- a/src/commcare_cloud/ansible/roles/couchdb2/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/couchdb2/tasks/main.yml
@@ -166,6 +166,17 @@
     - cron
     - backups
 
+- name: Set up check_s3_backups
+  become: yes
+  import_role:
+    name: backups
+    tasks_from: set_up_check_s3_backups.yml
+  vars:
+    service: 'couch'
+    condition: "{{ check_s3_backups_email and couch_s3 and backup_couch and ('couchdb2' in group_names) }}"
+    user: "couchdb"
+    service_backup_dir: "{{ couch_backup_dir }}"
+
 - import_tasks: compact.yml
   when: compact_couch_cron and inventory_hostname == groups.couchdb2.0
 

--- a/src/commcare_cloud/ansible/roles/pg_backup/tasks/backup.yml
+++ b/src/commcare_cloud/ansible/roles/pg_backup/tasks/backup.yml
@@ -10,3 +10,5 @@
 
 - include_tasks: backup_plain.yml
   when: "'pg_backup' in group_names and (backup_postgres == 'plain' or backup_postgres == 'dump')"
+  tags:
+    - always

--- a/src/commcare_cloud/ansible/roles/pg_backup/tasks/backup_plain.yml
+++ b/src/commcare_cloud/ansible/roles/pg_backup/tasks/backup_plain.yml
@@ -61,6 +61,17 @@
     user: postgres
     cron_file: backup_postgres
 
+- name: Set up check_s3_backups
+  become: yes
+  import_role:
+    name: backups
+    tasks_from: set_up_check_s3_backups.yml
+  vars:
+    service: 'postgres'
+    condition: "{{ check_s3_backups_email and postgres_s3 and backup_postgres and ('postgresql' in group_names or 'pg_backup' in group_names) }}"
+    user: "postgres"
+    service_backup_dir: "{{ postgresql_backup_dir }}"
+
 - name: copy retrieve script
   become: yes
   template:


### PR DESCRIPTION
##### SUMMARY
This we do daily backups on swiss but if they fail it's pretty silent. This adds a check that looks for the presence of a recent daily and weekly backup (just by matching filename) in s3, on a daily basis, and emails out if there's not.

##### ENVIRONMENTS AFFECTED
swiss
