### PR TITLE
nginx location for dumping devicelogs

### DIFF
--- a/src/commcare_cloud/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/cas_ssl.yml
@@ -104,6 +104,9 @@ nginx_sites:
          - zone_name: "overall_restore"
            burst: 100
            nodelay: True
+     - name: "/a/icds-cas/receiver/logs"
+       return: "201 '<OpenRosaResponse xmlns="http://openrosa.org/http/response"><message nature="submit_success">ignored</message></OpenRosaResponse>'"
+       add_header: "Content-Type application/xml"
      - name: "/a/icds-cas/receiver"
        balancer: "{{ deploy_env }}_cas_commcare"
        proxy_redirect: "http://{{ CAS_SITE_HOST }} https://{{ CAS_SITE_HOST }}"

--- a/src/commcare_cloud/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/cas_ssl.yml
@@ -105,7 +105,8 @@ nginx_sites:
            burst: 100
            nodelay: True
      - name: "/a/icds-cas/receiver/logs"
-       return: "201 '<OpenRosaResponse xmlns="http://openrosa.org/http/response"><message nature="submit_success">ignored</message></OpenRosaResponse>'"
+       return: >
+          201 '<OpenRosaResponse xmlns="http://openrosa.org/http/response"><message nature="submit_success">ignored</message></OpenRosaResponse>'
        add_header: "Content-Type application/xml"
      - name: "/a/icds-cas/receiver"
        balancer: "{{ deploy_env }}_cas_commcare"


### PR DESCRIPTION
##### SUMMARY
Device logs make up 15% of overall submissions on ICDS and at peak times we get as much as 30 per second. This constitutes a significant portion of requests.

We are already dumping device logs at the Django level but only after we've done various amounts of processing on them (as well as all the overhead that comes from login etc).

This PR adds an nginx location which will accept any request and return a 201 response with the OpenRosa response body.

Setting the `log_receiver_url` in the app will direct device logs to this endpoint.

Note that we have also set `logenabled=no` in the app config which should disable sending device logs at all but this also requires an LTS update which take a long time to roll out.

https://dimagi-dev.atlassian.net/browse/IIO-321

##### ENVIRONMENTS AFFECTED
ICDS