### PR TITLE
Clear filter for "OpenVPN Access Server 2.6.1"

### DIFF
--- a/src/commcare_cloud/terraform/modules/openvpn/variables.tf
+++ b/src/commcare_cloud/terraform/modules/openvpn/variables.tf
@@ -2,10 +2,6 @@
 data "aws_ami" "openvpn_image" {
   most_recent = true
   filter {
-    name   = "name"
-    values = ["OpenVPN Access Server 2.6.1-fe8020db-5343-4c43-9e65-5ed4a825c931-ami-0f5d312e085235ed4.4"]
-  }
-  filter {
     name   = "virtualization-type"
     values = ["hvm"]
   }


### PR DESCRIPTION
##### SUMMARY
This previous filter recently started coming up empty. It doesn't matter at all for existing environments. For a new one, if I'm wrong and there are other AMIs for this owner, then that'll become apparent pretty quickly. (Also as a practical note, there are no plans to set up a new AWS environment anytime soon.)

##### ENVIRONMENTS AFFECTED
production, india, staging
