### PR TITLE
Add "Worker Hosts" to celery-resource-report

### DIFF
--- a/src/commcare_cloud/commands/ansible/ops_tool.py
+++ b/src/commcare_cloud/commands/ansible/ops_tool.py
@@ -91,24 +91,27 @@ class CeleryResourceReport(CommandBase):
 
     def run(self, args, manage_args):
         environment = get_environment(args.env_name)
-        celery_processes = environment.app_processes_config.celery_processes
-        by_queue = defaultdict(lambda: {'num_workers': 0, 'concurrency': 0, 'pooling': set()})
+        celery_processes = environment.raw_app_processes_config.celery_processes
+        by_queue = defaultdict(lambda: {'num_workers': 0, 'concurrency': 0, 'pooling': set(), 'worker_hosts': set()})
         for host, queues in celery_processes.items():
             for queue_name, options in queues.items():
                 queue = by_queue[queue_name]
                 queue['num_workers'] += options.num_workers
                 queue['concurrency'] += options.concurrency * options.num_workers
                 queue['pooling'].add(options.pooling)
+                queue['worker_hosts'].add(host)
 
         max_name_len = max([len(name) for name in by_queue])
-        template = "{{:<8}} | {{:<{}}} | {{:<12}} | {{:<12}} | {{:<12}}".format(max_name_len + 2)
-        print(template.format('Pooling', 'Worker Queues', 'Processes', 'Concurrency', 'Avg Concurrency per worker'))
-        print(template.format('-------', '-------------', '---------', '-----------', '--------------------------'))
+        template = "{{:<8}} | {{:<{}}} | {{:<12}} | {{:<12}} | {{:<12}} | {{:<12}}".format(max_name_len + 2)
+        print(template.format('Pooling', 'Worker Queues', 'Processes', 'Concurrency', 'Avg Concurrency per worker', 'Worker Hosts'))
+        print(template.format('-------', '-------------', '---------', '-----------', '--------------------------', '------------'))
         for queue_name, stats in sorted(by_queue.items(), key=itemgetter(0)):
             workers = stats['num_workers']
             concurrency_ = stats['concurrency']
+            worker_hosts = stats['worker_hosts']
             print(template.format(
-                list(stats['pooling'])[0], queue_name, workers, concurrency_, concurrency_ // workers
+                list(stats['pooling'])[0], queue_name, workers, concurrency_, concurrency_ // workers,
+                ','.join(sorted(worker_hosts))
             ))
 
 

--- a/src/commcare_cloud/commands/ansible/ops_tool.py
+++ b/src/commcare_cloud/commands/ansible/ops_tool.py
@@ -110,7 +110,7 @@ class CeleryResourceReport(CommandBase):
             concurrency_ = stats['concurrency']
             worker_hosts = stats['worker_hosts']
             print(template.format(
-                list(stats['pooling'])[0], queue_name, workers, concurrency_, concurrency_ // workers,
+                list(stats['pooling'])[0], '`{}`'.format(queue_name), workers, concurrency_, concurrency_ // workers,
                 ','.join(sorted(worker_hosts))
             ))
 


### PR DESCRIPTION
##### SUMMARY
And improve the way it looks when interpreted as markdown.

Here's the new output (for production) directly pasted (which github renders as markdown):

Pooling  | Worker Queues                   | Processes    | Concurrency  | Avg Concurrency per worker | Worker Hosts
-------  | -------------                   | ---------    | -----------  | -------------------------- | ------------
gevent   | `analytics_queue`               | 1            | 10           | 10           | celery9
prefork  | `async_restore_queue`           | 3            | 24           | 8            | celery10,celery7,celery9
prefork  | `background_queue`              | 1            | 8            | 8            | celery9
prefork  | `beat`                          | 1            | 1            | 1            | celery12
prefork  | `case_import_queue`             | 2            | 8            | 4            | celery11,celery6
prefork  | `case_rule_queue`               | 2            | 8            | 4            | celery12,celery8
prefork  | `celery`                        | 2            | 8            | 4            | celery11,celery6
prefork  | `celery_periodic`               | 2            | 8            | 4            | celery12
gevent   | `email_queue`                   | 4            | 400          | 100          | celery11,celery6
prefork  | `export_download_queue`         | 3            | 15           | 5            | celery10,celery11,celery6
prefork  | `flower`                        | 1            | 1            | 1            | celery8
gevent   | `ils_gateway_sms_queue`         | 1            | 8            | 8            | celery12
prefork  | `logistics_background_queue`    | 1            | 2            | 2            | celery12
prefork  | `logistics_reminder_queue`      | 1            | 2            | 2            | celery12
gevent   | `reminder_case_update_queue`    | 2            | 10           | 5            | celery8
gevent   | `reminder_queue`                | 3            | 30           | 10           | celery8
prefork  | `reminder_rule_queue`           | 1            | 3            | 3            | celery8
gevent   | `repeat_record_queue`           | 12           | 600          | 50           | celery10,celery7,celery9
prefork  | `saved_exports_queue`           | 6            | 24           | 4            | celery10,celery9
prefork  | `send_report_throttled`         | 1            | 2            | 2            | celery9
gevent   | `sms_queue`                     | 3            | 30           | 10           | celery8
prefork  | `submission_reprocessing_queue` | 1            | 1            | 1            | celery7
gevent   | `sumologic_logs_queue`          | 1            | 50           | 50           | celery7
prefork  | `ucr_indicator_queue`           | 1            | 2            | 2            | celery7
prefork  | `ucr_queue`                     | 2            | 8            | 4            | celery12,celery7
