### PR TITLE
Rearrange production celery bigtime

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -6,120 +6,77 @@ celery_command_prefix: ''
 gunicorn_workers_static_factor: 0
 gunicorn_workers_factor: 1
 management_commands:
-  celery7:
+  celery12:
     submission_reprocessing_queue:
-  celery8:
     queue_schedule_instances:
     handle_survey_actions:
     sms_queue:
 celery_processes:
-  celery6:
-    celery:
-      concurrency: 4
-    case_import_queue:
-      concurrency: 4
-    email_queue:
+  celery6,celery7,celery8: {}
+  celery9,celery10,celery11:
+    analytics_queue:
       pooling: gevent
-      concurrency: 100
-      num_workers: 2
-    export_download_queue:
-      concurrency: 5
-  celery7:
-    submission_reprocessing_queue:
-      concurrency: 1
-    sumologic_logs_queue:
-      pooling: gevent
-      concurrency: 50
-    repeat_record_queue:
-      pooling: gevent
-      num_workers: 3
-      concurrency: 50
-    ucr_queue:
       concurrency: 4
-    ucr_indicator_queue:
-      concurrency: 2
     async_restore_queue:
       concurrency: 8
-  celery8:
-    flower: {}
+    background_queue:
+      concurrency: 3
+    case_import_queue:
+      concurrency: 3
+    case_rule_queue:
+      concurrency: 3
+    celery:
+      concurrency: 3
+    celery_periodic:
+      concurrency: 3
+    email_queue:
+      pooling: gevent
+      concurrency: 134
+    export_download_queue:
+      concurrency: 5
+    reminder_case_update_queue:
+      pooling: gevent
+      concurrency: 4
     reminder_queue:
       pooling: gevent
       concurrency: 10
-      num_workers: 3
+    reminder_rule_queue:
+      concurrency: 1
+    repeat_record_queue:
+      pooling: gevent
+      concurrency: 200
+    saved_exports_queue:
+      concurrency: 8
     sms_queue:
       pooling: gevent
       concurrency: 10
-      num_workers: 3
-    case_rule_queue:
-      concurrency: 4
-    reminder_case_update_queue:
-      pooling: gevent
-      concurrency: 5
-      num_workers: 2
-    reminder_rule_queue:
+    ucr_indicator_queue:
+      concurrency: 1
+    ucr_queue:
       concurrency: 3
+  celery12:
+    # not really queues
+    flower: {}
+    beat: {}
+    # custom queues
     ils_gateway_sms_queue:
       # Use 1 worker with concurrency 8 in order to enforce the
       # restriction of having 8 max simultaneous connections with
       # the push sms gateway
       pooling: gevent
       concurrency: 8
-    logistics_reminder_queue:
-      concurrency: 2
     logistics_background_queue:
       concurrency: 2
-  celery9:
-    background_queue:
-      concurrency: 8
+    logistics_reminder_queue:
+      concurrency: 2
+    # other queues we're okay running without redundancy
     send_report_throttled:
       concurrency: 2
-    async_restore_queue:
-      concurrency: 8
-    analytics_queue:
+    submission_reprocessing_queue:
+      concurrency: 1
+    sumologic_logs_queue:
       pooling: gevent
-      concurrency: 10
-    repeat_record_queue:
-      pooling: gevent
-      num_workers: 5
       concurrency: 50
-    saved_exports_queue:
-      num_workers: 3
-      concurrency: 4
-      optimize: True
-  celery10:
-    async_restore_queue:
-      concurrency: 8
-    saved_exports_queue:
-      num_workers: 3
-      concurrency: 4
-      optimize: True
-    export_download_queue:
-      concurrency: 5
-    repeat_record_queue:
-      pooling: gevent
-      num_workers: 4
-      concurrency: 50
-  celery11:
-    celery:
-      concurrency: 4
-    case_import_queue:
-      concurrency: 4
-    email_queue:
-      pooling: gevent
-      concurrency: 100
-      num_workers: 2
-    export_download_queue:
-      concurrency: 5
-  celery12:
-    beat: {}
-    celery_periodic:
-      num_workers: 2
-      concurrency: 4
-    case_rule_queue:
-      concurrency: 4
-    ucr_queue:
-      concurrency: 4
-
 
 pillows:
   pillow0:

--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -12,7 +12,6 @@ management_commands:
     handle_survey_actions:
     sms_queue:
 celery_processes:
-  celery6,celery7,celery8: {}
   celery9,celery10,celery11:
     analytics_queue:
       pooling: gevent

--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -107,15 +107,6 @@ kafka0
 [kafka:children]
 kafka0
 
-[celery6]
-10.202.12.126 hostname=celery6-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3
-
-[celery7]
-10.202.12.105 hostname=celery7-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3
-
-[celery8]
-10.202.12.146 hostname=celery8-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3
-
 [celery9]
 10.202.12.80 hostname=celery9-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3
 
@@ -130,9 +121,6 @@ kafka0
 
 
 [celery:children]
-celery6
-celery7
-celery8
 celery9
 celery10
 celery11

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -87,12 +87,6 @@ kafka0
 [kafka:children]
 kafka0
 
-{{ __celery6__ }}
-
-{{ __celery7__ }}
-
-{{ __celery8__ }}
-
 {{ __celery9__ }}
 
 {{ __celery10__ }}
@@ -103,9 +97,6 @@ kafka0
 
 
 [celery:children]
-celery6
-celery7
-celery8
 celery9
 celery10
 celery11

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -267,21 +267,21 @@ servers:
     group: "celery"
     os: bionic
   - server_name: "celery9-production"
-    server_instance_type: t3.xlarge
+    server_instance_type: t3.2xlarge
     network_tier: "app-private"
     az: "c"
     volume_size: 80
     group: "celery"
     os: bionic
   - server_name: "celery10-production"
-    server_instance_type: t3.xlarge
+    server_instance_type: t3.2xlarge
     network_tier: "app-private"
     az: "c"
     volume_size: 80
     group: "celery"
     os: bionic
   - server_name: "celery11-production"
-    server_instance_type: t3.xlarge
+    server_instance_type: t3.2xlarge
     network_tier: "app-private"
     az: "c"
     volume_size: 80

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -270,28 +270,28 @@ servers:
     server_instance_type: t3.2xlarge
     network_tier: "app-private"
     az: "c"
-    volume_size: 80
+    volume_size: 150
     group: "celery"
     os: bionic
   - server_name: "celery10-production"
     server_instance_type: t3.2xlarge
     network_tier: "app-private"
     az: "c"
-    volume_size: 80
+    volume_size: 150
     group: "celery"
     os: bionic
   - server_name: "celery11-production"
     server_instance_type: t3.2xlarge
     network_tier: "app-private"
     az: "c"
-    volume_size: 80
+    volume_size: 150
     group: "celery"
     os: bionic
   - server_name: "celery12-production"
     server_instance_type: t3.xlarge
     network_tier: "app-private"
     az: "c"
-    volume_size: 80
+    volume_size: 150
     group: "celery"
     os: bionic
 

--- a/src/commcare_cloud/commands/ansible/ops_tool.py
+++ b/src/commcare_cloud/commands/ansible/ops_tool.py
@@ -91,24 +91,27 @@ class CeleryResourceReport(CommandBase):
 
     def run(self, args, manage_args):
         environment = get_environment(args.env_name)
-        celery_processes = environment.app_processes_config.celery_processes
-        by_queue = defaultdict(lambda: {'num_workers': 0, 'concurrency': 0, 'pooling': set()})
+        celery_processes = environment.raw_app_processes_config.celery_processes
+        by_queue = defaultdict(lambda: {'num_workers': 0, 'concurrency': 0, 'pooling': set(), 'worker_hosts': set()})
         for host, queues in celery_processes.items():
             for queue_name, options in queues.items():
                 queue = by_queue[queue_name]
                 queue['num_workers'] += options.num_workers
                 queue['concurrency'] += options.concurrency * options.num_workers
                 queue['pooling'].add(options.pooling)
+                queue['worker_hosts'].add(host)
 
         max_name_len = max([len(name) for name in by_queue])
-        template = "{{:<8}} | {{:<{}}} | {{:<12}} | {{:<12}} | {{:<12}}".format(max_name_len + 2)
-        print(template.format('Pooling', 'Worker Queues', 'Processes', 'Concurrency', 'Avg Concurrency per worker'))
-        print(template.format('-------', '-------------', '---------', '-----------', '--------------------------'))
+        template = "{{:<8}} | {{:<{}}} | {{:<12}} | {{:<12}} | {{:<12}} | {{:<12}}".format(max_name_len + 2)
+        print(template.format('Pooling', 'Worker Queues', 'Processes', 'Concurrency', 'Avg Concurrency per worker', 'Worker Hosts'))
+        print(template.format('-------', '-------------', '---------', '-----------', '--------------------------', '------------'))
         for queue_name, stats in sorted(by_queue.items(), key=itemgetter(0)):
             workers = stats['num_workers']
             concurrency_ = stats['concurrency']
+            worker_hosts = stats['worker_hosts']
             print(template.format(
-                list(stats['pooling'])[0], queue_name, workers, concurrency_, concurrency_ // workers
+                list(stats['pooling'])[0], queue_name, workers, concurrency_, concurrency_ // workers,
+                ','.join(sorted(worker_hosts))
             ))
 
 

--- a/src/commcare_cloud/commands/ansible/ops_tool.py
+++ b/src/commcare_cloud/commands/ansible/ops_tool.py
@@ -110,7 +110,7 @@ class CeleryResourceReport(CommandBase):
             concurrency_ = stats['concurrency']
             worker_hosts = stats['worker_hosts']
             print(template.format(
-                list(stats['pooling'])[0], queue_name, workers, concurrency_, concurrency_ // workers,
+                list(stats['pooling'])[0], '`{}`'.format(queue_name), workers, concurrency_, concurrency_ // workers,
                 ','.join(sorted(worker_hosts))
             ))
 

--- a/src/commcare_cloud/commands/ansible/ops_tool.py
+++ b/src/commcare_cloud/commands/ansible/ops_tool.py
@@ -8,6 +8,7 @@ from commcare_cloud.commands.command_base import CommandBase, Argument
 from commcare_cloud.commands.inventory_lookup.getinventory import get_instance_group
 from commcare_cloud.commands.utils import PrivilegedCommand
 from commcare_cloud.environment.main import get_environment
+from commcare_cloud.environment.schemas.app_processes import get_machine_alias
 
 
 class ListDatabases(CommandBase):
@@ -91,7 +92,7 @@ class CeleryResourceReport(CommandBase):
 
     def run(self, args, manage_args):
         environment = get_environment(args.env_name)
-        celery_processes = environment.raw_app_processes_config.celery_processes
+        celery_processes = environment.app_processes_config.celery_processes
         by_queue = defaultdict(lambda: {'num_workers': 0, 'concurrency': 0, 'pooling': set(), 'worker_hosts': set()})
         for host, queues in celery_processes.items():
             for queue_name, options in queues.items():
@@ -111,7 +112,7 @@ class CeleryResourceReport(CommandBase):
             worker_hosts = stats['worker_hosts']
             print(template.format(
                 list(stats['pooling'])[0], '`{}`'.format(queue_name), workers, concurrency_, concurrency_ // workers,
-                ','.join(sorted(worker_hosts))
+                ','.join(sorted([get_machine_alias(environment, worker_host) for worker_host in worker_hosts]))
             ))
 
 

--- a/src/commcare_cloud/environment/main.py
+++ b/src/commcare_cloud/environment/main.py
@@ -45,7 +45,6 @@ class Environment(object):
         self.check_known_hosts()
         self.meta_config
         self.users_config
-        self.raw_app_processes_config
         self.app_processes_config
         self.fab_settings_config
         self.inventory_manager
@@ -258,7 +257,7 @@ class Environment(object):
                                         map(str, repeated_users))), self.meta_config.deploy_env))
 
     @memoized_property
-    def raw_app_processes_config(self):
+    def _raw_app_processes_config(self):
         """
         collated contents of app-processes.yml files, as an AppProcessesConfig object
 
@@ -275,7 +274,7 @@ class Environment(object):
 
     @memoized_property
     def app_processes_config(self):
-        app_processes_config = AppProcessesConfig.wrap(self.raw_app_processes_config.to_json())
+        app_processes_config = AppProcessesConfig.wrap(self._raw_app_processes_config.to_json())
         app_processes_config.check_and_translate_hosts(self)
         app_processes_config.check()
         return app_processes_config

--- a/src/commcare_cloud/environment/schemas/app_processes.py
+++ b/src/commcare_cloud/environment/schemas/app_processes.py
@@ -170,7 +170,7 @@ def _validate_all_required_machines_mentioned(environment, translated_app_proces
 
 def check_and_translate_hosts(environment, host_mapping):
     """
-    :param environment: name of the env used to lookup the inventory
+    :param environment: the env used to lookup the inventory
     :param host_mapping: dictionary where keys can be one of:
                          * host (must be in inventory file)
                          * inventory group containing a single host
@@ -180,7 +180,22 @@ def check_and_translate_hosts(environment, host_mapping):
              representative host
     """
     translated = {}
-    for host, config in host_mapping.items():
-        translated[environment.translate_host(host, environment.paths.app_processes_yml)] = config
+    for comma_separated_hosts, config in host_mapping.items():
+        for host in comma_separated_hosts.split(','):
+            translated[environment.translate_host(host, environment.paths.app_processes_yml)] = config
 
     return translated
+
+
+def get_machine_alias(environment, host):
+    """
+
+    :param environment: the env used to lookup the inventory
+    :param host: the inventory host (expressed as i.e. an ip address) to look up
+    :return: the canonical group name for that host
+    """
+    for group, hosts in environment.groups.items():
+        if len(hosts) == 1 and hosts[0] == host:
+            return group
+    else:
+        return host


### PR DESCRIPTION
##### SUMMARY
(Builds off https://github.com/dimagi/commcare-cloud/pull/3120 even though they seem somewhat unrelated.)

Rearrange produciton celery
    - have most queues processed in triplicate, symmetrically
    - have all non-queue celery stuff and a few non-redundant processors run on one another machine

##### ENVIRONMENTS AFFECTED
production
