### PR TITLE
Fix datadog ownership

### DIFF
--- a/src/commcare_cloud/ansible/roles/datadog/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/datadog/tasks/main.yml
@@ -14,7 +14,11 @@
     - datadog
 
 - name: copy datadog conf
-  template: src=datadog.conf.j2 dest=/etc/dd-agent/datadog.conf
+  template:
+    group: dd-agent
+    owner: dd-agent
+    src: datadog.conf.j2
+    dest: /etc/dd-agent/datadog.conf
   notify: restart datadog
   tags:
     - datadog


### PR DESCRIPTION
##### SUMMARY
Specify dd-agent as owner for datadog files. Datadog wasn't starting on new ICDS couch machines because these were owned by root

##### ENVIRONMENTS AFFECTED
all
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
datadog