### PR TITLE
Make django-manage and sudoers use py3

### DIFF
--- a/src/commcare_cloud/ansible/roles/bootstrap-users/tasks/remove_users.yml
+++ b/src/commcare_cloud/ansible/roles/bootstrap-users/tasks/remove_users.yml
@@ -4,6 +4,7 @@
   shell: "ps -o pid= -u \"{{ dev_users.absent|join(',') }}\""
   register: running_processes
   changed_when: no
+  failed_when: no
 
 - name: Kill running processes
   become: yes

--- a/src/commcare_cloud/ansible/roles/bootstrap-users/templates/sudoers.j2
+++ b/src/commcare_cloud/ansible/roles/bootstrap-users/templates/sudoers.j2
@@ -11,7 +11,7 @@ Runas_Alias HIPAA_ACTOR = {{ cchq_user }}
 Cmnd_Alias NGINX = /usr/sbin/nginx
 Cmnd_Alias PACKAGES = /usr/bin/apt-get
 Cmnd_Alias GIT = /usr/bin/git
-Cmnd_Alias PYTHON = /home/{{ cchq_user }}/www/{{ deploy_env }}/python_env/bin/python,/home/{{ cchq_user }}/www/{{ deploy_env }}/python_env/bin/pip
+Cmnd_Alias PYTHON = {{ py3_virtualenv_home }}/bin/python,{{ py3_virtualenv_home }}/bin/pip
 {% if inventory_hostname in groups['commcarehq'] %}
 Cmnd_Alias SUPERVISORD = /bin/bash -l -c sudo /usr/bin/supervisorctl*,/usr/bin/supervisorctl*,/usr/bin/echo_supervisord_conf > /tmp/supervisord_deploy.tmp
 {% endif %}

--- a/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -207,9 +207,15 @@ class DjangoManage(CommandBase):
         else:
             code_dir = '/home/{cchq_user}/www/{deploy_env}/current'.format(
                 cchq_user=cchq_user, deploy_env=deploy_env)
+
+        if environment.fab_settings_config.py3_run_deploy:
+            python_env = 'python_env-3.6'
+        else:  # for old python 2 envs
+            python_env = 'python_env'
         remote_command = (
-            'bash -c "cd {code_dir}; python_env/bin/python manage.py {args}"'
+            'bash -c "cd {code_dir}; {python_env}/bin/python manage.py {args}"'
             .format(
+                python_env=python_env,
                 cchq_user=cchq_user,
                 code_dir=code_dir,
                 args=' '.join(shlex_quote(arg) for arg in manage_args),


### PR DESCRIPTION
##### SUMMARY
This changes the last accidental holdouts to use py3:
- django-manage
- the sudoers file (which includes the virtualenv python and pip as a whitelisted commands)

##### ENVIRONMENTS AFFECTED
all
