### PR TITLE
turn off case messaging sync on save

### DIFF
--- a/environments/icds-cas/public.yml
+++ b/environments/icds-cas/public.yml
@@ -307,6 +307,7 @@ localsettings:
   # sumologic toggle is set to 0 so having this here just incurs another cache hit for nothing
   # can re-enable if we want to
   SUMOLOGIC_URL: # "{{ localsettings_private.SUMOLOGIC_URL }}"
+  SYNC_CASE_FOR_MESSAGING_ON_SAVE: False
   ENABLE_PRELOGIN_SITE: False
   CUSTOM_LANDING_TEMPLATE: 'icds/login.html'
   ENTERPRISE_MODE: True


### PR DESCRIPTION
##### SUMMARY
This has moved to a pillow on ICDS so once the pillow has caught up we can disable the save via celery.

##### ENVIRONMENTS AFFECTED
ICDS

##### ISSUE TYPE
- Change Pull Request

See https://github.com/dimagi/commcare-cloud/pull/3100, https://github.com/dimagi/commcare-hq/pull/24973