### PR TITLE
Upgrade to nginx 1.17.3

### DIFF
--- a/src/commcare_cloud/ansible/deploy_proxy.yml
+++ b/src/commcare_cloud/ansible/deploy_proxy.yml
@@ -7,7 +7,7 @@
       file: path="{{ nginx_static_home }}" owner="{{ cchq_user }}" group="{{ cchq_user }}" mode=0755 state=directory
 
     - name: install nginx
-      include_role:
+      import_role:
         name: nginx
         tasks_from: install
       when: not nginx_installed|default(False)

--- a/src/commcare_cloud/ansible/roles/nginx/handlers/main.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/handlers/main.yml
@@ -1,3 +1,7 @@
 ---
 - name: reload nginx
   include_tasks: reload.yml
+
+- name: quick start nginx
+  become: yes
+  service: name=nginx state=started enabled=yes

--- a/src/commcare_cloud/ansible/roles/nginx/tasks/install.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/tasks/install.yml
@@ -4,13 +4,18 @@
 # we might be able install from the default bionic apt repo
 # and not add the official nginx repo.
 # See: https://github.com/dimagi/commcare-cloud/pull/2901#pullrequestreview-250517794
+
+- name: Add Nginx apt key
+  become: yes
+  apt_key: url=https://nginx.org/keys/nginx_signing.key state=present
+
 - name: Add nginx repository
   become: yes
-  apt_repository: repo='ppa:nginx/stable' state=present
+  apt_repository: repo='deb http://nginx.org/packages/mainline/ubuntu/ bionic nginx' state=present
 
 - name: Install nginx
   become: yes
-  apt: name="{{ nginx_ubuntu_pkg }}" state=latest update_cache=yes cache_valid_time=3600
+  apt: name="nginx=1.17.3-1~bionic" state=present update_cache=yes cache_valid_time=3600
 
 - name: Make sure nofile ulimit is high
   become: yes

--- a/src/commcare_cloud/ansible/roles/nginx/tasks/install.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/tasks/install.yml
@@ -16,6 +16,9 @@
 - name: Install nginx
   become: yes
   apt: name="nginx=1.17.3-1~bionic" state=present update_cache=yes cache_valid_time=3600
+  notify: 'quick start nginx'
+
+- meta: flush_handlers  # need to start nginx as quickly as possible for minimal downtime
 
 - name: Make sure nofile ulimit is high
   become: yes

--- a/src/commcare_cloud/ansible/roles/nginx/vars/main.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/main.yml
@@ -1,5 +1,4 @@
 ---
-nginx_ubuntu_pkg: nginx
 nginx_user: www-data
 nginx_access_log_name: nginx_access.log
 nginx_error_log_name: nginx_error.log


### PR DESCRIPTION
##### SUMMARY

This should address CVE-2019-9511, CVE-2019-9513, CVE-2019-9516:
https://www.nginx.com/blog/nginx-updates-mitigate-august-2019-http-2-vulnerabilities/

##### ENVIRONMENTS AFFECTED
all

##### ISSUE TYPE
- Security Pull Request

There will be a blip of downtime as we replace the nginx server, so will be worth coordinating the rollout time

##### COMPONENT NAME
nginx

##### ADDITIONAL INFORMATION

It took a little trial and error to figure out how to install the newer versions of nginx, but I ended up following https://www.linuxbabe.com/ubuntu/install-nginx-latest-version-ubuntu-18-04 on staging, first manually as I was figuring it out, and then ported it to ansible, and tested it runs cleanly on the (already upgraded) staging proxy. I haven't yet tested its ability to upgrade from scratch, but I'll do so before rolling it out on other environments