### PR TITLE
 get submodule list before entering 'cd' context

### DIFF
--- a/src/commcare_cloud/fab/operations/release.py
+++ b/src/commcare_cloud/fab/operations/release.py
@@ -212,13 +212,14 @@ def _get_local_submodule_urls(path):
 
 
 def _get_remote_submodule_urls(path):
+    submodule_list = _get_submodule_list()
     with cd(env.code_current):
         remote_submodule_config = [
             GitConfig(
                 key='submodule.{}.url'.format(submodule),
                 value=sudo("git config submodule.{}.url".format(submodule))
             )
-            for submodule in _get_submodule_list()]
+            for submodule in submodule_list]
     return remote_submodule_config
 
 


### PR DESCRIPTION
I'm not sure why this started failing but I encountered it while setting up new VMs on ICDS. When executed inside the `with cd()` context the returned list is empty (despite actually executing the command to list the submodules).

I did not debug any further.