### PR TITLE
set umask during bootrap and set for current session

### DIFF
--- a/src/commcare_cloud/ansible/roles/bootstrap-machine/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/bootstrap-machine/tasks/main.yml
@@ -4,3 +4,17 @@
       - htop
     state: present
   become: yes
+
+- name: Set proper umask
+  lineinfile:
+    dest: /etc/login.defs
+    state: present
+    regexp: "^UMASK"
+    line: "UMASK\t\t022"
+  tags:
+    - umask
+
+- name: Set proper umask for this session
+  shell: umask 022
+  tags:
+    - umask

--- a/src/commcare_cloud/ansible/roles/common/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/common/tasks/main.yml
@@ -133,16 +133,6 @@
     - postfix
 
 
-- name: Set proper umask
-  lineinfile:
-    dest: /etc/login.defs
-    state: present
-    regexp: "^UMASK"
-    line: "UMASK\t\t022"
-  tags:
-    - umask
-
-
 - import_tasks: antivirus.yml
   tags:
     - antivirus


### PR DESCRIPTION
##### SUMMARY
Prior to this the umask would only take effect after next login. It was also set after common installs were run making commands like `virtualenv-clone` fail.