### PR TITLE
Delete yaml file instead of py.

### DIFF
--- a/src/commcare_cloud/fab/operations/staticfiles.py
+++ b/src/commcare_cloud/fab/operations/staticfiles.py
@@ -32,7 +32,7 @@ def _version_static():
     cmd = 'resource_static'
     with cd(env.code_root):
         sudo(
-            'rm -f tmp.sh resource_versions.py; {venv}/bin/python manage.py {cmd}'.format(
+            'rm -f tmp.sh resource_versions.yaml; {venv}/bin/python manage.py {cmd}'.format(
                 venv=env.virtualenv_root, cmd=cmd
             ),
             user=env.sudo_user


### PR DESCRIPTION
##### SUMMARY
Delete yaml file instead of py when force updating staticfiles.

This was changed ~week ago and may mean that hotfix + force_update_static has been broken since then https://github.com/dimagi/commcare-hq/pull/25027

##### ENVIRONMENTS AFFECTED
all
##### ISSUE TYPE
- Bugfix Pull Request

