### PR TITLE
Revert "Revert "Add more case messaging pillows""

### DIFF
--- a/environments/icds-cas/app-processes.yml
+++ b/environments/icds-cas/app-processes.yml
@@ -565,8 +565,8 @@ pillows:
       total_processes: 120
     case_messaging_sync_pillow:
       start_process: 0
-      num_processes: 9
-      total_processes: 120
+      num_processes: 5
+      total_processes: 65
   'pillow28':
     kafka-ucr-static-cases:
       start_process: 9
@@ -578,9 +578,9 @@ pillows:
       num_processes: 9
       total_processes: 120
     case_messaging_sync_pillow:
-      start_process: 9
-      num_processes: 9
-      total_processes: 120
+      start_process: 5
+      num_processes: 5
+      total_processes: 65
   'pillow29':
     kafka-ucr-static-cases:
       start_process: 18
@@ -592,9 +592,9 @@ pillows:
       num_processes: 9
       total_processes: 120
     case_messaging_sync_pillow:
-      start_process: 18
-      num_processes: 9
-      total_processes: 120
+      start_process: 10
+      num_processes: 5
+      total_processes: 65
   'pillow30':
     kafka-ucr-static-cases:
       start_process: 27
@@ -606,9 +606,9 @@ pillows:
       num_processes: 9
       total_processes: 120
     case_messaging_sync_pillow:
-      start_process: 27
-      num_processes: 9
-      total_processes: 120
+      start_process: 15
+      num_processes: 5
+      total_processes: 65
   'pillow31':
     kafka-ucr-static-cases:
       start_process: 36
@@ -620,9 +620,9 @@ pillows:
       num_processes: 9
       total_processes: 120
     case_messaging_sync_pillow:
-      start_process: 36
-      num_processes: 9
-      total_processes: 120
+      start_process: 20
+      num_processes: 5
+      total_processes: 65
   'pillow32':
     kafka-ucr-static-cases:
       start_process: 45
@@ -634,9 +634,9 @@ pillows:
       num_processes: 9
       total_processes: 120
     case_messaging_sync_pillow:
-      start_process: 45
-      num_processes: 9
-      total_processes: 120
+      start_process: 25
+      num_processes: 5
+      total_processes: 65
   'pillow33':
     kafka-ucr-static-cases:
       start_process: 54
@@ -648,9 +648,9 @@ pillows:
       num_processes: 9
       total_processes: 120
     case_messaging_sync_pillow:
-      start_process: 54
-      num_processes: 9
-      total_processes: 120
+      start_process: 30
+      num_processes: 5
+      total_processes: 65
   'pillow34':
     kafka-ucr-static-cases:
       start_process: 63
@@ -662,9 +662,9 @@ pillows:
       num_processes: 9
       total_processes: 120
     case_messaging_sync_pillow:
-      start_process: 63
-      num_processes: 9
-      total_processes: 120
+      start_process: 35
+      num_processes: 5
+      total_processes: 65
   'pillow35':
     kafka-ucr-static-cases:
       start_process: 72
@@ -676,9 +676,9 @@ pillows:
       num_processes: 9
       total_processes: 120
     case_messaging_sync_pillow:
-      start_process: 72
-      num_processes: 9
-      total_processes: 120
+      start_process: 40
+      num_processes: 5
+      total_processes: 65
   'pillow36':
     kafka-ucr-static-cases:
       start_process: 81
@@ -690,9 +690,9 @@ pillows:
       num_processes: 9
       total_processes: 120
     case_messaging_sync_pillow:
-      start_process: 81
-      num_processes: 9
-      total_processes: 120
+      start_process: 45
+      num_processes: 4
+      total_processes: 65
   'pillow37':
     kafka-ucr-static-cases:
       start_process: 90
@@ -704,9 +704,9 @@ pillows:
       num_processes: 9
       total_processes: 120
     case_messaging_sync_pillow:
-      start_process: 90
-      num_processes: 9
-      total_processes: 120
+      start_process: 49
+      num_processes: 4
+      total_processes: 65
   'pillow38':
     kafka-ucr-static-cases:
       start_process: 99
@@ -718,9 +718,9 @@ pillows:
       num_processes: 9
       total_processes: 120
     case_messaging_sync_pillow:
-      start_process: 99
-      num_processes: 9
-      total_processes: 120
+      start_process: 53
+      num_processes: 4
+      total_processes: 65
   'pillow39':
     kafka-ucr-static-cases:
       start_process: 108
@@ -732,9 +732,9 @@ pillows:
       num_processes: 9
       total_processes: 120
     case_messaging_sync_pillow:
-      start_process: 108
-      num_processes: 9
-      total_processes: 120
+      start_process: 57
+      num_processes: 4
+      total_processes: 65
   'pillow40':
     kafka-ucr-static-cases:
       start_process: 117
@@ -746,9 +746,9 @@ pillows:
       num_processes: 3
       total_processes: 120
     case_messaging_sync_pillow:
-      start_process: 117
-      num_processes: 3
-      total_processes: 120
+      start_process: 61
+      num_processes: 4
+      total_processes: 65
   'pillow41':
     FormSubmissionMetadataTrackerPillow:
       num_processes: 16

--- a/environments/icds-cas/app-processes.yml
+++ b/environments/icds-cas/app-processes.yml
@@ -563,6 +563,10 @@ pillows:
       start_process: 0
       num_processes: 9
       total_processes: 120
+    case_messaging_sync_pillow:
+      start_process: 0
+      num_processes: 9
+      total_processes: 120
   'pillow28':
     kafka-ucr-static-cases:
       start_process: 9
@@ -570,6 +574,10 @@ pillows:
       total_processes: 120
       processor_chunk_size: 100
     CaseToElasticsearchPillow:
+      start_process: 9
+      num_processes: 9
+      total_processes: 120
+    case_messaging_sync_pillow:
       start_process: 9
       num_processes: 9
       total_processes: 120
@@ -583,6 +591,10 @@ pillows:
       start_process: 18
       num_processes: 9
       total_processes: 120
+    case_messaging_sync_pillow:
+      start_process: 18
+      num_processes: 9
+      total_processes: 120
   'pillow30':
     kafka-ucr-static-cases:
       start_process: 27
@@ -590,6 +602,10 @@ pillows:
       total_processes: 120
       processor_chunk_size: 100
     CaseToElasticsearchPillow:
+      start_process: 27
+      num_processes: 9
+      total_processes: 120
+    case_messaging_sync_pillow:
       start_process: 27
       num_processes: 9
       total_processes: 120
@@ -603,6 +619,10 @@ pillows:
       start_process: 36
       num_processes: 9
       total_processes: 120
+    case_messaging_sync_pillow:
+      start_process: 36
+      num_processes: 9
+      total_processes: 120
   'pillow32':
     kafka-ucr-static-cases:
       start_process: 45
@@ -610,6 +630,10 @@ pillows:
       total_processes: 120
       processor_chunk_size: 100
     CaseToElasticsearchPillow:
+      start_process: 45
+      num_processes: 9
+      total_processes: 120
+    case_messaging_sync_pillow:
       start_process: 45
       num_processes: 9
       total_processes: 120
@@ -623,6 +647,10 @@ pillows:
       start_process: 54
       num_processes: 9
       total_processes: 120
+    case_messaging_sync_pillow:
+      start_process: 54
+      num_processes: 9
+      total_processes: 120
   'pillow34':
     kafka-ucr-static-cases:
       start_process: 63
@@ -630,6 +658,10 @@ pillows:
       total_processes: 120
       processor_chunk_size: 100
     CaseToElasticsearchPillow:
+      start_process: 63
+      num_processes: 9
+      total_processes: 120
+    case_messaging_sync_pillow:
       start_process: 63
       num_processes: 9
       total_processes: 120
@@ -643,6 +675,10 @@ pillows:
       start_process: 72
       num_processes: 9
       total_processes: 120
+    case_messaging_sync_pillow:
+      start_process: 72
+      num_processes: 9
+      total_processes: 120
   'pillow36':
     kafka-ucr-static-cases:
       start_process: 81
@@ -650,6 +686,10 @@ pillows:
       total_processes: 120
       processor_chunk_size: 100
     CaseToElasticsearchPillow:
+      start_process: 81
+      num_processes: 9
+      total_processes: 120
+    case_messaging_sync_pillow:
       start_process: 81
       num_processes: 9
       total_processes: 120
@@ -663,6 +703,10 @@ pillows:
       start_process: 90
       num_processes: 9
       total_processes: 120
+    case_messaging_sync_pillow:
+      start_process: 90
+      num_processes: 9
+      total_processes: 120
   'pillow38':
     kafka-ucr-static-cases:
       start_process: 99
@@ -673,6 +717,10 @@ pillows:
       start_process: 99
       num_processes: 9
       total_processes: 120
+    case_messaging_sync_pillow:
+      start_process: 99
+      num_processes: 9
+      total_processes: 120
   'pillow39':
     kafka-ucr-static-cases:
       start_process: 108
@@ -680,6 +728,10 @@ pillows:
       total_processes: 120
       processor_chunk_size: 100
     CaseToElasticsearchPillow:
+      start_process: 108
+      num_processes: 9
+      total_processes: 120
+    case_messaging_sync_pillow:
       start_process: 108
       num_processes: 9
       total_processes: 120
@@ -694,7 +746,9 @@ pillows:
       num_processes: 3
       total_processes: 120
     case_messaging_sync_pillow:
-      num_processes: 10
+      start_process: 117
+      num_processes: 3
+      total_processes: 120
   'pillow41':
     FormSubmissionMetadataTrackerPillow:
       num_processes: 16


### PR DESCRIPTION
This reverts commit 79e9a535d8bd181bbab795fa37ab5941b99c0f59.

Reverted this to try and get through the pillow error queue faster but it turns out the slow part is getting the errors into the queue - not the processing side.