### PR TITLE
register no_tags in pgbouncer role

### DIFF
--- a/src/commcare_cloud/ansible/roles/pgbouncer/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/tasks/main.yml
@@ -40,7 +40,7 @@
   tags:
     - pgbouncer
 
-# Allows to excecute task only when a tag is specified: https://serverfault.com/a/748864
+# Allows to execute task only when a tag is specified: https://serverfault.com/a/748864
 - shell: /bin/true
   changed_when: false
   register: no_tags

--- a/src/commcare_cloud/ansible/roles/pgbouncer/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/tasks/main.yml
@@ -40,6 +40,11 @@
   tags:
     - pgbouncer
 
+# Allows to excecute task only when a tag is specified: https://serverfault.com/a/748864
+- shell: /bin/true
+  changed_when: false
+  register: no_tags
+
 - name: Restarts pgbouncer (affect max open files limit)
   command: /bin/true
   notify: Restart pgbouncer


### PR DESCRIPTION
##### SUMMARY
This was missing since pgbouncer was split out from the postgres role

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
pgbouncer

##### ADDITIONAL INFORMATION
Without this pgbouncer get's restarted on every run of the role.