### PR TITLE
add umask for pip installs

### DIFF
--- a/src/commcare_cloud/ansible/roles/ansible-control/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/ansible-control/tasks/main.yml
@@ -33,6 +33,7 @@
       - virtualenv
       - virtualenvwrapper
     extra_args: '--ignore-installed six'
+    umask: 0022
 
 - name: Check whether init has been run
   become: yes

--- a/src/commcare_cloud/ansible/roles/common_installs/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/common_installs/tasks/main.yml
@@ -84,6 +84,7 @@
       - httplib2
       - pexpect
     executable: pip2
+    umask: 0022
   become: yes
 
 - name: Install virtualenv-clone
@@ -92,3 +93,4 @@
     name: virtualenv-clone
     version: 0.5.1
     executable: pip2
+    umask: 0022


### PR DESCRIPTION
##### SUMMARY
New Ubuntu VMs on Vmware have umask set to 0002 which makes pip installs unusable by non-privileged users. Setting the umask during install should fix that.

##### ISSUE TYPE
- Change Pull Request
