### PR TITLE
Fix {min,max}_commcare_version text in changelog entries

### DIFF
--- a/docs/changelog/0004-add-analytics-queue.md
+++ b/docs/changelog/0004-add-analytics-queue.md
@@ -8,7 +8,7 @@
 
 
 ## CommCare Version Dependency
-CommCare versions beyond this commit require this change to function correctly:
+CommCare versions beyond the following commit require this change to function correctly:
 [a5077576](https://github.com/dimagi/commcare-hq/commit/a507757628bc5c087fd1badc0145e39c5bf790ae)
 
 

--- a/docs/changelog/0005-support-multiple-kafak-brokers.md
+++ b/docs/changelog/0005-support-multiple-kafak-brokers.md
@@ -8,7 +8,7 @@
 
 
 ## CommCare Version Dependency
-This version of CommCare must be deployed before rolling out this change:
+The following version of CommCare must be deployed before rolling out this change:
 [cfdabcc9](https://github.com/dimagi/commcare-hq/commit/cfdabcc9e397d21b14918fadac2087f18e8fb5f9)
 
 

--- a/docs/changelog/0006-new-case-importer-celery-queue.md
+++ b/docs/changelog/0006-new-case-importer-celery-queue.md
@@ -8,7 +8,7 @@
 
 
 ## CommCare Version Dependency
-CommCare versions beyond this commit require this change to function correctly:
+CommCare versions beyond the following commit require this change to function correctly:
 [bc07919f](https://github.com/dimagi/commcare-hq/commit/bc07919f38828306015c688469a35df2fd8f9527)
 
 

--- a/docs/changelog/0007-reorganize-pillows.md
+++ b/docs/changelog/0007-reorganize-pillows.md
@@ -8,7 +8,7 @@
 
 
 ## CommCare Version Dependency
-This version of CommCare must be deployed before rolling out this change:
+The following version of CommCare must be deployed before rolling out this change:
 [44615b3a](https://github.com/dimagi/commcare-hq/commit/44615b3a1eea823dc01a09c9809adae0b0f29812)
 
 

--- a/docs/changelog/0008-blob-metadata-part-1.md
+++ b/docs/changelog/0008-blob-metadata-part-1.md
@@ -8,7 +8,7 @@
 
 
 ## CommCare Version Dependency
-This version of CommCare must be deployed before rolling out this change:
+The following version of CommCare must be deployed before rolling out this change:
 [d7a5ee92](https://github.com/dimagi/commcare-hq/commit/d7a5ee92d32f719e3e19c5841fdc7cecd2072985)
 
 

--- a/docs/changelog/0009-blob-metadata-part-2.md
+++ b/docs/changelog/0009-blob-metadata-part-2.md
@@ -8,7 +8,7 @@
 
 
 ## CommCare Version Dependency
-This version of CommCare must be deployed before rolling out this change:
+The following version of CommCare must be deployed before rolling out this change:
 [6503d45c](https://github.com/dimagi/commcare-hq/commit/6503d45c425701d3c0caeda7dc4964720f9a466b)
 
 

--- a/docs/changelog/0012-generalize-load-case-from-fixture.md
+++ b/docs/changelog/0012-generalize-load-case-from-fixture.md
@@ -8,7 +8,7 @@
 
 
 ## CommCare Version Dependency
-CommCare versions beyond this commit require this change to function correctly:
+CommCare versions beyond the following commit require this change to function correctly:
 [e25dbd4a](https://github.com/dimagi/commcare-hq/commit/e25dbd4aa88523e3913f0acfae7c98e32f4c06c1)
 
 

--- a/docs/changelog/0015-separate-celery-datadog-http-check.md
+++ b/docs/changelog/0015-separate-celery-datadog-http-check.md
@@ -8,7 +8,7 @@
 
 
 ## CommCare Version Dependency
-CommCare versions beyond this commit require this change to function correctly:
+CommCare versions beyond the following commit require this change to function correctly:
 [81325fbd](https://github.com/dimagi/commcare-hq/commit/81325fbd9e3131c710179f7246dbe9caccb45154)
 
 

--- a/docs/changelog/0016-invoke-celery-directly.md
+++ b/docs/changelog/0016-invoke-celery-directly.md
@@ -8,9 +8,9 @@
 
 
 ## CommCare Version Dependency
-CommCare versions beyond this commit require this change to function correctly:
+CommCare versions beyond the following commit require this change to function correctly:
 [0ffef2b5](https://github.com/dimagi/commcare-hq/commit/0ffef2b55910f9476d9aa4c9cc5c7d47b4f4e390)
-This version of CommCare must be deployed before rolling out this change:
+The following version of CommCare must be deployed before rolling out this change:
 [08e5a3c1](https://github.com/dimagi/commcare-hq/commit/08e5a3c1f7482ea30f071044431e42fe1c6e2f04)
 
 

--- a/docs/changelog/0019-remove-celery-results-backend-from-localsettings.md
+++ b/docs/changelog/0019-remove-celery-results-backend-from-localsettings.md
@@ -8,9 +8,9 @@
 
 
 ## CommCare Version Dependency
-CommCare versions beyond this commit require this change to function correctly:
+CommCare versions beyond the following commit require this change to function correctly:
 [0ffef2b5](https://github.com/dimagi/commcare-hq/commit/0ffef2b55910f9476d9aa4c9cc5c7d47b4f4e390)
-This version of CommCare must be deployed before rolling out this change:
+The following version of CommCare must be deployed before rolling out this change:
 [425793a8](https://github.com/dimagi/commcare-hq/commit/425793a8928910e993d3a6159ffd4a665d1fbfba)
 
 

--- a/docs/changelog/0023-upgrade-to-python-3.md
+++ b/docs/changelog/0023-upgrade-to-python-3.md
@@ -8,7 +8,7 @@
 
 
 ## CommCare Version Dependency
-This version of CommCare must be deployed before rolling out this change:
+The following version of CommCare must be deployed before rolling out this change:
 [476e3291](https://github.com/dimagi/commcare-hq/commit/476e32910bf757d950b2575423c043bd71e83a48)
 
 

--- a/src/commcare_cloud/manage_commcare_cloud/changelog.md.j2
+++ b/src/commcare_cloud/manage_commcare_cloud/changelog.md.j2
@@ -14,12 +14,12 @@
 
 ## CommCare Version Dependency
 {% if changelog_entry.max_commcare_version -%}
-CommCare versions beyond this commit require this change to function correctly:
+CommCare versions beyond the following commit require this change to function correctly:
 [{{ changelog_entry.max_commcare_version[:8] }}](https://github.com/dimagi/commcare-hq/commit/{{ changelog_entry.max_commcare_version }})
 {% endif %}
 
 {%- if changelog_entry.min_commcare_version -%}
-This version of CommCare must be deployed before rolling out this change:
+The following version of CommCare must be deployed before rolling out this change:
 [{{ changelog_entry.min_commcare_version[:8] }}](https://github.com/dimagi/commcare-hq/commit/{{ changelog_entry.min_commcare_version }})
 {% endif %}
 


### PR DESCRIPTION
##### SUMMARY
I noticed this potential confusion in https://forum.dimagi.com/t/python-2-deprecation-notice-30-days-to-upgrade/6699/7 (though it may not have been the source of their question).

##### ENVIRONMENTS AFFECTED
none

##### ISSUE TYPE
- Docs Pull Request
