### PR TITLE
Add -e 'CCHQ_IS_FRESH_INSTALL=1' to first time setup

### DIFF
--- a/docs/setup/new_environment.md
+++ b/docs/setup/new_environment.md
@@ -193,7 +193,7 @@ You will be prompted for the ansible vault password that you entered in [Step 2]
 In this step, you will be prompted for an SSH password. This is the root user's password. After this step, the root user will not be able to log in via SSH.
 
 ``` bash
-$ commcare-cloud monolith deploy-stack --first-time
+$ commcare-cloud monolith deploy-stack --first-time -e 'CCHQ_IS_FRESH_INSTALL=1'
 ```
 
 ```


### PR DESCRIPTION
##### SUMMARY
In response to https://forum.dimagi.com/t/python-2-deprecation-notice-30-days-to-upgrade/6699/9 I noticed our new_environment docs don't tell you to run it with `-e 'CCHQ_IS_FRESH_INSTALL=1'` on the first time setup, but I think that's just a mistake. A couple lines below it is included in the retry command.

##### ENVIRONMENTS AFFECTED
new setups

##### ISSUE TYPE
- Docs Pull Request
