### PR TITLE
restore tasks for custom certs

### DIFF
--- a/src/commcare_cloud/ansible/roles/nginx/tasks/certs.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/tasks/certs.yml
@@ -113,3 +113,29 @@
   when: not fake_ssl_cert and REACH_SITE_HOST | default(None)
   tags:
     - link_ssl_reach
+
+# support for custom certs
+- name: Copy cchq SSL cert
+  become: yes
+  copy:
+    content: '{{ nginx_combined_cert_value }}'
+    dest: "{{ ssl_certs_dir }}/{{ nginx_ssl_cert }}"
+    mode: 0400
+    owner: root
+    group: root
+  when: not fake_ssl_cert and nginx_combined_cert_value
+  tags:
+    - update-cert
+
+- name: Copy cchq SSL Key
+  become: yes
+  copy:
+    content: "{{ nginx_key_value }}"
+    dest: "{{ ssl_keys_dir }}/{{ nginx_ssl_key }}"
+    mode: 0400
+    owner: root
+    group: root
+  no_log: true
+  when: not fake_ssl_cert and nginx_key_value
+  tags:
+    - update-cert


### PR DESCRIPTION
##### SUMMARY
Allow specifying nginx certs explicitly.

This will support 3rd parties who already have certificates which they wish to use.