### PR TITLE
include citus_master hosts in PG hosts

### DIFF
--- a/src/commcare_cloud/environment/schemas/postgresql.py
+++ b/src/commcare_cloud/environment/schemas/postgresql.py
@@ -113,6 +113,7 @@ class PostgresqlConfig(jsonobject.JsonObject):
         postgresql_hosts = environment.groups.get('postgresql', [])
         if self.DEFAULT_POSTGRESQL_HOST not in postgresql_hosts:
             postgresql_hosts.append(self.DEFAULT_POSTGRESQL_HOST)
+        postgresql_hosts.extend(environment.groups.get('citusdb_master', []))
 
         dbs_by_host = defaultdict(list)
         for db in sorted_dbs:


### PR DESCRIPTION
##### SUMMARY
Since citus hosts aren't part of the `postgresql` group they DBs assigned to them were not getting included in the `by_host` output.

##### ENVIRONMENTS AFFECTED
* icds

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
* PostgreSQL, CitusDB, pgbouncer

##### ADDITIONAL INFORMATION
This affects the the `pgbouncer.ini` file