### PR TITLE
Remove djangomanage0-production

### DIFF
--- a/environments/production/aws-resources.yml
+++ b/environments/production/aws-resources.yml
@@ -7,7 +7,6 @@ couch12-production: 10.202.40.52
 couch13-production: 10.202.40.154
 couch14-production: 10.202.40.216
 couchproxy0-production: 10.202.40.162
-djangomanage0-production: 10.202.10.185
 djangomanage1-production: 10.202.10.54
 es10-production: 10.202.40.116
 es11-production: 10.202.40.91

--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -228,8 +228,6 @@ couchproxy0
 [control]
 10.202.10.79 hostname=control-production ufw_private_interface=eth0
 
-[djangomanage0]
-10.202.10.185 hostname=djangomanage0-production ufw_private_interface=eth0
 [djangomanage1]
 10.202.10.54 hostname=djangomanage1-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3
 

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -186,7 +186,6 @@ couchproxy0
 
 {{ __control__ }}
 
-{{ __djangomanage0__ }}
 {{ __djangomanage1__ }}
 
 [django_manage:children]

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -36,13 +36,6 @@ servers:
     group: "control"
     os: trusty
 
-  - server_name: "djangomanage0-production"
-    server_instance_type: c5.xlarge
-    network_tier: "app-private"
-    az: "a"
-    volume_size: 80
-    group: "django_manage"
-    os: trusty
   - server_name: "djangomanage1-production"
     server_instance_type: c5.xlarge
     network_tier: "app-private"


### PR DESCRIPTION
##### SUMMARY
This hasn't officially been the `[django_manage]` machine since early July, but I forgot to remove the machine. In this case I also forgot to _stop_ it. The extra cost we incurred isn't crazy (~$80) but still worth doing.

##### ENVIRONMENTS AFFECTED
production
