### PR TITLE
optimize service operations

### DIFF
--- a/src/commcare_cloud/commands/ansible/helpers.py
+++ b/src/commcare_cloud/commands/ansible/helpers.py
@@ -74,20 +74,20 @@ def add_factory_auth_cmd(environment):
 
 
 def get_django_webworker_name(environment):
-    environment_environment = environment.meta_config.deploy_env
-    project = environment.fab_settings_config.project
-    return "{project}-{environment}-django".format(
-        project=project,
-        environment=environment_environment
-    )
+    return _get_process_name(environment, 'django')
 
 
 def get_formplayer_spring_instance_name(environment):
-    environment_environment = environment.meta_config.deploy_env
+    return _get_process_name(environment, 'formsplayer-spring')
+
+
+def _get_process_name(environment, short_name):
+    deploy_env = environment.meta_config.deploy_env
     project = environment.fab_settings_config.project
-    return "{project}-{environment}-formsplayer-spring".format(
+    return "{project}-{deploy_env}-{short_name}".format(
         project=project,
-        environment=environment_environment
+        deploy_env=deploy_env,
+        short_name=short_name
     )
 
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,9 +1,11 @@
 from __future__ import print_function
 
+from nose.tools import assert_equal, assert_dict_equal
 from nose_parameterized import parameterized
 
 from commcare_cloud.commands.ansible.helpers import ProcessDescriptor
-from commcare_cloud.commands.ansible.service import get_managed_service_options, get_processes_by_host
+from commcare_cloud.commands.ansible.service import get_managed_service_options, get_processes_by_host, \
+    optimize_process_operations
 
 process_descriptors = [
         ProcessDescriptor('h1', 'p1', 0, 'p1-0'),
@@ -27,35 +29,37 @@ def test_get_managed_service_options():
 @parameterized([
     # no filtering
     (['h1', 'h2', 'h3', 'h4'], process_descriptors, None, {
-        ('h1',): ['p1-0', 'p1-1', 'p2-0'],
-        ('h2',): ['p1-2'],
-        ('h3','h4'): ['p3-0']
+        'h1': ['p1-0', 'p1-1', 'p2-0'],
+        'h2': ['p1-2'],
+        'h3': ['p3-0'],
+        'h4': ['p3-0']
     }),
     # filter hosts
     (['h1', 'h3'], process_descriptors, None, {
-        ('h1',): ['p1-0', 'p1-1', 'p2-0'],
-        ('h3',): ['p3-0']
+        'h1': ['p1-0', 'p1-1', 'p2-0'],
+        'h3': ['p3-0']
     }),
     # filter processes
     (['h1', 'h2', 'h3', 'h4'], process_descriptors, 'p3', {
-        ('h3', 'h4'): ['p3-0'],
+        'h3': ['p3-0'],
+        'h4': ['p3-0'],
     }),
     # filter process and host
     (['h3'], process_descriptors, 'p3', {
-        ('h3',): ['p3-0'],
+        'h3': ['p3-0'],
     }),
     # filter process with num
     (['h1', 'h2'], process_descriptors, 'p1:1', {
-        ('h1',): ['p1-1'],
+        'h1': ['p1-1'],
     }),
     # filter just process for process with multiple instances
     (['h1', 'h2'], process_descriptors, 'p1', {
-        ('h1',): ['p1-0', 'p1-1'],
-        ('h2',): ['p1-2'],
+        'h1': ['p1-0', 'p1-1'],
+        'h2': ['p1-2'],
     }),
     # filter multiple services
     (['h1', 'h2'], process_descriptors, 'p1:1,p2:0', {
-        ('h1',): ['p1-1', 'p2-0'],
+        'h1': ['p1-1', 'p2-0'],
     })
 ])
 def test_get_processes_by_host(all_hosts, process_descriptors, process_pattern, expected_response):
@@ -66,4 +70,19 @@ def test_get_processes_by_host(all_hosts, process_descriptors, process_pattern, 
         hosts: sorted(process)
         for hosts, process in processes_by_host.items()
     }
-    assert processes_by_host == expected_response, processes_by_host
+    assert_equal(processes_by_host, expected_response)
+
+
+def test_optimized_process_operations():
+    all_processes_by_host = {
+        'h1': ['p1', 'p2'],
+        'h2': ['p3', 'p4'],
+        'h3': ['p5'],
+    }
+    process_host_mapping = {
+        'h1': ['p1', 'p2'],
+        'h2': ['p3',],
+        'h3': ['p5',],
+    }
+    opt_process_host_mapping = optimize_process_operations(all_processes_by_host, process_host_mapping)
+    assert_dict_equal(opt_process_host_mapping, {('h2',): ['p3'], ('h1', 'h3'): ['all']})


### PR DESCRIPTION
##### SUMMARY
Optimise the 'supervisor' based service commands to run more commands in parallel.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Service commands for:
* pillowtop
* celery

##### ADDITIONAL INFORMATION
When starting / stopping / restarting celery and pillowtop processes a separate ansible command is run for each host (usually) in serial. This can be a very slow process.

Since we generally have celery and pillow processes isolated to dedicated VMs it should be possible to operate on them all at once rather than per host.

This change should make running operations like this perform just a single ansible play:
```
cchq <env> service pillowtop restart
cchq <env> service celery stop
``` 

Note: this builds on https://github.com/dimagi/commcare-cloud/pull/3169