### PR TITLE
Make fab deploy_formplayer the only way to deploy formplayer

### DIFF
--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -398,8 +398,6 @@ def kill_stale_celery_workers():
 def deploy_formplayer():
     execute(announce_formplayer_deploy_start)
     execute(formplayer.build_formplayer, True)
-    if getattr(env, 'NEEDS_FORMPLAYER_RESTART', False):
-        execute(supervisor.restart_formplayer)
 
 
 @task
@@ -801,8 +799,6 @@ def silent_services_restart(use_current_release=False):
     """
     execute(db.set_in_progress_flag, use_current_release)
     if not env.is_monolith:
-        if getattr(env, 'NEEDS_FORMPLAYER_RESTART', False):
-            execute(supervisor.restart_formplayer)
         execute(supervisor.restart_all_except_webworkers)
     execute(supervisor.restart_webworkers)
 

--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -398,6 +398,8 @@ def kill_stale_celery_workers():
 def deploy_formplayer():
     execute(announce_formplayer_deploy_start)
     execute(formplayer.build_formplayer, True)
+    if getattr(env, 'NEEDS_FORMPLAYER_RESTART', False):
+        execute(supervisor.restart_formplayer)
 
 
 @task

--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -876,7 +876,6 @@ ONLINE_DEPLOY_COMMANDS = [
     staticfiles.collectstatic,
     staticfiles.compress,
     staticfiles.update_translations,
-    formplayer.build_formplayer,
     conditionally_stop_pillows_and_celery_during_migrate,
     db.create_kafka_topics,
     db.flip_es_aliases,

--- a/src/commcare_cloud/fab/operations/formplayer.py
+++ b/src/commcare_cloud/fab/operations/formplayer.py
@@ -59,8 +59,7 @@ def build_formplayer(use_current_release=False):
         with cd(build_dir):
             sudo('ln -sfn {} current'.format(release_name))
             sudo('ln -sf current/libs/formplayer.jar formplayer.jar')
-        env.NEEDS_FORMPLAYER_RESTART = True
-
+        supervisor.restart_formplayer()
 
 
 @roles(ROLES_FORMPLAYER)

--- a/src/commcare_cloud/fab/operations/supervisor.py
+++ b/src/commcare_cloud/fab/operations/supervisor.py
@@ -102,6 +102,8 @@ def restart_webworkers():
 
 @roles(ROLES_FORMPLAYER)
 def restart_formplayer():
+    # since this just restarts "all"
+    # on a monolith this actually restarts all services
     _services_restart()
 
 


### PR DESCRIPTION
##### SUMMARY
by removing it from the main deploy

Web Apps and App Preview break for a few minutes every time we deploy, which is daily on prod. We do fairly little active development on formplayer these days, so this will have little practical day-to-day consequences, and I think it's not terrible from a "philosophical" perspective either. So I propose we just don't deploy formplayer unless we explicitly want to, thereby removing 90% of the damage this flaw in formplayer architecture causes.

##### ENVIRONMENTS AFFECTED
all
