### PR TITLE
Fix bootstrap-users by making the suoders file edit the last task

### DIFF
--- a/src/commcare_cloud/ansible/roles/bootstrap-users/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/bootstrap-users/tasks/main.yml
@@ -64,12 +64,6 @@
 - import_tasks: remove_users.yml
   when: dev_users.absent
 
-- name: Copy sudoers file
-  become: yes
-  template: src=sudoers.j2 dest=/etc/sudoers.d/cchq validate='visudo -cf %s' owner=root group=root mode=0440
-  tags:
-    - sudoers
-
 - name: check users password valid time
   become: yes
   shell: getent shadow "{{ item }}" | cut -d':' -f5
@@ -82,3 +76,9 @@
   shell: chage -M -1 "{{ item['item'] }}"
   loop: "{{ users_pw_valid.results }}"
   when: item.stdout is defined and item.stdout != ''
+
+- name: Copy sudoers file
+  become: yes
+  template: src=sudoers.j2 dest=/etc/sudoers.d/cchq validate='visudo -cf %s' owner=root group=root mode=0440
+  tags:
+    - sudoers

--- a/src/commcare_cloud/ansible/roles/bootstrap-users/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/bootstrap-users/tasks/main.yml
@@ -77,6 +77,10 @@
   loop: "{{ users_pw_valid.results }}"
   when: item.stdout is defined and item.stdout != ''
 
+
+# This must be the last task in the file
+# It disables factory auth (e.g. root user with password login)
+# and this role has to be able to finish entirely using factory auth (to bootstrap the users)
 - name: Copy sudoers file
   become: yes
   template: src=sudoers.j2 dest=/etc/sudoers.d/cchq validate='visudo -cf %s' owner=root group=root mode=0440


### PR DESCRIPTION
##### SUMMARY
This fixes --first-time deploy, which I think was first broken in https://github.com/dimagi/commcare-cloud/pull/3064. I haven't re-run this on a fresh install, but I think the premise is correct

##### ENVIRONMENTS AFFECTED
all
##### ISSUE TYPE

- Bugfix Pull Request
