### PR TITLE
Terminating trusty os(ubuntu 14.04) HQ and Mobile Web workers in a production environment

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -44,20 +44,6 @@ servers:
     group: "django_manage"
     os: bionic
 
-  - server_name: "web0-production"
-    server_instance_type: m5.2xlarge
-    network_tier: "app-private"
-    az: "a"
-    volume_size: 40
-    group: "hq_webworkers"
-    os: trusty
-  - server_name: "web1-production"
-    server_instance_type: m5.2xlarge
-    network_tier: "app-private"
-    az: "a"
-    volume_size: 40
-    group: "hq_webworkers"
-    os: trusty
   - server_name: "web2-production"
     server_instance_type: m5.2xlarge
     network_tier: "app-private"
@@ -80,34 +66,6 @@ servers:
     group: "hq_webworkers"
     os: bionic
     
-  - server_name: "web6-production"
-    server_instance_type: m5.2xlarge
-    network_tier: "app-private"
-    az: "b"
-    volume_size: 40
-    group: "mobile_webworkers"
-    os: trusty
-  - server_name: "web7-production"
-    server_instance_type: m5.2xlarge
-    network_tier: "app-private"
-    az: "b"
-    volume_size: 40
-    group: "mobile_webworkers"
-    os: trusty
-  - server_name: "web8-production"
-    server_instance_type: m5.2xlarge
-    network_tier: "app-private"
-    az: "b"
-    volume_size: 40
-    group: "mobile_webworkers"
-    os: trusty
-  - server_name: "web9-production"
-    server_instance_type: m5.2xlarge
-    network_tier: "app-private"
-    az: "a"
-    volume_size: 40
-    group: "mobile_webworkers"
-    os: trusty
   - server_name: "web10-production"
     server_instance_type: m5.2xlarge
     network_tier: "app-private"


### PR DESCRIPTION
Terminating trusty os(ubuntu 14.04) HQ and Mobile web workers in a production environment