### PR TITLE
Make --control flag faster by doing setup just once

### DIFF
--- a/src/commcare_cloud/commcare_cloud.py
+++ b/src/commcare_cloud/commcare_cloud.py
@@ -91,7 +91,7 @@ def run_on_control_instead(args, sys_argv):
     branch = getattr(args, 'branch', 'master')
     cmd_parts = [
         executable, args.env_name, 'ssh', 'control', '-t',
-        'source ~/init-ansible && git fetch --prune && git checkout {branch} '
+        'cd ~/commcare-cloud && git fetch --prune && git checkout {branch} '
         '&& git reset --hard origin/{branch} && source ~/init-ansible && {cchq} {cchq_args}'
         .format(branch=branch, cchq=executable, cchq_args=' '.join([shlex_quote(arg) for arg in argv]))
     ]


### PR DESCRIPTION
##### SUMMARY
I'm kind of embarrassed now that I didn't make this PR sooner. This cuts the setup time in half when you're using the `--control` flag; the first `~/init-ansible` here was just being used to get into the git directory, and it's a silly and expensive way to do that.