### PR TITLE
Fix _get_simple_processes for missing groups

### DIFF
--- a/src/commcare_cloud/commands/ansible/helpers.py
+++ b/src/commcare_cloud/commands/ansible/helpers.py
@@ -207,7 +207,7 @@ def get_management_command_processes(environment):
 
 
 def _get_simple_processes(environment, inventory_group, process_name):
-    for host in environment.groups[inventory_group]:
+    for host in environment.groups.get(inventory_group, []):
         yield ProcessDescriptor(host, process_name, 0, process_name)
 
 


### PR DESCRIPTION
##### SUMMARY
Small fix to https://github.com/dimagi/commcare-cloud/pull/3170.

##### ENVIRONMENTS AFFECTED
general

##### ISSUE TYPE
- Bugfix Pull Request

##### ADDITIONAL INFORMATION

Fixes
```
(ccc) francine:commcare-cloud droberts$ cchq production service celery restart --only=repeat_record_queue
[WARNING]: log file at /var/log/ansible.log is not writeable and we cannot create it, aborting

Traceback (most recent call last):
  File "/Users/droberts/.virtualenvs/ccc/bin/cchq", line 11, in <module>
    load_entry_point('commcare-cloud', 'console_scripts', 'cchq')()
  File "/Users/droberts/dimagi/commcare-cloud/src/commcare_cloud/commcare_cloud.py", line 168, in main
    exit_code = call_commcare_cloud()
  File "/Users/droberts/dimagi/commcare-cloud/src/commcare_cloud/commcare_cloud.py", line 159, in call_commcare_cloud
    exit_code = commands[args.command].run(args, unknown_args)
  File "/Users/droberts/dimagi/commcare-cloud/src/commcare_cloud/commands/ansible/service.py", line 685, in run
    exit_code = service.run(args.action, args.limit, args.process_pattern)
  File "/Users/droberts/dimagi/commcare-cloud/src/commcare_cloud/commands/ansible/service.py", line 73, in run
    return self.execute_action(action, host_pattern, process_pattern)
  File "/Users/droberts/dimagi/commcare-cloud/src/commcare_cloud/commands/ansible/service.py", line 161, in execute_action
    all_processes_by_host = get_all_supervisor_processes_by_host(self.environment)
  File "/Users/droberts/dimagi/commcare-cloud/src/commcare_cloud/commands/ansible/helpers.py", line 227, in get_all_supervisor_processes_by_host
    for process in processes:
  File "/Users/droberts/dimagi/commcare-cloud/src/commcare_cloud/commands/ansible/helpers.py", line 210, in _get_simple_processes
    for host in environment.groups[inventory_group]:
KeyError: 'airflow'
```
