### PR TITLE
Fix serious formplayer issue after deploy with stop-gap measure

### DIFF
--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -799,6 +799,7 @@ def silent_services_restart(use_current_release=False):
     """
     execute(db.set_in_progress_flag, use_current_release)
     if not env.is_monolith:
+        execute(supervisor.restart_formplayer)
         execute(supervisor.restart_all_except_webworkers)
     execute(supervisor.restart_webworkers)
 


### PR DESCRIPTION
##### SUMMARY
My temporary fix is to just restart formplayer after deploy,
even though it wasnt actually updated. And since there's a restart there
will still be the 1-2m of formplayer downtime that we're "used" to. The
longer term fix will be to move the formplayer directory out from inside
the commcare-hq code directory so that deploying commcare doesn't change
the file pointed to by the formplayer jar path that supervisor uses to run the jar.

The serious formplayer issue was I believe introduced by https://github.com/dimagi/commcare-cloud/pull/3174 (though we had seen it pop up very occasionally before—in retrospect possibly the rare time when we deployed and formplayer wasn't restarted). I think that PR is still overall in the right direction, so rather than revert it, I'm going to just put in the simplest stop-gap fix.

##### ENVIRONMENTS AFFECTED
all

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
formplayer
