### PR TITLE
only install from a single requirements file

### DIFF
--- a/src/commcare_cloud/fab/operations/release.py
+++ b/src/commcare_cloud/fab/operations/release.py
@@ -288,7 +288,6 @@ def update_virtualenv(full_cluster=True):
                      user=env.sudo_user)
                 pip_install(cmd_prefix, timeout=60, quiet=True, proxy=env.http_proxy, requirements=[
                     posixpath.join(requirements, 'prod-requirements.txt'),
-                    posixpath.join(requirements, 'requirements.txt'),
                 ])
 
         _update_virtualenv(


### PR DESCRIPTION
##### SUMMARY
Since we use pip-compile to generate the requirements files and that
'prod-requirements' includes 'requirements' there is no need to run pip install with both. It can cause
problems if the same dependency exists in both but with different versions.

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
deploy
