### PR TITLE
Fix setup_limited_release

### DIFF
--- a/src/commcare_cloud/fab/operations/release.py
+++ b/src/commcare_cloud/fab/operations/release.py
@@ -287,7 +287,6 @@ def update_virtualenv(full_cluster=True):
                      user=env.sudo_user)
                 pip_install(cmd_prefix, timeout=60, quiet=True, proxy=env.http_proxy, requirements=[
                     posixpath.join(requirements, 'prod-requirements.txt'),
-                    posixpath.join(requirements, 'requirements.txt'),
                 ])
 
         _update_virtualenv(

--- a/src/commcare_cloud/fab/operations/release.py
+++ b/src/commcare_cloud/fab/operations/release.py
@@ -291,14 +291,9 @@ def update_virtualenv(full_cluster=True):
                 ])
 
         _update_virtualenv(
-            env.py2_virtualenv_current, env.py2_virtualenv_root,
-            posixpath.join(env.code_root, 'requirements')
+            env.py3_virtualenv_current, env.py3_virtualenv_root,
+            posixpath.join(env.code_root, 'requirements-python3')
         )
-        if env.py3_include_venv:
-            _update_virtualenv(
-                env.py3_virtualenv_current, env.py3_virtualenv_root,
-                posixpath.join(env.code_root, 'requirements-python3')
-            )
 
     return update
 


### PR DESCRIPTION
##### SUMMARY

Until `setup_limited_release` is available without `fab`, this change makes it use the Python 3.6 virtualenv.

This change also assumes that `prod-requirements.txt` is a superset or `requirements.txt`.

##### ENVIRONMENTS AFFECTED

None

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

fab

##### ADDITIONAL INFORMATION

Currently `setup_limited_release` fails when trying to install requirements in a Python 2 virtualenv.
```
Fatal error: One or more hosts failed while executing task 'update'
...
Traceback (most recent call last):
...
  File "/srv/share/src/dimagi/commcare-cloud/src/commcare_cloud/fab/fabfile.py", line 449, in setup_limited_release
    _setup_release(parse_int_or_exit(keep_days), full_cluster=False)
  File "/srv/share/src/dimagi/commcare-cloud/src/commcare_cloud/fab/fabfile.py", line 479, in _setup_release
    execute_with_timing(release.update_virtualenv(full_cluster))
...
Exception: One or more hosts failed while executing task 'update'
```