### PR TITLE
export sentry events command

### DIFF
--- a/docs/commcare-cloud/commands/index.md
+++ b/docs/commcare-cloud/commands/index.md
@@ -11,7 +11,7 @@ All `commcare-cloud` commands take the following form:
 ```
 commcare-cloud [--control]
                <env>
-               {bootstrap-users,ansible-playbook,django-manage,aps,aws-sign-in,tmux,ap,validate-environment-settings,openvpn-activate-user,deploy-stack,service,update-supervisor-confs,update-users,ping,migrate_couchdb,lookup,run-module,update-config,copy-files,deploy,mosh,list-postgresql-dbs,after-reboot,ssh,downtime,fab,update-local-known-hosts,send-datadog-event,pillow-resource-report,aws-list,aws-fill-inventory,migrate-couchdb,terraform,openvpn-claim-user,celery-resource-report,run-shell-command,terraform-migrate-state}
+               {bootstrap-users,ansible-playbook,django-manage,aps,aws-sign-in,tmux,ap,validate-environment-settings,openvpn-activate-user,deploy-stack,export-sentry-events,service,update-supervisor-confs,update-users,ping,migrate_couchdb,lookup,run-module,update-config,copy-files,deploy,mosh,list-postgresql-dbs,after-reboot,ssh,downtime,fab,update-local-known-hosts,send-datadog-event,pillow-resource-report,aws-list,aws-fill-inventory,migrate-couchdb,terraform,openvpn-claim-user,celery-resource-report,run-shell-command,terraform-migrate-state}
                ...
 ```
 
@@ -564,6 +564,43 @@ If a command specified, then it will always run in a new window.
 If a command is *not* specified, then a it will rejoin the most
 recently visited tmux window; only if there are no currently open
 tmux windows will a new one be opened.
+
+---
+
+#### `export-sentry-events`
+
+Export Sentry events. One line per event JSON.
+
+```
+commcare-cloud <env> export-sentry-events [-k API_KEY] [-q QUERY] [--start START] [--end END]
+                                          [--project-id PROJECT_ID] [--organization ORGANIZATION]
+```
+
+##### Optional Arguments
+
+###### `-k API_KEY, --api-key API_KEY`
+
+Sentry API Key
+
+###### `-q QUERY, --query QUERY`
+
+Text query
+
+###### `--start START`
+
+UTC start date. Format YYYY-MM-DDTHH:MM:SS
+
+###### `--end END`
+
+UTC end date. Format YYYY-MM-DDTHH:MM:SS
+
+###### `--project-id PROJECT_ID`
+
+Sentry project ID. If not supplied the value for the environment will be used (requires Vault access)
+
+###### `--organization ORGANIZATION`
+
+Organization slug
 
 ---
 ### Operational

--- a/src/commcare_cloud/commands/sentry.py
+++ b/src/commcare_cloud/commands/sentry.py
@@ -1,0 +1,63 @@
+import json
+import sys
+
+import requests
+
+from commcare_cloud.environment.main import get_environment
+from .command_base import CommandBase, Argument
+
+
+class ExportSentryEvents(CommandBase):
+    command = 'export-sentry-events'
+    help = (
+        "Export Sentry events. One line per event JSON."
+    )
+
+    arguments = (
+        Argument('-k', '--api-key', help="Sentry API Key"),
+        Argument('-q', '--query', help="Text query", default=None),
+        Argument('--start', help="UTC start date. Format YYYY-MM-DDTHH:MM:SS", default=None),
+        Argument('--end', help="UTC end date. Format YYYY-MM-DDTHH:MM:SS", default=None),
+        Argument('--project-id',
+                 help="Sentry project ID. If not supplied the value for the environment "
+                      "will be used (requires Vault access)", default=None
+         ),
+        Argument('--organization', help="Organization slug", default='dimagi'),
+    )
+
+    def run(self, args, unknown_args):
+        env = get_environment(args.env_name)
+
+        url = "https://sentry.io/api/0/organizations/{organization_slug}/events/".format(
+            organization_slug=args.organization_slug,
+        )
+
+        params = {'environment': env.meta_config.env_monitoring_id}
+        if args.query:
+            params['query'] = args.query
+        if args.start:
+            params['start'] = args.start
+        if args.end:
+            params['end'] = args.end
+        if args.project_id:
+            params['project'] = args.project_id
+        else:
+            params['project'] = env.get_vault_var('localsettings_private.SENTRY_PROJECT_ID')
+
+        while True:
+            resp = requests.get(url, params, headers={
+                'Authorization': 'Bearer {}'.format(args.api_key)
+            })
+            events = resp.json()
+            for event in events:
+                print(json.dumps(event))
+
+            # see https://docs.sentry.io/api/pagination/
+            links = resp.headers['Link']
+            prev, next = links.split(',')
+            next_url, rel, results, cursor = next.split(';')
+            if results.strip() != 'results="true"':
+                return
+
+            sys.stderr.write("Fetching next page: {}\n".format(cursor.strip()))
+            url = next_url.strip()[1:-1]

--- a/src/commcare_cloud/commcare_cloud.py
+++ b/src/commcare_cloud/commcare_cloud.py
@@ -15,6 +15,7 @@ from commcare_cloud.commands.ansible.downtime import Downtime
 from commcare_cloud.commands.deploy import Deploy
 from commcare_cloud.commands.migrations.couchdb import MigrateCouchdb
 from commcare_cloud.commands.migrations.copy_files import CopyFiles
+from commcare_cloud.commands.sentry import ExportSentryEvents
 from commcare_cloud.commands.terraform.aws import AwsList, AwsFillInventory, AwsSignIn
 from commcare_cloud.commands.terraform.openvpn import OpenvpnActivateUser, OpenvpnClaimUser
 from commcare_cloud.commands.terraform.terraform import Terraform
@@ -53,6 +54,7 @@ COMMAND_GROUPS = OrderedDict([
         SendDatadogEvent,
         DjangoManage,
         Tmux,
+        ExportSentryEvents,
     ]),
     ('operational', [
         Ping,


### PR DESCRIPTION
##### SUMMARY
A utility command to export Sentry events.

I've found this useful on a few occasions.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Sentry

##### ADDITIONAL INFORMATION
Example usage:
```
cchq icds export-sentry-events --api-key XXX --query MissingFormXml --start 2019-08-20T08:50:00 --end 2019-08-20T09:45:00 --project-id 12345 > events.txt
```