### PR TITLE
add settings for new trial experience flag

### DIFF
--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -112,6 +112,7 @@ localsettings:
   STATIC_ROOT:
   STATIC_CDN: 'https://d2f60qxn5rwjxl.cloudfront.net'
   WS4REDIS_CONNECTION_HOST: "{{ groups.redis.0 }}"
+  ENABLE_NEW_TRIAL_EXPERIENCE: True
 
 # comment these two lines out to make a new rackspace machine
 commcare_cloud_root_user: ubuntu

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -809,6 +809,10 @@ MAX_RULE_UPDATES_IN_ONE_RUN = {{ localsettings.MAX_RULE_UPDATES_IN_ONE_RUN }}
 REPEATERS_WHITELIST = {{ localsettings.REPEATERS_WHITELIST }}
 {% endif %}
 
+{% if localsettings.get('ENABLE_NEW_TRIAL_EXPERIENCE') %}
+ENABLE_NEW_TRIAL_EXPERIENCE = True
+{% endif %}
+
 {% if localsettings.AUDIT_MODEL_SAVE is defined %}
 AUDIT_MODEL_SAVE= [
   {% for model in localsettings.get("AUDIT_MODEL_SAVE") -%}


### PR DESCRIPTION
##### SUMMARY
adding `ENABLE_NEW_TRIAL_EXPERIENCE` to `localsettings`

##### ENVIRONMENTS AFFECTED
staging is the only environment where this will be set to `True`

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
localsettings

##### ADDITIONAL INFORMATION
related hq PR coming soon