### PR TITLE
clean formplayer releases

### DIFF
--- a/src/commcare_cloud/fab/operations/formplayer.py
+++ b/src/commcare_cloud/fab/operations/formplayer.py
@@ -77,26 +77,34 @@ def offline_build_formplayer():
 @roles(ROLES_FORMPLAYER)
 def rollback_formplayer():
     build_dir = os.path.join(env.code_current, FORMPLAYER_BUILD_DIR)
+
+    builds = _get_old_formplayer_builds(build_dir)
+    if not builds:
+        utils.abort('No formplayer builds to rollback to.')
+
+    rollback_build = builds[0]
+    if not console.confirm('Confirm rollback to "{}"'.format(rollback_build), default=False):
+        utils.abort('Action aborted.')
+
     with cd(build_dir):
-        current_build = sudo('readlink -f current').split('/')[-1]
-
-        previous_build_paths = sudo('find . -name "{}*" -type d'.format('formplayer__')).strip()
-        if not previous_build_paths:
-            utils.abort('No formplayer builds to rollback to.')
-
-        builds = sorted(_get_builds(previous_build_paths.split('\n')), reverse=True)
-        builds.remove(current_build)
-        if not builds:
-            utils.abort('No formplayer builds to rollback to.')
-
-        rollback_build = builds[0]
-        if not console.confirm('Confirm rollback to "{}"'.format(rollback_build), default=False):
-            utils.abort('Action aborted.')
-
         sudo('ln -sfn {build_dir}/{rollback} {build_dir}/current'.format(
             build_dir=build_dir,
             rollback=rollback_build
         ))
+
+
+def clean_formplayer_releases(commcare_release_path, keep=1):
+    build_dir = os.path.join(commcare_release_path, FORMPLAYER_BUILD_DIR)
+    if not files.exists(build_dir):
+        return
+
+    builds = _get_old_formplayer_builds(build_dir)
+    if not builds:
+        return
+
+    with cd(build_dir):
+        for build in builds[keep:]:
+            sudo('rm -rf {}'.format(build))
 
 
 def _get_builds(build_paths):
@@ -111,3 +119,16 @@ def _get_builds(build_paths):
         else:
             builds.append(filename)
     return builds
+
+
+def _get_old_formplayer_builds(build_dir):
+    with cd(build_dir):
+        current_build = sudo('readlink -f current').split('/')[-1]
+
+        previous_build_paths = sudo('find . -name "{}*" -type d'.format('formplayer__')).strip()
+        if not previous_build_paths:
+            return []
+
+        old_builds = sorted(_get_builds(previous_build_paths.split('\n')), reverse=True)
+        old_builds.remove(current_build)
+        return old_builds

--- a/src/commcare_cloud/fab/operations/release.py
+++ b/src/commcare_cloud/fab/operations/release.py
@@ -27,6 +27,7 @@ from ..const import (
     FORMPLAYER_BUILD_DIR,
     ROLES_CONTROL)
 from commcare_cloud.fab.utils import pip_install
+from .formplayer import clean_formplayer_releases
 
 GitConfig = namedtuple('GitConfig', 'key value')
 
@@ -415,6 +416,10 @@ def clean_releases(keep=3):
 
     for release in to_remove:
         sudo('rm -rf {}/{}'.format(env.releases, release))
+
+    remaining_releases = set(releases) - set(to_remove)
+    for release in remaining_releases:
+        clean_formplayer_releases(os.path.join(env.releases, release))
 
     # as part of the clean up step, run gc in the 'current' directory
     git_gc_current()


### PR DESCRIPTION
##### SUMMARY
As far as I can tell formplayer releases continue to accumulate and are copied from release to release.

Staging had 60GB of formplayer releases.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Deploy

##### ADDITIONAL INFORMATION
This will remove all formplayer releases except the current one and the one prior to that.