### PR TITLE
Fix the way `{{` is rendered in the docs

### DIFF
--- a/changelog/0027-fix-python3-virtualenv.yml
+++ b/changelog/0027-fix-python3-virtualenv.yml
@@ -18,7 +18,6 @@ update_steps: |
   1. Run the following command, replacing `<env>` for the name of your environment:
 
   ```
-  $ commcare-cloud <env> run-shell-command webworkers:pillowtop:celery:airflow:proxy:formplayer:django_manage sed -i -e "s~/home/cchq/www/{{ deploy_env }}/current~$(readlink -f /home/cchq/www/{{ deploy_env }}/current/)~g" /home/cchq/www/{{ deploy_env }}/current/python_env-3.6/bin/activate" -e deploy_env=<env>
-  $ commcare-cloud <env> run-shell-command webworkers:pillowtop:celery:airflow:proxy:formplayer:django_manage 'sed -i -e "s~/home/cchq/www/{{ deploy_env }}/current~$(readlink -f /home/cchq/www/{{ deploy_env }}/current/)~g" /home/cchq/www/{{ deploy_env }}/current/python_env-3.6/bin/activate' -e deploy_env=<env> -b
+  $ commcare-cloud <env> run-shell-command webworkers:pillowtop:celery:airflow:proxy:formplayer:django_manage 'sed -i -e "s~/home/cchq/www/{{ deploy_env }}/current~$(readlink -f /home/cchq/www/{{ deploy_env }}/current/)~g" /home/cchq/www/{{ deploy_env }}/current/python_env-3.6/bin/activate' -e deploy_env=<env> -b --become-user cchq
 
   ```

--- a/changelog/0027-fix-python3-virtualenv.yml
+++ b/changelog/0027-fix-python3-virtualenv.yml
@@ -19,5 +19,6 @@ update_steps: |
 
   ```
   $ commcare-cloud <env> run-shell-command webworkers:pillowtop:celery:airflow:proxy:formplayer:django_manage sed -i -e "s~/home/cchq/www/{{ deploy_env }}/current~$(readlink -f /home/cchq/www/{{ deploy_env }}/current/)~g" /home/cchq/www/{{ deploy_env }}/current/python_env-3.6/bin/activate" -e deploy_env=<env>
+  $ commcare-cloud <env> run-shell-command webworkers:pillowtop:celery:airflow:proxy:formplayer:django_manage 'sed -i -e "s~/home/cchq/www/{{ deploy_env }}/current~$(readlink -f /home/cchq/www/{{ deploy_env }}/current/)~g" /home/cchq/www/{{ deploy_env }}/current/python_env-3.6/bin/activate' -e deploy_env=<env> -b
 
   ```

--- a/docs/changelog/0027-fix-python3-virtualenv.md
+++ b/docs/changelog/0027-fix-python3-virtualenv.md
@@ -25,6 +25,6 @@ can cause problems when updating python libraries.
 1. Run the following command, replacing `<env>` for the name of your environment:
 
 ```
-$ commcare-cloud <env> run-shell-command webworkers:pillowtop:celery:airflow:proxy:formplayer:django_manage sed -i -e "s~/home/cchq/www/{{ deploy_env }}/current~$(readlink -f /home/cchq/www/{{ deploy_env }}/current/)~g" /home/cchq/www/{{ deploy_env }}/current/python_env-3.6/bin/activate" -e deploy_env=<env>
+$ commcare-cloud <env> run-shell-command webworkers:pillowtop:celery:airflow:proxy:formplayer:django_manage sed -i -e "s~/home/cchq/www/{{ '{{' }} deploy_env }}/current~$(readlink -f /home/cchq/www/{{ '{{' }} deploy_env }}/current/)~g" /home/cchq/www/{{ '{{' }} deploy_env }}/current/python_env-3.6/bin/activate" -e deploy_env=<env>
 
 ```

--- a/docs/changelog/0027-fix-python3-virtualenv.md
+++ b/docs/changelog/0027-fix-python3-virtualenv.md
@@ -25,6 +25,6 @@ can cause problems when updating python libraries.
 1. Run the following command, replacing `<env>` for the name of your environment:
 
 ```
-$ commcare-cloud <env> run-shell-command webworkers:pillowtop:celery:airflow:proxy:formplayer:django_manage sed -i -e "s~/home/cchq/www/{{ '{{' }} deploy_env }}/current~$(readlink -f /home/cchq/www/{{ '{{' }} deploy_env }}/current/)~g" /home/cchq/www/{{ '{{' }} deploy_env }}/current/python_env-3.6/bin/activate" -e deploy_env=<env>
+$ commcare-cloud <env> run-shell-command webworkers:pillowtop:celery:airflow:proxy:formplayer:django_manage 'sed -i -e "s~/home/cchq/www/{{ '{{' }} deploy_env }}/current~$(readlink -f /home/cchq/www/{{ '{{' }} deploy_env }}/current/)~g" /home/cchq/www/{{ '{{' }} deploy_env }}/current/python_env-3.6/bin/activate' -e deploy_env=<env> -b --become-user cchq
 
 ```

--- a/src/commcare_cloud/manage_commcare_cloud/make_changelog.py
+++ b/src/commcare_cloud/manage_commcare_cloud/make_changelog.py
@@ -114,4 +114,4 @@ class MakeChangelog(CommandBase):
         template = j2.get_template('changelog.md.j2')
 
         text = template.render(changelog_entry=changelog_entry, ordinal=ordinal)
-        print(text.rstrip().encode("utf-8"))
+        print(text.rstrip().encode("utf-8").replace('{{', "{{ '{{' }}"))


### PR DESCRIPTION
##### SUMMARY

{{ deploy_env }} in markdown was being rendered as an empty string

##### ENVIRONMENTS AFFECTED
none

##### ISSUE TYPE
- Docs Pull Request
