### PR TITLE
Increase production celery memory

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -251,28 +251,28 @@ servers:
     os: trusty
 
   - server_name: "celery9-production"
-    server_instance_type: t3.2xlarge
+    server_instance_type: r5.2xlarge
     network_tier: "app-private"
     az: "c"
     volume_size: 150
     group: "celery"
     os: bionic
   - server_name: "celery10-production"
-    server_instance_type: t3.2xlarge
+    server_instance_type: r5.2xlarge
     network_tier: "app-private"
     az: "c"
     volume_size: 150
     group: "celery"
     os: bionic
   - server_name: "celery11-production"
-    server_instance_type: t3.2xlarge
+    server_instance_type: r5.2xlarge
     network_tier: "app-private"
     az: "c"
     volume_size: 150
     group: "celery"
     os: bionic
   - server_name: "celery12-production"
-    server_instance_type: t3.xlarge
+    server_instance_type: r5.xlarge
     network_tier: "app-private"
     az: "c"
     volume_size: 150


### PR DESCRIPTION
##### SUMMARY
As per https://dimagi-dev.atlassian.net/browse/PLAT-188

As shown in https://aws.amazon.com/ec2/pricing/on-demand/, this will take the celery machines from

- 8 variable-perf CPU and 32GB RAM to
- 8 consistent-perf CPU and 64GB RAM

For celery12 (which runs side processes) I'm doing the analogous thing but down one size.

This can be rolled out one machine at a time, so no downtime expected (but restart alerts expected). Restarting celery 12 will temporarily interrupt beat, queuing processes, etc., but I think not to an extent that any user will notice

##### ENVIRONMENTS AFFECTED
production

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
Celery
