### PR TITLE
enable obfuscate passwords and draconian security on staging

### DIFF
--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -112,6 +112,8 @@ localsettings:
   STATIC_ROOT:
   STATIC_CDN: 'https://d2f60qxn5rwjxl.cloudfront.net'
   WS4REDIS_CONNECTION_HOST: "{{ groups.redis.0 }}"
+  OBFUSCATE_PASSWORD_FOR_NIC_COMPLIANCE: True
+  ENABLE_DRACONIAN_SECURITY_FEATURES: yes
 
 # comment these two lines out to make a new rackspace machine
 commcare_cloud_root_user: ubuntu


### PR DESCRIPTION
##### SUMMARY
Adds the following to staging's localsettings so that QA can carry out changes related to requirejs updates for the login and password pages.

```
OBFUSCATE_PASSWORD_FOR_NIC_COMPLIANCE: True
 ENABLE_DRACONIAN_SECURITY_FEATURES: yes
```

##### ENVIRONMENTS AFFECTED
staging

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
localsettings on staging
