### PR TITLE
Use read -r arg to respect backspaces in input

### DIFF
--- a/scripts/example-apply-terraform-rolling-restart.sh
+++ b/scripts/example-apply-terraform-rolling-restart.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
-# bash scripts/example-terraform-resize-disk.sh production couch3:couch4 master
+# bash scripts/example-apply-terraform-rolling-restart.sh production couch3:couch4 master
 
 env=$1
 hosts=$2
 branch=$3
 
-read -sp "Vault Password for '${env}': " vault_password
+read -rsp "Vault Password for '${env}': " vault_password
 
 for host in $(echo ${hosts} | sed 's/:/ /g')
 do

--- a/scripts/example-apply-terraform-to-single-server-and-bring-back-up.sh
+++ b/scripts/example-apply-terraform-to-single-server-and-bring-back-up.sh
@@ -6,7 +6,7 @@ env=$1
 host=$2
 branch=$3
 
-read -sp "Vault Password for '${env}': " vault_password
+read -rsp "Vault Password for '${env}': " vault_password
 
 cchq ${env} terraform apply --skip-secrets -target module.server__${host}-${env}.aws_instance.server &&
 until cchq production ping ${host}

--- a/scripts/example-terraform-resize-disk.sh
+++ b/scripts/example-terraform-resize-disk.sh
@@ -6,7 +6,7 @@ env=$1
 hosts=$2
 branch=$3
 
-read -sp "Vault Password for '${env}': " vault_password
+read -rsp "Vault Password for '${env}': " vault_password
 
 for host in $(echo ${hosts} | sed 's/:/ /g')
 do


### PR DESCRIPTION
##### SUMMARY
Without -r, read -s will strip backspaces from the password you enter

This only effects some example scripts I use to glue together some operations