### PR TITLE
temporarily turn on ICDS login pages on staging

### DIFF
--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -114,6 +114,7 @@ localsettings:
   WS4REDIS_CONNECTION_HOST: "{{ groups.redis.0 }}"
   OBFUSCATE_PASSWORD_FOR_NIC_COMPLIANCE: True
   ENABLE_DRACONIAN_SECURITY_FEATURES: yes
+  CUSTOM_LANDING_TEMPLATE: 'icds/login.html'
 
 # comment these two lines out to make a new rackspace machine
 commcare_cloud_root_user: ubuntu


### PR DESCRIPTION
##### SUMMARY
temporarily enables the ICDS login page on staging so that we can test the requirejs changes to login js

##### ENVIRONMENTS AFFECTED
staging

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
localsettings
