### PR TITLE
Add command to roll out supervisor changes to end of recent changelog entries

### DIFF
--- a/changelog/0024-define-management-commands.yml
+++ b/changelog/0024-define-management-commands.yml
@@ -40,3 +40,5 @@ update_steps: |
     server_hostname:
       submission_reprocessing_queue:
   ```
+
+  5. Run `cchq <env> update-supervisor-confs`

--- a/changelog/0025-rename-management-commands.yml
+++ b/changelog/0025-rename-management-commands.yml
@@ -17,3 +17,4 @@ details: |
 
 update_steps: |
   1. Change any references to the old management command names to the new name in `app-processes.yml`
+  2. Run `cchq <env> update-supervisor-confs`

--- a/changelog/0026-move-remaining-management-commands.yml
+++ b/changelog/0026-move-remaining-management-commands.yml
@@ -24,3 +24,4 @@ update_steps: |
   +   pillowN:
   +     run_pillow_retry_queue:
   ```
+  2. Run `cchq <env> update-supervisor-confs`

--- a/docs/changelog/0024-define-management-commands.md
+++ b/docs/changelog/0024-define-management-commands.md
@@ -46,3 +46,5 @@ management_commands:
   server_hostname:
     submission_reprocessing_queue:
 ```
+
+5. Run `cchq <env> update-supervisor-confs`

--- a/docs/changelog/0025-rename-management-commands.md
+++ b/docs/changelog/0025-rename-management-commands.md
@@ -24,3 +24,4 @@ the actual Django management command names:
 
 ## Steps to update
 1. Change any references to the old management command names to the new name in `app-processes.yml`
+2. Run `cchq <env> update-supervisor-confs`

--- a/docs/changelog/0026-move-remaining-management-commands.md
+++ b/docs/changelog/0026-move-remaining-management-commands.md
@@ -31,3 +31,4 @@ will be deployed as configured by the `management_commands` section in `app-proc
 +   pillowN:
 +     run_pillow_retry_queue:
 ```
+2. Run `cchq <env> update-supervisor-confs`


### PR DESCRIPTION
##### SUMMARY
I think even though these are supposed to be roughly no-op, it makes sense to tell people to update supervisor confs right after. Related to https://dimagi-dev.atlassian.net/browse/PLAT-209

##### ENVIRONMENTS AFFECTED
none

##### ISSUE TYPE
- Docs Pull Request
