### PR TITLE
limit MM download bandwidth to 500k per request

### DIFF
--- a/src/commcare_cloud/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/cas_ssl.yml
@@ -72,6 +72,7 @@ nginx_sites:
          - zone_name: "multimedia"
            burst: 50
            nodelay: True
+       limit_rate: 500k
      - name: "/a/icds-test/apps/download"
        balancer: "{{ deploy_env }}_cas_commcare"
        proxy_redirect: "http://{{ CAS_SITE_HOST }} https://{{ CAS_SITE_HOST }}"


### PR DESCRIPTION
##### SUMMARY
Limit the bandwidth usage per request for multimedia downloads. The limit will only kick in after the first 100k has been sent which mean it should only get applied to larger files like videos.

This works in combination with the rate limit to limit the bandwidth usage. 

At this rate a 12M file will take ~30s to download.

Setting the rate limit to 50r/s means our max bandwith usage for MM would be 24MiB/s.

##### ENVIRONMENTS AFFECTED
ICDS

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
nginx

We could also add `limit_rate_after 100k` to only limit larger files but that makes it much harder to know what our max usage will be.