### PR TITLE
Terminating old trusty Elasticsearch instances on production environment

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -96,26 +96,6 @@ servers:
     os: bionic
 
 
-  - server_name: "esmaster0-production"
-    server_instance_type: t3.large
-    network_tier: "db-private"
-    az: "b"
-    volume_size: 40
-    group: "elasticsearch"
-    os: trusty
-  - server_name: "esmaster1-production"
-    server_instance_type: t3.large
-    network_tier: "db-private"
-    az: "b"
-    volume_size: 40
-    group: "elasticsearch"
-    os: trusty
-  - server_name: "esmaster2-production"
-    server_instance_type: t3.large
-    network_tier: "db-private"
-    az: "a"
-    group: "elasticsearch"
-    os: trusty
   - server_name: "esmaster3-production"
     server_instance_type: t3.large
     network_tier: "db-private"
@@ -137,41 +117,7 @@ servers:
     group: "elasticsearch"
     os: bionic
 
-  - server_name: "es10-production"
-    server_instance_type: m5.2xlarge
-    network_tier: "db-private"
-    az: "a"
-    volume_size: 660
-    group: "elasticsearch"
-    os: trusty
-  - server_name: "es11-production"
-    server_instance_type: m5.2xlarge
-    network_tier: "db-private"
-    az: "a"
-    volume_size: 660
-    group: "elasticsearch"
-    os: trusty
-  - server_name: "es12-production"
-    server_instance_type: m5.2xlarge
-    network_tier: "db-private"
-    az: "a"
-    volume_size: 660
-    group: "elasticsearch"
-    os: trusty
-  - server_name: "es13-production"
-    server_instance_type: m5.2xlarge
-    network_tier: "db-private"
-    az: "a"
-    volume_size: 660
-    group: "elasticsearch"
-    os: trusty
-  - server_name: "es14-production"
-    server_instance_type: m5.2xlarge
-    network_tier: "db-private"
-    az: "a"
-    volume_size: 660
-    group: "elasticsearch"
-    os: trusty
+
   - server_name: "es15-production"
     server_instance_type: m5.2xlarge
     network_tier: "db-private"


### PR DESCRIPTION
Terminating old trusty Elasticsearch instances on production environment