### PR TITLE
exclude username from app download cache key

### DIFF
--- a/src/commcare_cloud/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/cas_ssl.yml
@@ -21,6 +21,12 @@ nginx_sites:
         # If the header is not provided, do not rate limit
         - key: '""'
           value: '""'
+    # Extract request path from request_uri (https://stackoverflow.com/a/45587134)
+    - name: "$request_uri_path"
+      variable: "$request_uri"
+      var_mappings:
+        - key: '"~^(?P<path>[^?]*)(\?.*)?$"'
+          value: '$path'
    limit_req_zones:
     - name: "incremental_restore" # Limits restores that are not new device or 412s
       zone: "$incremental_sync"
@@ -88,6 +94,8 @@ nginx_sites:
        proxy_cache: app_cache
        proxy_cache_lock: "on"
        proxy_cache_lock_timeout: 30s
+       # exclude username arg from cache key
+       proxy_cache_key: "$proxy_host$request_uri_path$arg_latest$arg_profile"
        client_body_buffer_size: 5m
        proxy_ignore_headers: Set-Cookie
        limit_reqs:

--- a/src/commcare_cloud/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/cas_ssl.yml
@@ -21,12 +21,19 @@ nginx_sites:
         # If the header is not provided, do not rate limit
         - key: '""'
           value: '""'
-    # Extract request path from request_uri (https://stackoverflow.com/a/45587134)
-    - name: "$request_uri_path"
+    # Remove 'username' query param from request uri for use in cache key
+    # https://stackoverflow.com/a/45587134
+    # https://stackoverflow.com/a/35772678
+    - name: "$request_uri_no_username"
       variable: "$request_uri"
+      default_value: "$request_uri"
       var_mappings:
-        - key: '"~^(?P<path>[^?]*)(\?.*)?$"'
-          value: '$path'
+        # username is first query param
+        - key: '"~^(?P<path>[^?]*)\?(username=[^&]*)&?(?P<args>.*)?$"'
+          value: '$path?$args'
+        # username is not first query param
+        - key: '"~^(?P<path>[^?]*)\?(?P<args1>.*?)(&?username=[^&]*)(?P<args2>&?.*)?$"'
+          value: '$path?$args1$args2'
    limit_req_zones:
     - name: "incremental_restore" # Limits restores that are not new device or 412s
       zone: "$incremental_sync"
@@ -95,7 +102,7 @@ nginx_sites:
        proxy_cache_lock: "on"
        proxy_cache_lock_timeout: 30s
        # exclude username arg from cache key
-       proxy_cache_key: "$proxy_host$request_uri_path$arg_latest$arg_profile"
+       proxy_cache_key: "$proxy_host$request_uri_no_username"
        client_body_buffer_size: 5m
        proxy_ignore_headers: Set-Cookie
        limit_reqs:


### PR DESCRIPTION
##### SUMMARY
App download caching has been broken for a long time (since `username` was added as a request param): https://github.com/dimagi/commcare-android/pull/1747

This changes the cache key to exclude username. 

##### ENVIRONMENTS AFFECTED
ICDS

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nginx cache

##### ADDITIONAL INFORMATION
This takes a the approach or stripping out the username but leaving the rest of the URL intact. I felt this was safer than only using specific parts of the URI in the key (https://github.com/dimagi/commcare-cloud/commit/566ed45d8c6d9e3358e6fc8fb225965eef82f56a) since if the URI changes the cache may not work but at least we won't be serving incorrect resources.

I used https://github.com/nginxinc/NGINX-Demos/tree/master/nginx-regex-tester to test the regexes.