### PR TITLE
set icds_use_citus

### DIFF
--- a/environments/icds-cas/public.yml
+++ b/environments/icds-cas/public.yml
@@ -136,6 +136,7 @@ localsettings:
   ENABLE_SOFT_ASSERT_EMAILS: True
   HQ_INSTANCE: 'icds'
   INACTIVITY_TIMEOUT: 20160
+  ICDS_USE_CITUS: True
   INVOICE_FROM_ADDRESS:
     'name': "Dimagi, Inc."
     'first_line': "585 Massachusetts Ave"

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -895,3 +895,7 @@ UCR_COMPARISONS = {
 {% if localsettings.KAFKA_API_VERSION is defined %}
 KAFKA_API_VERSION = tuple({{ localsettings.KAFKA_API_VERSION }})
 {% endif %}
+
+{% if localsettings.ICDS_USE_CITUS is defined %}
+ICDS_USE_CITUS = localsettings.ICDS_USE_CITUS
+{% endif %}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This sets `ICDS_USE_CITUS` in localsettings, which causes the dashboard to default to citus
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
ICDS
