### PR TITLE
Use Fabric3 (python3 compatible fork) instead of Fabric

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ dimagi-memoized==1.1.1
 dnspython==1.16.0
 docutils==0.14            # via botocore
 enum34==1.1.6             # via cryptography
-fabric==1.10.2
+fabric3==1.10.2.post3
 futures==3.2.0            # via s3transfer
 gevent==1.4.0             # via couchdb-cluster-admin
 greenlet==0.4.15          # via gevent
@@ -39,7 +39,7 @@ jsonobject==0.9.9
 markupsafe==1.1.1         # via jinja2
 ndg-httpsclient==0.5.1
 netaddr==0.7.19
-paramiko==2.4.2           # via fabric
+paramiko==2.4.2           # via fabric3
 passlib==1.7.1
 pyasn1==0.4.5             # via ndg-httpsclient, paramiko
 pycparser==2.19           # via cffi

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         'datadog==0.2.0',
         'dimagi-memoized>=1.1.0',
         'dnspython',
-        'Fabric==1.10.2',
+        'Fabric3>=1.10.2,<1.11',
         # can remove once requests bumps its version requirement
         # https://github.com/requests/requests/issues/4681
         'idna==2.6',


### PR DESCRIPTION
##### SUMMARY

https://pypi.org/project/Fabric3/
Release version numbers mirror Fabric version numbers, followed by
.post1, .post2, etc. Currently pinning to the latest "post" for the
previously-pinned version, 1.10.2.

##### ENVIRONMENTS AFFECTED
all

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
deploy / fab
