### PR TITLE
Add interface for deploying formplayer

### DIFF
--- a/docs/commcare-cloud/commands/index.md
+++ b/docs/commcare-cloud/commands/index.md
@@ -956,8 +956,14 @@ Use `-l` instead of a command to see the full list of commands.
 Deploy CommCare
 
 ```
-commcare-cloud <env> deploy [--resume] [--skip-record] [--commcare-branch COMMCARE_BRANCH]
+commcare-cloud <env> deploy [--resume] [--skip-record] [--commcare-branch COMMCARE_BRANCH] [{commcare,formplayer}]
 ```
+
+##### Positional Arguments
+
+###### `{commcare,formplayer}`
+
+The component to deploy.
 
 ##### Optional Arguments
 

--- a/src/commcare_cloud/commands/deploy.py
+++ b/src/commcare_cloud/commands/deploy.py
@@ -1,3 +1,5 @@
+from clint.textui.colored import yellow, blue
+
 from commcare_cloud.alias import commcare_cloud
 from commcare_cloud.cli_utils import check_branch, ask
 from commcare_cloud.commands import shared_args
@@ -12,6 +14,9 @@ class Deploy(CommandBase):
     )
 
     arguments = (
+        Argument('component', nargs='?', choices=['commcare', 'formplayer'], default='commcare', help="""
+            The component to deploy.
+        """),
         Argument('--resume', action='store_true', help="""
             Rather than starting a new deploy, start where you left off the last one.
         """),
@@ -28,14 +33,39 @@ class Deploy(CommandBase):
     def run(self, args, unknown_args):
         check_branch(args)
         environment = get_environment(args.env_name)
-        commcare_branch = self._confirm_commcare_branch(environment, args.commcare_branch)
-        fab_func_args = self.get_fab_func_args(args)
+        commcare_branch = self._confirm_commcare_branch(environment, args.commcare_branch,
+                                                        quiet=args.quiet)
+        if args.component == 'commcare':
+            print(blue("You are about to deploy commcare"))
+            print(blue("branch: {}".format(commcare_branch)))
+            if ask('Deploy commcare?', quiet=args.quiet):
+                print(yellow("Formplayer will not be deployed right now,"))
+                print(yellow("but we recommend deploying formplayer about once a month as well."))
+                print(yellow("It causes about 1 minute of service interruption to Web Apps and App Preview,"))
+                print(yellow("but keeps these services up to date."))
+                print(yellow("You can do so by running `commcare-cloud <env> deploy formplayer`"))
+
+                self.deploy_commcare(environment, commcare_branch, args, unknown_args)
+        elif args.component == 'formplayer':
+            self.deploy_formplayer(environment, commcare_branch, args, unknown_args)
+
+    def deploy_commcare(self, environment, commcare_branch, args, unknown_args):
+        fab_func_args = self.get_deploy_commcare_fab_func_args(args)
         commcare_cloud(environment.name, 'fab', 'deploy_commcare{}'.format(fab_func_args),
                        '--set', 'code_branch={}'.format(commcare_branch),
                        branch=args.branch, *unknown_args)
 
+    def deploy_formplayer(self, environment, commcare_branch, args, unknown_args):
+        """
+        Because of how our fab code is structured, the code_branch variable is still required,
+        even though it is used only barely, if in any consequential way at all.
+        """
+        commcare_cloud(environment.name, 'fab', 'deploy_formplayer',
+                       '--set', 'code_branch={}'.format(commcare_branch),
+                       branch=args.branch, *unknown_args)
+
     @staticmethod
-    def get_fab_func_args(args):
+    def get_deploy_commcare_fab_func_args(args):
         fab_func_args = []
 
         if args.quiet:
@@ -51,12 +81,9 @@ class Deploy(CommandBase):
             return ''
 
     @staticmethod
-    def _confirm_commcare_branch(environment, commcare_branch):
+    def _confirm_commcare_branch(environment, commcare_branch, quiet):
         default_branch = environment.fab_settings_config.default_branch
         if not commcare_branch:
-            print("commcare_branch not specified, using '{}'. "
-                  "You can override this with '--commcare-branch=<branch>'"
-                  .format(default_branch))
             return default_branch
 
         if commcare_branch != default_branch:
@@ -64,7 +91,7 @@ class Deploy(CommandBase):
                 "Whoa there bud! You're using branch {commcare_branch}. "
                 "ARE YOU DOING SOMETHING EXCEPTIONAL THAT WARRANTS THIS?"
             ).format(commcare_branch=commcare_branch)
-            if not ask(branch_message):
+            if not ask(branch_message, quiet=quiet):
                 exit(-1)
 
         return commcare_branch


### PR DESCRIPTION
##### SUMMARY

Following up on https://github.com/dimagi/commcare-cloud/pull/3174. I realized we currently didn't have an "official" way to deploy formplayer ever since pulling out formplayer_deploy from normal deploy and shortly after switching to the deploy command.

Normal deploy includes a reminder to deploy formplayer occasionally with
the command to do so.

Normal deploy:
<img width="734" alt="Screen Shot 2019-09-09 at 5 43 46 PM" src="https://user-images.githubusercontent.com/137212/64572109-ac57cb00-d32b-11e9-8cef-d94bd3a6975a.png">

Formplayer deploy:

<img width="761" alt="Screen Shot 2019-09-09 at 5 59 44 PM" src="https://user-images.githubusercontent.com/137212/64572116-b1b51580-d32b-11e9-9e26-8d23ded7ed25.png">


##### ENVIRONMENTS AFFECTED
all

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
Deploy (formplayer)
