### PR TITLE
Double UCR form pillows on ICDS

### DIFF
--- a/environments/icds-cas/app-processes.yml
+++ b/environments/icds-cas/app-processes.yml
@@ -258,26 +258,26 @@ pillows:
   'pillow23':
     kafka-ucr-static-forms:
       start_process: 0
-      num_processes: 12
-      total_processes: 48
+      num_processes: 24
+      total_processes: 96
       processor_chunk_size: 100
   'pillow24':
     kafka-ucr-static-forms:
-      start_process: 12
-      num_processes: 12
-      total_processes: 48
+      start_process: 24
+      num_processes: 24
+      total_processes: 96
       processor_chunk_size: 100
   'pillow25':
     kafka-ucr-static-forms:
-      start_process: 24
-      num_processes: 12
-      total_processes: 48
+      start_process: 48
+      num_processes: 24
+      total_processes: 96
       processor_chunk_size: 100
   'pillow26':
     kafka-ucr-static-forms:
-      start_process: 36
-      num_processes: 12
-      total_processes: 48
+      start_process: 72
+      num_processes: 24
+      total_processes: 96
       processor_chunk_size: 100
   'pillow41':
     FormSubmissionMetadataTrackerPillow:


### PR DESCRIPTION
##### SUMMARY
This doubles the kafka-ucr-static-forms pillows as a temporary measure. I'm doing this because of the issue described https://github.com/dimagi/commcare-hq/pull/25334. There are roughly 16 topics that have gotten over the hump of duplicate forms and doing this will ensure those stay up to date. Once the remaining topics get past that hump, they should also be able to get up to date much faster.

I do not intend to merge this as it should be reverted once 

##### ENVIRONMENTS AFFECTED
icds
##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
pillows