### PR TITLE
fix references to vars from other hosts

### DIFF
--- a/src/commcare_cloud/ansible/roles/haproxy/templates/service.j2
+++ b/src/commcare_cloud/ansible/roles/haproxy/templates/service.j2
@@ -58,7 +58,7 @@ backend {{ item.service.haproxy_service_name }}-back
 
 {% for host_name in item.service.haproxy_backend_nodes %}
 {% if hostvars[host_name] is defined %}
-{%   set ip_addr = hostvars[host_name][internal_network_interface_fact].ipv4.address %}
+{%   set ip_addr = hostvars[host_name][hostvars[host_name].internal_network_interface_fact].ipv4.address %}
 {% endif %}
     {{ [
         "server",
@@ -70,7 +70,7 @@ backend {{ item.service.haproxy_service_name }}-back
 
 {% for host_name in item.service.haproxy_backup_nodes|default([]) %}
 {% if hostvars[host_name] is defined %}
-{%   set ip_addr = hostvars[host_name].internal_ipv4.address %}
+{%   set ip_addr = hostvars[host_name][hostvars[host_name].internal_network_interface_fact].ipv4.address %}
 {% endif %}
     {{ [
         "server",

--- a/src/commcare_cloud/ansible/roles/rabbitmq/tasks/config-cluster.yml
+++ b/src/commcare_cloud/ansible/roles/rabbitmq/tasks/config-cluster.yml
@@ -2,8 +2,8 @@
 - name: rabbitmq_clustering | ensure hostnames are in the host file
   lineinfile:
     dest: /etc/hosts
-    regexp: "^{{ hostvars[item][internal_network_interface_fact].ipv4.address }}\\s"
-    line: "{{ hostvars[item][internal_network_interface_fact].ipv4.address }} {{ hostvars[item]['ansible_hostname'] }}"
+    regexp: "^{{ hostvars[item][hostvars[item].internal_network_interface_fact].ipv4.address }}\\s"
+    line: "{{ hostvars[item][hostvars[item].internal_network_interface_fact].ipv4.address }} {{ hostvars[item]['ansible_hostname'] }}"
   with_items: "{{ groups['rabbitmq'] }}"
 
 - name: rabbitmq_clustering | Capturing Erlang Cookie On Master


### PR DESCRIPTION
##### SUMMARY
When selecting a var from a different host you must use the var name for that host.

##### ISSUE TYPE
- Bugfix Pull Request

