### PR TITLE
Add check for old commcare-cloud install

### DIFF
--- a/src/commcare_cloud/commcare_cloud.py
+++ b/src/commcare_cloud/commcare_cloud.py
@@ -10,7 +10,7 @@ from collections import OrderedDict
 
 from clint.textui import puts
 
-from commcare_cloud.cli_utils import print_command
+from commcare_cloud.cli_utils import print_command, check_repo_staleness
 from commcare_cloud.colors import color_error
 from commcare_cloud.commands.ansible.downtime import Downtime
 from commcare_cloud.commands.deploy import Deploy
@@ -162,6 +162,9 @@ def call_commcare_cloud(input_argv=sys.argv):
 
     if args.control:
         run_on_control_instead(args, input_argv)
+
+    check_repo_staleness()
+
     try:
         exit_code = commands[args.command].run(args, unknown_args)
     except CommandError as e:


### PR DESCRIPTION
##### SUMMARY
One difficulty with keeping things in sync across developers and environments is that it's fairly easy not to notice you're on an old version of commcare-cloud, and sometimes that can cause issues that happen silently (like something not getting deployed the right way).

This is an unpolished spike at just always warning the user if their install is older than X (here 10) days. Before pushing this burdensome workflow out or taking more time to improve it, I thought I'd just put the idea out there to get feedback about whether something like this would be a positive addition.