### PR TITLE
increase proxy temp file size

### DIFF
--- a/src/commcare_cloud/ansible/roles/nginx/vars/cchq_ssl.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/cchq_ssl.yml
@@ -22,6 +22,7 @@ nginx_sites:
    root: "/var/www/html"
    server_name: "{{ SITE_HOST }}"
    client_max_body_size: 600m
+   proxy_max_temp_file_size: 5120m
    proxy_set_headers:
    - "Host $host"
    - "X-Forwarded-For $remote_addr"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Nginx was truncating streaming requests greater than the size of this variable. This increases it to the point that it can comfortably hold our largest cas exports.