### PR TITLE
add static root back in on staging localsettings

### DIFF
--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -111,6 +111,7 @@ localsettings:
   SMS_QUEUE_ENABLED: True
   WS4REDIS_CONNECTION_HOST: "{{ groups.redis.0 }}"
   ENABLE_NEW_TRIAL_EXPERIENCE: True
+  STATIC_ROOT:
 
 # comment these two lines out to make a new rackspace machine
 commcare_cloud_root_user: ubuntu


### PR DESCRIPTION
##### SUMMARY
adds `STATIC_ROOT` back to localsettings on staging as it was before

##### ENVIRONMENTS AFFECTED
staging

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
localsettings
