### PR TITLE
Stop restarting formplayer during normal deploy

### DIFF
--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -722,7 +722,7 @@ def silent_services_restart(use_current_release=False):
     """
     execute(db.set_in_progress_flag, use_current_release)
     if not env.is_monolith:
-        execute(supervisor.restart_formplayer)
+        execute(supervisor.restart_formplayer_if_it_is_running_from_old_release_location)
         execute(supervisor.restart_all_except_webworkers)
     execute(supervisor.restart_webworkers)
 

--- a/src/commcare_cloud/fab/operations/formplayer.py
+++ b/src/commcare_cloud/fab/operations/formplayer.py
@@ -132,3 +132,11 @@ def _get_old_formplayer_builds(build_dir):
         old_builds = sorted(_get_builds(previous_build_paths.split('\n')), reverse=True)
         old_builds.remove(current_build)
         return old_builds
+
+
+def formplayer_is_running_from_old_release_location():
+    ps_formplayer = sudo('ps aux | grep formplaye[r]')
+    if env.code_current in ps_formplayer:
+        return True
+    else:
+        return False

--- a/src/commcare_cloud/fab/operations/supervisor.py
+++ b/src/commcare_cloud/fab/operations/supervisor.py
@@ -107,6 +107,15 @@ def restart_formplayer():
     _services_restart()
 
 
+@roles(ROLES_FORMPLAYER)
+def restart_formplayer_if_it_is_running_from_old_release_location():
+    from commcare_cloud.fab.operations.formplayer import \
+        formplayer_is_running_from_old_release_location
+
+    if formplayer_is_running_from_old_release_location():
+        _services_restart()
+
+
 def _services_restart():
     """Stop and restart all supervisord services"""
     supervisor_command('stop all')


### PR DESCRIPTION
##### SUMMARY
I think we're finally ready to stop restarting formplayer during normal deploy. This PR will continuing restarting it as long as it detects that formplayer is running from the old release location (in which case the restart is necessary). Any env that has had `cchq <env> deploy formplayer` run on it since 16 hours ago or so will have formplayer running from the new location, and will not have formplayer restarted on normal deploys after this PR is merged.

I've tested the old/new formplayer location detection logic on staging (new) and india (old), and it worked as intended.

##### ENVIRONMENTS AFFECTED
all

##### ISSUE TYPE
- Change/Bugfix Pull Request

##### COMPONENT NAME
formplayer
