### PR TITLE
Fix issue where new formplayer deploy leaves it unable to find config files

### DIFF
--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_formplayer_spring.conf.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_formplayer_spring.conf.j2
@@ -8,5 +8,5 @@ autorestart=true
 stdout_logfile={{ log_home }}/formplayer-spring.log
 redirect_stderr=true
 stderr_logfile={{ log_home }}/formplayer-spring.error.log
-directory={{ www_home }}/formplayer_build
+directory={{ www_home }}/formplayer_build/current
 startsecs=10


### PR DESCRIPTION
##### SUMMARY
This wasn't caught because I'd done a few iterations on staging and by chance there were config files in the place it was looking. This updates it to look for the config files in the correct place.

##### ENVIRONMENTS AFFECTED
all

##### ISSUE TYPE
- Bugfix Pull Request
