### PR TITLE
Terminating trusty RabbitMQ and formplayer Instances on prod environment

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -197,7 +197,6 @@ servers:
     volume_size: 80
     group: "rabbitmq"
     os: bionic
-    
 
   - server_name: "celery9-production"
     server_instance_type: r5.2xlarge

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -197,6 +197,7 @@ servers:
     volume_size: 80
     group: "rabbitmq"
     os: bionic
+    
 
   - server_name: "celery9-production"
     server_instance_type: r5.2xlarge

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -190,13 +190,6 @@ servers:
     group: "couchdb2"
     os: bionic
 
-  - server_name: "rabbit0-production"
-    server_instance_type: t3.large
-    network_tier: "db-private"
-    az: "c"
-    volume_size: 80
-    group: "rabbitmq"
-    os: trusty
   - server_name: "rabbit1-production"
     server_instance_type: t3.large
     network_tier: "db-private"
@@ -241,22 +234,6 @@ servers:
     volume_size: 150
     group: "pillowtop"
     os: bionic
-
-  - server_name: "formplayer0-production"
-    server_instance_type: t3.large
-    network_tier: "app-private"
-    az: "a"
-    volume_size: 150
-    group: "formplayer"
-    os: trusty
-
-  - server_name: "formplayer1-production"
-    server_instance_type: t3.large
-    network_tier: "app-private"
-    az: "a"
-    volume_size: 150
-    group: "formplayer"
-    os: trusty
     
   - server_name: "formplayer2-production"
     server_instance_type: t3.large


### PR DESCRIPTION
Terminating trusty RabbitMQ and formplayer Instances on prod environment