### PR TITLE
Fix travis timeout by removing concurrency from control/init.sh

### DIFF
--- a/control/init.sh
+++ b/control/init.sh
@@ -1,4 +1,5 @@
 #! /bin/bash
+set -x
 
 if [[ $_ == $0 ]]
 then
@@ -92,14 +93,13 @@ if [ -z "$(which manage-commcare-cloud)" ]; then
     # installs strictly what's in requirements.txt, so versions are pre-pinned
     cd ${COMMCARE_CLOUD_REPO} && pip install pip-tools && pip-sync && pip install -e . && cd -
 else
-    { cd ${COMMCARE_CLOUD_REPO} && pip install pip-tools && pip-sync && pip install -e . && cd - ; } &
+    { cd ${COMMCARE_CLOUD_REPO} && pip install pip-tools && pip-sync && pip install -e . && cd - ; }
 fi
 
 echo "Downloading dependencies from galaxy and pip"
 export ANSIBLE_ROLES_PATH=~/.ansible/roles
-pip install pip --upgrade &
-manage-commcare-cloud install & # includes ansible-galaxy install
-wait
+pip install pip --upgrade
+manage-commcare-cloud install  # includes ansible-galaxy install
 
 # workaround for some envs that got in a bad state
 python -c 'import Crypto' || {


### PR DESCRIPTION
##### SUMMARY
This makes it take a little longer to run, but fixes tests. Next step is
to debug the "wait" that causes the timeout.

I've started debugging here https://github.com/dimagi/commcare-cloud/pull/3288, but didn't get to a better fix fast enough and all the builds have been failing for a week now