### PR TITLE
Wait only for specific processes in init script to fix travis timeout

### DIFF
--- a/control/init.sh
+++ b/control/init.sh
@@ -1,5 +1,4 @@
 #! /bin/bash
-set -x
 
 if [[ $_ == $0 ]]
 then
@@ -93,13 +92,14 @@ if [ -z "$(which manage-commcare-cloud)" ]; then
     # installs strictly what's in requirements.txt, so versions are pre-pinned
     cd ${COMMCARE_CLOUD_REPO} && pip install pip-tools && pip-sync && pip install -e . && cd -
 else
-    { cd ${COMMCARE_CLOUD_REPO} && pip install pip-tools && pip-sync && pip install -e . && cd - ; }
+    { cd ${COMMCARE_CLOUD_REPO} && pip install pip-tools && pip-sync && pip install -e . && cd - ; } &
 fi
 
 echo "Downloading dependencies from galaxy and pip"
 export ANSIBLE_ROLES_PATH=~/.ansible/roles
-pip install pip --upgrade
-manage-commcare-cloud install  # includes ansible-galaxy install
+pip install pip --upgrade &
+manage-commcare-cloud install & # includes ansible-galaxy install
+wait
 
 # workaround for some envs that got in a bad state
 python -c 'import Crypto' || {


### PR DESCRIPTION
##### SUMMARY
Fixes the travis build. This fixes the same issue https://github.com/dimagi/commcare-cloud/pull/3294 did but in a better way.

This adds back the minor concurrency to `control/init.sh`, while skipping background processes not stated by the script. 