### PR TITLE
Change djangomanage1-production c5 => m5

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -37,7 +37,7 @@ servers:
     os: trusty
 
   - server_name: "djangomanage1-production"
-    server_instance_type: c5.xlarge
+    server_instance_type: m5.xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 80


### PR DESCRIPTION
##### SUMMARY

We are currently underusing our m5 RIs, so this is just cost optimization. Doubles RAM and keeps number of vCPU the same (but reduces standardized CPU performance by about 5.8%).

##### ENVIRONMENTS AFFECTED
production

##### ISSUE TYPE
- Change Pull Request
