### PR TITLE
Require terraform < 0.11.15

### DIFF
--- a/src/commcare_cloud/commands/terraform/templates/terraform.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/terraform.tf.j2
@@ -5,7 +5,7 @@ terraform {
     region  = {{ state_bucket_region|tojson }}
     encrypt = true
   }
-  required_version = "~> 0.11.0"
+  required_version = "~> 0.11.0, < 0.11.15"
 }
 
 provider "aws" {


### PR DESCRIPTION
##### SUMMARY

Ṫerraform refuses to work with shared state files created by a future version.
Today I ran into this when my terraform refused to operate because the shared
state file was created with terraform 0.11.15. My first attempt to solve
was to install 0.11.15, but this proved difficult, as my current method
of installing terraform on my Mac, Homebrew, did not recognize this version.
On terraform's own versions page https://releases.hashicorp.com/terraform/
0.11.15 is listed as "0.11.15-oci", which is nonstandard version naming
and the terraform github repo does not list 0.11.15 as a release at all.

It gives me no pleasure to force those with 0.11.15 to downgrade,
but it appears to be our best option here, given that Mac/Homebrew
is a common way to handle installs on our team, and the strange
nature of this 0.11.15 terraform release.

We will eventually want to support upgrading, but when we do, the effort will go into upgrading to 0.12.x which (despite the misleading version number) is a substantial and occasionally backwards incompatible upgrade.