### PR TITLE
Grant usage permissions to commcare user

### DIFF
--- a/src/commcare_cloud/ansible/setup_pg_logical_replication.yml
+++ b/src/commcare_cloud/ansible/setup_pg_logical_replication.yml
@@ -140,6 +140,14 @@
       when: item.target_host == inventory_hostname
       register: result
 
+    - name: Grant usage to hq user
+      postgres
+      postgresql_query:
+        db: '{{ item.target_db_name }}'
+        query: "GRANT USAGE ON SCHEMA pglogical TO {{ secrets.POSTGRES_USERS.commcare }};"
+      loop: "{{ replications }}"
+      when: item.target_host == inventory_hostname
+
 # status
 - hosts:
     - shard_dbs


### PR DESCRIPTION
##### SUMMARY
https://sentry.io/organizations/dimagi/issues/1260738676/?referrer=slack

Context: https://github.com/2ndQuadrant/pglogical/issues/176

Occurred when deploying https://github.com/dimagi/commcare-hq/pull/25569/files#diff-09066e20e199c5840c772df7e9c996d9

We need to grant usage permissions to use DDL commands after setting up a pglogical subscriber. I did this manually (ex: `commcare-cloud icds run-shell-command pgshard20 -b --become-user postgres "psql -c 'GRANT USAGE ON SCHEMA pglogical TO hqweb2postgres;' commcarehq_p20 ")` for ICDS's databases, but I'm incorporating this in pglogical setup. No other environment has used pglogical to split shards, so no other cleanup is necessary.

##### ENVIRONMENTS AFFECTED
icds

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
postgres