### PR TITLE
Add gauge for number of locks not granted

### DIFF
--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -65,6 +65,7 @@ old_s3_bulk_delete_chunksize: ~
 s3_blob_db_access_key: "{{ s3_access_key|default('') }}"
 s3_blob_db_secret_key:  "{{ s3_secret_key|default('') }}"
 
+datadog_integration_airflow: false
 datadog_integration_cloudant: false
 datadog_integration_couch: false
 datadog_integration_elastic: false

--- a/src/commcare_cloud/ansible/roles/datadog/templates/postgres.yaml.j2
+++ b/src/commcare_cloud/ansible/roles/datadog/templates/postgres.yaml.j2
@@ -19,3 +19,9 @@ instances:
            descriptors:  # map columns to tags
              - [datname, database]
              - [state, state]
+         - query: SELECT pgdb.datname AS database, %s FROM pg_locks pl, pg_database pgdb WHERE pl.database = pgdb.oid AND NOT pl.granted GROUP BY pgdb.datname;
+           metrics:
+             "count(*)": [postgresql.locks.not_granted, GAUGE]
+           relation: false
+           descriptors:  # map columns to tags
+             - [database, database]


### PR DESCRIPTION
##### SUMMARY
This adds a gauge for PG databases for number of locks that are blocking queries. I've used this quite a bit when changing the dashboard agg and also understanding our recent pillow issues.

I think it would be useful to have as a metric to better understand how this fluctuates throughout the day. I'm not sure how useful it will be to non-ICDS environments, but it doesn't seem like it would hurt

##### ENVIRONMENTS AFFECTED
all

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
postgres