### PR TITLE
Use t3 instead of t2 for "prove-deploy" build

### DIFF
--- a/.travis/spec.yml
+++ b/.travis/spec.yml
@@ -1,7 +1,7 @@
 aws_config:
   pem: /home/travis/.ssh/commcarehq_testing.pem
   ami: ami-58167327
-  type: t2.micro
+  type: t3.micro
   key_name: commcarehq_testing
   security_group_id: sg-8f9a57fa
   subnet: subnet-ea62acc5


### PR DESCRIPTION
##### SUMMARY
It benefits us to limit the number of different instance classes we use, because then we have more flexibility with our discount purchases. Just happened to come across this and it seemed like a small thing worth changing.
