### PR TITLE
Use all current RIs

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -220,7 +220,7 @@ servers:
     group: "celery"
     os: bionic
   - server_name: "celery12-production"
-    server_instance_type: r5.xlarge
+    server_instance_type: t3.2xlarge  # todo: switch back to r5.xlarge after t3 RI expires
     network_tier: "app-private"
     az: "c"
     volume_size: 150

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -163,7 +163,7 @@ servers:
     os: bionic
 
   - server_name: "couch12-production"
-    server_instance_type: c5.9xlarge
+    server_instance_type: c5.9xlarge  # todo: switch to m5.8xlarge once c5 RI expires
     network_tier: "db-private"
     az: "a"
     volume_size: 30
@@ -172,7 +172,7 @@ servers:
     group: "couchdb2"
     os: bionic
   - server_name: "couch13-production"
-    server_instance_type: c5.9xlarge
+    server_instance_type: c5.9xlarge  # todo: switch to m5.8xlarge once c5 RI expires
     network_tier: "db-private"
     az: "a"
     volume_size: 30
@@ -181,7 +181,7 @@ servers:
     group: "couchdb2"
     os: bionic
   - server_name: "couch14-production"
-    server_instance_type: c5.9xlarge
+    server_instance_type: m5.8xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 30


### PR DESCRIPTION
##### SUMMARY
Because of having shifted around some instance class types in the last few months, we're currently slightly underutilizing the Reserved Instances of the t3 and m5 instance types.

##### ENVIRONMENTS AFFECTED
production
