### PR TITLE
Comment out redis0 in inventory

### DIFF
--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -152,7 +152,7 @@ formplayer3
 10.202.40.34 hostname=redis1-production ufw_private_interface=eth0 swap_size=1G
 
 [redis:children]
-redis0
+#redis0
 redis1
 
 [shareddir0]

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -123,7 +123,7 @@ formplayer3
 {{ __redis1__ }} swap_size=1G
 
 [redis:children]
-redis0
+#redis0
 redis1
 
 {{ __shareddir0__ }}


### PR DESCRIPTION
##### SUMMARY
It's not ready yet. This caused issues after a formplayer deploy because formplayer deploy now updates the formplayer config as well, and doing that made it point to the new redis node which apparently wasn't properly set up yet, as it resulted in these errors: https://sentry.io/organizations/dimagi/issues/619342116/?environment=production&project=136860&query=is%3Aunresolved.

##### ENVIRONMENTS AFFECTED
production

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
redis
