### PR TITLE
Do not update config files on formplayer deploy

### DIFF
--- a/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
@@ -104,7 +104,6 @@
       filename: sentry.properties
   tags:
     - localsettings
-    - formplayer_deploy
 
 # This should be the last task in the file
 # (and certainly the last one tagged with `formplayer_deploy`)


### PR DESCRIPTION
##### SUMMARY
This was a takeaway from the Retro entitled
> Retrospectives: Formplayer error "CLUSTERDOWN Hash slot not served" for ~20 minutes Oct 17, 2019

##### ENVIRONMENTS AFFECTED
all
