### PR TITLE
increase ucr_indicator_queue threshold

### DIFF
--- a/environments/icds-cas/app-processes.yml
+++ b/environments/icds-cas/app-processes.yml
@@ -2,6 +2,7 @@ formplayer_memory: "8000m"
 gunicorn_workers_static_factor: 4
 
 celery_heartbeat_thresholds:
+  ucr_indicator_queue: 86400
   case_rule_queue: 86400
   ucr_queue: 7200
   submission_reprocessing_queue: 7200


### PR DESCRIPTION
##### SUMMARY
Increase UCR queue blockage threshold.

##### ENVIRONMENTS AFFECTED
ICDS

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
Celery

##### ADDITIONAL INFORMATION
Since we've been stopping and starting the queue quite a lot I changed this to 1 day to reduce the noise of alerts since it fails the `serverup` check.