### PR TITLE
Add todo switch away from r5a in Q1

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -228,7 +228,7 @@ servers:
     os: bionic
 
   - server_name: "pillow1-production"
-    server_instance_type: r5a.4xlarge
+    server_instance_type: r5a.4xlarge  # todo: switch to m5.4xlarge once r5a RI expires
     network_tier: "app-private"
     az: "c"
     volume_size: 150


### PR DESCRIPTION
##### SUMMARY
The effect of what the todo is suggesting (once implemented) is to cut pillowtop memory in half, which it can handle: https://app.datadoghq.com/dashboard/nbz-bie-nip/host-groups?abstraction_level=1&aggregate_up=false&display_timeline=false&from_ts=1569251988093&is_auto=false&live=true&page=0&per_page=30&tile_size=m&to_ts=1571843988093&tpl_var_environment=production&tpl_var_host_group=pillowtop&use_date_happened=true, as well as keep the number of vCPUs the same but with better CPU performance.

##### ENVIRONMENTS AFFECTED
production (but no change right now)
