### PR TITLE
Remove support for old *:bionic naming convention

### DIFF
--- a/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
@@ -90,9 +90,7 @@ module "server__{{ server.server_name }}" {
   secondary_volume_size = {{ server.block_device.volume_size|default(0)|tojson }}
   secondary_volume_type = {{ server.block_device.volume_type|default("")|tojson }}
 
-{# Remove the :bionic in group option once this has been rolled out -#}
-{# and any open PRs have had a chance to adopt the new convention -#}
-{% if server.os == 'bionic' or ':bionic' in server.group %}
+{% if server.os == 'bionic' %}
   server_image = "${var.bionic_server_image}"
 {% else %}
   server_image = "${var.server_image}"


### PR DESCRIPTION
##### SUMMARY
There was a point early in the migration to Ubuntu bionic that we were suffixing group names in `terraform.yml` with `:bionic` to get it to use the bionic image, which we quickly replaced with setting `os: bionic` on the server in `terraform.yml`. This removes support for the old convention

##### ENVIRONMENTS AFFECTED
None
