### PR TITLE
Fixed local temp pub key deletion during auth setup of postgres

### DIFF
--- a/src/commcare_cloud/ansible/roles/setup_auth_keys.yml
+++ b/src/commcare_cloud/ansible/roles/setup_auth_keys.yml
@@ -29,4 +29,4 @@
   with_items: "{{ hostTo }}"
 
 - name: Deleting temp files
-  local_action: file  path=/tmp/id_rsa.tmp state=absent
+  local_action: file path=/tmp/id_rsa.tmp state=absent


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* Fixed local temp pub key deletion during auth setup of postgres
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
* ALL
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request