### PR TITLE
remove references to no-longer used ICDS DBs

### DIFF
--- a/environments/icds-cas/postgresql.yml
+++ b/environments/icds-cas/postgresql.yml
@@ -2,7 +2,6 @@ DEFAULT_POSTGRESQL_HOST: pgmain0
 
 REPORTING_DATABASES:
   ucr: ucr
-  icds-ucr-non-dashboard: icds-ucr-non-dashboard
   icds-ucr-citus: icds-ucr-citus
 
 LOAD_BALANCED_APPS:
@@ -121,11 +120,6 @@ dbs:
         shards: [976, 1023]
         host: pgshard29
   custom:
-    - django_alias: icds-ucr-non-dashboard
-      name: commcarehq_icds_aggregatedata
-      host: pgnondashboarducr0
-      query_stats: True
-      django_migrate: False
     - django_alias: icds-ucr-citus
       name: icds_ucr
       django_migrate: True  # ICDS dashboard models are stored here

--- a/environments/india/postgresql.yml
+++ b/environments/india/postgresql.yml
@@ -1,10 +1,7 @@
 DEFAULT_POSTGRESQL_HOST: rds_pgmain0
 REPORTING_DATABASES:
   ucr: ucr
-  icds-ucr: icds-ucr
   icds-ucr-citus: icds-ucr-citus
-  icds-test-ucr: icds-ucr
-  icds-ucr-non-dashboard: icds-ucr
   aaa-data: aaa-data
 
 pgbouncer_override:
@@ -56,10 +53,6 @@ dbs:
         shards: [820, 1023]
         pgbouncer_host: pgbouncer0
   custom:
-    - django_alias: icds-ucr
-      name: icds-ucr
-      django_migrate: True  # ICDS dashboard models are stored here
-      pgbouncer_host: pgbouncer0
     - django_alias: icds-ucr-citus
       name: icds-ucr-citus
       django_migrate: True  # ICDS dashboard models are stored here


### PR DESCRIPTION
##### SUMMARY
These databases are no longer in use by ICDS. The data in the DBs has been migrated to CitusDB.

##### ENVIRONMENTS AFFECTED
* india
* icds-cas

##### ISSUE TYPE
- Change Pull Request