### PR TITLE
Add more RAM to django_manage VM

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -37,7 +37,7 @@ servers:
     os: bionic
 
   - server_name: "djangomanage1-production"
-    server_instance_type: m5.xlarge
+    server_instance_type: m5.2xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 80


### PR DESCRIPTION
##### SUMMARY

Increase size of django_manage VM on production.

##### ENVIRONMENTS AFFECTED
production

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
django_manage

##### ADDITIONAL INFORMATION
This is for the Couch to SQL migration, which has been running out of memory for the case diff process lately. It can be reverted once that is no longer an issue.

Commands (already run)
```paste below
$ cchq production terraform init

$ cchq production terraform plan -target module.server__djangomanage1-production.aws_instance.server

$ cchq production terraform apply -target module.server__djangomanage1-production.aws_instance.server

$ cchq production after-reboot django_manage --branch=dm/bigger-django-manage
```