### PR TITLE
Add citusdb service

### DIFF
--- a/docs/commcare-cloud/commands/index.md
+++ b/docs/commcare-cloud/commands/index.md
@@ -981,8 +981,8 @@ Manage services.
 ```
 commcare-cloud <env> service [--only PROCESS_PATTERN]
                              
-                             {celery,commcare,couchdb2,elasticsearch,elasticsearch-classic,formplayer,kafka,nginx,pillowtop,postgresql,rabbitmq,redis,webworker}
-                             [{celery,commcare,couchdb2,elasticsearch,elasticsearch-classic,formplayer,kafka,nginx,pillowtop,postgresql,rabbitmq,redis,webworker} ...]
+                             {celery,citusdb,commcare,couchdb2,elasticsearch,elasticsearch-classic,formplayer,kafka,nginx,pillowtop,postgresql,rabbitmq,redis,webworker}
+                             [{celery,citusdb,commcare,couchdb2,elasticsearch,elasticsearch-classic,formplayer,kafka,nginx,pillowtop,postgresql,rabbitmq,redis,webworker} ...]
                              {start,stop,restart,status,logs,help}
 ```
 
@@ -1004,7 +1004,7 @@ service and the `pgbouncer` service. We'll call the actual services
 
 ##### Positional Arguments
 
-###### `{celery,commcare,couchdb2,elasticsearch,elasticsearch-classic,formplayer,kafka,nginx,pillowtop,postgresql,rabbitmq,redis,webworker}`
+###### `{celery,citusdb,commcare,couchdb2,elasticsearch,elasticsearch-classic,formplayer,kafka,nginx,pillowtop,postgresql,rabbitmq,redis,webworker}`
 
 The name of the service group(s) to apply the action to.
 There is a preset list of service groups that are supported.

--- a/src/commcare_cloud/commands/ansible/service.py
+++ b/src/commcare_cloud/commands/ansible/service.py
@@ -407,6 +407,16 @@ class Postgresql(MultiAnsibleService):
                    'Pgbouncer: /var/log/postgresql/pgbouncer.log'
 
 
+class Citusdb(Postgresql):
+    name = 'citusdb'
+    service_process_mapping = {
+        'postgresql': ('postgresql', 'postgresql,pg_standby'),
+        'pgbouncer': ('pgbouncer', 'postgresql,pg_standby')
+    }
+    log_location = 'Postgres: /opt/data/postgresql/<version>/main/pg_log\n' \
+                   'Pgbouncer: /var/log/postgresql/pgbouncer.log'
+
+
 class SingleSupervisorService(SupervisorService):
     """Single service that is managed by supervisor"""
     managed_services = []
@@ -573,6 +583,7 @@ def optimize_process_operations(all_processes_by_host, process_host_mapping):
 
 SERVICES = [
     Postgresql,
+    Citusdb,
     Nginx,
     Couchdb2,
     RabbitMq,


### PR DESCRIPTION
#### SUMMARY
Yesterday I found that `cchq icds postgresql stop` does not also stop the postgres instances for citus and we don't really have a way to do that now so I needed to run `monit stop` on the master node manually. 

I'm not opposed other methods to solve this (such as adding the citus servers to the postgresql group in the inventory), but this was the quickest solution I could think of that would not require more investigation of the difference between our current groups.

##### ENVIRONMENTS AFFECTED
icds

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
citus