### PR TITLE
Set archive_command to /bin/true for citusdb

### DIFF
--- a/environments/icds-cas/inventory/citusdb.csv
+++ b/environments/icds-cas/inventory/citusdb.csv
@@ -29,6 +29,7 @@ citusworker23standby,100.71.184.246,citusdb,citusdb_worker,pg_standby,MUMGCCWCDP
 group,var,val,type,,,,,,
 citusdb,ansible_python_interpreter,/usr/bin/python3,S,,,,,,
 citusdb,pgbouncer_max_connections,3500,I,,,,,,
+citusdb,postgresql_archive_command,/bin/true,S,,,,,,
 citusdb_master,pgbouncer_default_pool,790,I,,,,,,
 citusdb_master,postgresql_checkpoint_completion_target,0.9,F,,,,,,
 citusdb_master,postgresql_default_statistics_target,500,I,,,,,,


### PR DESCRIPTION
##### SUMMARY
@rohit-dimagi I saw that the archive_command is `/bin/true` on all citus workers. Is this expected? I couldn't find a PR that included this change

##### ENVIRONMENTS AFFECTED
icds

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
citusdb

##### ADDITIONAL INFORMATION
A deploy currently looks like this:

```
--- before: /etc/postgresql/11/main/postgresql.conf
+++ after: /home/jemord/.ansible/tmp/ansible-local-581vMquJM/tmpHuNyIp/postgresql.conf.j2
@@ -35,7 +35,7 @@
 
 # WRITE AHEAD LOG
 archive_mode = on
-archive_command = '/bin/true'
+archive_command = 'cp %p /opt/data/postgresql/wal_archive/%f'
 archive_timeout = 300
 
 wal_level = hot_standby
```