### PR TITLE
Only tag deploy commits for Dimagi-controlled environments

### DIFF
--- a/environments/icds-cas/fab-settings.yml
+++ b/environments/icds-cas/fab-settings.yml
@@ -3,3 +3,4 @@ acceptable_maintenance_window:
   hour_end: 23
   timezone: Asia/Kolkata
 email_enabled: True
+tag_deploy_commits: True

--- a/environments/india/fab-settings.yml
+++ b/environments/india/fab-settings.yml
@@ -1,0 +1,1 @@
+tag_deploy_commits: True

--- a/environments/production/fab-settings.yml
+++ b/environments/production/fab-settings.yml
@@ -1,0 +1,1 @@
+tag_deploy_commits: True

--- a/environments/staging/fab-settings.yml
+++ b/environments/staging/fab-settings.yml
@@ -1,2 +1,3 @@
 ignore_kafka_checkpoint_warning: True
 default_branch: autostaging
+tag_deploy_commits: True

--- a/environments/swiss/fab-settings.yml
+++ b/environments/swiss/fab-settings.yml
@@ -1,1 +1,2 @@
 ignore_kafka_checkpoint_warning: True
+tag_deploy_commits: True

--- a/src/commcare_cloud/environment/schemas/fab_settings.py
+++ b/src/commcare_cloud/environment/schemas/fab_settings.py
@@ -18,6 +18,7 @@ class FabSettingsConfig(jsonobject.JsonObject):
     ignore_kafka_checkpoint_warning = jsonobject.BooleanProperty()
     acceptable_maintenance_window = jsonobject.ObjectProperty(lambda: AcceptableMaintenanceWindow)
     email_enabled = jsonobject.BooleanProperty()
+    tag_deploy_commits = jsonobject.BooleanProperty(default=False)
 
     @classmethod
     def wrap(cls, data):

--- a/src/commcare_cloud/fab/utils.py
+++ b/src/commcare_cloud/fab/utils.py
@@ -163,6 +163,8 @@ class DeployMetadata(object):
 
 @memoized
 def _get_github_credentials():
+    if not env.tag_deploy_commits:
+        return (None, None)
     try:
         from .config import GITHUB_APIKEY
     except ImportError:
@@ -181,7 +183,7 @@ def _get_github_credentials():
 @memoized
 def _get_github():
     login_or_token, password = _get_github_credentials()
-    if not login_or_token:
+    if env.tag_deploy_commits and not login_or_token:
         print(magenta(
             "Warning: Creation of release tags is disabled. "
             "Provide Github auth details to enable release tags."

--- a/src/commcare_cloud/fab/utils.py
+++ b/src/commcare_cloud/fab/utils.py
@@ -162,13 +162,7 @@ class DeployMetadata(object):
 
 
 @memoized
-def _get_github():
-    def _show_no_auth_message():
-        print(magenta(
-            "Warning: Creation of release tags is disabled. "
-            "Provide Github auth details to enable release tags."
-        ))
-
+def _get_github_credentials():
     try:
         from .config import GITHUB_APIKEY
     except ImportError:
@@ -177,30 +171,27 @@ def _get_github():
             "    $ cp {project_root}/config.example.py {project_root}/config.py\n"
             "Then edit {project_root}/config.py"
         ).format(project_root=PROJECT_ROOT))
-        username = input('Github username (leave blank for no auth): ')
+        username = input('Github username (leave blank for no auth): ') or None
         password = getpass('Github password: ') if username else None
-        if not username:
-            _show_no_auth_message()
-        return Github(
-            login_or_token=username or None,
-            password=password,
-        )
+        return (username, password)
     else:
-        if GITHUB_APIKEY is None:
-            _show_no_auth_message()
-        return Github(
-            login_or_token=GITHUB_APIKEY,
-        )
+        return (GITHUB_APIKEY, None)
+
+
+@memoized
+def _get_github():
+    login_or_token, password = _get_github_credentials()
+    if not login_or_token:
+        print(magenta(
+            "Warning: Creation of release tags is disabled. "
+            "Provide Github auth details to enable release tags."
+        ))
+    return Github(login_or_token=login_or_token, password=password)
 
 
 @memoized
 def _github_auth_provided():
-    try:
-        from .config import GITHUB_APIKEY
-    except ImportError:
-        return True  # user is prompted for auth
-    else:
-        return GITHUB_APIKEY is not None
+    return bool(_get_github_credentials()[0])
 
 
 def _get_checkpoint_filename():


### PR DESCRIPTION
##### SUMMARY
Currently, we attempt to tag the commits for all deploys.  This requires credentials with write access to the commcare-hq repo.  If the user hasn't copied over fab/config.yml, they'll be nudged to do so and prompted for a username and password, though they can leave this blank.  To silence the prompt, the user needs to copy that config and set their API key to use auth, or leave it as `None` to not tag their deploys.  In this latter case, they still get a warning that release tags are not being created.

None of this makes sense for non-Dimagi users, since they'll never be able to create tags.  This PR is my proposal for addressing that.  I'm introducing a flag to enable tagging deploy commits for specific environments - those controlled by Dimagi.  For these environments, I've attempted to preserve the existing behavior.  For other environments, we won't even look for the credentials in the first place, and we won't warn the user about them missing.

Notably, I did not enable these flags for echis or pna, since those envs are primarily outside our control.  I _did_ enable it for swiss, since Dimagi deploys it regularly.  LMK if you have feedback on those decisions.

A possible extension of this work would be to require credentials to deploy the envs that request deploy tags.  That would be nice, since it'd make the record a bit more reliable.  I'm considering that out of scope for this change, but would be open to submitting a subsequent PR to do that, or letting someone else run with it if they like the idea.

@dannyroberts FYI

##### ENVIRONMENTS AFFECTED
All, sorta

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Change Pull Request

<!-- If Downtime is selected, include information on how you will either be mitigating the downtime or scheduling it. --> 

##### COMPONENT NAME
Deploy tags

##### ADDITIONAL INFORMATION
