### PR TITLE
Making localsettings.py user-readable only

### DIFF
--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/main.yml
@@ -144,6 +144,7 @@
     state: file
     owner: "{{ cchq_user }}"
     group: "{{ cchq_user }}"
+    mode: 0600
   tags:
     - localsettings
     - hq-localsettings


### PR DESCRIPTION
Making localsettings.py user-readable only