### PR TITLE
Remove management / debugging options from Formplayer 

### DIFF
--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_formplayer_spring.conf.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_formplayer_spring.conf.j2
@@ -1,7 +1,7 @@
 [program:{{ project }}-{{ deploy_env }}-formsplayer-spring]
 environment={% for name, value in item.env_vars.items() %}{% if value %}{{ name }}="{{ value }}",{% endif %}{% endfor %}
 
-command=java {% if app_processes_config.newrelic_javaagent %}-javaagent:/home/cchq/www/{{ deploy_env }}/newrelic/newrelic.jar{% endif %} -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9998 -Xmx{{ app_processes_config.formplayer_memory }} -XX:MaxMetaspaceSize=128m -XX:-OmitStackTraceInFastThrow -Xss1024k -XX:NativeMemoryTracking=summary -XX:+UnlockDiagnosticVMOptions -jar {{ www_home }}/formplayer_build/current/formplayer.jar
+command=java {% if app_processes_config.newrelic_javaagent %}-javaagent:/home/cchq/www/{{ deploy_env }}/newrelic/newrelic.jar{% endif %} -Xmx{{ app_processes_config.formplayer_memory }} -XX:MaxMetaspaceSize=128m -XX:-OmitStackTraceInFastThrow -Xss1024k -jar {{ www_home }}/formplayer_build/current/formplayer.jar
 user={{ cchq_user }}
 autostart=true
 autorestart=true


### PR DESCRIPTION
##### SUMMARY

Removes management and debug options that were attached to formplayer while we debugged memory leaks after the recent library updates, as well as VisualVM Debugging commands that I believe Will added which shouldn't have been on there for security reasons.

Shouldn't meaningfully affect anything other than a slight reduction in resources and locking down access to the process.

##### ENVIRONMENTS AFFECTED

All

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
Formplayer