### PR TITLE
Use correct IP address for haproxy config

### DIFF
--- a/src/commcare_cloud/ansible/roles/haproxy/templates/service.j2
+++ b/src/commcare_cloud/ansible/roles/haproxy/templates/service.j2
@@ -57,25 +57,19 @@ backend {{ item.service.haproxy_service_name }}-back
 
 
 {% for host_name in item.service.haproxy_backend_nodes %}
-{% if hostvars[host_name] is defined %}
-{%   set ip_addr = hostvars[host_name][hostvars[host_name].internal_network_interface_fact].ipv4.address %}
-{% endif %}
     {{ [
         "server",
-        (host_name.name | default(host_name)) | string,
-        (host_name.ip_addr | default(ip_addr)) + ":" + haproxy_backend_port | string,
+        host_name | string,
+        host_name + ":" + haproxy_backend_port | string,
         "check",
     ] | join(' ') }}
 {% endfor %}
 
 {% for host_name in item.service.haproxy_backup_nodes|default([]) %}
-{% if hostvars[host_name] is defined %}
-{%   set ip_addr = hostvars[host_name][hostvars[host_name].internal_network_interface_fact].ipv4.address %}
-{% endif %}
     {{ [
         "server",
-        (host_name.name | default(host_name)) | string,
-        (host_name.ip_addr | default(ip_addr)) + ":" + haproxy_backend_port | string,
+        host_name | string,
+        host_name + ":" + haproxy_backend_port | string,
         "check",
         "backup"
     ] | join(' ') }}


### PR DESCRIPTION
##### SUMMARY
This template was previously attempting to lookup the machine's IP dynamically.  This led to an issue where a the resulting IP address was one which was inaccessible from other machines.

This commit switches it to use the address defined in the inventory, as is done in nginx:
https://github.com/dimagi/commcare-cloud/blob/b4a72c49ba680f6f00ce1fe098217f8967be4f55/src/commcare_cloud/ansible/roles/nginx/templates/site.j2#L15-L16

Shout out to @dannyroberts for assistance debugging and finding a solution.
@snopoke looks like you were the last person to do work on these files, do you know of a reason not to do this change?

##### ENVIRONMENTS AFFECTED

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
haproxy

##### ADDITIONAL INFORMATION
