### PR TITLE
Ignore options startup parameter in pgbouncer

### DIFF
--- a/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer.ini.j2
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer.ini.j2
@@ -97,8 +97,9 @@ server_reset_query = {% if pgbouncer_pool_mode == 'session' %}DISCARD ALL{% endi
 ; in startup packet.
 ; - extra_float_digits - Newer JDBC versions require the extra_float_digits here.
 ; - geqo - Some ODBC connections like Tableau pass this in startup, pgbouncer should ignore this.
+; - options - postgres-checkup passes this
 ;
-ignore_startup_parameters = extra_float_digits, geqo
+ignore_startup_parameters = extra_float_digits, geqo, options
 
 ;
 ; When taking idle server into use, this query is ran first.


### PR DESCRIPTION
##### SUMMARY
This would ignore an options parameter in pgbouncer. The main point of this would be to be able to use https://gitlab.com/postgres-ai/postgres-checkup. I tested this on the old warehouse db that is not used anymore and this was a blocker on the postgres stats. (postgres-checkup also allows you to use ssh to get general system information).

An example full report can be found here https://gitlab.com/postgres-ai/postgres-checkup-tests/blob/master/1.3.0/md_reports/1_2019_11_05T11_03_58_+0000/0_Full_report.md This appears to be much more comprehensive than pghero and there's a roadmap of adding more features and checks.

They also have some other checkup services mentioned on the company's site https://postgres.ai/ (the slackbot query optimizer looks really cool, but probably not worth setting that up at this time)

Any thoughts on using this as part of firefighting postgres issues?

##### ENVIRONMENTS AFFECTED
pgbouncer

##### ISSUE TYPE
- Change Pull Request