### PR TITLE
Fix list-postgresql-dbs

### DIFF
--- a/src/commcare_cloud/commands/ansible/ops_tool.py
+++ b/src/commcare_cloud/commands/ansible/ops_tool.py
@@ -84,7 +84,7 @@ class ListDatabases(CommandBase):
     def get_expected_dbs(args):
         environment = get_environment(args.env_name)
         dbs_expected_on_host = collections.defaultdict(list)
-        dbs = environment.postgresql_config.to_generated_variables()['postgresql_dbs']['all']
+        dbs = environment.postgresql_config.to_generated_variables(environment)['postgresql_dbs']['all']
         for db in dbs:
             dbs_expected_on_host[db['host']].append(db['name'])
         return dbs_expected_on_host


### PR DESCRIPTION
##### SUMMARY
A partner reported this error when running list-postgresql-dbs:

```
TypeError: to_generated_variables() takes exactly 2 arguments (1 given).
```

Looks like the postgresql_config version of `to_generated_variables` requires that `environment` be passed in as of https://github.com/dimagi/commcare-cloud/pull/2863

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
list-postgresql-dbs

##### ADDITIONAL INFORMATION
