### PR TITLE
remove unused variables from localsettings

### DIFF
--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -551,28 +551,6 @@ INTERNAL_DATA = {
                 "Vatican City", "Venezuela", "Vietnam", "Yemen", "Zambia", "Zimbabwe"]
 }
 
-INDICATOR_ENABLED_PROJECTS = ["mvp-potou", "mvp-sauri", "mvp-bonsaaso", "mvp-ruhiira", "mvp-mwandama", "mvp-sada"]
-
-INDICATOR_NAMESPACES = {
-    'mvp-sauri': (
-        ('mvp_indicators', "MVP"),
-    ),
-    'mvp-potou': (
-        ('mvp_indicators', "MVP"),
-    ),
-    'mvp-bonsaaso': (
-        ('mvp_indicators', "MVP"),
-    ),
-    'mvp-ruhiira': (
-        ('mvp_indicators', "MVP"),
-    ),
-    'mvp-mwandama': (
-        ('mvp_indicators', "MVP"),
-    ),
-    'mvp-sada': (
-        ('mvp_indicators', "MVP"),
-    ),
-}
 COUCH_STALE_QUERY = 'update_after'
 
 API_THROTTLE_REQUESTS = 5


### PR DESCRIPTION
Think these have been unnecessary since MVP was removed.

Just happened to see them in a slack chat.