### PR TITLE
Fix pgbouncer host definition

### DIFF
--- a/src/commcare_cloud/ansible/deploy_postgres.yml
+++ b/src/commcare_cloud/ansible/deploy_postgres.yml
@@ -15,7 +15,7 @@
     - {role: postgresql, tags: 'postgresql'}
 
 - name: pgbouncer
-  hosts: postgresql:pg_standby!citusdb
+  hosts: postgresql:pg_standby:!citusdb
   become: true
   roles:
     - {role: pgbouncer, tags: 'pgbouncer'}


### PR DESCRIPTION
##### SUMMARY
This was causing pgbouncer to not be installed/configured on the new standby nodes

##### ENVIRONMENTS AFFECTED
icds
##### ISSUE TYPE
- Bugfix Pull Request
