### PR TITLE
Route by new formplayer_session cookie instead of sessionid cookie

### DIFF
--- a/src/commcare_cloud/ansible/roles/nginx/vars/cchq_ssl.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/cchq_ssl.yml
@@ -11,9 +11,11 @@ nginx_sites:
     - name: "{{ deploy_env }}_formplayer"
       hosts: formplayer
       port: "{{ formplayer_port }}"
-      # hash off sessionid cookie or X-FORMPLAYER-SESSION header
-      # but only one of the two will be present in any given request
-      method: "hash $cookie_sessionid$http_x_formplayer_session consistent"
+      # hash off formplayer_session cookie or X-FORMPLAYER-SESSION header
+      # Note: this assumes only one of the two is present in any given request.
+      # (If a request sends _both_, that will break sticky routing
+      # unless it's done perfectly consistently. Please don't!)
+      method: "hash $cookie_formplayer_session$http_x_formplayer_session consistent"
    proxy_cache_path:
     - name: "hq_media_cache"
       path: "{{ www_home }}/hq_media/cache"


### PR DESCRIPTION
#### SUMMARY
Currently when a user logs out and logs back in, they are routed
randomly to one of the formplayer machines. This change gives the caller
the freedom to route based on whatever they like, and we will use that
in commcare-hq to route based on user_id instead of django sessionid.

The caller can now route by setting either the X-FORMPLAYER-SESSION
header or the formplayer_session cookie. A blemish of this
implementation is that if they sometimes but not always send _both_ the
header and the cookie, that will break sticky routing.

Note that this is not safe to roll out until https://github.com/dimagi/commcare-hq/pull/26127 is rolled out. If that happened the behavior would either be to break sticky routing entirely or to always route to the same machine, I'm not sure.

##### ENVIRONMENTS AFFECTED
production for sure, but any env with multiple formplayer machines

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Formplayer (Web Apps / App Preview)

##### ADDITIONAL INFORMATION
On prod the relevant part of the diff would be:

```diff
 upstream production_formplayer {
   zone production_formplayer 64k;

-    hash $cookie_sessionid$http_x_formplayer_session consistent;
+    hash $cookie_formplayer_session$http_x_formplayer_session consistent;
```