### PR TITLE
Fix direct fab calls without `--set code_branch=...`

### DIFF
--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -168,9 +168,15 @@ def load_env():
 def _setup_env(env_name):
     env.env_name = env_name
     load_env()
+    _confirm_branch(env.default_branch)
     _confirm_environment_time(env_name)
     execute(env_common)
     execute(_confirm_deploying_same_code)
+
+
+def _confirm_branch(default_branch):
+    if not getattr(env, 'code_branch', None):
+        env.code_branch = default_branch
 
 
 def _confirm_environment_time(env_name):

--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -168,13 +168,13 @@ def load_env():
 def _setup_env(env_name):
     env.env_name = env_name
     load_env()
-    _confirm_branch(env.default_branch)
+    _set_code_branch(env.default_branch)
     _confirm_environment_time(env_name)
     execute(env_common)
     execute(_confirm_deploying_same_code)
 
 
-def _confirm_branch(default_branch):
+def _set_code_branch(default_branch):
     if not getattr(env, 'code_branch', None):
         env.code_branch = default_branch
     print("Using commcare-hq branch {}".format(env.code_branch))

--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -177,6 +177,7 @@ def _setup_env(env_name):
 def _confirm_branch(default_branch):
     if not getattr(env, 'code_branch', None):
         env.code_branch = default_branch
+    print("Using commcare-hq branch {}".format(env.code_branch))
 
 
 def _confirm_environment_time(env_name):


### PR DESCRIPTION
##### SUMMARY
When I moved deploy into its own commcare-cloud command, I neglected
to retain the behavior of the many other fab calls we use regularly
but less frequently (setup_limited_release, etc.), and they would fail
unless you added e.g. `--set code_branch=master` to them.
This brings back earlier behavior of choosing the default branch
specified in fab_settings.yml
