### PR TITLE
set pillows to read from standbys

### DIFF
--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_pillowtop.conf.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_pillowtop.conf.j2
@@ -2,7 +2,7 @@
 {% for num_process in range(params.get('start_process', 0), params.get('start_process', 0) + params.get('num_processes', 1)) %}
 
 [program:commcare-hq-{{ deploy_env }}-pillowtop-{{ pillow_name }}-{{ num_process }}]
-environment=TMPDIR="{{ encrypted_tmp }}"
+environment=TMPDIR="{{ encrypted_tmp }}",READ_FROM_PLPROXY_STANDBYS="1"
 command={{ py3_virtualenv_home }}/bin/python
     {{ code_home }}/manage.py run_ptop
     --pillow-name {{ pillow_name }}


### PR DESCRIPTION
##### SUMMARY
Add env var to pillowtop processes to allow them to read from plproxy shard standbys if they are configured and available.

Not making this optional since it will only have effect if the proxy standbys are configured in localsettings.

##### ENVIRONMENTS AFFECTED
ALL (though only practically ICDS)

##### ISSUE TYPE
- Change Pull Request
