### PR TITLE
rollback reads to plproxy standbys

### DIFF
--- a/environments/icds-cas/postgresql.yml
+++ b/environments/icds-cas/postgresql.yml
@@ -67,8 +67,6 @@ dbs:
   form_processing:
     proxy:
       host: plproxy0
-    proxy_standby:
-      host: plproxy1
     partitions:
       p10:
         shards: [0, 51]


### PR DESCRIPTION
Today I rolled out changes to make all pillows read from plproxy standbys. In case that needs to be rolled back:

1. Merge this PR
2. run `update-code` on ICDS control
3. run `cchq icds update-config`
4. run `cchq icds service commcare restart --limit pillowtop`