### PR TITLE
Blacklist IP that is hitting endpoints maliciously

### DIFF
--- a/environments/production/proxy.yml
+++ b/environments/production/proxy.yml
@@ -16,6 +16,7 @@ nginx_block_ips:
   - '180.191.158.205'
   - '82.205.123.94'
   - '94.26.113.209'
+  - '185.189.112.76'
 
 # commtrack.org
 commtrack_nginx_combined_cert_value: "{{ ssl_secrets.certs.commtrack_org }}"

--- a/environments/production/proxy.yml
+++ b/environments/production/proxy.yml
@@ -15,6 +15,7 @@ letsencrypt_cchq_ssl: True
 nginx_block_ips:
   - '180.191.158.205'
   - '82.205.123.94'
+  - '94.26.113.209'
 
 # commtrack.org
 commtrack_nginx_combined_cert_value: "{{ ssl_secrets.certs.commtrack_org }}"

--- a/environments/production/proxy.yml
+++ b/environments/production/proxy.yml
@@ -14,6 +14,7 @@ letsencrypt_cchq_ssl: True
 
 nginx_block_ips:
   - '180.191.158.205'
+  - '82.205.123.94'
 
 # commtrack.org
 commtrack_nginx_combined_cert_value: "{{ ssl_secrets.certs.commtrack_org }}"


### PR DESCRIPTION
##### SUMMARY
Having an issue with requests from this IP. Will fix the actual vulnerability (which just incurs us costs and isn't a security issue).

##### ENVIRONMENTS AFFECTED
production

##### ADDITIONAL INFORMATION
Diffs look like this, on all sites:

```diff
--- before: /etc/nginx/sites-available/production_commcare_static
+++ after: /Users/droberts/.ansible/tmp/ansible-local-956374wxavO/tmpu8lLOz/site.j2
@@ -9,6 +9,7 @@
 server {

   deny 180.191.158.205;
+  deny 82.205.123.94;

   access_log /home/cchq/www/production/log/production_commcare_static-nginx_access.log rt_cache;
   error_log /home/cchq/www/production/log/production_commcare_static-nginx_error.log warn;

changed: [10.202.20.47] => (item=production_commcare_static)

```

