### PR TITLE
[Amazon SES] remove modifiers to commcarehq-noreply and use separate emails

### DIFF
--- a/environments/india/public.yml
+++ b/environments/india/public.yml
@@ -60,7 +60,7 @@ s3_signature_version: 's3v4'
 root_email: commcarehq-ops+root@dimagi.com
 server_email: commcarehq-noreply@dimagi.com
 server_admin_email: commcarehq-ops+admins@dimagi.com
-default_from_email: commcarehq-noreply+india@dimagi.com
+default_from_email: commcarehq-noreply-india@dimagi.com
 return_path_email: commcarehq-bounces+india@dimagi.com
 support_email: support@dimagi.com
 probono_support_email: pro-bono@dimagi.com

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -2,7 +2,7 @@ daily_deploy_email: tech-announce-daily@dimagi.com
 root_email: commcarehq-ops+root@dimagi.com
 server_email: commcarehq-noreply@dimagi.com
 server_admin_email: commcarehq-ops+admins@dimagi.com
-default_from_email: commcarehq-noreply+production@dimagi.com
+default_from_email: commcarehq-noreply-production@dimagi.com
 return_path_email: commcarehq-bounces+production@dimagi.com
 support_email: support@dimagi.com
 probono_support_email: pro-bono@dimagi.com

--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -23,7 +23,7 @@ KSPLICE_ACTIVE: yes
 root_email: commcarehq-ops+root@dimagi.com
 server_email: commcarehq-noreply@dimagi.com
 server_admin_email: commcarehq-ops+admins@dimagi.com
-default_from_email: commcarehq-noreply+staging@dimagi.com
+default_from_email: commcarehq-noreply-staging@dimagi.com
 return_path_email: commcarehq-bounces+staging@dimagi.com
 support_email: support@dimagi.com
 probono_support_email: pro-bono@dimagi.com

--- a/environments/swiss/public.yml
+++ b/environments/swiss/public.yml
@@ -59,7 +59,7 @@ BROKER_URL: 'redis://{{ groups.redis.0 }}:6379/0'
 root_email: commcarehq-ops+root@dimagi.com
 server_email: commcarehq-noreply@dimagi.com
 server_admin_email: commcarehq-ops+admins@dimagi.com
-default_from_email: commcarehq-noreply+swiss@dimagi.com
+default_from_email: commcarehq-noreply-swiss@dimagi.com
 return_path_email: commcarehq-bounces+swiss@dimagi.com
 support_email: support@dimagi.com
 probono_support_email: pro-bono@dimagi.com


### PR DESCRIPTION
##### SUMMARY
It looks like Amazon SES does, in fact, strip the `+` modifiers from email addresses. I verified these new emails with SES and now have SNS notifications forwarding to `commcarehq-bounces@dimagi.com`. From there I should be able to process the more reliably-formatted SNS notifications *per environment* with the raw emails as a fallback.

##### ENVIRONMENTS AFFECTED
production, india, swiss, staging

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
`localsettings` `DEFAULT_FROM_EMAIL`