### PR TITLE
Update production RDS

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -305,45 +305,45 @@ proxy_servers:
 
 rds_instances:
   - identifier: "pgmain0-production"
-    instance_type: "db.t2.xlarge"
+    instance_type: "db.t3.large"
     storage: 500
     multi_az: true
     engine_version: 9.6.15
 
   - identifier: "pgucr0-production"
-    instance_type: "db.t2.xlarge"
+    instance_type: "db.t3.large"
     storage: 500
     multi_az: true
     engine_version: 9.6.15
 
   - identifier: "pgshard1-production"
-    instance_type: "db.t2.large"
+    instance_type: "db.t3.medium"
     storage: 250
     multi_az: true
     engine_version: 9.6.15
   - identifier: "pgshard2-production"
-    instance_type: "db.t2.large"
+    instance_type: "db.t3.medium"
     storage: 250
     multi_az: true
     engine_version: 9.6.15
   - identifier: "pgshard3-production"
-    instance_type: "db.t2.large"
+    instance_type: "db.t3.medium"
     storage: 250
     multi_az: true
     engine_version: 9.6.15
   - identifier: "pgshard4-production"
-    instance_type: "db.t2.large"
+    instance_type: "db.t3.medium"
     storage: 250
     multi_az: true
     engine_version: 9.6.15
   - identifier: "pgshard5-production"
-    instance_type: "db.t2.large"
+    instance_type: "db.t3.medium"
     storage: 250
     multi_az: true
     engine_version: 9.6.15
 
   - identifier: "pgsynclog0-production"
-    instance_type: "db.t3.large"
+    instance_type: "db.t3.medium"
     storage: 1000
     multi_az: true
     engine_version: 9.6.15

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -343,7 +343,7 @@ rds_instances:
     engine_version: 9.6.15
 
   - identifier: "pgsynclog0-production"
-    instance_type: "db.t3.medium"
+    instance_type: "db.t3.large"
     storage: 1000
     multi_az: true
     engine_version: 9.6.15

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -304,43 +304,49 @@ proxy_servers:
 
 
 rds_instances:
-  - identifier: "pgmain0-production"  # replaces old hqdb0
+  - identifier: "pgmain0-production"
     instance_type: "db.t2.xlarge"
     storage: 500
     multi_az: true
+    engine_version: 9.6.15
 
-  - identifier: "pgucr0-production"  # replaces old hqdb3
+  - identifier: "pgucr0-production"
     instance_type: "db.t2.xlarge"
     storage: 500
     multi_az: true
+    engine_version: 9.6.15
 
-  # replace old hqdb1, hqdb5
   - identifier: "pgshard1-production"
     instance_type: "db.t2.large"
     storage: 250
     multi_az: true
+    engine_version: 9.6.15
   - identifier: "pgshard2-production"
     instance_type: "db.t2.large"
     storage: 250
     multi_az: true
+    engine_version: 9.6.15
   - identifier: "pgshard3-production"
     instance_type: "db.t2.large"
     storage: 250
     multi_az: true
+    engine_version: 9.6.15
   - identifier: "pgshard4-production"
     instance_type: "db.t2.large"
     storage: 250
     multi_az: true
+    engine_version: 9.6.15
   - identifier: "pgshard5-production"
     instance_type: "db.t2.large"
     storage: 250
     multi_az: true
+    engine_version: 9.6.15
 
-  # replaces old pgsynclog1
   - identifier: "pgsynclog0-production"
-    instance_type: "db.t2.large"
+    instance_type: "db.t3.large"
     storage: 1000
     multi_az: true
+    engine_version: 9.6.15
     params:
       work_mem: 2457kB
       shared_buffers: 3840MB


### PR DESCRIPTION
##### SUMMARY
This updates the postgres version to 9.6.15 (from 9.6.6), which I've already rolled out, switches the machines to the t3 class (from t2) and downsizes all machines. They've always been underutilized but since our RDS Reserved Instance 1-year commitment ran out a few days ago, we can actually do something about it. The postgres upgrade was necessary in order to upgrade to t3, which is a slightly better deal than t2.

##### ENVIRONMENTS AFFECTED
production
