### PR TITLE
utility command to get pillow topic assignments

### DIFF
--- a/docs/commcare-cloud/commands/index.md
+++ b/docs/commcare-cloud/commands/index.md
@@ -11,7 +11,7 @@ All `commcare-cloud` commands take the following form:
 ```
 commcare-cloud [--control]
                <env>
-               {bootstrap-users,ansible-playbook,django-manage,aps,aws-sign-in,tmux,ap,validate-environment-settings,openvpn-activate-user,deploy-stack,export-sentry-events,service,update-supervisor-confs,update-users,ping,migrate_couchdb,lookup,run-module,update-config,copy-files,couchdb-cluster-info,deploy,mosh,list-postgresql-dbs,after-reboot,ssh,downtime,fab,update-local-known-hosts,send-datadog-event,pillow-resource-report,aws-list,aws-fill-inventory,migrate-couchdb,terraform,openvpn-claim-user,celery-resource-report,run-shell-command,terraform-migrate-state}
+               {bootstrap-users,ansible-playbook,django-manage,aps,aws-sign-in,tmux,ap,validate-environment-settings,pillow-topic-assignments,openvpn-activate-user,deploy-stack,export-sentry-events,service,update-supervisor-confs,update-users,ping,migrate_couchdb,lookup,run-module,update-config,copy-files,couchdb-cluster-info,deploy,mosh,list-postgresql-dbs,after-reboot,ssh,downtime,fab,update-local-known-hosts,send-datadog-event,pillow-resource-report,aws-list,aws-fill-inventory,migrate-couchdb,terraform,openvpn-claim-user,celery-resource-report,run-shell-command,terraform-migrate-state}
                ...
 ```
 
@@ -599,6 +599,28 @@ Organization slug
 ###### `--full`
 
 Export the full event details
+
+---
+
+#### `pillow-topic-assignments`
+
+Print out the list of Kafka partitions assigned to each pillow process.
+
+```
+commcare-cloud <env> pillow-topic-assignments [--csv] pillow_name
+```
+
+##### Positional Arguments
+
+###### `pillow_name`
+
+Name of the pillow.
+
+##### Optional Arguments
+
+###### `--csv`
+
+Output as CSV
 
 ---
 ### Operational

--- a/src/commcare_cloud/commcare_cloud.py
+++ b/src/commcare_cloud/commcare_cloud.py
@@ -34,7 +34,7 @@ from .commands.ansible.run_module import RunAnsibleModule, RunShellCommand, Ping
 from .commands.fab import Fab
 from .commands.inventory_lookup.inventory_lookup import Lookup, Ssh, Mosh, DjangoManage, Tmux
 from .commands.ansible.ops_tool import ListDatabases, CeleryResourceReport, PillowResourceReport, \
-    CouchDBClusterInfo, UpdateLocalKnownHosts
+    CouchDBClusterInfo, UpdateLocalKnownHosts, PillowTopicAssignments
 from commcare_cloud.commands.command_base import CommandBase, Argument, CommandError
 from .environment.paths import (
     get_available_envs,
@@ -57,6 +57,7 @@ COMMAND_GROUPS = OrderedDict([
         DjangoManage,
         Tmux,
         ExportSentryEvents,
+        PillowTopicAssignments,
     ]),
     ('operational', [
         Ping,


### PR DESCRIPTION
##### SUMMARY
To make it easier to find out where a Kafka topic is assigned.

##### ENVIRONMENTS AFFECTED
NA

##### ISSUE TYPE
- Feature Pull Request

