### PR TITLE
Bug fix

### DIFF
--- a/src/commcare_cloud/ansible/deploy_commcarehq.yml
+++ b/src/commcare_cloud/ansible/deploy_commcarehq.yml
@@ -66,7 +66,7 @@
       tags: services
 
 - name: Airflow Supervisor Config
-  hosts: airflow
+  hosts: airflow_scheduler
   tasks:
     - include_tasks: roles/commcarehq/tasks/airflow.yml
       tags: services

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/airflow.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/airflow.yml
@@ -11,7 +11,6 @@
   register: airflow_webserver_conf_file
 
 - name: define airflow scheduler service
-  hosts: airflow_scheduler
   become: yes
   template:
     src: "../templates/supervisor_airflow_scheduler.conf.j2"


### PR DESCRIPTION
```TASK [include_tasks] *********************************************************************************************************************************************************************
fatal: [100.71.188.13]: FAILED! => {"reason": "'hosts' is not a valid attribute for a Task\n\nThe error appears to be in '/home/rohit/dimagi.com/commcare-cloud/src/commcare_cloud/ansible/roles/commcarehq/tasks/airflow.yml': line 13, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: define airflow scheduler service\n  ^ here\n\nThis error can be suppressed as a warning using the \"invalid_task_attribute_failed\" configuration"}

PLAY RECAP *********************```