### PR TITLE
Coercing to a bool doesn't work like you think

### DIFF
--- a/src/commcare_cloud/ansible/letsencrypt_cert.yml
+++ b/src/commcare_cloud/ansible/letsencrypt_cert.yml
@@ -41,11 +41,11 @@
 
     - name: Run Certbot command when there is a www host
       command: "certbot certonly --webroot -w /var/www/letsencrypt/ -m {{ root_email }} --agree-tos -n -d {{SITE_HOST}} -d {{ NO_WWW_SITE_HOST }}{% if ALTERNATE_HOSTS %} -d {{ ALTERNATE_HOSTS | join(' -d ') }}{% endif %} --expand"
-      when: NO_WWW_SITE_HOST|bool
+      when: NO_WWW_SITE_HOST is defined and NO_WWW_SITE_HOST
 
     - name: Run Certbot command when there is no www host
       command: "certbot certonly --webroot -w /var/www/letsencrypt/ -m {{ root_email }} --agree-tos -n -d {{SITE_HOST}}{% if ALTERNATE_HOSTS %} -d {{ ALTERNATE_HOSTS | join(' -d ') }}{% endif %} --expand"
-      when: not NO_WWW_SITE_HOST
+      when: NO_WWW_SITE_HOST is not defined or not NO_WWW_SITE_HOST
 
     - name: Reload Nginx
       service:

--- a/src/commcare_cloud/ansible/letsencrypt_cert.yml
+++ b/src/commcare_cloud/ansible/letsencrypt_cert.yml
@@ -41,11 +41,11 @@
 
     - name: Run Certbot command when there is a www host
       command: "certbot certonly --webroot -w /var/www/letsencrypt/ -m {{ root_email }} --agree-tos -n -d {{SITE_HOST}} -d {{ NO_WWW_SITE_HOST }}{% if ALTERNATE_HOSTS %} -d {{ ALTERNATE_HOSTS | join(' -d ') }}{% endif %} --expand"
-      when: NO_WWW_SITE_HOST is defined and NO_WWW_SITE_HOST
+      when: NO_WWW_SITE_HOST | default(False)
 
     - name: Run Certbot command when there is no www host
       command: "certbot certonly --webroot -w /var/www/letsencrypt/ -m {{ root_email }} --agree-tos -n -d {{SITE_HOST}}{% if ALTERNATE_HOSTS %} -d {{ ALTERNATE_HOSTS | join(' -d ') }}{% endif %} --expand"
-      when: NO_WWW_SITE_HOST is not defined or not NO_WWW_SITE_HOST
+      when: not NO_WWW_SITE_HOST
 
     - name: Reload Nginx
       service:


### PR DESCRIPTION
##### SUMMARY

https://github.com/ansible/ansible/issues/25893

When VAR is a string:

    when: VAR | bool  ->  False
    when: not VAR  ->  False

Only "yes", "on", "true", "1", and 1 result in True when [cooerced to boolean](https://github.com/ansible/ansible/blob/0fa556f75183238633396c7ab59bddd23c9a1931/lib/ansible/plugins/filter/core.py#L91)


##### ENVIRONMENTS AFFECTED
Any with a `NO_WWW_SITE_HOST` specified

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
certbot

##### ADDITIONAL INFORMATION
This pattern here seems to function as I'd like, and I see it used elsewhere.  When `NO_WWW_SITE_HOST` is defined (prod), I see:

```
task [run certbot command when there is a www host] ******
skipping: [10.202.20.47] => {"changed": false, "msg": "skipped, running in check mode"}

task [run certbot command when there is no www host] ******
skipping: [10.202.20.47] => {"changed": false, "skip_reason": "conditional result was false"}
```

When `NO_WWW_SITE_HOST` is NOT defined (staging), I see:

```
TASK [Run Certbot command when there is a www host] ******
skipping: [10.201.20.89] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Run Certbot command when there is no www host] ******
skipping: [10.201.20.89] => {"changed": false, "msg": "skipped, running in check mode"}
```
