### PR TITLE
Dedicate a longer window to couch compaction on production

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -77,7 +77,7 @@ couchdb2:
   password: "{{ localsettings_private.COUCH_PASSWORD }}"
 
 couchdb_compaction_settings:
-  _default: '[{db_fragmentation, "6%"}, {view_fragmentation, "6%"}, {from, "17:00"}, {to, "5:00"}]'
+  _default: '[{db_fragmentation, "6%"}, {view_fragmentation, "6%"}, {from, "16:00"}, {to, "6:00"}]'
 
 
 couchdb2_client_max_body_size: 100M


### PR DESCRIPTION
##### SUMMARY
One of the machines (couch12) recently got out of its normal good compaction cycle and grew without limit until the disk filled up. I'm not 100% sure it's because there wasn't enough compaction time to keep up versus something more incident oriented (like the process responsible for scheduling compaction getting killed or something). So I'm not totally sure this change is necessary, but it's something I rolled out while looking at this, and I don't think it'll hurt.

##### ENVIRONMENTS AFFECTED
production
