### PR TITLE
Fix ES CORS to enable Elasticsearch Head

### DIFF
--- a/src/commcare_cloud/ansible/roles/elasticsearch/templates/config/elasticsearch.yml.j2
+++ b/src/commcare_cloud/ansible/roles/elasticsearch/templates/config/elasticsearch.yml.j2
@@ -21,6 +21,7 @@ transport.tcp.port: {{ elasticsearch_tcp_port }}
 http.port: {{ elasticsearch_http_port }}
 
 http.cors.enabled: true
+http.cors.allow-origin: "null"
 path.data: {{ elasticsearch_data_dir }}/data
 path.logs: {{ elasticsearch_data_dir }}/logs
 


### PR DESCRIPTION
##### SUMMARY
allow-origin "null" means allowing requests from file:// urls.
So if you run Elasticsearch Head locally from file://.../index.html
then this will re-enable it.

I haven't fully validated this, but my guess is that the upgrade to ES 2
gave cors a stricter default setting.

##### ENVIRONMENTS AFFECTED
all

##### COMPONENT NAME
Elasticsearch
