### PR TITLE
Use USER_REPORTING_METADATA_BATCH_ENABLED on production

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -148,7 +148,6 @@ localsettings:
   SUMOLOGIC_URL: "{{ localsettings_private.SUMOLOGIC_URL }}"
   STATIC_ROOT:
   STATIC_CDN: 'https://dnwn0mt1jqwp0.cloudfront.net'
-  WS4REDIS_CONNECTION_HOST: "{{ groups.redis.0 }}"
   STATIC_TOGGLE_STATES:
     mobile_ucr_linked_domain:
       always_enabled:
@@ -158,6 +157,8 @@ localsettings:
         - 'ews-ghana'
         - 'ils-gateway'
         - 'ils-gateway-train'
+  USER_REPORTING_METADATA_BATCH_ENABLED: True
+  WS4REDIS_CONNECTION_HOST: "{{ groups.redis.0 }}"
 
 # comment these two lines out to make a new rackspace machine
 commcare_cloud_root_user: ubuntu


### PR DESCRIPTION
##### SUMMARY
I'm getting the sense that the `USER_REPORTING_METADATA_BATCH_ENABLED = False` is being maintained as an afterthought at this point, since ICDS is the only division actively working changes to user reporting metadata and they're on `USER_REPORTING_METADATA_BATCH_ENABLED = False`, and recent changes ICDS has made has caused a high volume of errors on production (and likely affected the freshness/accuracy of the reports). I think if that's the case, then our best bet is to get production on the new system and to remove the flag and keep only the new implementation.

##### ENVIRONMENTS AFFECTED
production
