### PR TITLE
Filter out deprecated pillows

### DIFF
--- a/commcare-cloud-bootstrap/environment/app-processes.yml.j2
+++ b/commcare-cloud-bootstrap/environment/app-processes.yml.j2
@@ -37,8 +37,6 @@ pillows:
 #      num_processes: 1
 #    FormSubmissionMetadataTrackerPillow:
 #      num_processes: 1
-#    GeographyFluffPillow:
-#      num_processes: 1
 #    GroupPillow:
 #      num_processes: 1
 #    GroupToUserPillow:

--- a/environments/64-test/app-processes.yml
+++ b/environments/64-test/app-processes.yml
@@ -36,8 +36,6 @@ pillows:
       num_processes: 1
     FormSubmissionMetadataTrackerPillow:
       num_processes: 1
-    GeographyFluffPillow:
-      num_processes: 1
     GroupPillow:
       num_processes: 1
     GroupToUserPillow:

--- a/environments/development/app-processes.yml
+++ b/environments/development/app-processes.yml
@@ -40,8 +40,6 @@ pillows:
       num_processes: 1
     FormSubmissionMetadataTrackerPillow:
       num_processes: 1
-    GeographyFluffPillow:
-      num_processes: 1
     GroupPillow:
       num_processes: 1
     GroupToUserPillow:

--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -100,10 +100,6 @@ pillows:
       num_processes: 1
     DomainDbKafkaPillow:
       num_processes: 1
-    FarmerRecordFluffPillow:
-      num_processes: 1
-    GeographyFluffPillow:
-      num_processes: 1
     KafkaDomainPillow:
       num_processes: 1
     LedgerToElasticsearchPillow:


### PR DESCRIPTION
##### SUMMARY
These were deleted a few months ago from commcare-hq, just never got around to doing the cleanup.

For other environments that have these pillows in their list (or others we deprecate in the future), they'll get a warning like so:

<img width="973" alt="Screen Shot 2020-01-28 at 4 05 03 PM" src="https://user-images.githubusercontent.com/137212/73322916-5963af00-420b-11ea-87ef-e21c5d870c9e.png">


##### ENVIRONMENTS AFFECTED
probably just production, which is affected by not getting harmless warning-level errors on every deploy/service restart.
