### PR TITLE
more appropriate airflow config for india

### DIFF
--- a/environments/india/public.yml
+++ b/environments/india/public.yml
@@ -202,3 +202,6 @@ localsettings:
 
 commcare_cloud_root_user: ubuntu
 commcare_cloud_pem: ~/.ssh/id_rsa
+
+airflow_dag_concurrency: 4
+airflow_parallelism: 8

--- a/src/commcare_cloud/ansible/roles/airflow/defaults/main.yml
+++ b/src/commcare_cloud/ansible/roles/airflow/defaults/main.yml
@@ -2,4 +2,5 @@ airflow_code_dir: "{{ airflow_home }}/pipes"
 airflow_dag_dir: "{{ airflow_home }}/dags"
 airflow_version: "master"
 airflow_repository: https://github.com/dimagi/pipes.git
-
+airflow_dag_concurrency: 16
+airflow_parallelism: 32

--- a/src/commcare_cloud/ansible/roles/airflow/templates/airflow.cfg.j2
+++ b/src/commcare_cloud/ansible/roles/airflow/templates/airflow.cfg.j2
@@ -32,10 +32,10 @@ sql_alchemy_pool_recycle = 3600
 # The amount of parallelism as a setting to the executor. This defines
 # the max number of task instances that should run simultaneously
 # on this airflow installation
-parallelism = 32
+parallelism = {{ airflow_parallelism }}
 
 # The number of task instances allowed to run concurrently by the scheduler
-dag_concurrency = 16
+dag_concurrency = {{ airflow_dag_concurrency }}
 
 # Are DAGs paused by default at creation
 dags_are_paused_at_creation = True


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
current parallelism variables were too high for the size of the india airflow machine. This allows the agg to run there without swamping the machine.
