### PR TITLE
increase shard count for new smslogs index

### DIFF
--- a/environments/icds-cas/elasticsearch.yml
+++ b/environments/icds-cas/elasticsearch.yml
@@ -5,3 +5,5 @@ settings:
     number_of_replicas: 0
   hqusers:
     number_of_replicas: 2  # stored in triplicate
+  smslogs:
+    number_of_shards: 10


### PR DESCRIPTION
##### SUMMARY
New SMS index being created without `_all` field: https://github.com/dimagi/commcare-hq/pull/26515

Create index with 10 shards instead of 5.

##### ENVIRONMENTS AFFECTED
ICDS

##### ISSUE TYPE
- Change Pull Request