### PR TITLE
changed random_page_cost value to 1.1

### DIFF
--- a/environments/icds-cas/inventory/postgresql.csv
+++ b/environments/icds-cas/inventory/postgresql.csv
@@ -108,3 +108,6 @@ shard_dbs,postgresql_autovacuum_max_workers,5,I,,,,,,,
 shard_dbs,postgresql_autovacuum_analyze_scale_factor,0.05,F,,,,,,,
 shard_dbs,postgresql_autovacuum_multixact_freeze_max_age,1000000000,I,,,,,,,
 shard_dbs,postgresql_autovacuum_vacuum_scale_factor,0.1,F,,,,,,,
+postgresql,postgresql_random_page_cost,1.1,F,,,,,,
+pg_standby,postgresql_random_page_cost,1.1,F,,,,,,
+


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
As part of postgresql tuning , adjusting the "random_page_cost" value  to 1.1

pg_shards
pg_main
plproxy
pg_synclog

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

changing random_page_cost value from 4.0 to 1.1

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
ICDS

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Change Pull Request


<!-- If Downtime is selected, include information on how you will either be mitigating the downtime or scheduling it. --> 

Merge will be done over a downtime window.


##### COMPONENT NAME
<!--- Write the short name of the script, playbook, task or feature below -->

pg_shards
pg_main
plproxy
pg_synclog