### PR TITLE
fix ssh-common-args for ansible 2.9

### DIFF
--- a/src/commcare_cloud/commands/ansible/helpers.py
+++ b/src/commcare_cloud/commands/ansible/helpers.py
@@ -59,7 +59,7 @@ def get_common_ssh_args(environment, use_factory_auth=False):
         common_ssh_args.append('-o=UserKnownHostsFile={}'.format(known_hosts_filepath))
 
     if common_ssh_args:
-        cmd_parts_with_common_ssh_args += ('--ssh-common-args', ' '.join(shlex_quote(arg) for arg in common_ssh_args))
+        cmd_parts_with_common_ssh_args += ('--ssh-common-args="{}"'.format(' '.join(shlex_quote(arg) for arg in common_ssh_args)),)
     return cmd_parts_with_common_ssh_args
 
 


### PR DESCRIPTION
ansible 2.9 uses argparse which requires special treatement of ssh-common-args

See https://github.com/ansible/ansible/issues/64897
