### PR TITLE
trigger pg_repack at 5% dead tuples

### DIFF
--- a/src/commcare_cloud/ansible/roles/pg_repack/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/pg_repack/tasks/main.yml
@@ -65,7 +65,7 @@
   become: yes
   cron:
     name: "pg_repack {{ item }}"
-    job: "{{ pg_repack_script_path }} --pg-repack {{ postgres_install_dir }}/bin/pg_repack -d {{ item }}"
+    job: "{{ pg_repack_script_path }} --pg-repack {{ postgres_install_dir }}/bin/pg_repack --dead-tup-ratio 0.05 -d {{ item }}"
     minute: "30"
     hour: "{{ nadir_hour + 2 }}"
     user: postgres


### PR DESCRIPTION
##### SUMMARY
Run pg_repack more aggressively (at 5% dead tuple ration instead of 10%)

##### ENVIRONMENTS AFFECTED
ICDS

##### ISSUE TYPE
- Change Pull Request

##### COMPONENT NAME
PostgreSQL, pg_repack

##### ADDITIONAL INFORMATION
Already rolled out to ICDS