### PR TITLE
Default a few more emails to example.com

### DIFF
--- a/environments/icds-cas/public.yml
+++ b/environments/icds-cas/public.yml
@@ -82,6 +82,9 @@ feedback_email: hq-feedback@dimagi.com
 eula_change_email: eula-notifications@dimagi.com
 contact_email: info@dimagi.com
 soft_assert_email: commcarehq-ops+soft_asserts@dimagi.com
+bug_report_email: commcarehq-support@dimagi.com
+new_domain_email: inquiries@dimagi.com
+exchange_email: exchange@dimagi.com
 
 commcare_errors_branch: "master-icds"
 

--- a/environments/india/public.yml
+++ b/environments/india/public.yml
@@ -79,6 +79,9 @@ feedback_email: hq-feedback@dimagi.com
 eula_change_email: eula-notifications@dimagi.com
 contact_email: info@dimagi.com
 soft_assert_email: commcarehq-ops+soft_asserts@dimagi.com
+bug_report_email: commcarehq-support@dimagi.com
+new_domain_email: inquiries@dimagi.com
+exchange_email: exchange@dimagi.com
 
 TWO_FACTOR_GATEWAY_ENABLED: True
 

--- a/environments/phi-cas/public.yml
+++ b/environments/phi-cas/public.yml
@@ -67,6 +67,9 @@ eula_change_email: eula-notifications@dimagi.com
 contact_email: info@dimagi.com
 soft_assert_email: commcarehq-ops+soft_asserts@dimagi.com
 check_s3_backups_email: commcarehq-ops+root@dimagi.com
+bug_report_email: commcarehq-support@dimagi.com
+new_domain_email: inquiries@dimagi.com
+exchange_email: exchange@dimagi.com
 
 TWO_FACTOR_GATEWAY_ENABLED: False
 

--- a/environments/pna/public.yml
+++ b/environments/pna/public.yml
@@ -64,6 +64,9 @@ feedback_email: hq-feedback@dimagi.com
 eula_change_email: eula-notifications@dimagi.com
 contact_email: info@dimagi.com
 soft_assert_email: commcarehq-ops+soft_asserts@dimagi.com
+bug_report_email: commcarehq-support@dimagi.com
+new_domain_email: inquiries@dimagi.com
+exchange_email: exchange@dimagi.com
 
 KSPLICE_ACTIVE: yes
 

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -22,6 +22,9 @@ feedback_email: hq-feedback@dimagi.com
 eula_change_email: eula-notifications@dimagi.com
 contact_email: info@dimagi.com
 soft_assert_email: commcarehq-ops+soft_asserts@dimagi.com
+bug_report_email: commcarehq-support@dimagi.com
+new_domain_email: inquiries@dimagi.com
+exchange_email: exchange@dimagi.com
 ALTERNATE_HOSTS:
   - rec-mobile.sante.gov.bf
 

--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -42,6 +42,9 @@ feedback_email: hq-feedback@dimagi.com
 eula_change_email: eula-notifications@dimagi.com
 contact_email: info@dimagi.com
 soft_assert_email: commcarehq-ops+soft_asserts@dimagi.com
+bug_report_email: commcarehq-support@dimagi.com
+new_domain_email: inquiries@dimagi.com
+exchange_email: exchange@dimagi.com
 ALTERNATE_HOSTS:
   - sanjay1.commcarehq.org
 

--- a/environments/swiss/public.yml
+++ b/environments/swiss/public.yml
@@ -79,6 +79,9 @@ eula_change_email: eula-notifications@dimagi.com
 contact_email: info@dimagi.com
 soft_assert_email: commcarehq-ops+soft_asserts@dimagi.com
 check_s3_backups_email: commcarehq-ops+root@dimagi.com,httu.admin@swisstph.ch
+bug_report_email: commcarehq-support@dimagi.com
+new_domain_email: inquiries@dimagi.com
+exchange_email: exchange@dimagi.com
 
 TWO_FACTOR_GATEWAY_ENABLED: True
 

--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -119,6 +119,9 @@ soft_assert_email: commcarehq-ops+soft_asserts@example.com
 daily_deploy_email: null
 check_s3_backups_email: null
 return_path_email: null
+bug_report_email: commcarehq-support@example.com
+new_domain_email: inquiries@example.com
+exchange_email: exchange@example.com
 
 
 ALTERNATE_HOSTS: []

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -353,9 +353,9 @@ EULA_COMPLIANCE = {{ localsettings.EULA_COMPLIANCE|default(False) }}
 
 AXES_LOCK_OUT_AT_FAILURE = False
 
-BUG_REPORT_RECIPIENTS = ['commcarehq-support@dimagi.com']
-NEW_DOMAIN_RECIPIENTS = ['inquiries@dimagi.com']
-EXCHANGE_NOTIFICATION_RECIPIENTS = ["exchange@dimagi.com"]
+BUG_REPORT_RECIPIENTS = ['{{ bug_report_email }}']
+NEW_DOMAIN_RECIPIENTS = ['{{ new_domain_email }}']
+EXCHANGE_NOTIFICATION_RECIPIENTS = ["{{ exchange_email }}"]
 
 CUSTOM_REPORT_MAP = {
     "pathfinder": [


### PR DESCRIPTION
##### SUMMARY
Turns out there were still a few @dimagi.com emails hardcoded in localsettings.  This PR defaults a those to example.com, then explicitly sets the values back to the dimagi.com addresses for Dimagi managed envs.  This means that there shouldn't be any diff next time localsettings is deployed on those envs (verified on prod and staging).

##### ENVIRONMENTS AFFECTED
None

##### ISSUE TYPE

- Change Pull Request

<!-- If Downtime is selected, include information on how you will either be mitigating the downtime or scheduling it. --> 

##### COMPONENT NAME
localsettings

##### ADDITIONAL INFORMATION
