### PR TITLE
Start supervisord in after-reboot

### DIFF
--- a/src/commcare_cloud/ansible/roles/supervisor/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/supervisor/tasks/main.yml
@@ -23,6 +23,8 @@
   changed_when: false
   failed_when: which_supervisord.rc != 0 and which_supervisord.rc != 1
   check_mode: no
+  tags:
+    - after-reboot
 
 - name: check for sysvinit conf
   stat: path=/etc/init.d/supervisor
@@ -83,3 +85,5 @@
   become: yes
   service: name=supervisord enabled=yes state=started
   when: which_supervisord.stdout
+  tags:
+    - after-reboot


### PR DESCRIPTION
##### SUMMARY
to prevent errors like

```
[10.203.20.59] out: unix:///tmp/supervisor.sock no such file
[10.203.20.59] out:
[10.203.20.59] sudo: supervisorctl reread
[10.203.20.59] out: error: <class 'socket.error'>, [Errno 2] No such file or directory: file: /usr/lib/python2.7/socket.py line: 228
```
and to generally leave app process machines in good shape after reboot.
