### PR TITLE
Remove pgproxy2- and pgbouncer1-production

### DIFF
--- a/environments/production/aws-resources.yml
+++ b/environments/production/aws-resources.yml
@@ -19,10 +19,8 @@ esmaster5-production: 10.202.40.226
 formplayer2-production: 10.202.10.129
 formplayer3-production: 10.202.10.13
 kafka1-production: 10.202.40.200
-pgbouncer1-production: 10.202.40.8
 pgbouncer2-production: 10.202.40.59
 pgmain0-production: pgmain0-production.cl9dmuo3ok4h.us-east-1.rds.amazonaws.com
-pgproxy2-production: 10.202.40.5
 pgshard1-production: pgshard1-production.cl9dmuo3ok4h.us-east-1.rds.amazonaws.com
 pgshard2-production: pgshard2-production.cl9dmuo3ok4h.us-east-1.rds.amazonaws.com
 pgshard3-production: pgshard3-production.cl9dmuo3ok4h.us-east-1.rds.amazonaws.com

--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -41,12 +41,6 @@ web13
 hq_webworkers
 mobile_webworkers
 
-[pgproxy2]
-10.202.40.5 hostname=pgproxy2-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3
-
-[pgbouncer1]
-10.202.40.8 hostname=pgbouncer1-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3
-
 [pgbouncer2]
 10.202.40.59 hostname=pgbouncer2-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3
 
@@ -85,8 +79,6 @@ rds_pgshard5
 rds_pgsynclog0
 
 [postgresql:children]
-pgproxy2
-pgbouncer1
 pgbouncer2
 remote_postgresql
 

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -33,10 +33,6 @@ web13
 hq_webworkers
 mobile_webworkers
 
-{{ __pgproxy2__ }}
-
-{{ __pgbouncer1__ }}
-
 {{ __pgbouncer2__ }}
 
 {{ __rds_pgmain0__ }}
@@ -66,8 +62,6 @@ rds_pgshard5
 rds_pgsynclog0
 
 [postgresql:children]
-pgproxy2
-pgbouncer1
 pgbouncer2
 remote_postgresql
 

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -275,22 +275,6 @@ servers:
     group: "kafka"
     os: bionic
 
-  - server_name: "pgproxy2-production"
-    server_instance_type: t3.large
-    network_tier: "db-private"
-    az: "a"
-    volume_size: 80
-    group: "postgresql"
-    os: bionic
-
-  - server_name: "pgbouncer1-production"
-    server_instance_type: t3.medium
-    network_tier: "db-private"
-    az: "a"
-    volume_size: 80
-    group: "postgresql"
-    os: bionic
-
   - server_name: "pgbouncer2-production"
     server_instance_type: t3.2xlarge
     network_tier: "db-private"


### PR DESCRIPTION
##### SUMMARY
They're no longer serving any connections. Followup to https://github.com/dimagi/commcare-cloud/pull/3593

##### ENVIRONMENTS AFFECTED
production
