### PR TITLE
Add /opt/data disk monitor for SaaS envs

### DIFF
--- a/src/commcare_cloud/manage_commcare_cloud/monitors/saas_data_disk.yml
+++ b/src/commcare_cloud/manage_commcare_cloud/monitors/saas_data_disk.yml
@@ -1,0 +1,31 @@
+env_key: host.environment
+id: 16004813
+message: |-
+  {{#is_alert}}ALERT: Disk usage {{comparator}} {{threshold}} ({{value}}) {{/is_alert}}
+  {{#is_warning}}WARNING: Disk usage {{comparator}} {{warn_threshold}} ({{value}}) {{/is_warning}}
+  https://dimagi.github.io/commcare-cloud/firefighting/#full-drives--out-of-disk-space
+  << notification_block >>
+name: Disk space running low on data disk {{host.name}} ({{device.name}})
+options:
+  escalation_message: |-
+    {{#is_alert}}ALERT: Disk usage still {{comparator}} {{threshold}} ({{value}}) {{/is_alert}}
+    {{#is_warning}}WARNING: Disk usage still {{comparator}} {{warn_threshold}} ({{value}}) {{/is_warning}}
+    https://dimagi.github.io/commcare-cloud/firefighting/#full-drives--out-of-disk-space
+    << notification_block >>
+  include_tags: false
+  locked: false
+  new_host_delay: 300
+  no_data_timeframe: null
+  notify_audit: false
+  notify_no_data: false
+  renotify_interval: 1440
+  require_full_window: true
+  silenced: {}
+  thresholds:
+    critical: 0.9
+    warning: 0.8
+  timeout_h: 0
+query: min(last_1h):max:system.disk.in_use{device:/opt/data,!environment:icds,!environment:pna} by
+  {host,environment,device}.rollup(max) >= 0.9
+tags: []
+type: query alert


### PR DESCRIPTION
##### SUMMARY
It looks like ICDS has its own /opt/data monitor so I'm just making an equivalent one for SaaS environments. This will send us a slack alert whenever an /opt/data disk is 80% or fuller

##### ENVIRONMENTS AFFECTED
production, india, staging, swiss
