### PR TITLE
Add ecrypted option on block_device in terraform.yml

### DIFF
--- a/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
@@ -89,6 +89,7 @@ module "server__{{ server.server_name }}" {
   volume_size = {{ server.volume_size|tojson }}
   secondary_volume_size = {{ server.block_device.volume_size|default(0)|tojson }}
   secondary_volume_type = {{ server.block_device.volume_type|default("")|tojson }}
+  secondary_volume_encrypted = {{ server.block_device.encrypted|default(False)|tojson }}
 
 {% if server.os == 'bionic' %}
   server_image = "${var.bionic_server_image}"

--- a/src/commcare_cloud/environment/schemas/terraform.py
+++ b/src/commcare_cloud/environment/schemas/terraform.py
@@ -1,4 +1,6 @@
 import jsonobject
+from clint.textui import puts
+from commcare_cloud.colors import color_warning
 
 
 class TerraformConfig(jsonobject.JsonObject):
@@ -61,6 +63,15 @@ class BlockDevice(jsonobject.JsonObject):
     _allow_dynamic_properties = False
     volume_type = jsonobject.StringProperty(default='gp2', choices=['gp2', 'io1', 'standard'])
     volume_size = jsonobject.IntegerProperty(required=True)
+    encrypted = jsonobject.BooleanProperty(default=False, required=True)
+
+    @classmethod
+    def wrap(cls, data):
+        if 'encrypted' in data:
+            puts(color_warning(
+                'Warning! The "encrypted" option on block_device is experimental '
+                'and not well-integrated into provisioning scripts.'))
+        return super(BlockDevice, cls).wrap(data)
 
 
 class RdsInstanceConfig(jsonobject.JsonObject):

--- a/src/commcare_cloud/terraform/modules/server/main.tf
+++ b/src/commcare_cloud/terraform/modules/server/main.tf
@@ -37,6 +37,7 @@ resource "aws_ebs_volume" "ebs_volume" {
   availability_zone = "${aws_instance.server.availability_zone}"
   size = "${var.secondary_volume_size}"
   type = "${var.secondary_volume_type}"
+  encrypted = "${var.secondary_volume_encrypted}"
 
   tags {
     Name = "data-vol-${var.server_name}"

--- a/src/commcare_cloud/terraform/modules/server/variables.tf
+++ b/src/commcare_cloud/terraform/modules/server/variables.tf
@@ -18,5 +18,6 @@ variable "network_tier" {}
 variable "volume_size" {}
 variable "secondary_volume_size" {}
 variable "secondary_volume_type" {}
+variable "secondary_volume_encrypted" {}
 variable "az" {}
 variable "group_tag" {}


### PR DESCRIPTION
##### SUMMARY
This will let us eventually use native AWS EBS encryption
instead of ecryptfs for our large data volumes.

Down the road this will enable zero-intervention startup, which is a prerequisite for any kind of automatic scale up and down, whether it's stopping a couple webworkers during trough periods, or actual autoscaling. It also may reduce the cost of our couch snapshot backups.

I spiked this and it appears to work, so I wanted to just get it in the the caveat so I could come back to it when I have time