### PR TITLE
adjust per ip limit

### DIFF
--- a/src/commcare_cloud/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/cas_ssl.yml
@@ -73,7 +73,7 @@ nginx_sites:
     - name: "per_ip_restore"
       zone: "$per_ip_limit"
       size: "50m"
-      rate: "2r/m"
+      rate: "6r/m"
     - name: "submissions"
       zone: "$global_limit"
       size: "10m"


### PR DESCRIPTION
Data analysis of nginx logs show a significant portion of requests
being rate limited at 2/s. Bumping to 6/s allows 95% of users
to sync.

##### ENVIRONMENTS AFFECTED
ICDS

##### ISSUE TYPE
- Change Pull Request
