### PR TITLE
Increase processors for form & case pillows on production

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -73,9 +73,9 @@ celery_processes:
 pillows:
   pillow1:
     case-pillow:
-      num_processes: 4
+      num_processes: 8
     xform-pillow:
-      num_processes: 4
+      num_processes: 8
     user-pillow:
       num_processes: 1
     group-pillow:


### PR DESCRIPTION
##### SUMMARY
I increased the number of partitions in form, form-sql, case, case-sql topics to 32 each, and this PR increases the number of processes to 8 each for form-pillow and case-pillow. (Needed to increase partitions to be able to increase processes, but I increased more than I needed to to be able to increase processes again in the future.)

##### ENVIRONMENTS AFFECTED
production
