### PR TITLE
fix url for redis auth

### DIFF
--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -401,7 +401,7 @@ redis_cache = {
     'BACKEND': 'django_redis.cache.RedisCache',
 {% set redis_url = 'redis://' ~ localsettings.REDIS_HOST ~ ':' ~ localsettings.REDIS_PORT %}
 {% if localsettings.get('REDIS_PASSWORD') %}
-{% set redis_url = 'redis://' ~ localsettings.REDIS_PASSWORD ~ '@' ~ localsettings.REDIS_HOST ~ ':' ~ localsettings.REDIS_PORT %}
+{% set redis_url = 'redis://:' ~ localsettings.REDIS_PASSWORD ~ '@' ~ localsettings.REDIS_HOST ~ ':' ~ localsettings.REDIS_PORT %}
 {% endif %}
 {% if 'REDIS_DB' in localsettings %}
     'LOCATION': '{{ redis_url }}/{{ localsettings.REDIS_DB }}',


### PR DESCRIPTION
Turns out the extra ':' is necessary