### PR TITLE
Increase concurrency for reminder_case_update_queue on production

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -35,7 +35,7 @@ celery_processes:
       concurrency: 5
     reminder_case_update_queue:
       pooling: gevent
-      concurrency: 4
+      concurrency: 64
     reminder_queue:
       pooling: gevent
       concurrency: 10


### PR DESCRIPTION
##### SUMMARY

Yesterday I rolled this out with num_processes: 2, and today I scaled it back to this.
In steady state we have very few of these, but occasionally we get a huge number of task,
and when we do, high gevent concurrency is enough to really speed up our processing of the backlog

##### ENVIRONMENTS AFFECTED
production
