### PR TITLE
Give case-pillow and form-pillow both 16 processors

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -73,9 +73,9 @@ celery_processes:
 pillows:
   pillow1:
     case-pillow:
-      num_processes: 64
+      num_processes: 16
     xform-pillow:
-      num_processes: 8
+      num_processes: 16
     user-pillow:
       num_processes: 1
     group-pillow:


### PR DESCRIPTION
##### SUMMARY
I had upped case-pillow to 64 while trying to figure out
why the processing pattern was so weird. That appears to be fixed in
https://github.com/dimagi/commcare-hq/pull/26842, so I think it makes
sense to give it 16 processors which is still 4x what it has until recently been.

##### ENVIRONMENTS AFFECTED
production
