### PR TITLE
disable materializing for citus workers

### DIFF
--- a/src/commcare_cloud/ansible/group_vars/citusdb_worker.yml
+++ b/src/commcare_cloud/ansible/group_vars/citusdb_worker.yml
@@ -2,3 +2,4 @@ datadog_integration_pgbouncer: true
 datadog_integration_postgres: true
 is_pg_standby: false
 allow_direct_citusdb_access: true
+enable_material: false

--- a/src/commcare_cloud/ansible/roles/postgresql_base/templates/postgresql.conf.j2
+++ b/src/commcare_cloud/ansible/roles/postgresql_base/templates/postgresql.conf.j2
@@ -158,6 +158,11 @@ lc_time = 'en_US.UTF-8'
 
 default_text_search_config = 'pg_catalog.english'
 
+# QUERY PLANNER SETTINGS
+{% if not enable_material|default(True) %}
+enable_material = off
+{% endif %}
+
 {% for setting in postgresql_custom_settings|sort %}
 {{setting}}
 {% endfor %}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The child health monthly step of the aggregation seems to have very different performance characteristics based on whether or not the postgres query planner chooses to partially materialize the query. This penalizes materialization in the planner costing algorithm, although it will still use it if required for correctness. I suspect the best option is to try to improve postgres stats so it will just choose the correct plan, but given turnover in these tables (we delete and recreate a substantial part of it in each agg), that might be hard to do.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
ICDS
India

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Change Pull Request

<!-- If Downtime is selected, include information on how you will either be mitigating the downtime or scheduling it. --> 

##### COMPONENT NAME
<!--- Write the short name of the script, playbook, task or feature below -->
Citus
