### PR TITLE
Remove unused support and exchange emails; update ICDS support email

### DIFF
--- a/environments/64-test/public.yml
+++ b/environments/64-test/public.yml
@@ -73,7 +73,6 @@ default_from_email: droberts+commcarehq-noreply@dimagi.com
 return_path_email: droberts+commcarehq-bounces@dimagi.com
 support_email: droberts+support@dimagi.com
 probono_support_email: droberts+pro-bono@dimagi.com
-cchq_bug_report_email: droberts+commcarehq-bug-reports@dimagi.com
 accounts_email: droberts+accounts@dimagi.com
 data_email: droberts+datatree@dimagi.com
 subscription_change_email: droberts+accounts+subchange@dimagi.com

--- a/environments/icds-cas/public.yml
+++ b/environments/icds-cas/public.yml
@@ -85,7 +85,6 @@ ssh_allow_password_users:
 
 default_from_email: commcarehq-noreply@icds-cas.gov.in
 server_email: commcarehq-noreply@icds-cas.gov.in
-cchq_bug_report_email: commcarehq-bug-reports@icds-cas.gov.in
 root_email: commcarehq-ops+root@dimagi.com
 server_admin_email: commcarehq-ops+admins@dimagi.com
 support_email: support@dimagi.com
@@ -104,7 +103,6 @@ feedback_email: hq-feedback@dimagi.com
 eula_change_email: eula-notifications@dimagi.com
 contact_email: info@dimagi.com
 soft_assert_email: commcarehq-ops+soft_asserts@dimagi.com
-bug_report_email: commcarehq-support@dimagi.com
 new_domain_email: inquiries@dimagi.com
 exchange_email: exchange@dimagi.com
 

--- a/environments/icds-cas/public.yml
+++ b/environments/icds-cas/public.yml
@@ -104,7 +104,6 @@ eula_change_email: eula-notifications@dimagi.com
 contact_email: info@dimagi.com
 soft_assert_email: commcarehq-ops+soft_asserts@dimagi.com
 new_domain_email: inquiries@dimagi.com
-exchange_email: exchange@dimagi.com
 
 commcare_errors_branch: "master-icds"
 

--- a/environments/icds-cas/public.yml
+++ b/environments/icds-cas/public.yml
@@ -87,7 +87,7 @@ default_from_email: commcarehq-noreply@icds-cas.gov.in
 server_email: commcarehq-noreply@icds-cas.gov.in
 root_email: commcarehq-ops+root@dimagi.com
 server_admin_email: commcarehq-ops+admins@dimagi.com
-support_email: support@dimagi.com
+support_email: icds-support@dimagi.com
 probono_support_email: pro-bono@dimagi.com
 accounts_email: accounts@dimagi.com
 data_email: datatree@dimagi.com

--- a/environments/icds-staging/public.yml
+++ b/environments/icds-staging/public.yml
@@ -51,7 +51,7 @@ server_email: commcarehq-noreply@dimagi.com
 server_admin_email: commcarehq-ops+admins@dimagi.com
 default_from_email: commcarehq-noreply-india@dimagi.com
 return_path_email: commcarehq-bounces+india@dimagi.com
-support_email: support@dimagi.com
+support_email: icds-support@dimagi.com
 probono_support_email: pro-bono@dimagi.com
 accounts_email: accounts@dimagi.com
 data_email: datatree@dimagi.com

--- a/environments/icds-staging/public.yml
+++ b/environments/icds-staging/public.yml
@@ -53,7 +53,6 @@ default_from_email: commcarehq-noreply-india@dimagi.com
 return_path_email: commcarehq-bounces+india@dimagi.com
 support_email: support@dimagi.com
 probono_support_email: pro-bono@dimagi.com
-cchq_bug_report_email: commcarehq-bug-reports@dimagi.com
 accounts_email: accounts@dimagi.com
 data_email: datatree@dimagi.com
 subscription_change_email: accounts+subchange@dimagi.com
@@ -68,7 +67,6 @@ feedback_email: hq-feedback@dimagi.com
 eula_change_email: eula-notifications@dimagi.com
 contact_email: info@dimagi.com
 soft_assert_email: commcarehq-ops+soft_asserts@dimagi.com
-bug_report_email: commcarehq-support@dimagi.com
 new_domain_email: inquiries@dimagi.com
 exchange_email: exchange@dimagi.com
 

--- a/environments/icds-staging/public.yml
+++ b/environments/icds-staging/public.yml
@@ -68,7 +68,6 @@ eula_change_email: eula-notifications@dimagi.com
 contact_email: info@dimagi.com
 soft_assert_email: commcarehq-ops+soft_asserts@dimagi.com
 new_domain_email: inquiries@dimagi.com
-exchange_email: exchange@dimagi.com
 
 TWO_FACTOR_GATEWAY_ENABLED: True
 

--- a/environments/india/public.yml
+++ b/environments/india/public.yml
@@ -83,7 +83,6 @@ eula_change_email: eula-notifications@dimagi.com
 contact_email: info@dimagi.com
 soft_assert_email: commcarehq-ops+soft_asserts@dimagi.com
 new_domain_email: inquiries@dimagi.com
-exchange_email: exchange@dimagi.com
 
 TWO_FACTOR_GATEWAY_ENABLED: True
 

--- a/environments/india/public.yml
+++ b/environments/india/public.yml
@@ -68,7 +68,6 @@ default_from_email: commcarehq-noreply-india@dimagi.com
 return_path_email: commcarehq-bounces+india@dimagi.com
 support_email: support@dimagi.com
 probono_support_email: pro-bono@dimagi.com
-cchq_bug_report_email: commcarehq-bug-reports@dimagi.com
 accounts_email: accounts@dimagi.com
 data_email: datatree@dimagi.com
 subscription_change_email: accounts+subchange@dimagi.com
@@ -83,7 +82,6 @@ feedback_email: hq-feedback@dimagi.com
 eula_change_email: eula-notifications@dimagi.com
 contact_email: info@dimagi.com
 soft_assert_email: commcarehq-ops+soft_asserts@dimagi.com
-bug_report_email: commcarehq-support@dimagi.com
 new_domain_email: inquiries@dimagi.com
 exchange_email: exchange@dimagi.com
 

--- a/environments/phi-cas/public.yml
+++ b/environments/phi-cas/public.yml
@@ -51,7 +51,6 @@ server_admin_email: commcarehq-ops+admins@dimagi.com
 default_from_email: commcarehq-noreply@icds-cas.gov.in
 support_email: support@dimagi.com
 probono_support_email: pro-bono@dimagi.com
-cchq_bug_report_email: commcarehq-bug-reports@icds-cas.gov.in
 accounts_email: accounts@dimagi.com
 data_email: datatree@dimagi.com
 subscription_change_email: accounts+subchange@dimagi.com
@@ -67,7 +66,6 @@ eula_change_email: eula-notifications@dimagi.com
 contact_email: info@dimagi.com
 soft_assert_email: commcarehq-ops+soft_asserts@dimagi.com
 check_s3_backups_email: commcarehq-ops+root@dimagi.com
-bug_report_email: commcarehq-support@dimagi.com
 new_domain_email: inquiries@dimagi.com
 exchange_email: exchange@dimagi.com
 

--- a/environments/phi-cas/public.yml
+++ b/environments/phi-cas/public.yml
@@ -67,7 +67,6 @@ contact_email: info@dimagi.com
 soft_assert_email: commcarehq-ops+soft_asserts@dimagi.com
 check_s3_backups_email: commcarehq-ops+root@dimagi.com
 new_domain_email: inquiries@dimagi.com
-exchange_email: exchange@dimagi.com
 
 TWO_FACTOR_GATEWAY_ENABLED: False
 

--- a/environments/phi-cas/public.yml
+++ b/environments/phi-cas/public.yml
@@ -49,7 +49,7 @@ root_email: commcarehq-ops+root@dimagi.com
 server_email: commcarehq-noreply@icds-cas.gov.in
 server_admin_email: commcarehq-ops+admins@dimagi.com
 default_from_email: commcarehq-noreply@icds-cas.gov.in
-support_email: support@dimagi.com
+support_email: icds-support@dimagi.com
 probono_support_email: pro-bono@dimagi.com
 accounts_email: accounts@dimagi.com
 data_email: datatree@dimagi.com

--- a/environments/pna/public.yml
+++ b/environments/pna/public.yml
@@ -64,7 +64,6 @@ eula_change_email: eula-notifications@dimagi.com
 contact_email: info@dimagi.com
 soft_assert_email: commcarehq-ops+soft_asserts@dimagi.com
 new_domain_email: inquiries@dimagi.com
-exchange_email: exchange@dimagi.com
 
 KSPLICE_ACTIVE: yes
 

--- a/environments/pna/public.yml
+++ b/environments/pna/public.yml
@@ -49,7 +49,6 @@ root_email: commcarehq-ops+root@dimagi.com
 server_admin_email: commcarehq-ops+admins@dimagi.com
 support_email: support@dimagi.com
 probono_support_email: pro-bono@dimagi.com
-cchq_bug_report_email: commcarehq-bug-reports@dimagi.com
 accounts_email: accounts@dimagi.com
 data_email: datatree@dimagi.com
 subscription_change_email: accounts+subchange@dimagi.com
@@ -64,7 +63,6 @@ feedback_email: hq-feedback@dimagi.com
 eula_change_email: eula-notifications@dimagi.com
 contact_email: info@dimagi.com
 soft_assert_email: commcarehq-ops+soft_asserts@dimagi.com
-bug_report_email: commcarehq-support@dimagi.com
 new_domain_email: inquiries@dimagi.com
 exchange_email: exchange@dimagi.com
 

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -6,7 +6,6 @@ default_from_email: commcarehq-noreply-production@dimagi.com
 return_path_email: commcarehq-bounces+production@dimagi.com
 support_email: support@dimagi.com
 probono_support_email: pro-bono@dimagi.com
-cchq_bug_report_email: commcarehq-bug-reports@dimagi.com
 accounts_email: accounts@dimagi.com
 data_email: datatree@dimagi.com
 subscription_change_email: accounts+subchange@dimagi.com
@@ -22,7 +21,6 @@ feedback_email: hq-feedback@dimagi.com
 eula_change_email: eula-notifications@dimagi.com
 contact_email: info@dimagi.com
 soft_assert_email: commcarehq-ops+soft_asserts@dimagi.com
-bug_report_email: commcarehq-support@dimagi.com
 new_domain_email: inquiries@dimagi.com
 exchange_email: exchange@dimagi.com
 ALTERNATE_HOSTS:

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -22,7 +22,6 @@ eula_change_email: eula-notifications@dimagi.com
 contact_email: info@dimagi.com
 soft_assert_email: commcarehq-ops+soft_asserts@dimagi.com
 new_domain_email: inquiries@dimagi.com
-exchange_email: exchange@dimagi.com
 ALTERNATE_HOSTS:
   - rec-mobile.sante.gov.bf
 

--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -32,7 +32,6 @@ default_from_email: commcarehq-noreply-staging@dimagi.com
 return_path_email: commcarehq-bounces+staging@dimagi.com
 support_email: support@dimagi.com
 probono_support_email: pro-bono@dimagi.com
-cchq_bug_report_email: commcarehq-bug-reports@dimagi.com
 accounts_email: accounts@dimagi.com
 data_email: datatree@dimagi.com
 subscription_change_email: accounts+subchange@dimagi.com
@@ -47,7 +46,6 @@ feedback_email: hq-feedback@dimagi.com
 eula_change_email: eula-notifications@dimagi.com
 contact_email: info@dimagi.com
 soft_assert_email: commcarehq-ops+soft_asserts@dimagi.com
-bug_report_email: commcarehq-support@dimagi.com
 new_domain_email: inquiries@dimagi.com
 exchange_email: exchange@dimagi.com
 

--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -47,7 +47,6 @@ eula_change_email: eula-notifications@dimagi.com
 contact_email: info@dimagi.com
 soft_assert_email: commcarehq-ops+soft_asserts@dimagi.com
 new_domain_email: inquiries@dimagi.com
-exchange_email: exchange@dimagi.com
 
 couch_dbs:
   default:

--- a/environments/swiss/public.yml
+++ b/environments/swiss/public.yml
@@ -63,7 +63,6 @@ default_from_email: commcarehq-noreply-swiss@dimagi.com
 return_path_email: commcarehq-bounces+swiss@dimagi.com
 support_email: support@dimagi.com
 probono_support_email: pro-bono@dimagi.com
-cchq_bug_report_email: commcarehq-bug-reports@dimagi.com
 accounts_email: accounts@dimagi.com
 data_email: datatree@dimagi.com
 subscription_change_email: accounts+subchange@dimagi.com
@@ -79,7 +78,6 @@ eula_change_email: eula-notifications@dimagi.com
 contact_email: info@dimagi.com
 soft_assert_email: commcarehq-ops+soft_asserts@dimagi.com
 check_s3_backups_email: commcarehq-ops+root@dimagi.com,httu.admin@swisstph.ch
-bug_report_email: commcarehq-support@dimagi.com
 new_domain_email: inquiries@dimagi.com
 exchange_email: exchange@dimagi.com
 

--- a/environments/swiss/public.yml
+++ b/environments/swiss/public.yml
@@ -79,7 +79,6 @@ contact_email: info@dimagi.com
 soft_assert_email: commcarehq-ops+soft_asserts@dimagi.com
 check_s3_backups_email: commcarehq-ops+root@dimagi.com,httu.admin@swisstph.ch
 new_domain_email: inquiries@dimagi.com
-exchange_email: exchange@dimagi.com
 
 TWO_FACTOR_GATEWAY_ENABLED: True
 

--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -122,7 +122,6 @@ daily_deploy_email: null
 check_s3_backups_email: null
 return_path_email: null
 new_domain_email: inquiries@example.com
-exchange_email: exchange@example.com
 
 
 ALTERNATE_HOSTS: []

--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -103,7 +103,6 @@ server_admin_email: commcarehq-ops+admins@example.com
 default_from_email: commcarehq-noreply@example.com
 support_email: support@example.com
 probono_support_email: pro-bono@example.com
-cchq_bug_report_email: commcarehq-bug-reports@example.com
 accounts_email: accounts@example.com
 data_email: datatree@example.com
 subscription_change_email: accounts+subchange@example.com
@@ -122,7 +121,6 @@ soft_assert_email: commcarehq-ops+soft_asserts@example.com
 daily_deploy_email: null
 check_s3_backups_email: null
 return_path_email: null
-bug_report_email: commcarehq-support@example.com
 new_domain_email: inquiries@example.com
 exchange_email: exchange@example.com
 

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -358,7 +358,6 @@ EULA_COMPLIANCE = {{ localsettings.EULA_COMPLIANCE|default(False) }}
 AXES_LOCK_OUT_AT_FAILURE = False
 
 NEW_DOMAIN_RECIPIENTS = ['{{ new_domain_email }}']
-EXCHANGE_NOTIFICATION_RECIPIENTS = ["{{ exchange_email }}"]
 
 CUSTOM_REPORT_MAP = {
     "pathfinder": [

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -357,7 +357,6 @@ EULA_COMPLIANCE = {{ localsettings.EULA_COMPLIANCE|default(False) }}
 
 AXES_LOCK_OUT_AT_FAILURE = False
 
-BUG_REPORT_RECIPIENTS = ['{{ bug_report_email }}']
 NEW_DOMAIN_RECIPIENTS = ['{{ new_domain_email }}']
 EXCHANGE_NOTIFICATION_RECIPIENTS = ["{{ exchange_email }}"]
 
@@ -883,7 +882,6 @@ DEFAULT_FROM_EMAIL = '{{ default_from_email }}'
 RETURN_PATH_EMAIL = '{{ return_path_email }}'
 SUPPORT_EMAIL = '{{ support_email }}'
 PROBONO_SUPPORT_EMAIL = '{{ probono_support_email }}'
-CCHQ_BUG_REPORT_EMAIL = '{{ cchq_bug_report_email }}'
 ACCOUNTS_EMAIL = '{{ accounts_email }}'
 DATA_EMAIL = '{{ data_email }}'
 SUBSCRIPTION_CHANGE_EMAIL = '{{ subscription_change_email }}'


### PR DESCRIPTION
##### SUMMARY
This removes the email address constants that were deprecated in https://github.com/dimagi/commcare-hq/pull/26927 and https://github.com/dimagi/commcare-hq/pull/25919/

It also updates the support email address for ICDS environments.

@dannyroberts  is there a standard way to communicate dependencies on HQ PRs, or a typical length of time to wait before merging the dependent PR? This shouldn't be merged until https://github.com/dimagi/commcare-hq/pull/26927 is merged.

##### ENVIRONMENTS AFFECTED
All

##### ISSUE TYPE
- Change Pull Request