### PR TITLE
queue async indicators all day

### DIFF
--- a/environments/icds-cas/public.yml
+++ b/environments/icds-cas/public.yml
@@ -173,12 +173,6 @@ localsettings:
   ALLOWED_HOSTS:
     - '{{ CAS_SITE_HOST }}'
   ASYNC_INDICATORS_TO_QUEUE: 60000
-  ASYNC_INDICATOR_QUEUE_TIMES:
-    '*':
-      - [16, 23]
-      - [0, 3]
-    7:
-      - [0, 24]
   AUDIT_MODEL_SAVE: []
   AUDIT_MODULES: []
   AUDIT_VIEWS: []


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
We normally only queue indicators at night but given the lower form submissions as AWCs, we will run them all day to help clear the backlog.

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
ICDS