### PR TITLE
Revert (temporarily?) to default partitioner on production

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -166,7 +166,7 @@ localsettings:
         - 'ews-ghana'
         - 'ils-gateway'
         - 'ils-gateway-train'
-  USE_KAFKA_SHORTEST_BACKLOG_PARTITIONER: True
+#  USE_KAFKA_SHORTEST_BACKLOG_PARTITIONER: True
   USER_REPORTING_METADATA_BATCH_ENABLED: True
   WS4REDIS_CONNECTION_HOST: "{{ groups.redis.0 }}"
 


### PR DESCRIPTION
Without this change https://github.com/dimagi/commcare-hq/pull/26842, which was reverted,
the "shortest backlog" partitioner exacerbates lag issues by preventing larger queues
from getting any new messages, whereas the new maessages are what trigger it to keep processing.
Once the bug in that PR is resolved, we can reintroduce this.


##### ENVIRONMENTS AFFECTED
production