### PR TITLE
Respect COMMCARE_CLOUD_DEFAULT_USER in ssh commands

### DIFF
--- a/src/commcare_cloud/commands/inventory_lookup/getinventory.py
+++ b/src/commcare_cloud/commands/inventory_lookup/getinventory.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import
 import re
 import sys
 
+from commcare_cloud.commands.terraform.aws import get_default_username
 from commcare_cloud.environment.main import get_environment
 
 
@@ -30,7 +31,11 @@ def get_server_address(environment, group, exit=sys.exit):
         username, group = group.split('@', 1)
         username += "@"
     else:
-        username = ""
+        default_username = get_default_username()
+        if default_username.is_guess:
+            username = ""
+        else:
+            username = "{}@".format(default_username)
 
     if re.match(r'(\d+\.?){4}', group):
         # short circuit for IP addresses


### PR DESCRIPTION
Changes the `cchq <env> ssh <host>` command to respect the `COMMCARE_CLOUD_DEFAULT_USER` env variable that terraform commands and deploy use. It has the same meaning (your name of your ubuntu user on the host), and not using it after a user went through the trouble of setting it is surprising behavior. If the env variable is not set, it will still use <host> instead of explicit <user>@<host> to let whatever is in .ssh/config take control.

##### ENVIRONMENTS AFFECTED
None specifically