### PR TITLE
Have django-manage use login shell

### DIFF
--- a/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -217,7 +217,7 @@ class DjangoManage(CommandBase):
                 cchq_user=cchq_user, deploy_env=deploy_env)
 
         def _get_ssh_args(remote_command):
-            return ['sudo -u {cchq_user} bash -c {remote_command}'.format(
+            return ['sudo -iu {cchq_user} bash -c {remote_command}'.format(
                 cchq_user=cchq_user,
                 remote_command=shlex_quote(remote_command),
             )]


### PR DESCRIPTION
This (probably among other things) preserves ipython history when using django-manage shell.

Small thing I noticed that has bothered me before, where I do some discovery in the shell and then log out by mistake before copying it somewhere so I can turn it into a useful script or something, and then I have to log back in and recreated what I'd done earlier.

##### ENVIRONMENTS AFFECTED
all/none specifically