### PR TITLE
Update cryptography to 2.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ ansible-vault==1.1.1      # via commcare-cloud (setup.py)
 ansible==2.9.5            # via ansible-vault, commcare-cloud (setup.py)
 argparse==1.4.0           # via commcare-cloud (setup.py), couchdb-cluster-admin
 args==0.1.0               # via clint
-asn1crypto==0.24.0        # via cryptography
 attrs==19.1.0             # via commcare-cloud (setup.py)
 bcrypt==3.1.6             # via paramiko
 boto3==1.9.153            # via commcare-cloud (setup.py)
@@ -18,7 +17,7 @@ cffi==1.12.3              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via requests
 clint==0.5.1              # via commcare-cloud (setup.py)
 couchdb-cluster-admin==0.5.0  # via commcare-cloud (setup.py)
-cryptography==2.6.1       # via ansible, commcare-cloud (setup.py), paramiko, pyopenssl
+cryptography==2.8         # via ansible, commcare-cloud (setup.py), paramiko, pyopenssl
 datadog==0.2.0            # via commcare-cloud (setup.py)
 decorator==4.4.0          # via datadog
 deprecated==1.2.5         # via pygithub
@@ -37,7 +36,7 @@ jinja2==2.10.1            # via ansible, jinja2-cli
 jmespath==0.9.4           # via boto3, botocore
 jsonobject==0.9.9         # via commcare-cloud (setup.py), couchdb-cluster-admin
 markupsafe==1.1.1         # via jinja2
-ndg-httpsclient==0.5.1    # via -r requirements-python-lt-2.7.9-ssl-issue.in (line 2)
+ndg-httpsclient==0.5.1    # via -r requirements-python-lt-2.7.9-ssl-issue.in
 netaddr==0.7.19           # via commcare-cloud (setup.py)
 paramiko==2.4.2           # via fabric3
 passlib==1.7.1            # via commcare-cloud (setup.py)
@@ -47,7 +46,7 @@ pycryptodome==3.8.1       # via commcare-cloud (setup.py)
 pygithub==1.43.7          # via commcare-cloud (setup.py)
 pyjwt==1.7.1              # via pygithub
 pynacl==1.3.0             # via paramiko
-pyopenssl==19.0.0         # via -r requirements-python-lt-2.7.9-ssl-issue.in (line 1), ndg-httpsclient
+pyopenssl==19.0.0         # via -r requirements-python-lt-2.7.9-ssl-issue.in, ndg-httpsclient
 python-dateutil==2.8.0    # via botocore
 pytz==2017.2              # via commcare-cloud (setup.py)
 pyyaml==5.1               # via ansible, couchdb-cluster-admin

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,10 @@ setup(
         'boto3>=1.9.131',
         'clint',
         'couchdb-cluster-admin>=0.5.0',
-        'cryptography>=2.3',  # security update
+	# 2.8 solves issue on MacOS Catalina
+	# https://github.com/pypa/pip/issues/7254
+	# but 2.9 fails to compile
+        'cryptography~=2.8.0',
         'datadog==0.2.0',
         'dimagi-memoized>=1.1.0',
         'dnspython',


### PR DESCRIPTION
Solved issue on my new mac
> ```
> # 2.8 solves issue on MacOS Catalina
> # https://github.com/pypa/pip/issues/7254
> # but 2.9 fails to compile
> ```