### PR TITLE
Fix ES monit

### DIFF
--- a/src/commcare_cloud/ansible/roles/elasticsearch/templates/monit.elasticsearch.j2
+++ b/src/commcare_cloud/ansible/roles/elasticsearch/templates/monit.elasticsearch.j2
@@ -1,4 +1,4 @@
-check file elasticsearch with path {{ elasticsearch_data_dir }}/logs/icds-2.0.log
+check file elasticsearch with path {{ elasticsearch_data_dir }}/logs/{{ elasticsearch_cluster_name }}.log
    group database
    group elasticsearch
    start program = "/bin/systemctl start {{ elasticsearch_service_name }}"


### PR DESCRIPTION
Took me hours to figure this out. I was testing something out on staging ES, and as a side effect deployed monit. Apparently it was checking for a file that didn't exist and just restarting ES in a loop, because fixing the path to the correct path for the log file fixed it.

##### ENVIRONMENTS AFFECTED
Fixed would-be issue in all environments but ICDS