### PR TITLE
Refetch tags on first failure

### DIFF
--- a/src/commcare_cloud/fab/operations/release.py
+++ b/src/commcare_cloud/fab/operations/release.py
@@ -46,7 +46,9 @@ def update_code(full_cluster=True):
             _update_code_from_previous_release()
         with cd(env.code_root if not use_current_release else env.code_current):
             sudo('git remote prune origin')
-            sudo('git fetch origin --tags -q')
+            # this can get into a state where running it once fails
+            # but primes it to succeed the next time it runs
+            sudo('git fetch origin --tags -q || git fetch origin --tags -q')
             sudo('git checkout {}'.format(git_tag))
             sudo('git reset --hard {}'.format(git_tag))
             sudo('git submodule sync')


### PR DESCRIPTION
Seeing errors like this on deploy across environments. Likely related to the upgrade to git 2.26.1.

```
[10.203.10.117] out: fatal: git upload-pack: not our ref 59cbfc3f2b9469367c4946b32075ea6e49dc4ff7
[10.203.10.117] out: fatal: remote error: upload-pack: not our ref 59cbfc3f2b9469367c4946b32075ea6e49dc4ff7
[10.203.10.117] out: Errors during submodule fetch:
[10.203.10.117] out:    corehq/apps/hqmedia/static/hqmedia/MediaUploader
```

https://docs.google.com/document/d/161EpZDZYAoiag4Ya2PPYlQ1jMYVYUv4T25qet2kesB4/edit#heading=h.j3m99ov3z102

##### ENVIRONMENTS AFFECTED

all