### PR TITLE
Increase prod queue processors

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -23,7 +23,7 @@ celery_processes:
     case_import_queue:
       concurrency: 3
     case_rule_queue:
-      concurrency: 3
+      concurrency: 8
     celery:
       concurrency: 4
     celery_periodic:

--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -46,7 +46,7 @@ celery_processes:
       pooling: gevent
       concurrency: 200
     saved_exports_queue:
-      concurrency: 8
+      concurrency: 12
     sms_queue:
       pooling: gevent
       concurrency: 10


### PR DESCRIPTION
Bumping up max concurrency on the queues most often facing delays on production. They're both very peaky in that they start once a day at the same time every day, so if just bumping it up doesn't help much and it becomes a user-facing issue, that might be the next thing to look at, but I expect a couple rounds of this kind of thing will be all that's needed for now

##### ENVIRONMENTS AFFECTED
production
