### PR TITLE
Defaulted --control to use first control machine

### DIFF
--- a/src/commcare_cloud/commcare_cloud.py
+++ b/src/commcare_cloud/commcare_cloud.py
@@ -98,7 +98,7 @@ def run_on_control_instead(args, sys_argv):
     executable = 'commcare-cloud'
     branch = getattr(args, 'branch', 'master')
     cmd_parts = [
-        executable, args.env_name, 'ssh', 'control', '-t',
+        executable, args.env_name, 'ssh', 'control:0', '-t',
         'cd ~/commcare-cloud && git fetch --prune && git checkout {branch} '
         '&& git reset --hard origin/{branch} && source ~/init-ansible && {cchq} {cchq_args}'
         .format(branch=branch, cchq=executable, cchq_args=' '.join([shlex_quote(arg) for arg in argv]))


### PR DESCRIPTION
ICDS now has two control machines, which interferes with usage of the `--control` flag.

##### ENVIRONMENTS AFFECTED
None