### PR TITLE
Wipe Postgres DBs, Kafka topics

### DIFF
--- a/docs/howto/wipe_persistent_data.md
+++ b/docs/howto/wipe_persistent_data.md
@@ -1,0 +1,76 @@
+How To Wipe Persistent Data
+===========================
+
+1. Wipe BlobDB, ES, Couch using management commands.
+
+       $ cchq monolith django-manage wipe_blobdb --commit
+       $ cchq monolith django-manage wipe_es --commit
+       $ cchq monolith django-manage delete_couch_dbs --commit
+
+2. Prepend "wipe_environment_enabled: True" to public.yml (because it
+   is easier to spot if it's prepended than appended).
+
+       $ printf '%s\n%s\n' "wipe_environment_enabled: True" \
+         "$(cat ~/environments/monolith/public.yml)" \
+         > ~/environments/monolith/public.yml
+
+3. Stop CommCare and close Postgres sessions.
+
+       $ cchq monolith service commcare stop
+       $ cchq monolith service postgresql stop
+       $ cchq monolith service postgresql status
+
+   If that doesn't stop Postgres and PgBouncer, and if Postgres is
+   running on the same machine as you are logged in on, you can call
+   `service` directly:
+
+       $ sudo service pgbouncer stop
+       $ sudo service postgresql stop
+       $ sudo service postgresql start
+       $ sudo service pgbouncer start
+
+4. Wipe PostgreSQL databases
+
+       $ cchq monolith ap wipe_postgres.yml
+
+5. Wipe Kafka topics
+
+       $ cchq monolith ap wipe_kafka.yml
+
+   You can check they have been removed by confirming that
+   "__consumer_offsets" is the only topic remaining:
+
+       $ kafka-topics.sh --zookeeper localhost:2181 --list
+       __consumer_offsets
+
+
+Rebuilding environment
+----------------------
+
+1. Drop the first line public.yml. This step assumes the first line is
+   "wipe_environment_enabled: True", prepended in the steps above.
+
+       $ tail -n +2 ~/environments/monolith/public.yml > public.yml.tmp
+       $ mv public.yml.tmp ~/environments/monolith/public.yml
+
+2. Run Ansible playbook to recreate databases
+
+       $ cchq monolith ap deploy_db.yml
+
+3. Run management commands to create Kafka topics, create Postgres
+   tables, and Elasticsearch indices.
+
+       $ cchq monolith django-manage create_kafka_topics
+       $ cchq monolith django-manage preindex_everything
+       $ cchq monolith django-manage ptop_es_manage --flip_all_aliases
+       $ cchq monolith django-manage check_services
+       $ sudo -iu cchq  # Required to set CCHQ_IS_FRESH_INSTALL=1
+       (cchq) $ cd www/monolith/current
+       (cchq) $ source python_env-3.6/bin/activate
+       (cchq) $ env CCHQ_IS_FRESH_INSTALL=1 ./manage.py migrate_multi
+       (cchq) $ exit
+
+4. Recreate a superuser (where you substitute your address in place of
+   "you@your.domain").
+
+       $ cchq monolith django-manage make_superuser you@your.domain

--- a/src/commcare_cloud/ansible/roles/kafka/templates/server.properties.j2
+++ b/src/commcare_cloud/ansible/roles/kafka/templates/server.properties.j2
@@ -19,6 +19,13 @@
 # The id of the broker. This must be set to a unique integer for each broker.
 broker.id={{ kafka_broker_id }}
 
+{% if allow_topic_deletion|default(False) %}
+################################## Bad Ideas ##################################
+
+# Allow topics to be deleted
+delete.topic.enable=true
+
+{% endif %}
 ############################# Socket Server Settings #############################
 
 # The port the socket server listens on

--- a/src/commcare_cloud/ansible/roles/kafka/templates/server.properties.j2
+++ b/src/commcare_cloud/ansible/roles/kafka/templates/server.properties.j2
@@ -19,7 +19,7 @@
 # The id of the broker. This must be set to a unique integer for each broker.
 broker.id={{ kafka_broker_id }}
 
-{% if allow_topic_deletion|default(False) %}
+{% if wipe_environment_enabled|default(False) %}
 ################################## Bad Ideas ##################################
 
 # Allow topics to be deleted

--- a/src/commcare_cloud/ansible/wipe_kafka.yml
+++ b/src/commcare_cloud/ansible/wipe_kafka.yml
@@ -8,9 +8,11 @@
         that: "{{ wipe_environment_enabled|default(False) }} == True"
         fail_msg: 'This playbook will delete all data. To continue, set
           "wipe_environment_enabled: True" in public.yml. Take care to unset
-          "wipe_environment_enabled" when the environment setup is complete.'
+          "wipe_environment_enabled" and run the `deploy_kafka.yml` playbook
+          again when the environment setup is complete.'
 
     - name: Import kafka role for `kafka_conf_dir` value
+      # ... and to update server.properties
       import_role:
         name: kafka
 
@@ -39,8 +41,6 @@
       template:
         src: roles/kafka/templates/server.properties.j2
         dest: "{{ kafka_conf_dir }}/server.properties"
-      vars:
-        allow_topic_deletion: True
 
     - name: Restart Kafka
       # `kafka-server` service does not support reload
@@ -54,15 +54,3 @@
         --delete
         --zookeeper localhost:{{ zookeeper_client_port }}
         --topic {{ item }}"
-
-    - name: Prevent Kafka server from deleting topics
-      template:
-        src: roles/kafka/templates/server.properties.j2
-        dest: "{{ kafka_conf_dir }}/server.properties"
-      vars:
-        allow_topic_deletion: False
-
-    - name: Restart Kafka
-      service:
-        name: kafka-server
-        state: restarted

--- a/src/commcare_cloud/ansible/wipe_kafka.yml
+++ b/src/commcare_cloud/ansible/wipe_kafka.yml
@@ -20,10 +20,8 @@
           "wipe_environment_enabled" and run the `deploy_kafka.yml` playbook
           again when the environment setup is complete.'
 
-    - name: Import kafka role for `kafka_conf_dir` value
-      # ... and to update server.properties
-      import_role:
-        name: kafka
+    - name: Get PostgreSQL defaults
+      include_vars: roles/kafka/defaults/main.yml
 
     - name: Get Kafka topics
       # django_manage does not support check mode, and this task does not
@@ -47,9 +45,11 @@
       #    }
 
     - name: Allow Kafka server to delete topics
-      template:
-        src: roles/kafka/templates/server.properties.j2
-        dest: "{{ kafka_conf_dir }}/server.properties"
+      lineinfile:
+        line: 'delete.topic.enable=true'
+        path: "{{kafka_conf_dir}}/server.properties"
+        regexp: 'delete\.topic\.enable'
+        state: present
 
     - name: Restart Kafka
       # `kafka-server` service does not support reload

--- a/src/commcare_cloud/ansible/wipe_kafka.yml
+++ b/src/commcare_cloud/ansible/wipe_kafka.yml
@@ -1,0 +1,68 @@
+---
+- name: Delete all Kafka topics
+  become: true
+  hosts: zookeeper  # Doesn't need to run on all Kafka hosts
+  tasks:
+    - name: Check wipe_environment_enabled has been set to True
+      assert:
+        that: "{{ wipe_environment_enabled|default(False) }} == True"
+        fail_msg: 'This playbook will delete all data. To continue, set
+          "wipe_environment_enabled: True" in public.yml. Take care to unset
+          "wipe_environment_enabled" when the environment setup is complete.'
+
+    - name: Import kafka role for `kafka_conf_dir` value
+      import_role:
+        name: kafka
+
+    - name: Get Kafka topics
+      # django_manage does not support check mode, and this task does not
+      # change the system. Force this task to run in normal mode even when
+      # check mode is on:
+      check_mode: no
+      django_manage:
+        command: 'list_kafka_topics'
+        app_path: "{{ code_home }}"
+        virtualenv: "{{ py3_virtualenv_home }}"
+      register: topics_result
+      # topics_result does not have `stdout` or `stdout_lines`. Use
+      # `out.split()` instead. e.g.
+      #    {
+      #        "changed": false,
+      #        "failed": false,
+      #        "out": "case\ncase-sql\ncommcare-user\ndomain\nform\nform-sql\n"
+      #               "group\nledger\nmeta\nsms\nweb-user\napp\nlocation\n"
+      #               "synclog-sql\n",
+      #        # ...
+      #    }
+
+    - name: Allow Kafka server to delete topics
+      template:
+        src: roles/kafka/templates/server.properties.j2
+        dest: "{{ kafka_conf_dir }}/server.properties"
+      vars:
+        allow_topic_deletion: True
+
+    - name: Restart Kafka
+      # `kafka-server` service does not support reload
+      service:
+        name: kafka-server
+        state: restarted
+
+    - name: Delete topics
+      loop: "{{ topics_result.out.split() }}"
+      command: "/opt/kafka/bin/kafka-topics.sh
+        --delete
+        --zookeeper localhost:{{ zookeeper_client_port }}
+        --topic {{ item }}"
+
+    - name: Prevent Kafka server from deleting topics
+      template:
+        src: roles/kafka/templates/server.properties.j2
+        dest: "{{ kafka_conf_dir }}/server.properties"
+      vars:
+        allow_topic_deletion: False
+
+    - name: Restart Kafka
+      service:
+        name: kafka-server
+        state: restarted

--- a/src/commcare_cloud/ansible/wipe_kafka.yml
+++ b/src/commcare_cloud/ansible/wipe_kafka.yml
@@ -2,7 +2,16 @@
 - name: Delete all Kafka topics
   become: true
   hosts: zookeeper  # Doesn't need to run on all Kafka hosts
+  vars_prompt:
+    - name: confirm_wipe
+      prompt: "Are you sure you want to delete all Kafka topics? [yN]"
+      private: no
+
   tasks:
+    - name: Check confirm_wipe
+      assert:
+        that: confirm_wipe == 'y'
+
     - name: Check wipe_environment_enabled has been set to True
       assert:
         that: "{{ wipe_environment_enabled|default(False) }} == True"

--- a/src/commcare_cloud/ansible/wipe_postgres.yml
+++ b/src/commcare_cloud/ansible/wipe_postgres.yml
@@ -1,0 +1,31 @@
+---
+
+- name: Delete all PostgreSQL databases
+  hosts: postgresql:pg_standby:!citusdb
+  vars:
+    postgresql_host: "{{ inventory_hostname }}"
+  tasks:
+    - name: Check wipe_environment_enabled has been set to True
+      assert:
+        that: "{{ wipe_environment_enabled|default(False) }} == True"
+        fail_msg: 'This playbook will delete all data. To continue, set
+          "wipe_environment_enabled: True" in public.yml. Take care to unset
+          "wipe_environment_enabled" when the environment setup is complete.'
+
+    - name: Get PostgreSQL defaults
+      include_vars: roles/postgresql_base/defaults/main.yml
+
+    - name: Drop PostgreSQL databases
+      become_user: postgres
+      vars:
+        ansible_ssh_pipelining: true
+      with_items: "{{ postgresql_dbs.all }}"
+      # Only delete the databases we created (standby DB is not created, and not deleted)
+      when: item.create and ((item.host == postgresql_host) or is_monolith|bool)
+      postgresql_db:
+        name: "{{ item.name }}"
+        state: absent
+        port: "{{ postgresql_port }}"
+        login_host: 127.0.0.1
+        login_user: "{{ item.user }}"
+        login_password: "{{ item.password }}"

--- a/src/commcare_cloud/ansible/wipe_postgres.yml
+++ b/src/commcare_cloud/ansible/wipe_postgres.yml
@@ -4,7 +4,16 @@
   hosts: postgresql:pg_standby:!citusdb
   vars:
     postgresql_host: "{{ inventory_hostname }}"
+  vars_prompt:
+    - name: confirm_wipe
+      prompt: "Are you sure you want to delete all PostgreSQL databases? [yN]"
+      private: no
+
   tasks:
+    - name: Check confirm_wipe
+      assert:
+        that: confirm_wipe == 'y'
+
     - name: Check wipe_environment_enabled has been set to True
       assert:
         that: "{{ wipe_environment_enabled|default(False) }} == True"

--- a/src/commcare_cloud/ansible/wipe_postgres.yml
+++ b/src/commcare_cloud/ansible/wipe_postgres.yml
@@ -26,6 +26,12 @@
         name: "{{ item.name }}"
         state: absent
         port: "{{ postgresql_port }}"
+        # This task will fail if `login_host` does not match the host
+        # definition in pg_hba.conf. See pg_hba.conf.j2:
+        #     IPv4 local connections:
+        #     host    all             all             127.0.0.1/32            md5
+        # (I tried to use sockets by dropping both `port` and `login_host`,
+        # but that also failed.)
         login_host: 127.0.0.1
         login_user: "{{ item.user }}"
         login_password: "{{ item.password }}"


### PR DESCRIPTION
Context: [SC-514](https://dimagi-dev.atlassian.net/browse/SC-514)

Two short playbooks to:
* Wipe Postgres databases created by `set_up_dbs.yml`
* Wipe Kafka topics created by the `create_kafka_topics` Django management command

Both commands require 

    wipe_environment_enabled: True

to be set in in public.yml. This is a precaution against running these playbooks in the wrong environment.

##### ENVIRONMENTS AFFECTED
Only environments that have `wipe_environment_enabled: True` in public.yml. The `wipe_postgres.yml` playbook does not work with remote DBs like Amazon RDS.

