### PR TITLE
Set --prefetch-multiplier=4 on celery tasks

### DIFF
--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_celery_workers.conf.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_celery_workers.conf.j2
@@ -9,6 +9,7 @@ command=/bin/bash {{ service_home }}/{{ deploy_env }}_celery_bash_runner{% if ce
     --events --loglevel=INFO --without-gossip
     --queues={{ queue_names }}
     --hostname={{ inventory_hostname }}_{{ queue_names }}_{{ worker_num }} {% if celery_params.pooling == 'prefork' %} --autoscale={{ celery_params.concurrency }},0 -Ofair {% if celery_params.max_tasks_per_child %}--maxtasksperchild={{ celery_params.max_tasks_per_child }}{% endif %}{% endif %}{% if celery_params.pooling == 'gevent' %} -P gevent --concurrency={{ celery_params.concurrency }}{% endif %}
+    --prefetch-multiplier=4
 
 directory={{ code_home }}
 user={{ cchq_user }}


### PR DESCRIPTION
This is the documented default but I recently saw
many more than 4 * concurrency tasks in a workers Reserved queue.

If the docs are correct and we're not overriding this in our code (or library code), which it appears we're not, then this change will have no effect, and then it's a mystery why I was seeing so many reserved tasks earlier today. If this helps, it's a mystery why `--prefetch-multiplier` wasn't already set to 4, the documented default. I can't imagine that this will _hurt_. If somehow our current settings have unlimited prefetch, then this could _theoretically_ introduce some (sub-second) latency, but only if the processing of tasks is uniformly way, way faster than pulling a task off the rabbitmq queue; it seems a low risk.

##### ENVIRONMENTS AFFECTED
all