### PR TITLE
A more extreme approach to wiping persistent data

### DIFF
--- a/src/commcare_cloud/ansible/purge_elasticsearch.yml
+++ b/src/commcare_cloud/ansible/purge_elasticsearch.yml
@@ -1,0 +1,39 @@
+---
+- name: Uninstall Elasticsearch and remove data directory
+  hosts: elasticsearch
+  become: true
+  vars_prompt:
+    - name: confirm_purge
+      prompt: "Are you sure you want to purge Elasticsearch? [yN]"
+      private: no
+
+  tasks:
+    - name: Confirm purge
+      assert:
+        that: confirm_purge == 'y'
+
+    - name: Check wipe_environment_enabled has been set to True
+      assert:
+        that: "{{ wipe_environment_enabled|default(False) }} == True"
+        fail_msg: 'This playbook is extremely destructive. To continue, set
+          "wipe_environment_enabled: True" in public.yml. Take care to unset
+          "wipe_environment_enabled" when the environment setup is complete.'
+
+    - name: Load variables from elasticsearch role
+      include_vars: roles/elasticsearch/defaults/main.yml
+
+    - name: Stop Elasticsearch
+      service:
+        name: elasticsearch
+        state: stopped
+
+    - name: Uninstall Elasticsearch
+      file:
+        path: "{{ elasticsearch_home }}"
+        state: absent
+
+    - name: Remove Elasticsearch data directory
+      become: yes
+      file:
+        path: "{{ elasticsearch_data_dir }}"
+        state: absent

--- a/src/commcare_cloud/ansible/purge_kafka.yml
+++ b/src/commcare_cloud/ansible/purge_kafka.yml
@@ -1,0 +1,51 @@
+---
+- name: Confirm purge Kafka
+  tasks:
+    - name: Confirm purge
+      assert:
+        that: confirm_purge == 'y'
+
+    - name: Check wipe_environment_enabled has been set to True
+      assert:
+        that: "{{ wipe_environment_enabled|default(False) }} == True"
+        fail_msg: 'This playbook is extremely destructive. To continue, set
+          "wipe_environment_enabled: True" in public.yml. Take care to unset
+          "wipe_environment_enabled" when the environment setup is complete.'
+
+- name: Uninstall Kafka
+  hosts: kafka
+  become: true
+  tasks:
+    - name: Load variables from kafka role
+      include_vars: roles/kafka/defaults/main.yml
+
+    - name: Stop Kafka
+      service:
+        name: kafka-server
+        state: stopped
+
+    - name: Remove symlink
+      file:
+        path: /opt/kafka
+        state: absent
+
+    - name: Remove Kafka
+      file:
+        path: "/opt/kafka_2.10-{{ kafka_version }}"
+        state: absent
+
+    - name: Remove Kafka data directory
+      file:
+        path: "{{ kafka_data_dir }}"
+        state: absent
+
+- name: Uninstall Zookeeper
+  hosts: zookeeper
+  become: true
+  tasks:
+    - name: Uninstall zookeeper
+      apt:
+        name:
+          - zookeeper
+          - zookeeperd
+        state: absent

--- a/src/commcare_cloud/ansible/purge_postgres.yml
+++ b/src/commcare_cloud/ansible/purge_postgres.yml
@@ -1,0 +1,48 @@
+---
+- name: Uninstall PostgreSQL and remove data directory
+  hosts: postgresql:pg_standby:!citusdb
+  become: true
+  vars_prompt:
+    - name: confirm_purge
+      prompt: "Are you sure you want to purge PostgreSQL? [yN]"
+      private: no
+
+  tasks:
+    - name: Confirm purge
+      assert:
+        that: confirm_purge == 'y'
+
+    - name: Check wipe_environment_enabled has been set to True
+      assert:
+        that: "{{ wipe_environment_enabled|default(False) }} == True"
+        fail_msg: 'This playbook is extremely destructive. To continue, set
+          "wipe_environment_enabled: True" in public.yml. Take care to unset
+          "wipe_environment_enabled" when the environment setup is complete.'
+
+    - name: Load variables from postgresql_base role
+      include_vars: roles/postgresql_base/defaults/main.yml
+
+    - name: Stop pgbouncer
+      service:
+        name: pgbouncer
+        state: stopped
+
+    - name: Uninstall pgbouncer
+      apt:
+        name: pgbouncer
+        state: absent
+
+    - name: Stop PostgreSQL
+      service:
+        name: postgresql
+        state: stopped
+
+    - name: Uninstall PostgreSQL
+      apt:
+        name: "{{postgresql_binary}}"
+        state: absent
+
+    - name: Remove PostgreSQL data directory
+      file:
+        path: "{{ postgresql_data_dir }}"
+        state: absent

--- a/src/commcare_cloud/ansible/roles/elasticsearch/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/elasticsearch/tasks/main.yml
@@ -20,6 +20,7 @@
     src: "/home/{{ cchq_user }}/downloads/elasticsearch-{{ elasticsearch_version }}.tar.gz"
     dest: /opt/
     copy: no
+    creates: "{{ elasticsearch_home }}"
 
 - name: Chown Elasticsearch
   become: yes


### PR DESCRIPTION
I have stopped trying to resolve the problems with my previous attempt at wiping persistent data from an environment. (cf. PR #3791)

Instead of just dropping databases, etc., this branch takes a more extreme approach. It uses the inverse of Ansible tasks to install persistent storage. It uninstalls the software and deletes the data directories. My hope is that this will make it simpler to rebuild an environment after it has been wiped. Considering I don't know exactly why my previous fails, I'm not sure this will avoid the same problem. But, you know, 

> *If at first you don't succeed, use a bigger hammer.*

A potential problem with this approach is that it is more destructive, and will remove non-CommCare data, if a host is being used for more than just CommCare.

All suggestions welcome.
