### PR TITLE
Increase prod formplayer_memory to ~50% of available memory

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -3,6 +3,7 @@ django_command_prefix: ''
 celery_command_prefix: ''
 gunicorn_workers_static_factor: 0
 gunicorn_workers_factor: 1
+formplayer_memory: "15g"
 management_commands:
   celery12:
     run_submission_reprocessing_queue:


### PR DESCRIPTION
Formplayer machines are now 32G RAM, so setting formplayer max memory to 15G (just under 50%). The reason for not going closer to 100% is because formplayer does appear to benefit from using RAM for a fair amount of os caching.

##### ENVIRONMENTS AFFECTED
production