### PR TITLE
add 24 more workers for reminder_case_update

### DIFF
--- a/environments/icds-cas/app-processes.yml
+++ b/environments/icds-cas/app-processes.yml
@@ -241,7 +241,12 @@ celery_processes:
       pooling: gevent
       concurrency: 5
       num_workers: 4
-  celery78,celery79,celery80,celery81,celery82,celery83,celery84,celery85:
+  celery78,celery79,celery80:
+    reminder_case_update_queue:
+      pooling: gevent
+      concurrency: 5
+      num_workers: 8
+  celery81,celery82,celery83,celery84,celery85:
 pillows:
   'pillow21':
     # Catch all server for low volume pillows


### PR DESCRIPTION
As a follow up https://github.com/dimagi/commcare-cloud/pull/3829

which upgraded the 
`reminder_rule_queue` to process two such rules in parallel and
`reminder_case_update` workers from 20 to 36

Since we are running the processing per shard now, there are more cases being sent for processing with task `sync_case_for_messaging_rule`
So to keep up with that change, need to add more power on "reminder_case_update"
Added 24 more workers to make 60 in total which is not exactly the double because worried if that would put major load of db and redis. Hence increasing by 24 as of now.

##### ENVIRONMENTS AFFECTED
ICDS