### PR TITLE
Add back TWO_FACTOR_GATEWAY_ENABLED option

### DIFF
--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -711,6 +711,11 @@ WS4REDIS_CONNECTION = {
 }
 {% endif %}
 
+{% if TWO_FACTOR_GATEWAY_ENABLED %}
+TWO_FACTOR_SMS_GATEWAY = 'corehq.apps.hqwebapp.two_factor_gateways.Gateway'
+TWO_FACTOR_CALL_GATEWAY = 'corehq.apps.hqwebapp.two_factor_gateways.Gateway'
+{% endif %}
+
 {% if 'ENFORCE_TWO_FACTOR_FOR_SUPERUSERS' in localsettings %}
 ENFORCE_TWO_FACTOR_FOR_SUPERUSERS = {{ localsettings.ENFORCE_TWO_FACTOR_FOR_SUPERUSERS }}
 {% endif %}


### PR DESCRIPTION
Removed in https://github.com/dimagi/commcare-cloud/commit/ae45e90253f9ace19d1dc721b44bb04a93c464b7
(mistakenly I believe)

<!--- Provide a link to the ticket or document which prompted this change -->

##### ENVIRONMENTS AFFECTED
production, india, swiss