### PR TITLE
Make the aws ssl policy configurable

### DIFF
--- a/environments/staging/terraform.yml
+++ b/environments/staging/terraform.yml
@@ -3,6 +3,7 @@ state_bucket: dimagi-terraform
 state_bucket_region: "us-east-1"
 region: "us-east-1"
 environment: "staging"
+ssl_policy: 'ELBSecurityPolicy-FS-1-2-Res-2019-08'
 azs:
   - "us-east-1a"
   - "us-east-1b"

--- a/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
@@ -179,4 +179,5 @@ module "ga_alb_waf" {
     {%- endfor %}
   ]
   account_id = {{ account_id|tojson }}
+  ssl_policy = {{ ssl_policy|tojson }}
 }

--- a/src/commcare_cloud/environment/schemas/terraform.py
+++ b/src/commcare_cloud/environment/schemas/terraform.py
@@ -15,6 +15,7 @@ class TerraformConfig(jsonobject.JsonObject):
     openvpn_image = jsonobject.StringProperty()
     azs = jsonobject.ListProperty(str)
     az_codes = jsonobject.ListProperty(str, default=['a', 'b', 'c'])
+    ssl_policy = jsonobject.StringProperty(default="ELBSecurityPolicy-2016-08")
     vpc_begin_range = jsonobject.StringProperty()
     vpn_connections = jsonobject.ListProperty(lambda: VpnConnectionConfig)
     external_routes = jsonobject.ListProperty(lambda: ExternalRouteConfig)

--- a/src/commcare_cloud/terraform/modules/ga_alb_waf/main.tf
+++ b/src/commcare_cloud/terraform/modules/ga_alb_waf/main.tf
@@ -142,7 +142,7 @@ resource "aws_lb_listener" "front_end" {
   load_balancer_arn = "${aws_lb.front_end.arn}"
   port              = "443"
   protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  ssl_policy        = "${var.ssl_policy}"
   certificate_arn   = "${aws_acm_certificate.front_end.arn}"
 
   default_action {

--- a/src/commcare_cloud/terraform/modules/ga_alb_waf/variables.tf
+++ b/src/commcare_cloud/terraform/modules/ga_alb_waf/variables.tf
@@ -14,3 +14,4 @@ variable "proxy_server_ids" {
 }
 
 variable "account_id" {}
+variable "ssl_policy" {}


### PR DESCRIPTION
And set staging to most restrictive ssl policy, `ELBSecurityPolicy-FS-1-2-Res-2019-08` (https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies)

##### ENVIRONMENTS AFFECTED
staging