### PR TITLE
Use ssl_policy ELBSecurityPolicy-FS-1-2-Res-2019-08 on production

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -3,6 +3,7 @@ state_bucket: dimagi-terraform
 state_bucket_region: "us-east-1"
 region: "us-east-1"
 environment: "production"
+ssl_policy: 'ELBSecurityPolicy-FS-1-2-Res-2019-08'
 azs:
   - "us-east-1a"
   - "us-east-1b"


### PR DESCRIPTION
This will make our Monday switchover to using the load balancer WAF setup result in no change to our cipher set. Followup to https://github.com/dimagi/commcare-cloud/pull/3837

Similar to what we did for staging in https://github.com/dimagi/commcare-cloud/pull/3838

##### ENVIRONMENTS AFFECTED
production