### PR TITLE
Update npm 6.4.1 => 6.14.5

### DIFF
--- a/src/commcare_cloud/ansible/roles/nodejs/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/nodejs/tasks/main.yml
@@ -45,6 +45,6 @@
   npm: name="{{ item.name }}" version="{{ item.version }}" state=present global=yes
   become: yes
   with_items:
-    - {name: 'npm', version: '6.4.1'}
+    - {name: 'npm', version: '6.14.5'}
   tags:
     - npm


### PR DESCRIPTION
This appeared to be a necessary step in fixing a blocking phantomjs install during deploy