### PR TITLE
requesting valid root_email address and adding SSL.md Document link

### DIFF
--- a/docs/setup/new_environment.md
+++ b/docs/setup/new_environment.md
@@ -311,11 +311,29 @@ $ commcare-cloud monolith after-reboot all
 ```
 
 
-### In Order to set up valid SSL certificates 
-If you wish to set up valid SSL certificate please follow instructions provide in this link (../services/nginx/ssl.md)
+## Step 7: Setting set up valid SSL certificates 
+If you wish to set up valid SSL certificate please follow below instructions 
+
+    ### 1. Request a letsencrypt cert
+
+Run the playbook to request a letsencrypt cert:
+```bash
+cchq <env> ansible-playbook letsencrypt_cert.yml --skip-check
+```
+
+### 2. Update settings to take advantage of new certs
+
+In `proxy.yml`:
+- set `fake_ssl_cert` to `no`
+
+and deploy proxy again.
+
+```bash
+cchq <env> ansible-playbook deploy_proxy.yml
+```
 
 
-## Step 7: Getting started with CommCareHQ
+## Step 8: Getting started with CommCareHQ
 
 ### Make a user
 

--- a/docs/setup/new_environment.md
+++ b/docs/setup/new_environment.md
@@ -83,7 +83,9 @@ This document will walk you through the process of setting up a new monolith ser
      - `ALLOWED_HOSTS`
      - `server_email`
      - `default_from_email`
-
+3. Add valid `root_email` address in public.yml file
+    - `public.yml`
+      - `root_email`
 1. Next, we're going to set up an encrypted "ansible vault" file.  This will store all the passwords used in this CommCare environment.  You'll need to create a strong password and save it somewhere safe.  This is the master password that grants access to the vault.  You'll need it for any future changes to this file, as well as when you deploy or make configuration changes to this machine.
 
     Encrypt the provided vault file, using that password:
@@ -309,6 +311,11 @@ If you ever reboot this machine, make sure to follow the [after reboot procedure
 ``` bash
 $ commcare-cloud monolith after-reboot all
 ```
+
+
+### In Order to set up valid SSL certificates 
+If you wish to set up valid SSL certificate please follow instructions provide in this link (../services/nginx/ssl.md)
+
 
 ## Step 7: Getting started with CommCareHQ
 

--- a/docs/setup/new_environment.md
+++ b/docs/setup/new_environment.md
@@ -83,8 +83,6 @@ This document will walk you through the process of setting up a new monolith ser
      - `ALLOWED_HOSTS`
      - `server_email`
      - `default_from_email`
-3. Add valid `root_email` address in public.yml file
-    - `public.yml`
       - `root_email`
 1. Next, we're going to set up an encrypted "ansible vault" file.  This will store all the passwords used in this CommCare environment.  You'll need to create a strong password and save it somewhere safe.  This is the master password that grants access to the vault.  You'll need it for any future changes to this file, as well as when you deploy or make configuration changes to this machine.
 

--- a/docs/setup/new_environment.md
+++ b/docs/setup/new_environment.md
@@ -314,7 +314,7 @@ $ commcare-cloud monolith after-reboot all
 ## Step 7: Setting set up valid SSL certificates 
 If you wish to set up valid SSL certificate please follow below instructions 
 
-    ### 1. Request a letsencrypt cert
+### 1. Request a letsencrypt cert
 
 Run the playbook to request a letsencrypt cert:
 ```bash


### PR DESCRIPTION
Changes:
1. Requesting user to set valid root_email address. This is to validate the SSL certificates which we are provision using Letsencrypt without any issues.
2. Adding SSL.md instructions link in the new_environment.md so that the user can obtain Valid SSL certificates for the monolith env.

Please let me know your suggestions. Thanks.
<!--- Provide a link to the ticket or document which prompted this change -->

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
