### PR TITLE
Fix --control by adding back -A ssh flag

### DIFF
--- a/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -73,7 +73,7 @@ class Ssh(_Ssh):
     """
 
     def run(self, args, ssh_args):
-        if args.server == 'control' and '-A' not in ssh_args:
+        if args.server.split(':')[0] == 'control' and '-A' not in ssh_args:
             # Always include ssh agent forwarding on control machine
             ssh_args = ['-A'] + ssh_args
         ukhf = "UserKnownHostsFile="


### PR DESCRIPTION
when the server arg is e.g. control:0 instead of control.
Introduced by https://github.com/dimagi/commcare-cloud/commit/608612f4553f9d53543a1dd09dd2ece9c8b1df97

Made this change last week and forgot to PR