### PR TITLE
Remove config for backup_es_s3 on production/india

### DIFF
--- a/environments/india/public.yml
+++ b/environments/india/public.yml
@@ -12,7 +12,7 @@ elasticsearch_download_sha256: 5f7e4bb792917bb7ffc2a5f612dfec87416d54563f795d6a7
 
 backup_blobdb: False
 backup_postgres: plain
-backup_es_s3: True
+backup_es_s3: False
 postgres_s3: True
 postgresql_backup_weeks: 1
 postgresql_backup_days: 1

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -45,7 +45,7 @@ nofile_limit: 65536
 
 backup_blobdb: False
 backup_postgres: plain
-backup_es_s3: True
+backup_es_s3: False
 backup_couch: False
 postgres_s3: True
 postgresql_backup_days: 1


### PR DESCRIPTION
We already changed how we do this on production/india
and I believe this is now broken anyway.
Having it around is just one more moving part we need to worry about.

##### ENVIRONMENTS AFFECTED
production, india
