### PR TITLE
Add root_encryption_mode=aws logic for when there is no block_device

### DIFF
--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -17,16 +17,16 @@ proxy1
 10.202.10.102 hostname=web5-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3
 
 [web6]
-10.202.10.65 hostname=web6-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3
+10.202.10.65 hostname=web6-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 root_encryption_mode=aws
 
 [web7]
-10.202.10.201 hostname=web7-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3
+10.202.10.201 hostname=web7-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 root_encryption_mode=aws
 
 [web8]
-10.202.10.223 hostname=web8-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3
+10.202.10.223 hostname=web8-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 root_encryption_mode=aws
 
 [web9]
-10.202.10.55 hostname=web9-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3
+10.202.10.55 hostname=web9-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 root_encryption_mode=aws
 
 [web10]
 10.202.11.233 hostname=web10-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3

--- a/src/commcare_cloud/commands/terraform/aws.py
+++ b/src/commcare_cloud/commands/terraform/aws.py
@@ -194,6 +194,10 @@ class AwsFillInventoryHelper(object):
                     inventory_vars.append(
                         ('root_encryption_mode', 'aws'),
                     )
+            elif server.volume_encrypted:
+                inventory_vars.append(
+                    ('root_encryption_mode', 'aws'),
+                )
 
             context.update(
                 self.get_host_group_definition(resource_name=server.server_name, vars=inventory_vars)

--- a/src/commcare_cloud/environment/schemas/terraform.py
+++ b/src/commcare_cloud/environment/schemas/terraform.py
@@ -67,14 +67,6 @@ class BlockDevice(jsonobject.JsonObject):
     volume_size = jsonobject.IntegerProperty(required=True)
     encrypted = jsonobject.BooleanProperty(default=True, required=True)
 
-    @classmethod
-    def wrap(cls, data):
-        if 'encrypted' in data:
-            puts(color_warning(
-                'Warning! The "encrypted" option on block_device is experimental '
-                'and not well-integrated into provisioning scripts.'))
-        return super(BlockDevice, cls).wrap(data)
-
 
 class RdsInstanceConfig(jsonobject.JsonObject):
     _allow_dynamic_properties = False


### PR DESCRIPTION
in which case it should be set if the boot volume is encrypted.

I will roll this out at a low-traffic time by rebooting the affected webworkers and confirming they start back up without the /opt/tmp using ecryptfs after `after-reboot`.

##### ENVIRONMENTS AFFECTED
production (and others going forward)