### PR TITLE
Mount secondary volume even when root_encryption_mode=aws

### DIFF
--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -202,13 +202,13 @@ shareddir1
 10.202.40.144 hostname=es19-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 elasticsearch_node_name=es19
 
 [es20]
-10.202.40.146 hostname=es20-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws elasticsearch_node_name=es20
+10.202.40.146 hostname=es20-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws elasticsearch_node_name=es20 datavol_fstype=xfs
 
 [es21]
-10.202.40.220 hostname=es21-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws elasticsearch_node_name=es21
+10.202.40.220 hostname=es21-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws elasticsearch_node_name=es21 datavol_fstype=xfs
 
 [es22]
-10.202.40.160 hostname=es22-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws elasticsearch_node_name=es22
+10.202.40.160 hostname=es22-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws elasticsearch_node_name=es22 datavol_fstype=xfs
 
 [esmaster3]
 10.202.41.183 hostname=esmaster3-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 elasticsearch_node_name=esmaster3

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -159,11 +159,11 @@ shareddir1
 
 {{ __es19__ }} elasticsearch_node_name=es19
 
-{{ __es20__ }} elasticsearch_node_name=es20
+{{ __es20__ }} elasticsearch_node_name=es20 datavol_fstype=xfs
 
-{{ __es21__ }} elasticsearch_node_name=es21
+{{ __es21__ }} elasticsearch_node_name=es21 datavol_fstype=xfs
 
-{{ __es22__ }} elasticsearch_node_name=es22
+{{ __es22__ }} elasticsearch_node_name=es22 datavol_fstype=xfs
 
 {{ __esmaster3__ }} elasticsearch_node_name=esmaster3
 

--- a/environments/staging/inventory.ini
+++ b/environments/staging/inventory.ini
@@ -25,7 +25,7 @@ web3
 web4
 
 [pgproxy1]
-10.201.40.187 hostname=pgproxy1-staging ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws
+10.201.40.187 hostname=pgproxy1-staging ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws datavol_fstype=xfs
 
 [rds_pg0]
 pg0-staging.czkracjslrn2.us-east-1.rds.amazonaws.com
@@ -38,13 +38,13 @@ pgproxy1
 remote_postgresql
 
 [couch3]
-10.201.40.182 hostname=couch3-staging ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws
+10.201.40.182 hostname=couch3-staging ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws datavol_fstype=xfs
 
 [couch4]
-10.201.40.62 hostname=couch4-staging ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws
+10.201.40.62 hostname=couch4-staging ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws datavol_fstype=xfs
 
 [couch5]
-10.201.40.147 hostname=couch5-staging ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws
+10.201.40.147 hostname=couch5-staging ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws datavol_fstype=xfs
 
 [couchdb2:children]
 couch3
@@ -62,7 +62,7 @@ couch3
 rabbit1
 
 [kafka1]
-10.201.40.14 hostname=kafka1-staging ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws kafka_broker_id=0
+10.201.40.14 hostname=kafka1-staging ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws kafka_broker_id=0 datavol_fstype=xfs
 
 [zookeeper:children]
 # Amazon EC2
@@ -87,10 +87,10 @@ celery1
 pillow1
 
 [formplayer1]
-10.201.10.234 hostname=formplayer1-staging ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws
+10.201.10.234 hostname=formplayer1-staging ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws datavol_fstype=xfs
 
 [formplayer2]
-10.201.10.198 hostname=formplayer2-staging ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws
+10.201.10.198 hostname=formplayer2-staging ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws datavol_fstype=xfs
 
 [formplayer:children]
 # Amazon EC2
@@ -98,16 +98,16 @@ formplayer1
 formplayer2
 
 [redis1]
-10.201.40.219 hostname=redis1-staging ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws
+10.201.40.219 hostname=redis1-staging ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws datavol_fstype=xfs
 
 [redis:children]
 redis1
 
 [es2]
-10.201.40.143 hostname=es2-staging ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws elasticsearch_node_name=es2-staging elasticsearch_node_zone=aws elasticsearch_master=true
+10.201.40.143 hostname=es2-staging ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws elasticsearch_node_name=es2-staging elasticsearch_node_zone=aws elasticsearch_master=true datavol_fstype=xfs
 
 [es3]
-10.201.40.171 hostname=es3-staging ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws elasticsearch_node_name=es3-staging elasticsearch_node_zone=aws elasticsearch_master=true
+10.201.40.171 hostname=es3-staging ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws elasticsearch_node_name=es3-staging elasticsearch_node_zone=aws elasticsearch_master=true datavol_fstype=xfs
 
 [elasticsearch:children]
 # Amazon EC2

--- a/environments/staging/inventory.ini.j2
+++ b/environments/staging/inventory.ini.j2
@@ -21,7 +21,7 @@ proxy0
 web3
 web4
 
-{{ __pgproxy1__ }}
+{{ __pgproxy1__ }} datavol_fstype=xfs
 
 {{ __rds_pg0__ }}
 
@@ -32,11 +32,11 @@ rds_pg0
 pgproxy1
 remote_postgresql
 
-{{ __couch3__ }}
+{{ __couch3__ }} datavol_fstype=xfs
 
-{{ __couch4__ }}
+{{ __couch4__ }} datavol_fstype=xfs
 
-{{ __couch5__ }}
+{{ __couch5__ }} datavol_fstype=xfs
 
 [couchdb2:children]
 couch3
@@ -52,7 +52,7 @@ couch3
 # Amazon EC2
 rabbit1
 
-{{ __kafka1__ }} kafka_broker_id=0
+{{ __kafka1__ }} kafka_broker_id=0 datavol_fstype=xfs
 
 [zookeeper:children]
 # Amazon EC2
@@ -74,23 +74,23 @@ celery1
 # Amazon EC2
 pillow1
 
-{{ __formplayer1__ }}
+{{ __formplayer1__ }} datavol_fstype=xfs
 
-{{ __formplayer2__ }}
+{{ __formplayer2__ }} datavol_fstype=xfs
 
 [formplayer:children]
 # Amazon EC2
 formplayer1
 formplayer2
 
-{{ __redis1__ }}
+{{ __redis1__ }} datavol_fstype=xfs
 
 [redis:children]
 redis1
 
-{{ __es2__ }} elasticsearch_node_name=es2-staging elasticsearch_node_zone=aws elasticsearch_master=true
+{{ __es2__ }} elasticsearch_node_name=es2-staging elasticsearch_node_zone=aws elasticsearch_master=true datavol_fstype=xfs
 
-{{ __es3__ }} elasticsearch_node_name=es3-staging elasticsearch_node_zone=aws elasticsearch_master=true
+{{ __es3__ }} elasticsearch_node_name=es3-staging elasticsearch_node_zone=aws elasticsearch_master=true datavol_fstype=xfs
 
 [elasticsearch:children]
 # Amazon EC2

--- a/src/commcare_cloud/ansible/roles/ecryptfs/defaults/main.yml
+++ b/src/commcare_cloud/ansible/roles/ecryptfs/defaults/main.yml
@@ -1,1 +1,2 @@
 datavol_device1: "{{ datavol_device }}1"
+datavol_fstype: ext4

--- a/src/commcare_cloud/ansible/roles/ecryptfs/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/ecryptfs/tasks/main.yml
@@ -24,7 +24,7 @@
 
 - name: Format block storage volume
   become: yes
-  filesystem: fstype=ext4 dev="{{ datavol_device1 }}"
+  filesystem: fstype="{{ datavol_fstype }}" dev="{{ datavol_device1 }}"
   when: datavol_device is defined
 
 - name: Mount block storage volume
@@ -32,7 +32,7 @@
   mount:
     name: "{{ encrypted_root }}"
     src: "{{ datavol_device1 }}"
-    fstype: ext4
+    fstype: "{{ datavol_fstype }}"
     state: mounted
     opts: "defaults,noatime{{ datavol_opts | default('') | regex_replace('^(?=.)', ',') }}"
     dump: "0"

--- a/src/commcare_cloud/ansible/roles/ecryptfs/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/ecryptfs/tasks/main.yml
@@ -1,45 +1,45 @@
 ---
 
+- name: Check for valid partition table on block storage device
+  become: yes
+  shell: fdisk -l 2>&1 | grep 'Disk {{ datavol_device }} doesn.t contain a valid partition table'
+  register: partition_check
+  when: datavol_device is defined and ansible_hostname not in groups.get('lvm', [])
+  changed_when: false
+  failed_when: false
+  check_mode: no
+
+- name: Create partition on block storage volume
+  become: yes
+  shell: echo -e "o\nn\np\n1\n\n\nw" | fdisk {{ datavol_device }}
+  # http://superuser.com/a/739586/86694
+  # o - clear in memory partition table
+  # n - new partition
+  # p - primary partition
+  # 1 - partition number 1
+  #   - default - start at beginning of disk
+  #   - default - use entire disk
+  # w - write the partition table
+  when: datavol_device is defined and partition_check.rc == 0 and ansible_hostname not in groups.get('lvm', [])
+
+- name: Format block storage volume
+  become: yes
+  filesystem: fstype=ext4 dev="{{ datavol_device1 }}"
+  when: datavol_device is defined
+
+- name: Mount block storage volume
+  become: yes
+  mount:
+    name: "{{ encrypted_root }}"
+    src: "{{ datavol_device1 }}"
+    fstype: ext4
+    state: mounted
+    opts: "defaults,noatime{{ datavol_opts | default('') | regex_replace('^(?=.)', ',') }}"
+    dump: "0"
+    passno: "0"
+  when: datavol_device is defined
+
 - block:
-    - name: Check for valid partition table on block storage device
-      become: yes
-      shell: fdisk -l 2>&1 | grep 'Disk {{ datavol_device }} doesn.t contain a valid partition table'
-      register: partition_check
-      when: datavol_device is defined and ansible_hostname not in groups.get('lvm', [])
-      changed_when: false
-      failed_when: false
-      check_mode: no
-
-    - name: Create partition on block storage volume
-      become: yes
-      shell: echo -e "o\nn\np\n1\n\n\nw" | fdisk {{ datavol_device }}
-      # http://superuser.com/a/739586/86694
-      # o - clear in memory partition table
-      # n - new partition
-      # p - primary partition
-      # 1 - partition number 1
-      #   - default - start at beginning of disk
-      #   - default - use entire disk
-      # w - write the partition table
-      when: datavol_device is defined and partition_check.rc == 0 and ansible_hostname not in groups.get('lvm', [])
-
-    - name: Format block storage volume
-      become: yes
-      filesystem: fstype=ext4 dev="{{ datavol_device1 }}"
-      when: datavol_device is defined
-
-    - name: Mount block storage volume
-      become: yes
-      mount:
-        name: "{{ encrypted_root }}"
-        src: "{{ datavol_device1 }}"
-        fstype: ext4
-        state: mounted
-        opts: "defaults,noatime{{ datavol_opts | default('') | regex_replace('^(?=.)', ',') }}"
-        dump: "0"
-        passno: "0"
-      when: datavol_device is defined
-
     - name: Check for already mounted encrypted drive
       shell: grep '{{ encrypted_root }} ecryptfs' /etc/mtab
       register: mtab_contents


### PR DESCRIPTION
This was the key issues causing the sequence of events that led today's ES outage. Our ansible automation was not properly mounting the secondary volume at `/opt/data` (now that we're relying on AWS EBS encryption), and so it filled up the boot volume quickly, and Sanjay had to intervene and fix it manually. Review with ?w=1.

##### ENVIRONMENTS AFFECTED
production