### PR TITLE
Add commcare waf rule group to terraform

### DIFF
--- a/src/commcare_cloud/commands/terraform/templates/terraform.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/terraform.tf.j2
@@ -9,7 +9,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.63"
+  version = "~> 2.66"
   region  = {{ region|tojson }}
 }
 

--- a/src/commcare_cloud/terraform/modules/ga_alb_waf/main.tf
+++ b/src/commcare_cloud/terraform/modules/ga_alb_waf/main.tf
@@ -35,6 +35,73 @@ resource "aws_wafv2_regex_pattern_set" "allow_xml_querystring_urls" {
   }
 }
 
+resource "aws_wafv2_rule_group" "commcare_whitelist_rules" {
+  name = "CommCareWhitelistRules"
+  capacity = "100"
+  scope = "REGIONAL"
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "CommCareWhitelistRules"
+    sampled_requests_enabled   = true
+  }
+
+  rule {
+    name = "AllowXMLQuerystring"
+    priority = 0
+
+    action {
+      allow {}
+    }
+
+    statement {
+      regex_pattern_set_reference_statement {
+        arn = "${aws_wafv2_regex_pattern_set.allow_xml_querystring_urls.arn}"
+        field_to_match {
+          uri_path {}
+        }
+        text_transformation {
+          priority = 0
+          type     = "NONE"
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name = "AllowXMLQuerystring"
+      sampled_requests_enabled = true
+    }
+  }
+
+  rule {
+    name = "AllowXMLBody"
+    priority = 1
+
+    action {
+      allow {}
+    }
+
+    statement {
+      regex_pattern_set_reference_statement {
+        arn = "${aws_wafv2_regex_pattern_set.allow_xml_post_urls.arn}"
+        field_to_match {
+          uri_path {}
+        }
+        text_transformation {
+          priority = 0
+          type     = "NONE"
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name = "AllowXMLBody"
+      sampled_requests_enabled = true
+    }
+  }
+}
+
 resource "aws_s3_bucket" "front_end_alb_logs" {
   bucket = "${local.log_bucket_name}"
   acl = "private"


### PR DESCRIPTION
I've been porting the WAF setup to terraform code bit by bit as terraform introduces support for the different components (e.g. [this one merged a week ago](https://github.com/terraform-providers/terraform-provider-aws/pull/12677))

##### ENVIRONMENTS AFFECTED
production, staging