### PR TITLE
Fix the shlex quoting of --ssh-common-args value

### DIFF
--- a/src/commcare_cloud/commands/ansible/helpers.py
+++ b/src/commcare_cloud/commands/ansible/helpers.py
@@ -62,7 +62,7 @@ def get_common_ssh_args(environment, use_factory_auth=False):
         common_ssh_args.append('-o=UserKnownHostsFile={}'.format(known_hosts_filepath))
 
     if common_ssh_args:
-        cmd_parts_with_common_ssh_args += ('--ssh-common-args="{}"'.format(' '.join(shlex_quote(arg) for arg in common_ssh_args)),)
+        cmd_parts_with_common_ssh_args += ('--ssh-common-args={}'.format(' '.join(common_ssh_args)),)
     return cmd_parts_with_common_ssh_args
 
 


### PR DESCRIPTION
Lately I've noticed the `UserKnownHostsFile` param sometimes not being respected, and today I dug into it, and indeed I was able to prove to myself that even with the `UserKnownHostsFile` option we clearly think we're sending, it was using my `~/.ssh/known_hosts`.

Looks like this issue was introduced some time around https://github.com/dimagi/commcare-cloud/commit/c03291403c2d5237cf308e13c25ef25e2d51009d (either by that commit or by the thing that commit was trying to fix).

This PR simplifies the shlex quoting and is in line with the issue linked from that commit message, so I do believe it's the right fix. I can confirm it fixed the issue locally for me.

##### ENVIRONMENTS AFFECTED
all