### PR TITLE
Fix vendorized ebsnvme-id

### DIFF
--- a/src/commcare_cloud/ansible/roles/ebsnvme/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/ebsnvme/tasks/main.yml
@@ -5,8 +5,8 @@
 
 - name: Copy ebsnvme-id
   become: yes
-  file:
-    src: "ebsnvme-id"
+  copy:
+    src: "_vendor/ebsnvme-id"
     dest: "/sbin/ebsnvme-id"
     owner: root
     group: root


### PR DESCRIPTION
This was another thing I had to do to get the setup of a new machine with a secondary volume on AWS working. This code hasn't changed in a while, and I'm originally responsible for it, but still I have no idea how it ever worked. I don't think `file` could have ever been copying it, and I don't think `ebsnvme-id` could have ever referred to `_vendor/ebsnvme-id`

##### ENVIRONMENTS AFFECTED
production/india/staging