### PR TITLE
Rotate couch logs hourly

### DIFF
--- a/src/commcare_cloud/ansible/deploy_couchdb2.yml
+++ b/src/commcare_cloud/ansible/deploy_couchdb2.yml
@@ -26,7 +26,7 @@
           path: "{{ couchdb_dir }}/var/log/*.stderr"
           options:
             - hourly
-            - size 100M
+            - size 300M
             - rotate 100
             - missingok
             - compress

--- a/src/commcare_cloud/ansible/deploy_couchdb2.yml
+++ b/src/commcare_cloud/ansible/deploy_couchdb2.yml
@@ -18,14 +18,16 @@
   become: true
   roles:
     - role: ansible-logrotate
-      tags: couchdb2
+      tags:
+        - couchdb2
+        - logging
       logrotate_scripts:
         - name: "{{ deploy_env }}_couchdb2"
           path: "{{ couchdb_dir }}/var/log/*.stderr"
           options:
-            - daily
+            - hourly
             - size 100M
-            - rotate 10
+            - rotate 100
             - missingok
             - compress
             - delaycompress


### PR DESCRIPTION
A day's worth on prod is about 3.5G, 35x the 100M file limit. This change will have it rotate 24x as often and keep 10x the number of files, for a total of ~100h (~4.2 days) instead of ~10 days.

Update: I changed this to store 3x as long by raising the file limit, so now about what it was before, but compressing more often

##### ENVIRONMENTS AFFECTED
all, targeting production