### PR TITLE
Reduce concurrency of daily bulk workloads on production

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -24,7 +24,7 @@ celery_processes:
     case_import_queue:
       concurrency: 3
     case_rule_queue:
-      concurrency: 8
+      concurrency: 4
     celery:
       concurrency: 4
     celery_periodic:
@@ -37,7 +37,6 @@ celery_processes:
     reminder_case_update_queue:
       pooling: gevent
       concurrency: 64
-      num_workers: 2
     reminder_queue:
       pooling: gevent
       concurrency: 20
@@ -47,7 +46,7 @@ celery_processes:
       pooling: gevent
       concurrency: 200
     saved_exports_queue:
-      concurrency: 12
+      concurrency: 8
     sms_queue:
       pooling: gevent
       concurrency: 20

--- a/src/commcare_cloud/environment/schemas/app_processes.py
+++ b/src/commcare_cloud/environment/schemas/app_processes.py
@@ -101,7 +101,7 @@ CELERY_PROCESSES = [
     CeleryProcess("async_restore_queue", required=False, blockage_threshold=60),
     CeleryProcess("background_queue", blockage_threshold=10 * 60),
     CeleryProcess("beat", required=False, is_queue=False),
-    CeleryProcess("case_rule_queue", blockage_threshold=10 * 60),
+    CeleryProcess("case_rule_queue", blockage_threshold=60 * 60),
     CeleryProcess("case_import_queue", blockage_threshold=60),
     CeleryProcess("celery", blockage_threshold=60),
     CeleryProcess("celery_periodic", required=False, blockage_threshold=10 * 60),


### PR DESCRIPTION
These collectively cause spikes in requests to ES that we could easily smooth out
over a few hours without serious user-facing effects.

Reducing drastically for now to reduce ES spikes, will increase judiciously
if the workload delays become long enough to have user-facing effects.

<!--- Provide a link to the ticket or document which prompted this change -->

##### ENVIRONMENTS AFFECTED
production