### PR TITLE
Add default branch for icds-staging

### DIFF
--- a/environments/icds-staging/fab-settings.yml
+++ b/environments/icds-staging/fab-settings.yml
@@ -1,1 +1,2 @@
 tag_deploy_commits: True
+default_branch: icds-autostaging


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
For supporting 
https://github.com/dimagi/commcare-hq/pull/27980 
we need to add `default_branch` in `environments/icds-staging/fab-settings.yml` so that we don't have to pass `--commcare-rev icds-autostaging` with every deploy
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
icds-staging