### PR TITLE
Add explicit permissions on copied formplayer config

### DIFF
--- a/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
@@ -90,6 +90,9 @@
     remote_src: yes
     src: "{{ formplayer_current_dir }}/{{ item.filename }}"
     dest: "{{ formplayer_release_dir }}/{{ item.filename }}"
+    owner: "{{ cchq_user }}"
+    group: "{{ cchq_user }}"
+    mode: 0644
   with_items:
     - filename: application.properties
     - filename: sentry.properties
@@ -103,8 +106,8 @@
   template:
     src: "{{ item.template }}"
     dest: "{{ _formplayer_target_dir }}/{{ item.filename }}"
-    group: cchq
-    owner: cchq
+    owner: "{{ cchq_user }}"
+    group: "{{ cchq_user }}"
     mode: 0644
   with_items:
     - template: application.properties.j2


### PR DESCRIPTION
We saw these files owned by root at some point and aren't quite sure how. This PR makes each step explicitly set the owner. There's not a strong story that says this will fix it, but it's more explicit and it's correct (i.e. can't hurt) and I want to just eliminate the possibility that it's somehow this task.

##### ENVIRONMENTS AFFECTED
production