### PR TITLE
RabbitMQ uograde on icds-staging and ansible version update for Rabbi…

### DIFF
--- a/environments/icds-staging/public.yml
+++ b/environments/icds-staging/public.yml
@@ -15,6 +15,7 @@ kafka_scala_version: 2.12
 kafka_inter_broker_protocol_version: 2.4
 kafka_inter_broker_protocol_version: 2.4
 
+rabbitmq_version: 3.8.5-1
 #RabbitMQ Broker URL
 BROKER_URL: 'amqp://{{ AMQP_USER }}:{{ AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }};amqp://{{ AMQP_USER }}:{{ AMQP_PASSWORD }}@{{ groups.rabbitmq.1 }}:5672/{{ AMQP_NAME }}'
 rabbitmq_create_cluster: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 #    pip-compile --output-file=requirements.txt requirements-python-lt-2.7.9-ssl-issue.in setup.py
 #
 ansible-vault==1.1.1      # via commcare-cloud (setup.py)
-ansible==2.9.5            # via ansible-vault, commcare-cloud (setup.py)
+ansible==2.9.7            # via ansible-vault, commcare-cloud (setup.py)
 argparse==1.4.0           # via commcare-cloud (setup.py), couchdb-cluster-admin
 args==0.1.0               # via clint
 attrs==19.1.0             # via commcare-cloud (setup.py)


### PR DESCRIPTION
…tMQ 3.8.X version check

<!--- Provide a link to the ticket or document which prompted this change -->

https://dimagi-dev.atlassian.net/browse/IIO-880

Ansible version 2.9.7 fixes the RabbitMQ version check.
https://github.com/ansible/ansible/blob/stable-2.9/changelogs/CHANGELOG-v2.9.rst#release-summary


##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->

ICDS-STAGING
ICDS

##### ADDITIONAL COMMENTS

Looping dannyroberts and millerdev as ansible version is getting updated to 2.9.7 version to fix the RabbitMQ version check for Cluster configuration.

