### PR TITLE
Make sure cas_sentry.yml doesn't break other envs

### DIFF
--- a/src/commcare_cloud/ansible/roles/nginx/vars/cas_sentry.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/cas_sentry.yml
@@ -11,4 +11,4 @@ nginx_sites:
    - "Host $host"
    locations:
      - name: /
-       proxy_pass: "http://{{groups.sentry.0}}:8080"
+       proxy_pass: "http://{{groups.sentry.0|default('')}}:8080"


### PR DESCRIPTION
The variables file is evaluated even for envs that aren't using the feature.
(These are set up this way to support removing nginx config files no longer needed.)
So make sure all the variables evaluate without erroring.

<!--- Provide a link to the ticket or document which prompted this change -->

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
