### PR TITLE
Revert "Double formplayer machine sizes on production"

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -320,7 +320,7 @@ servers:
     os: bionic
 
   - server_name: "formplayer2-production"
-    server_instance_type: r5.4xlarge
+    server_instance_type: r5.2xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 150
@@ -329,7 +329,7 @@ servers:
     os: bionic
 
   - server_name: "formplayer3-production"
-    server_instance_type: r5.4xlarge
+    server_instance_type: r5.2xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 150
@@ -338,7 +338,7 @@ servers:
     os: bionic
 
   - server_name: "formplayer4-production"
-    server_instance_type: r5.4xlarge
+    server_instance_type: r5.2xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 150
@@ -347,7 +347,7 @@ servers:
     os: bionic
 
   - server_name: "formplayer5-production"
-    server_instance_type: r5.4xlarge
+    server_instance_type: r5.2xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 150
@@ -356,7 +356,7 @@ servers:
     os: bionic
 
   - server_name: "formplayer6-production"
-    server_instance_type: r5.4xlarge
+    server_instance_type: r5.2xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 150
@@ -365,7 +365,7 @@ servers:
     os: bionic
 
   - server_name: "formplayer7-production"
-    server_instance_type: r5.4xlarge
+    server_instance_type: r5.2xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 150
@@ -374,7 +374,7 @@ servers:
     os: bionic
 
   - server_name: "formplayer8-production"
-    server_instance_type: r5.4xlarge
+    server_instance_type: r5.2xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 150
@@ -383,7 +383,7 @@ servers:
     os: bionic
 
   - server_name: "formplayer9-production"
-    server_instance_type: r5.4xlarge
+    server_instance_type: r5.2xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 150


### PR DESCRIPTION
I rolled this out during firefighting this morning. As far as we can tell the issues from this morning were caused by "too much memory". Presumably too much memory per machine. Very odd, but fairly conclusive

##### ENVIRONMENTS AFFECTED
production