### PR TITLE
Always use latest bionic AMI

### DIFF
--- a/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
@@ -94,7 +94,7 @@ module "server__{{ server.server_name }}" {
   secondary_volume_encrypted = {{ server.block_device.encrypted|default(False)|tojson }}
 
 {% if server.os == 'bionic' %}
-  server_image = "${var.bionic_server_image}"
+  server_image = "${data.aws_ami.ubuntu_bionic.id}"
 {% else %}
   server_image = "${var.server_image}"
 {% endif %}

--- a/src/commcare_cloud/commands/terraform/templates/variables.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/variables.tf.j2
@@ -18,16 +18,30 @@ variable "openvpn_instance_type" {
 }
 
 
+data "aws_ami" "ubuntu_bionic" {
+  # Should match what is in
+  # https://cloud-images.ubuntu.com/locator/ec2/
+  # with search hvm:ebs-ssd bionic amd64
+
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
+
 variable "server_image" {
   # Use 'hvm:ebs-ssd' AMIs from https://cloud-images.ubuntu.com/locator/ec2/
   default = "{{ {'us-east-1': 'ami-07cf43e1798df5582', 'ap-south-1': 'ami-04242e05c1ebface0'}[region] }}"
-}
-
-variable "bionic_server_image" {
-  # https://cloud-images.ubuntu.com/locator/ec2/
-  # Using search hvm:ebs-ssd bionic amd64
-  # Current release: 20200611
-  default = "{{ {'us-east-1': 'ami-0ac80df6eff0e70b5', 'ap-south-1': 'ami-02d55cb47e83a99a0'}[region] }}"
 }
 
 variable "dns_zone_id" {}


### PR DESCRIPTION
dynamically fetched by querying AWS


##### ENVIRONMENTS AFFECTED
production
