### PR TITLE
Integrate migration alerts into deploy

### DIFF
--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -30,40 +30,28 @@ from __future__ import print_function
 import datetime
 import functools
 import os
+import pipes
 import posixpath
+from distutils.util import strtobool
 from getpass import getpass
 
-import pipes
 import pytz
-from distutils.util import strtobool
-
-from fabric import utils
-from fabric.api import roles, execute, task, sudo, env, parallel
-from fabric.colors import blue, red, magenta
-from fabric.context_managers import cd
-from fabric.contrib import files, console
-from fabric.operations import require
 
 from commcare_cloud.environment.main import get_environment
 from commcare_cloud.environment.paths import get_available_envs
+from fabric import utils
+from fabric.api import env, execute, parallel, roles, sudo, task
+from fabric.colors import blue, magenta, red
+from fabric.context_managers import cd
+from fabric.contrib import console, files
+from fabric.operations import require
 
-from .const import (
-    ROLES_ALL_SRC,
-    ROLES_ALL_SERVICES,
-    ROLES_PILLOWTOP,
-    ROLES_DJANGO,
-    ROLES_DEPLOY,
-)
+from .checks import check_servers
+from .const import ROLES_ALL_SERVICES, ROLES_ALL_SRC, ROLES_DEPLOY, ROLES_DJANGO, ROLES_PILLOWTOP
 from .exceptions import PreindexNotFinished
-from .operations import (
-    db,
-    staticfiles,
-    supervisor,
-    formplayer,
-    release,
-    offline as offline_ops,
-    airflow
-)
+from .operations import airflow, db, formplayer
+from .operations import offline as offline_ops
+from .operations import release, staticfiles, supervisor
 from .utils import (
     DeployMetadata,
     cache_deploy_state,
@@ -72,9 +60,6 @@ from .utils import (
     retrieve_cached_deploy_checkpoint,
     retrieve_cached_deploy_env,
     traceback_string,
-)
-from .checks import (
-    check_servers,
 )
 
 if env.ssh_config_path and os.path.isfile(os.path.expanduser(env.ssh_config_path)):

--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -317,6 +317,13 @@ def _confirm_translated():
     )
 
 
+def _confirm_changes():
+    env.deploy_metadata.diff.warn_of_migrations()
+    return console.confirm(
+        'Are you sure you want to preindex and deploy to '
+        '{env.deploy_env}?'.format(env=env), default=False)
+
+
 @task
 def kill_stale_celery_workers():
     """
@@ -632,9 +639,7 @@ def deploy_commcare(confirm="yes", resume='no', offline='no', skip_record='no'):
     _require_target()
     if strtobool(confirm) and (
         not _confirm_translated() or
-        not console.confirm(
-            'Are you sure you want to preindex and deploy to '
-            '{env.deploy_env}?'.format(env=env), default=False)
+        not _confirm_changes()
     ):
         utils.abort('Deployment aborted.')
 

--- a/src/commcare_cloud/fab/operations/release.py
+++ b/src/commcare_cloud/fab/operations/release.py
@@ -353,7 +353,7 @@ def record_successful_deploy():
             'virtualenv_current': env.py3_virtualenv_current,
             'user': env.user,
             'environment': env.deploy_env,
-            'url': env.deploy_metadata.diff_url,
+            'url': env.deploy_metadata.diff.url,
             'minutes': str(int(delta.total_seconds() // 60))
         })
 

--- a/src/commcare_cloud/fab/utils.py
+++ b/src/commcare_cloud/fab/utils.py
@@ -60,7 +60,6 @@ class DeployMetadata(object):
         self.timestamp = datetime.datetime.utcnow().strftime(DATE_FMT)
         self._deploy_tag = None
         self._max_tags = 100
-        self._last_tag = None
         self._code_branch = code_branch
         self._environment = environment
 

--- a/src/commcare_cloud/fab/utils.py
+++ b/src/commcare_cloud/fab/utils.py
@@ -69,24 +69,8 @@ class DeployMetadata(object):
 
     @memoized_property
     def last_commit_sha(self):
-        if self.last_tag:
-            return self.last_tag.commit.sha
-
         with cd(env.code_current):
             return sudo('git rev-parse HEAD')
-
-    @memoized_property
-    def last_tag(self):
-        pattern = ".*-{}-deploy".format(re.escape(self._environment))
-        for tag in self.repo.get_tags()[:self._max_tags]:
-            if re.match(pattern, tag.name):
-                return tag
-
-        print(magenta('Warning: No previous tag found in last {} tags for {}'.format(
-            self._max_tags,
-            self._environment
-        )))
-        return None
 
     def tag_commit(self):
         if env.offline:

--- a/src/commcare_cloud/fab/utils.py
+++ b/src/commcare_cloud/fab/utils.py
@@ -124,25 +124,6 @@ class DeployMetadata(object):
                 tag=tag_name,
             ))
 
-    @property
-    def diff_url(self):
-        if env.offline:
-            return '"No diff url for offline deploy"'
-        if not env.tag_deploy_commits:
-            return '"Diff URLs are not enabled for this environment"'
-
-        if _github_auth_provided() and self._deploy_tag is None:
-            raise Exception("You haven't tagged anything yet.")
-
-        from_ = self.last_tag.name if self.last_tag and self.last_tag.name else self.last_commit_sha
-        if not from_:
-            return '"Previous deploy not found, cannot make comparison"'
-
-        return "https://github.com/dimagi/commcare-hq/compare/{}...{}".format(
-            from_,
-            self._deploy_tag or self.deploy_ref,
-        )
-
     @memoized_property
     def deploy_ref(self):
         if env.offline:
@@ -293,6 +274,11 @@ class DeployDiff:
         self.repo = repo
         self.last_commit = last_commit
         self.deploy_commit = deploy_commit
+
+    @property
+    def url(self):
+        """Human-readable diff URL"""
+        return "{}/compare/{}...{}".format(self.repo.html_url, self.last_commit, self.deploy_commit)
 
     def warn_of_migrations(self):
         if not _github_auth_provided():


### PR DESCRIPTION
Implements https://github.com/dimagi/commcare-hq/issues/27838, using @AliRizvi1 's work in https://github.com/dimagi/commcare-cloud/pull/3951


```
[10.201.11.173] Executing task 'deploy_commcare'
List of PRs since last deploy:
1. Bump statici18n to version supporting Django 2.2 https://github.com/dimagi/commcare-hq/pull/28084 | product/invisible
2. [ICDS Dashboard] Pull the program summary data on the same level https://github.com/dimagi/commcare-hq/pull/28075 | product/custom
3. Fix sorting for FCT count column https://github.com/dimagi/commcare-hq/pull/28087 | product/all-users-all-environments
Are you sure you want to preindex and deploy to staging? [y/N] y
```

Since this significantly increases API requests to github, all users are now prompted to set up a github API key, though they can still abstain.

It also drops the use of git tags for diff URLs, instead, it always inspects the code root for the currently deployed commit.  We did this already as a fallback, and I don't know that there was ever a good reason to not always do that.