### PR TITLE
Remove pgbouncer2-production

### DIFF
--- a/environments/production/aws-resources.yml
+++ b/environments/production/aws-resources.yml
@@ -73,8 +73,6 @@ formplayer25-production: 10.202.10.100
 formplayer25-production.instance_id: i-0ec149f99ee806763
 kafka1-production: 10.202.40.200
 kafka1-production.instance_id: i-0c8af5576e2c8e7a2
-pgbouncer2-production: 10.202.40.59
-pgbouncer2-production.instance_id: i-0c22ba54afd4deaf7
 pgbouncer3-production: 10.202.40.153
 pgbouncer3-production.instance_id: i-0894ff03612870021
 pgmain0-production: pgmain0-production.cl9dmuo3ok4h.us-east-1.rds.amazonaws.com

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -459,15 +459,6 @@ servers:
     group: "kafka"
     os: bionic
 
-  - server_name: "pgbouncer2-production"
-    server_instance_type: t3.2xlarge
-    network_tier: "db-private"
-    az: "a"
-    volume_size: 80
-    volume_encrypted: no
-    group: "postgresql"
-    os: bionic
-
   - server_name: "pgbouncer3-production"
     server_instance_type: m5.2xlarge
     network_tier: "db-private"


### PR DESCRIPTION
Followup to https://github.com/dimagi/commcare-cloud/pull/3974. Will merge once pgbouncer2's active connections (https://app.datadoghq.com/dashboard/unt-6cf-nbs/postgres---overview?from_ts=1594668866477&fullscreen_end_ts=1594683587568&fullscreen_paused=false&fullscreen_section=overview&fullscreen_start_ts=1594669187568&fullscreen_widget=256956003&live=true&to_ts=1594683266477&tpl_var_exclusions=pg_standby) goes to zero, which will be at the least after the next time we restart formplayer

##### ENVIRONMENTS AFFECTED
production