### PR TITLE
tag command that sets node version under "npm"

### DIFF
--- a/src/commcare_cloud/ansible/roles/nodejs/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/nodejs/tasks/main.yml
@@ -41,6 +41,8 @@
 - name: Update Node
   command: 'n 12.18.1'
   become: yes
+  tags:
+    - npm
 
 - name: Install correct npm version
   npm: name="{{ item.name }}" version="{{ item.version }}" state=present global=yes


### PR DESCRIPTION
##### ENVIRONMENTS AFFECTED
Note that `deploy-stack --tags=npm` will have to be re-run before the next set of deploys