### PR TITLE
Add support for defining N identical machines in terraform

### DIFF
--- a/src/commcare_cloud/commands/terraform/aws.py
+++ b/src/commcare_cloud/commands/terraform/aws.py
@@ -190,7 +190,7 @@ class AwsFillInventoryHelper(object):
             for server_name in server.get_all_server_names():
                 is_bionic = server.os in ('bionic', 'ubuntu_pro_bionic')
                 inventory_vars = [
-                    ('hostname', server_name),
+                    ('hostname', server_name.replace('_', '-')),
                     ('ufw_private_interface', ('ens5' if is_bionic else 'eth0')),
                     ('ansible_python_interpreter', ('/usr/bin/python3' if is_bionic else None)),
                 ]

--- a/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
@@ -80,10 +80,11 @@ resource "aws_dlm_lifecycle_policy" "data_volume_backups" {
 }
 
 {% for server in servers + proxy_servers %}
-module "server__{{ server.server_name }}" {
+{%- for server_name in server.get_all_server_names %}
+module "server__{{ server_name }}" {
   source = "./modules/server"
 
-  server_name = {{ server.server_name|tojson }}
+  server_name = {{ server_name|tojson }}
   server_instance_type = {{ server.server_instance_type|tojson }}
   network_tier = {{ server.network_tier|tojson }}
   az = {{ server.az|tojson }}
@@ -107,6 +108,7 @@ module "server__{{ server.server_name }}" {
   key_name = "${var.key_name}"
   group_tag= {{ server.group|tojson }}
 }
+{%- endfor %}
 {% endfor %}
 
 {% for server in proxy_servers %}

--- a/src/commcare_cloud/commands/terraform/terraform.py
+++ b/src/commcare_cloud/commands/terraform/terraform.py
@@ -140,7 +140,7 @@ def get_postgresql_params_by_rds_instance(environment):
 
 
 def generate_terraform_entrypoint(environment, key_name, run_dir, apply_immediately):
-    context = environment.terraform_config.to_json()
+    context = environment.terraform_config.to_generated_json()
     if key_name not in environment.users_config.dev_users.present:
         raise UnauthorizedUser(key_name)
 


### PR DESCRIPTION
Easiest with ?w=1

Lets you add something like

`terraform.yml`
```
  - server_name: "formplayer_a{i}-production"
    server_instance_type: r5.2xlarge
    network_tier: "app-private"
    az: "a"
    volume_size: 600
    group: "formplayer"
    os: bionic
    count: 32
```

`inventory.ini.j2`
```
{{ __formplayer_a__ }}

[formplayer:children]
formplayer_a
```

And it'll create 32 identical machines and put them in the inventory for you under individual groups (`[formplayer_a000]` as well as a group that contains all of them `[formplayer_a]`)

##### ENVIRONMENTS AFFECTED
None yet, but about to use on production