### PR TITLE
Don't display too many PRs on deploy

### DIFF
--- a/src/commcare_cloud/fab/utils.py
+++ b/src/commcare_cloud/fab/utils.py
@@ -1,29 +1,30 @@
 from __future__ import absolute_import
 from __future__ import print_function
+
 import datetime
 import os
 import pickle
+import re
 import sys
 import traceback
-from fabric.operations import sudo
-from fabric.context_managers import cd, settings
-from fabric.api import local
-import re
-from getpass import getpass
-from memoized import memoized_property, memoized
-
-from github import Github, UnknownObjectException
-from fabric.api import execute, env
-from fabric.colors import magenta, red
-from gevent.pool import Pool
 from collections import defaultdict
+from getpass import getpass
+
+from gevent.pool import Pool
+from github import Github, UnknownObjectException
+from memoized import memoized, memoized_property
+
+from fabric.api import env, execute, local
+from fabric.colors import blue, cyan, red, yellow
+from fabric.context_managers import cd, settings
+from fabric.operations import sudo
 
 from .const import (
-    PROJECT_ROOT,
     CACHED_DEPLOY_CHECKPOINT_FILENAME,
     CACHED_DEPLOY_ENV_FILENAME,
     DATE_FMT,
     OFFLINE_STAGING_DIR,
+    PROJECT_ROOT,
     RELEASE_RECORD,
 )
 
@@ -275,7 +276,7 @@ class DeployDiff:
         pool = Pool(5)
         pr_infos = [_f for _f in pool.map(self._get_pr_info, pr_numbers) if _f]
 
-        print("List of PRs since last deploy:")
+        print(blue("\nList of PRs since last deploy:"))
         self._print_prs_formatted(pr_infos)
 
         prs_by_label = self._get_prs_by_label(pr_infos)
@@ -316,10 +317,9 @@ class DeployDiff:
         return dict(prs_by_label)
 
     def _print_prs_formatted(self, pr_list):
-        i = 1
         for pr in pr_list:
-            print("{0}. ".format(i), end="")
-            print("{title} {url} | ".format(**pr), end="")
-            print(" ".join(label for label in pr['labels']))
-            i += 1
-
+            print(
+                cyan(pr['title']),
+                yellow(pr['url']),
+                ", ".join(label for label in pr['labels']),
+            )

--- a/src/commcare_cloud/fab/utils.py
+++ b/src/commcare_cloud/fab/utils.py
@@ -264,10 +264,14 @@ class DeployDiff:
         return "{}/compare/{}...{}".format(self.repo.html_url, self.last_commit, self.deploy_commit)
 
     def warn_of_migrations(self):
-        if not _github_auth_provided():
+        if not (_github_auth_provided() and self.last_commit and self.deploy_commit):
             return
 
         pr_numbers = self._get_pr_numbers()
+        if len(pr_numbers) > 500:
+            print(red("There are too many PRs to display"))
+            return
+
         pool = Pool(5)
         pr_infos = [_f for _f in pool.map(self._get_pr_info, pr_numbers) if _f]
 


### PR DESCRIPTION
Paranoid followup from https://github.com/dimagi/commcare-cloud/pull/3970
I was thinking of ways this might go bad, so I figured I'd put a couple guardrails on it.   Bonus colors for pizzazz too.

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
