### PR TITLE
Clean up how we mount a formplayer EFS drive

### DIFF
--- a/environments/staging/inventory.ini
+++ b/environments/staging/inventory.ini
@@ -87,15 +87,21 @@ celery2
 pillow2
 
 [formplayer1]
-10.201.10.234 hostname=formplayer1-staging ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws datavol_fstype=xfs formplayer_efs_dns=fs-ba70cd39.efs.us-east-1.amazonaws.com:/ use_formplayer_efs=true
+10.201.10.234 hostname=formplayer1-staging ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws datavol_fstype=xfs
 
 [formplayer2]
-10.201.10.198 hostname=formplayer2-staging ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws datavol_fstype=xfs formplayer_efs_dns=fs-ba70cd39.efs.us-east-1.amazonaws.com:/ use_formplayer_efs=true
+10.201.10.198 hostname=formplayer2-staging ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws datavol_fstype=xfs
 
 [formplayer:children]
 # Amazon EC2
 formplayer1
 formplayer2
+
+[formplayer:vars]
+formplayer_efs_dns=fs-ba70cd39.efs.us-east-1.amazonaws.com:/
+use_formplayer_efs=true
+cchq_uid=1026
+cchq_gid=1027
 
 [redis1]
 10.201.40.219 hostname=redis1-staging ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws datavol_fstype=xfs

--- a/environments/staging/inventory.ini.j2
+++ b/environments/staging/inventory.ini.j2
@@ -74,14 +74,20 @@ celery2
 # Amazon EC2
 pillow2
 
-{{ __formplayer1__ }} datavol_fstype=xfs formplayer_efs_dns={{ aws_resources['formplayer-efs'] }}:/ use_formplayer_efs=true
+{{ __formplayer1__ }} datavol_fstype=xfs
 
-{{ __formplayer2__ }} datavol_fstype=xfs formplayer_efs_dns={{ aws_resources['formplayer-efs'] }}:/ use_formplayer_efs=true
+{{ __formplayer2__ }} datavol_fstype=xfs
 
 [formplayer:children]
 # Amazon EC2
 formplayer1
 formplayer2
+
+[formplayer:vars]
+formplayer_efs_dns={{ aws_resources['formplayer-efs'] }}:/
+use_formplayer_efs=true
+cchq_uid=1026
+cchq_gid=1027
 
 {{ __redis1__ }} datavol_fstype=xfs
 

--- a/src/commcare_cloud/ansible/deploy_formplayer.yml
+++ b/src/commcare_cloud/ansible/deploy_formplayer.yml
@@ -10,6 +10,8 @@
         shared_drive_enabled: yes
         shared_mount_dir: /opt/formplayer_data
         shared_mount_address: "{{ formplayer_efs_dns }}"
+      tags:
+        - efs
     - import_tasks: roles/shared_dir/tasks/setup_client.yml
       when: 'formplayer_efs_dns|default(False)'
       vars:
@@ -17,6 +19,8 @@
         shared_mount_dir: /opt/formplayer_data
         shared_mount_address: "{{ formplayer_efs_dns }}"
         shared_mount_opts: "nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport"
+      tags:
+        - efs
   vars_files:
     - ./group_vars/all.yml
     - roles/shared_dir/vars/main.yml

--- a/src/commcare_cloud/ansible/deploy_formplayer.yml
+++ b/src/commcare_cloud/ansible/deploy_formplayer.yml
@@ -3,28 +3,15 @@
 - name: Formplayer EFS
   hosts: formplayer
   become: true
-  tasks:
-    - import_tasks: roles/shared_dir/tasks/install.yml
-      when: 'formplayer_efs_dns|default(False)'
+  roles:
+    - role: aws-efs
       vars:
-        shared_drive_enabled: yes
-        shared_mount_dir: /opt/formplayer_data
-        shared_mount_address: "{{ formplayer_efs_dns }}"
+        efs_mount_dir: /opt/formplayer_data
+        efs_mount_uid: "{{ cchq_uid|default(None) }}"
+        efs_mount_gid: "{{ cchq_gid|default(None) }}"
+      when: "formplayer_efs_dns|default(False)"
       tags:
         - efs
-    - import_tasks: roles/shared_dir/tasks/setup_client.yml
-      when: 'formplayer_efs_dns|default(False)'
-      vars:
-        shared_drive_enabled: yes
-        shared_mount_dir: /opt/formplayer_data
-        shared_mount_address: "{{ formplayer_efs_dns }}"
-        shared_mount_opts: "nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport"
-      tags:
-        - efs
-  vars_files:
-    - ./group_vars/all.yml
-    - roles/shared_dir/vars/main.yml
-
 
 - name: Formplayer
   hosts: formplayer

--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -34,6 +34,7 @@ shared_temp_dir_name: "temp"
 public_site_path: /opt/commcare-hq-public/site/output
 commtrack_public_site_path: /opt/commtrack-static/site/output/
 cchq_user: cchq
+cchq_group: cchq
 dev_group: dimagidev
 
 etc_hosts_lines: []

--- a/src/commcare_cloud/ansible/roles/aws-efs/defaults/main.yml
+++ b/src/commcare_cloud/ansible/roles/aws-efs/defaults/main.yml
@@ -1,0 +1,3 @@
+efs_mount_uid: null
+efs_mount_gid: null
+efs_mount_dir: null

--- a/src/commcare_cloud/ansible/roles/aws-efs/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/aws-efs/tasks/main.yml
@@ -1,0 +1,15 @@
+- assert:
+    that:
+      - efs_mount_uid != ''
+      - efs_mount_gid != ''
+      - efs_mount_dir != ''
+    success_msg: "{{ efs_mount_uid }} {{ efs_mount_gid }} {{ efs_mount_dir }}"
+
+- import_tasks: roles/shared_dir/tasks/setup_client.yml
+  vars:
+    shared_drive_enabled: yes
+    shared_mount_dir: "{{ efs_mount_dir }}"
+    shared_dir_user: "{{ efs_mount_uid }}"
+    shared_dir_group: "{{ efs_mount_gid }}"
+    shared_mount_address: "{{ formplayer_efs_dns }}"
+    shared_mount_opts: "nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport"

--- a/src/commcare_cloud/ansible/roles/aws-efs/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/aws-efs/tasks/main.yml
@@ -3,7 +3,8 @@
       - efs_mount_uid != ''
       - efs_mount_gid != ''
       - efs_mount_dir != ''
-    success_msg: "{{ efs_mount_uid }} {{ efs_mount_gid }} {{ efs_mount_dir }}"
+    fail_msg: "efs_mount_uid={{ efs_mount_uid }} efs_mount_gid={{ efs_mount_gid }} efs_mount_dir={{ efs_mount_dir }}"
+    success_msg: "efs_mount_uid={{ efs_mount_uid }} efs_mount_gid={{ efs_mount_gid }} efs_mount_dir={{ efs_mount_dir }}"
 
 - import_tasks: roles/shared_dir/tasks/setup_client.yml
   vars:

--- a/src/commcare_cloud/ansible/roles/bootstrap-users/defaults/main.yml
+++ b/src/commcare_cloud/ansible/roles/bootstrap-users/defaults/main.yml
@@ -1,3 +1,5 @@
 # this adds the env name to the prompt and also overrides the hostname if `alt_hostname` is defined
 bash_PS1: |
   '\[\e]0;({{ env_monitoring_id }}) \u@{{ alt_hostname|default('\h') }}: \w\a\]\[\033[01;33m\]({{ env_monitoring_id }})\[\033[00m\] \[\033[01;32m\]\u@{{ alt_hostname|default('\h') }}\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
+cchq_uid: null
+cchq_gid: null

--- a/src/commcare_cloud/ansible/roles/bootstrap-users/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/bootstrap-users/tasks/main.yml
@@ -15,6 +15,27 @@
     line: "PS1={{ bash_PS1 }}"
     state: present
 
+- name: Add cchq group
+  become: yes
+  group:
+    name: "{{ cchq_group }}"
+    state: present
+    gid: "{{ cchq_gid }}"
+  tags: commcarehq
+  when: "cchq_gid is not none"
+
+- name: Add cchq user
+  become: yes
+  user:
+    name: "{{ cchq_user }}"
+    state: present
+    shell: /bin/bash
+    group: "{{ cchq_group if cchq_gid else omit }}"
+    groups: "{{ dev_group }}"
+    uid: "{{ cchq_uid if cchq_uid else omit }}"
+    append: yes
+  tags: commcarehq
+
 - name: Add dev group
   become: yes
   group: name="{{ dev_group }}" state=present
@@ -30,11 +51,6 @@
   authorized_key: user="{{ item }}" state=present key="{{ lookup('file', authorized_keys_dir ~ item ~ '.pub') }}" exclusive=yes
   with_items: '{{ dev_users.present }}'
   ignore_errors: "{{ ansible_check_mode }}"
-
-- name: Add cchq user
-  become: yes
-  user: name="{{ cchq_user }}" state=present shell=/bin/bash groups={{ dev_group }} append=yes
-  tags: commcarehq
 
 - name: Remove public key for cchq user  # todo: remove after applied to all envs
   become: yes

--- a/src/commcare_cloud/ansible/roles/bootstrap-users/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/bootstrap-users/tasks/main.yml
@@ -24,6 +24,11 @@
   tags: commcarehq
   when: "cchq_gid is not none"
 
+- name: Add dev group
+  become: yes
+  group: name="{{ dev_group }}" state=present
+  tags: commcarehq
+
 - name: Add cchq user
   become: yes
   user:
@@ -34,11 +39,6 @@
     groups: "{{ dev_group }}"
     uid: "{{ cchq_uid if cchq_uid else omit }}"
     append: yes
-  tags: commcarehq
-
-- name: Add dev group
-  become: yes
-  group: name="{{ dev_group }}" state=present
   tags: commcarehq
 
 - name: Add users for current devs

--- a/src/commcare_cloud/ansible/roles/shared_dir/defaults/main.yml
+++ b/src/commcare_cloud/ansible/roles/shared_dir/defaults/main.yml
@@ -1,2 +1,0 @@
-shared_dir_user: nobody
-shared_dir_group: "{{ shared_dir_gid }}"

--- a/src/commcare_cloud/ansible/roles/shared_dir/defaults/main.yml
+++ b/src/commcare_cloud/ansible/roles/shared_dir/defaults/main.yml
@@ -1,0 +1,2 @@
+shared_dir_user: nobody
+shared_dir_group: "{{ shared_dir_gid }}"

--- a/src/commcare_cloud/ansible/roles/shared_dir/tasks/setup_client.yml
+++ b/src/commcare_cloud/ansible/roles/shared_dir/tasks/setup_client.yml
@@ -24,6 +24,7 @@
     group: "{{ shared_dir_gid }}"
     mode: 0775
     state: directory
+  run_once: yes
   tags:
     - nfs
 

--- a/src/commcare_cloud/ansible/roles/shared_dir/tasks/setup_client.yml
+++ b/src/commcare_cloud/ansible/roles/shared_dir/tasks/setup_client.yml
@@ -20,8 +20,8 @@
   when: shared_drive_enabled|bool
   file:
     path: "{{ shared_mount_dir }}"
-    owner: "nobody"
-    group: "{{ shared_dir_gid }}"
+    owner: "{{ shared_dir_user }}"
+    group: "{{ shared_dir_group }}"
     mode: 0775
     state: directory
   run_once: yes

--- a/src/commcare_cloud/ansible/roles/shared_dir/vars/main.yml
+++ b/src/commcare_cloud/ansible/roles/shared_dir/vars/main.yml
@@ -2,6 +2,9 @@
 #shared_data_dir: ...
 #shared_dir_gid: ...
 
+shared_dir_user: nobody
+shared_dir_group: "{{ shared_dir_gid }}"
+
 shared_dir_groupname: nfs
 
 shared_mount_address: "{{ groups.shared_dir_host[0] }}:{{ shared_data_dir }}"


### PR DESCRIPTION
The main important change here is that it lets you hardcode the `cchq` user's uid/gid for an inventory group (like formplayer) so that it has the same uid/gid across those machines, letting them share a drive without a confusing uid to user mapping.

(on staging and production formplayer machines, we already manually made this the case. On new machines it's safe, but I wouldn't recommend using this to _change_ existing machines uids.)

##### ENVIRONMENTS AFFECTED
staging, soon to be production