### PR TITLE
Tweak efs mount setup

### DIFF
--- a/environments/production/aws-resources.yml
+++ b/environments/production/aws-resources.yml
@@ -40,7 +40,7 @@ esmaster4-production: 10.202.41.247
 esmaster4-production.instance_id: i-0be1b553bdc9f0f5c
 esmaster5-production: 10.202.40.226
 esmaster5-production.instance_id: i-01e1279564c30ece6
-formplayer-efs: fs-abf0d228.efs.us-east-1.amazonaws.com
+formplayer-efs: fs-150b0596.efs.us-east-1.amazonaws.com
 formplayer_a000-production: 10.202.10.42
 formplayer_a000-production.instance_id: i-0c40d80587f58d84f
 formplayer_a001-production: 10.202.10.30

--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -262,6 +262,8 @@ formplayer_a031
 [formplayer_a:vars]
 swap_size=8G
 formplayer_efs_dns=fs-150b0596.efs.us-east-1.amazonaws.com:/
+cchq_uid=1025
+cchq_gid=1026
 
 [formplayer:children]
 formplayer_a

--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -261,7 +261,7 @@ formplayer_a031
 
 [formplayer_a:vars]
 swap_size=8G
-formplayer_efs_dns=fs-abf0d228.efs.us-east-1.amazonaws.com:/
+formplayer_efs_dns=fs-150b0596.efs.us-east-1.amazonaws.com:/
 
 [formplayer:children]
 formplayer_a

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -131,6 +131,8 @@ pillow1
 [formplayer_a:vars]
 swap_size=8G
 formplayer_efs_dns={{ aws_resources['formplayer-efs'] }}:/
+cchq_uid=1025
+cchq_gid=1026
 
 [formplayer:children]
 formplayer_a

--- a/src/commcare_cloud/ansible/roles/aws-efs/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/aws-efs/tasks/main.yml
@@ -13,4 +13,4 @@
     shared_dir_user: "{{ efs_mount_uid }}"
     shared_dir_group: "{{ efs_mount_gid }}"
     shared_mount_address: "{{ formplayer_efs_dns }}"
-    shared_mount_opts: "nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport"
+    shared_mount_opts: "_netdev,nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport"

--- a/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
@@ -131,6 +131,7 @@ resource "aws_efs_file_system" "formplayer" {
 resource "aws_efs_mount_target" "formplayer-{{ az }}" {
   file_system_id = "${aws_efs_file_system.formplayer.id}"
   subnet_id      = "${lookup(module.network.subnets-app-private, "{{ az }}", "")}"
+  security_groups = ["${module.network.app-private-sg}"]
 }
 {% endfor %}
 


### PR DESCRIPTION
- `_netdev` change is based off of https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-nfs-mount-settings.html
- security group change is just putting into terraform something I'd realized was missing and done manually before.

##### ENVIRONMENTS AFFECTED
production, staging, eventually india