### PR TITLE
Increase RAM for production ES cluster

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -204,7 +204,7 @@ servers:
     volume_encrypted: no
 
   - server_name: "es20-production"
-    server_instance_type: c5.9xlarge
+    server_instance_type: m5.8xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 30
@@ -215,7 +215,7 @@ servers:
     group: "elasticsearch"
     os: bionic
   - server_name: "es21-production"
-    server_instance_type: c5.9xlarge
+    server_instance_type: m5.8xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 30
@@ -226,7 +226,7 @@ servers:
     group: "elasticsearch"
     os: bionic
   - server_name: "es22-production"
-    server_instance_type: c5.9xlarge
+    server_instance_type: m5.8xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 30
@@ -237,7 +237,7 @@ servers:
     group: "elasticsearch"
     os: bionic
   - server_name: "es23-production"
-    server_instance_type: c5.9xlarge
+    server_instance_type: m5.8xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 30
@@ -248,7 +248,7 @@ servers:
     group: "elasticsearch"
     os: bionic
   - server_name: "es24-production"
-    server_instance_type: c5.9xlarge
+    server_instance_type: m5.8xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 30
@@ -259,7 +259,7 @@ servers:
     group: "elasticsearch"
     os: bionic
   - server_name: "es25-production"
-    server_instance_type: c5.9xlarge
+    server_instance_type: m5.8xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 30
@@ -270,7 +270,7 @@ servers:
     group: "elasticsearch"
     os: bionic
   - server_name: "es26-production"
-    server_instance_type: c5.9xlarge
+    server_instance_type: m5.8xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 30

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -280,6 +280,17 @@ servers:
       encrypted: yes
     group: "elasticsearch"
     os: bionic
+  - server_name: "es27-production"
+    server_instance_type: m5.8xlarge
+    network_tier: "db-private"
+    az: "a"
+    volume_size: 30
+    volume_encrypted: yes
+    block_device:
+      volume_size: 1400
+      encrypted: yes
+    group: "elasticsearch"
+    os: bionic
 
   - server_name: "couchproxy1-production"
     server_instance_type: "t3.medium"


### PR DESCRIPTION
7 x (36 vCPU / 72G RAM) => 8 x (32 vCPU / 128G RAM)

##### ENVIRONMENTS AFFECTED
production