### PR TITLE
Revert "make firehose role shareable"

### DIFF
--- a/src/commcare_cloud/terraform/modules/ga_alb_waf/main.tf
+++ b/src/commcare_cloud/terraform/modules/ga_alb_waf/main.tf
@@ -415,7 +415,7 @@ resource "aws_iam_role_policy" "firehose_role" {
         "logs:PutLogEvents"
       ],
       "Resource": [
-        "arn:aws:logs:us-east-1:${var.account_id}:log-group:/aws/kinesisfirehose/%FIREHOSE_STREAM_NAME%:log-stream:*"
+        "arn:aws:logs:us-east-1:${var.account_id}:log-group:/aws/kinesisfirehose/${aws_kinesis_firehose_delivery_stream.front_end_waf_logs.name}:log-stream:*"
       ]
     },
     {


### PR DESCRIPTION
Reverts dimagi/commcare-cloud#4038

I think I misunderstood what "% FIREHOSE_STREAM_NAME%" means. I thought it was some reflexive IAM policy syntax. According to https://docs.aws.amazon.com/firehose/latest/dev/create-configure.html though it's a meaningless placeholder and "You can safely ignore or safely delete lines with" them.

I think this change didn't cause serious problems because the permission being changed isn't that important; it grants access to log to cloudwatch when there's an error in the kinesis stream, something that never or almost never happens.