### PR TITLE
Turn off use_formplayer_efs on staging

### DIFF
--- a/environments/staging/inventory.ini
+++ b/environments/staging/inventory.ini
@@ -99,7 +99,6 @@ formplayer2
 
 [formplayer:vars]
 formplayer_efs_dns=fs-ba70cd39.efs.us-east-1.amazonaws.com:/
-use_formplayer_efs=true
 cchq_uid=1026
 cchq_gid=1027
 

--- a/environments/staging/inventory.ini.j2
+++ b/environments/staging/inventory.ini.j2
@@ -85,7 +85,6 @@ formplayer2
 
 [formplayer:vars]
 formplayer_efs_dns={{ aws_resources['formplayer-efs'] }}:/
-use_formplayer_efs=true
 cchq_uid=1026
 cchq_gid=1027
 


### PR DESCRIPTION
This was an experiment to see whether EFS would be performant enough to use as the disk for formplayer sqlite dbs, and the result of the experiment is that it wasn't. We won't be using this on prod, so I'm rolling back on staging as well.

##### ENVIRONMENTS AFFECTED
staging
