### PR TITLE
Add commit field to record_successful_deploy()

### DIFF
--- a/src/commcare_cloud/fab/operations/release.py
+++ b/src/commcare_cloud/fab/operations/release.py
@@ -373,12 +373,14 @@ def record_successful_deploy():
             '%(virtualenv_current)s/bin/python manage.py '
             'record_deploy_success --user "%(user)s" --environment '
             '"%(environment)s" --url %(url)s --minutes %(minutes)s --mail_admins'
+            '--commit %(commit)s'
         ) % {
             'virtualenv_current': env.py3_virtualenv_current,
             'user': env.user,
             'environment': env.deploy_env,
             'url': env.deploy_metadata.diff.url,
-            'minutes': str(int(delta.total_seconds() // 60))
+            'minutes': str(int(delta.total_seconds() // 60)),
+            'commit': env.deploy_metadata.deploy_ref
         })
 
 

--- a/src/commcare_cloud/fab/operations/release.py
+++ b/src/commcare_cloud/fab/operations/release.py
@@ -372,7 +372,7 @@ def record_successful_deploy():
         sudo((
             '%(virtualenv_current)s/bin/python manage.py '
             'record_deploy_success --user "%(user)s" --environment '
-            '"%(environment)s" --url %(url)s --minutes %(minutes)s --mail_admins'
+            '"%(environment)s" --url %(url)s --minutes %(minutes)s --mail_admins '
             '--commit %(commit)s'
         ) % {
             'virtualenv_current': env.py3_virtualenv_current,


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/issues/27839

Related to https://github.com/dimagi/commcare-hq/pull/28234, this PR is updating the commcare-cloud code to match the new commit field in the HqDeploy model.
##### ENVIRONMENTS AFFECTED
Deployments will now use the `--commit` flag of the `record_deploy_success` management command automatically.