### PR TITLE
add firehose stream to logshipping module

### DIFF
--- a/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
@@ -190,6 +190,7 @@ module "iam_user__{{ user.username }}" {
 module "logshipping" {
   environment = "${var.environment}"
   source = "./modules/logshipping"
+  account_id = {{ account_id|tojson }}
 }
 
 module "ga_alb_waf" {

--- a/src/commcare_cloud/terraform/modules/ga_alb_waf/main.tf
+++ b/src/commcare_cloud/terraform/modules/ga_alb_waf/main.tf
@@ -319,7 +319,7 @@ module "firehose_stream" {
   log_bucket_arn = "${var.log_bucket_arn}"
   log_bucket_prefix = "${local.log_bucket_waf_prefix}"
   log_bucket_error_prefix = "${local.log_bucket_waf_error_prefix}"
-  firehose_role_name = "${local.log_bucket_waf_prefix}"
+  firehose_stream_name= "aws-waf-logs-frontend-waf-${var.environment}"
 }
 
 resource "aws_wafv2_web_acl_association" "front_end" {

--- a/src/commcare_cloud/terraform/modules/ga_alb_waf/main.tf
+++ b/src/commcare_cloud/terraform/modules/ga_alb_waf/main.tf
@@ -319,6 +319,7 @@ module "firehose_stream" {
   log_bucket_arn = "${var.log_bucket_arn}"
   log_bucket_prefix = "${local.log_bucket_waf_prefix}"
   log_bucket_error_prefix = "${local.log_bucket_waf_error_prefix}"
+  firehose_role_name = "${local.log_bucket_waf_prefix}"
 }
 
 resource "aws_wafv2_web_acl_association" "front_end" {

--- a/src/commcare_cloud/terraform/modules/logshipping/firehose_stream/main.tf
+++ b/src/commcare_cloud/terraform/modules/logshipping/firehose_stream/main.tf
@@ -20,7 +20,7 @@ resource "aws_kinesis_firehose_delivery_stream" "firehose_stream" {
 }
 
 resource "aws_iam_role" "firehose_role" {
-  name = "firehose_delivery_role"
+  name = "${var.firehose_role_name}"
 
   assume_role_policy = <<EOF
 {"Version":"2012-10-17","Statement":[{"Sid":"","Effect":"Allow","Principal":{"Service":"firehose.amazonaws.com"},"Action":"sts:AssumeRole","Condition":{"StringEquals":{"sts:ExternalId":"${var.account_id}"}}}]}
@@ -28,7 +28,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "firehose_role" {
-  name = "firehose_delivery_role_policy"
+  name = "${var.firehose_role_name}-role-policy"
   role = "${aws_iam_role.firehose_role.id}"
   policy = <<EOF
 {

--- a/src/commcare_cloud/terraform/modules/logshipping/firehose_stream/main.tf
+++ b/src/commcare_cloud/terraform/modules/logshipping/firehose_stream/main.tf
@@ -1,7 +1,7 @@
 data "aws_region" "current" {}
 
 resource "aws_kinesis_firehose_delivery_stream" "firehose_stream" {
-  name = "aws-waf-logs-frontend-waf-${var.environment}"
+  name = "${var.firehose_stream_name}"
   destination = "extended_s3"
   server_side_encryption {
     enabled = true
@@ -20,7 +20,7 @@ resource "aws_kinesis_firehose_delivery_stream" "firehose_stream" {
 }
 
 resource "aws_iam_role" "firehose_role" {
-  name = "${var.firehose_role_name}"
+  name = "${var.firehose_stream_name}-role"
 
   assume_role_policy = <<EOF
 {"Version":"2012-10-17","Statement":[{"Sid":"","Effect":"Allow","Principal":{"Service":"firehose.amazonaws.com"},"Action":"sts:AssumeRole","Condition":{"StringEquals":{"sts:ExternalId":"${var.account_id}"}}}]}
@@ -28,7 +28,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "firehose_role" {
-  name = "${var.firehose_role_name}-role-policy"
+  name = "${var.firehose_stream_name}-role-policy"
   role = "${aws_iam_role.firehose_role.id}"
   policy = <<EOF
 {

--- a/src/commcare_cloud/terraform/modules/logshipping/firehose_stream/variables.tf
+++ b/src/commcare_cloud/terraform/modules/logshipping/firehose_stream/variables.tf
@@ -8,4 +8,4 @@ variable "log_bucket_arn" {}
 variable "log_bucket_prefix" {}
 variable "log_bucket_error_prefix" {}
 
-variable "firehose_role_name" {}
+variable "firehose_stream_name" {}

--- a/src/commcare_cloud/terraform/modules/logshipping/firehose_stream/variables.tf
+++ b/src/commcare_cloud/terraform/modules/logshipping/firehose_stream/variables.tf
@@ -7,3 +7,5 @@ variable "log_bucket_arn" {}
 
 variable "log_bucket_prefix" {}
 variable "log_bucket_error_prefix" {}
+
+variable "firehose_role_name" {}

--- a/src/commcare_cloud/terraform/modules/logshipping/main.tf
+++ b/src/commcare_cloud/terraform/modules/logshipping/main.tf
@@ -25,4 +25,5 @@ module "formplayer_request_response_logs_firehose_stream" {
   log_bucket_arn = "${aws_s3_bucket.log_bucket.arn}"
   log_bucket_prefix = "${local.formplayer_request_response_log_bucket_prefix}"
   log_bucket_error_prefix = "${local.formplayer_request_response_log_bucket_error_prefix}"
+  firehose_role_name = "${local.formplayer_request_response_log_bucket_prefix}"
 }

--- a/src/commcare_cloud/terraform/modules/logshipping/main.tf
+++ b/src/commcare_cloud/terraform/modules/logshipping/main.tf
@@ -1,5 +1,7 @@
 locals {
   log_bucket_name = "dimagi-commcare-${var.environment}-logs"
+  log_bucket_prefix = "frontend-logs-${var.environment}"
+  log_bucket_error_prefix = "frontend-logs-${var.environment}-error"
 }
 
 resource "aws_s3_bucket" "log_bucket" {
@@ -13,4 +15,14 @@ resource "aws_s3_bucket" "log_bucket" {
       }
     }
   }
+}
+
+module "firehose_stream" {
+  source = "./firehose_stream"
+  environment = "${var.environment}"
+  account_id = "${var.account_id}"
+  log_bucket_name = "${local.log_bucket_name}"
+  log_bucket_arn = "${aws_s3_bucket.log_bucket.arn}"
+  log_bucket_prefix = "${local.log_bucket_prefix}"
+  log_bucket_error_prefix = "${local.log_bucket_error_prefix}"
 }

--- a/src/commcare_cloud/terraform/modules/logshipping/main.tf
+++ b/src/commcare_cloud/terraform/modules/logshipping/main.tf
@@ -25,5 +25,5 @@ module "formplayer_request_response_logs_firehose_stream" {
   log_bucket_arn = "${aws_s3_bucket.log_bucket.arn}"
   log_bucket_prefix = "${local.formplayer_request_response_log_bucket_prefix}"
   log_bucket_error_prefix = "${local.formplayer_request_response_log_bucket_error_prefix}"
-  firehose_role_name = "${local.formplayer_request_response_log_bucket_prefix}"
+  firehose_stream_name = "${local.formplayer_request_response_log_bucket_prefix}"
 }

--- a/src/commcare_cloud/terraform/modules/logshipping/main.tf
+++ b/src/commcare_cloud/terraform/modules/logshipping/main.tf
@@ -1,7 +1,7 @@
 locals {
   log_bucket_name = "dimagi-commcare-${var.environment}-logs"
-  log_bucket_prefix = "frontend-logs-${var.environment}"
-  log_bucket_error_prefix = "frontend-logs-${var.environment}-error"
+  formplayer_request_response_log_bucket_prefix = "formplayer-request-response-logs-${var.environment}"
+  formplayer_request_response_log_bucket_error_prefix = "formplayer-request-response-logs-${var.environment}-error"
 }
 
 resource "aws_s3_bucket" "log_bucket" {
@@ -17,12 +17,12 @@ resource "aws_s3_bucket" "log_bucket" {
   }
 }
 
-module "firehose_stream" {
+module "formplayer_request_response_logs_firehose_stream" {
   source = "./firehose_stream"
   environment = "${var.environment}"
   account_id = "${var.account_id}"
   log_bucket_name = "${local.log_bucket_name}"
   log_bucket_arn = "${aws_s3_bucket.log_bucket.arn}"
-  log_bucket_prefix = "${local.log_bucket_prefix}"
-  log_bucket_error_prefix = "${local.log_bucket_error_prefix}"
+  log_bucket_prefix = "${local.formplayer_request_response_log_bucket_prefix}"
+  log_bucket_error_prefix = "${local.formplayer_request_response_log_bucket_error_prefix}"
 }

--- a/src/commcare_cloud/terraform/modules/logshipping/variables.tf
+++ b/src/commcare_cloud/terraform/modules/logshipping/variables.tf
@@ -1,1 +1,2 @@
 variable "environment" {}
+variable "account_id" {}


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Part 2 of https://trello.com/c/prhWvkky/37-hipaa-logging-improvements

Staging:
```
Terraform will perform the following actions:

  - module.server__rabbit1-staging.aws_instance.server

  + module.logshipping.module.firehose_stream.aws_iam_role.firehose_role
      id:                                                       <computed>
      arn:                                                      <computed>
      assume_role_policy:                                       "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"firehose.amazonaws.com\"},\"Action\":\"sts:AssumeRole\",\"Condition\":{\"StringEquals\":{\"sts:ExternalId\":\"737236193635\"}}}]}\n"
      create_date:                                              <computed>
      force_detach_policies:                                    "false"
      max_session_duration:                                     "3600"
      name:                                                     "firehose_delivery_role"
      path:                                                     "/"
      unique_id:                                                <computed>

  + module.logshipping.module.firehose_stream.aws_iam_role_policy.firehose_role
      id:                                                       <computed>
      name:                                                     "firehose_delivery_role_policy"
      policy:                                                   "<kev-redacted>"
      role:                                                     "${aws_iam_role.firehose_role.id}"

  + module.logshipping.module.firehose_stream.aws_kinesis_firehose_delivery_stream.firehose_stream
      id:                                                       <computed>
      arn:                                                      <computed>
      destination:                                              "extended_s3"
      destination_id:                                           <computed>
      extended_s3_configuration.#:                              "1"
      extended_s3_configuration.0.bucket_arn:                   "arn:aws:s3:::dimagi-commcare-staging-logs"
      extended_s3_configuration.0.buffer_interval:              "300"
      extended_s3_configuration.0.buffer_size:                  "5"
      extended_s3_configuration.0.cloudwatch_logging_options.#: <computed>
      extended_s3_configuration.0.compression_format:           "GZIP"
      extended_s3_configuration.0.error_output_prefix:          "frontend-logs-staging-error/"
      extended_s3_configuration.0.kms_key_arn:                  "arn:aws:kms:us-east-1:737236193635:alias/aws/s3"
      extended_s3_configuration.0.prefix:                       "frontend-logs-staging/"
      extended_s3_configuration.0.role_arn:                     "${aws_iam_role.firehose_role.arn}"
      extended_s3_configuration.0.s3_backup_mode:               "Disabled"
      name:                                                     "aws-waf-logs-frontend-waf-staging"
      server_side_encryption.#:                                 "1"
      server_side_encryption.0.enabled:                         "true"
      tags.%:                                                   "1"
      tags.Environment:                                         "staging"
      version_id:                                               <computed>


Plan: 3 to add, 0 to change, 1 to destroy.
```

Looks like it will destroy `module.server__rabbit1-staging.aws_instance.server`

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
staging, production, india