### PR TITLE
Add ability to straddle two rabbitmq instances 

### DIFF
--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -135,6 +135,10 @@ AMQP_HOST: "{{ groups.rabbitmq.0 }}"
 AMQP_NAME: commcarehq
 AMQP_PASSWORD: "{{ secrets.AMQP_PASSWORD | default(None) }}"
 AMQP_USER: "{{ secrets.AMQP_USER | default(None) }}"
+OLD_AMQP_HOST: null
+OLD_AMQP_NAME: commcarehq
+OLD_AMQP_PASSWORD: "{{ secrets.OLD_AMQP_PASSWORD | default(secrets.AMQP_PASSWORD) | default(None) }}"
+OLD_AMQP_USER: "{{ secrets.OLD_AMQP_USER | default(secrets.AMQP_USER) | default(None) }}"
 APPCUES_ID: "{{ localsettings_private.APPCUES_ID | default('', true) }}"
 APPCUES_KEY: "{{ localsettings_private.APPCUES_KEY | default('', true) }}"
 BANK_ACCOUNT_NUMBER: "{{ localsettings_private.BANK_ACCOUNT_NUMBER | default(None) }}"

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -379,7 +379,12 @@ GMAPS_API_KEY = '{{ GMAPS_API_KEY }}'
 MAPBOX_ACCESS_TOKEN = '{{ MAPBOX_ACCESS_TOKEN }}'
 FORMTRANSLATE_TIMEOUT = 5
 
+{% if OLD_BROKER_URL %}
+CELERY_BROKER_READ_URL = BROKER_READ_URL = '{{ OLD_BROKER_URL }}'
+CELERY_BROKER_WRITE_URL = BROKER_WRITE_URL = '{{ BROKER_URL }}'
+{% else %}
 CELERY_BROKER_URL = BROKER_URL = '{{ BROKER_URL }}'
+{% endif %}
 CELERY_HEARTBEAT_THRESHOLDS = {
 {% for queue, threshold in CELERY_HEARTBEAT_THRESHOLDS.items() | sort %}
     {{ queue | to_json }}: {% if threshold == None %}None{% else %}{{ threshold | to_json }}{% endif %},

--- a/src/commcare_cloud/ansible/roles/commcarehq/vars/main.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/vars/main.yml
@@ -3,6 +3,7 @@ code_source: "{{ code_releases }}/{{ ansible_date_time.date }}_{{ ansible_date_t
 py3_virtualenv_source: "{{ code_source }}/python_env-3.6"
 py3_virtualenv_home: "{{ code_home }}/python_env-3.6"
 BROKER_URL: 'amqp://{{ AMQP_USER }}:{{ AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
+OLD_BROKER_URL: "{{ ('amqp://' + OLD_AMQP_USER + ':' + OLD_AMQP_PASSWORD + '@' + OLD_AMQP_HOST + ':5672/' + OLD_AMQP_NAME) if OLD_AMQP_HOST else None }}"
 
 django_bash_runner_path: "{{ service_home }}/{{ deploy_env }}_django_bash_runner.sh"
 django_bash_runner: "/bin/bash {{ django_bash_runner_path }}"

--- a/src/commcare_cloud/ansible/roles/rabbitmq/tasks/install_latest.yml
+++ b/src/commcare_cloud/ansible/roles/rabbitmq/tasks/install_latest.yml
@@ -17,16 +17,16 @@
     update_cache: yes
   ignore_errors: '{{ ansible_check_mode }}'
 
+- name: Add trusted key
+  apt_key:
+    url: https://www.rabbitmq.com/rabbitmq-release-signing-key.asc
+    state: present
+
 - name: Add rabbitmq official apt repository
   apt_repository:
     repo: 'deb https://dl.bintray.com/rabbitmq/debian {{ ansible_distribution_release|lower }} main'
     state: present
     update_cache: yes
-
-- name: Add trusted key
-  apt_key:
-    url: https://www.rabbitmq.com/rabbitmq-release-signing-key.asc
-    state: present
 
 - name: Install package
   apt:


### PR DESCRIPTION
This adds a new option to migrate rabbitmq to a new machine rather than upgrading in place. It's not as clean as I'd hoped: specifically while `CELERY_BROKER_READ_URL` can take a list of endpoints, it actually just uses the first one unless it fails; i.e. further endpoints in that list are failover endpoints, not equal members in the list. What that means is basically that we need some celery nodes to have these "straddling" settings and others to have the future setup (so that they're reading from _and_ writing to the new rabbitmq instance) until the old rabbitmq instance is fully drained.

The alternative to this is to set up a cluster and learn to do the upgrade one node at a time when that's possible. We may want to have both options in our tool belt.

##### ENVIRONMENTS AFFECTED
available to all
