### PR TITLE
Fix tmp dir situation on AWS encrypted disks

### DIFF
--- a/src/commcare_cloud/ansible/roles/ecryptfs/tasks/tmp.yml
+++ b/src/commcare_cloud/ansible/roles/ecryptfs/tasks/tmp.yml
@@ -1,4 +1,31 @@
 ---
+- name: Create {{encrypted_tmp}} to use for as tmp directory.
+  become: yes
+  file:
+    path: "{{ encrypted_tmp }}"
+    mode: "u=rwx,g=rwx,o=rx"
+    state: directory
+    owner: cchq
+    group: cchq
+
+  tags:
+    - mount-ecryptfs
+    - after-reboot
+    - tmp-encrypt
+
+- name: Create purging cron jobs
+  become: yes
+  cron:
+    name: "Purge files in {{ item }}"
+    special_time: daily
+    job: "/usr/sbin/tmpreaper 2d {{ item }}"
+    user: root
+    cron_file: purge_tmp_files
+  with_items:
+    - "{{ encrypted_tmp }}"
+    - "/tmp"
+  tags: cron
+
 - block:
     - name: Check for already mounted encrypted tmp drive
       shell: grep '{{ encrypted_tmp }} ecryptfs' /etc/mtab
@@ -27,20 +54,6 @@
         - mount-ecryptfs
         - after-reboot
 
-    - name: Create {{encrypted_tmp}} to use for as tmp directory.
-      become: yes
-      file:
-        path: "{{ encrypted_tmp }}"
-        mode: "u=rwx,g=rwx,o=rx"
-        state: directory
-        owner: cchq
-        group: cchq
-
-      tags:
-        - mount-ecryptfs
-        - after-reboot
-        - tmp-encrypt
-
     - name: Mount tmp drive
       become: yes
       shell: "mount -t ecryptfs -o key=passphrase:passphrase_passwd={{ ECRYPTFS_PASSWORD }},user,noauto,ecryptfs_cipher=aes,ecryptfs_key_bytes=32,ecryptfs_unlink_sigs,ecryptfs_enable_filename_crypto=y,ecryptfs_fnek_sig={{ password_hash.stdout }},verbosity=0 {{ encrypted_tmp }}/ {{ encrypted_tmp }}/"
@@ -59,15 +72,4 @@
         group: root
         mode: 0770
       tags: mount-ecryptfs
-
-    - name: Create purging cron jobs
-      become: yes
-      cron:
-        name: "Purge files in {{ encrypted_tmp }}"
-        special_time: daily
-        job: "/usr/sbin/tmpreaper 2d {{ encrypted_tmp }}"
-        user: root
-        cron_file: purge_tmp_files
-      tags: cron
-      
   when: root_encryption_mode == 'ecryptfs'


### PR DESCRIPTION
Previously weren't creating /opt/tmp but still passing it in as TMPDIR
and processes were falling back to /tmp, which didn't have tmpreaper set up,
causing unbounded disk growth.
This commit both adds /opt/tmp and sets up tmpreaper on /tmp.

<!--- Provide a link to the ticket or document which prompted this change -->

##### ENVIRONMENTS AFFECTED
production, india, staging