### PR TITLE
create commcare server role in tf

### DIFF
--- a/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
@@ -79,6 +79,11 @@ resource "aws_dlm_lifecycle_policy" "data_volume_backups" {
   }
 }
 
+module "server_iam_role" {
+  source = "./modules/server/iam"
+  formplayer_request_response_logs_firehose_stream_arn = "${module.logshipping.formplayer_request_response_logs_firehose_stream_arn}"
+}
+
 {% for server_spec in servers + proxy_servers %}
 {%- for server_name in server_spec.get_all_server_names %}
 module "server__{{ server_name }}" {
@@ -93,6 +98,7 @@ module "server__{{ server_name }}" {
   secondary_volume_size = {{ server_spec.block_device.volume_size|default(0)|tojson }}
   secondary_volume_type = {{ server_spec.block_device.volume_type|default("")|tojson }}
   secondary_volume_encrypted = {{ server_spec.block_device.encrypted|default(False)|tojson }}
+  iam_instance_profile = "${module.server_iam_role.commcare_server_instance_profile}"
 
 {% if server_spec.os == 'ubuntu_pro_bionic' %}
   server_image = "${data.aws_ami.ubuntu_pro_bionic.id}"

--- a/src/commcare_cloud/terraform/modules/logshipping/outputs.tf
+++ b/src/commcare_cloud/terraform/modules/logshipping/outputs.tf
@@ -5,3 +5,7 @@ output "log_bucket_name" {
 output "log_bucket_arn" {
   value = "${aws_s3_bucket.log_bucket.arn}"
 }
+
+output "formplayer_request_response_logs_firehose_stream_arn" {
+  value = "${module.formplayer_request_response_logs_firehose_stream.firehose_stream_arn}"
+}

--- a/src/commcare_cloud/terraform/modules/server/iam/main.tf
+++ b/src/commcare_cloud/terraform/modules/server/iam/main.tf
@@ -1,0 +1,57 @@
+resource "aws_iam_role" "commcare_server_role" {
+  name = "CommCareServerRole"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "server_role_attach_cloudwatch_policy" {
+  role       = "${aws_iam_role.commcare_server_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "server_role_attach_awsmanagedinstance_policy" {
+  role       = "${aws_iam_role.commcare_server_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_role_policy" "request_response_stream_put_policy" {
+  name = "RequestResponseStreamPutPolicy"
+  role = "${aws_iam_role.commcare_server_role.id}"
+
+  policy = <<-EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "firehose:PutRecord",
+        "firehose:PutRecordBatch"
+      ],
+      "Resource": [
+        "${var.formplayer_request_response_logs_firehose_stream_arn}"
+      ]
+    }
+  ]
+}
+  EOF
+}
+
+resource "aws_iam_instance_profile" "commcare_server_instance_profile" {
+  name = "CommCareServerRole"
+  role = "${aws_iam_role.commcare_server_role.name}"
+}

--- a/src/commcare_cloud/terraform/modules/server/iam/outputs.tf
+++ b/src/commcare_cloud/terraform/modules/server/iam/outputs.tf
@@ -1,0 +1,8 @@
+output "commcare_server_role_arn" {
+  value = "${aws_iam_role.commcare_server_role.arn}"
+}
+
+output "commcare_server_instance_profile" {
+  value = "${aws_iam_instance_profile.commcare_server_instance_profile.name}"
+}
+

--- a/src/commcare_cloud/terraform/modules/server/iam/variables.tf
+++ b/src/commcare_cloud/terraform/modules/server/iam/variables.tf
@@ -1,0 +1,1 @@
+variable "formplayer_request_response_logs_firehose_stream_arn" {}

--- a/src/commcare_cloud/terraform/modules/server/main.tf
+++ b/src/commcare_cloud/terraform/modules/server/main.tf
@@ -7,6 +7,7 @@ resource aws_instance "server" {
   key_name                = "${var.key_name}"
   vpc_security_group_ids  = ["${var.security_group_options[var.network_tier]}"]
   source_dest_check       = false
+  iam_instance_profile    = "${var.iam_instance_profile}"
 
   disable_api_termination = true
   ebs_optimized = true

--- a/src/commcare_cloud/terraform/modules/server/variables.tf
+++ b/src/commcare_cloud/terraform/modules/server/variables.tf
@@ -12,6 +12,7 @@ variable "server_image" {}
 variable "environment" {}
 variable "vpc_id" {}
 
+variable "iam_instance_profile" {}
 variable "server_name" {}
 variable "server_instance_type" {}
 variable "network_tier" {}


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://trello.com/c/prhWvkky/37-hipaa-logging-improvements

We need to create a new `CommCareServerRole` that gives servers write access to the request response firehose stream.

Changes:
- create a `server/iam` module directory
  - `server/iam` module creates commcare server role, attaches the aws managed cloudwatch and managed instance roles, creates a role policy for the request response stream writes, and creates the instance profile to be used by `aws_instance`
- Passes in the newly created instance profile to aws instances

NOTE: `iam_instance_profile` is only used during instance creation according to the [docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance#iam_instance_profile), so adding this attribute does not replace the iam role on instances. I had to manually change the role for formplayer.

Progress and Testing:

All resources were applied on staging, and formplayer1 was manually moved over to the new iam role while formplayer2 was on the old to compare. It looks like formplayer1 is still reporting cloudwatch monitoring metrics.

The new role looks like:

<img width="1066" alt="Screen Shot 2020-08-06 at 3 07 39 PM" src="https://user-images.githubusercontent.com/615126/89573299-6683db00-d7f8-11ea-9424-439d57b9cbee.png">

