### PR TITLE
Increase gunicorn_workers_factor on production from 1 to 2

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -2,7 +2,7 @@ datadog_pythonagent: True
 django_command_prefix: ''
 celery_command_prefix: ''
 gunicorn_workers_static_factor: 0
-gunicorn_workers_factor: 1
+gunicorn_workers_factor: 2
 formplayer_memory: "30g"
 management_commands:
   celery12:


### PR DESCRIPTION
Our current data suggests when we're close to the max gunicorn
workers, our normalized system load peaks around .4.
That suggests to me we could server many more concurrent requests
per webworker than we currently are.

##### ENVIRONMENTS AFFECTED
production
