### PR TITLE
Resize proxy2-production

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -442,7 +442,7 @@ servers:
 
 proxy_servers:
   - server_name: "proxy2-production"
-    server_instance_type: "m5.large"
+    server_instance_type: "c5.large"
     network_tier: "public"
     az: "a"
     volume_size: 80


### PR DESCRIPTION
We recently added a second proxy node for the CPU.
Reducing the memory so that combined it is what this alone was before,
and so the two machines are the same.

(already applied)
##### ENVIRONMENTS AFFECTED
production