### PR TITLE
changed kinesis file pattern and increased formplayer log limit

### DIFF
--- a/environments/india/public.yml
+++ b/environments/india/public.yml
@@ -246,5 +246,5 @@ airflow_parallelism: 8
 firehose_endpoint: "firehose.ap-south-1.amazonaws.com"
 kinesis_endpoint: "kinesis.ap-south-1.amazonaws.com"
 kinesis_flows:
-  - file_pattern: "/opt/data/formplayer/log/request_response.log"
+  - file_pattern: "/opt/data/formplayer/log/request_response.*log"
     delivery_stream: "formplayer-request-response-logs-india"

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -210,5 +210,5 @@ commcare_cloud_root_user: ubuntu
 commcare_cloud_pem: ~/.ssh/id_rsa
 
 kinesis_flows:
-  - file_pattern: "/opt/data/formplayer/log/request_response.log"
+  - file_pattern: "/opt/data/formplayer/log/request_response.*log"
     delivery_stream: "formplayer-request-response-logs-production"

--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -147,5 +147,5 @@ commcare_cloud_root_user: ubuntu
 commcare_cloud_pem: ~/.ssh/id_rsa
 
 kinesis_flows:
-  - file_pattern: "/opt/data/formplayer/log/request_response.log"
+  - file_pattern: "/opt/data/formplayer/log/request_response.*log"
     delivery_stream: "formplayer-request-response-logs-staging"

--- a/src/commcare_cloud/ansible/roles/formplayer/templates/logback-spring.xml.j2
+++ b/src/commcare_cloud/ansible/roles/formplayer/templates/logback-spring.xml.j2
@@ -13,11 +13,11 @@
         <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
             <fileNamePattern>{{ formplayer_logging_dir }}/request_response.%i.log</fileNamePattern>
             <minIndex>1</minIndex>
-            <maxIndex>1</maxIndex>
+            <maxIndex>3</maxIndex>
         </rollingPolicy>
         <!-- Limit the log file size. -->
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>1MB</maxFileSize>
+            <maxFileSize>1GB</maxFileSize>
         </triggeringPolicy>
         <encoder>
             <pattern>%msg%n</pattern>


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
A continuation of https://github.com/dimagi/commcare-cloud/pull/4077

- Changes kinesis file_pattern so we detect log rotation
- increase the limit of formplayer logs from 1MB to 1GB while maintaining 3 extra log rotated files instead of just 1. 

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
staging, prod, india
