### PR TITLE
scale sentry workers

### DIFF
--- a/src/commcare_cloud/ansible/roles/sentry/defaults/main.yml
+++ b/src/commcare_cloud/ansible/roles/sentry/defaults/main.yml
@@ -8,7 +8,7 @@ sentry_system_secret_key: 'secret'
 sentry_home_dir: /home/sentry
 sentry_app_config: "{{ sentry_home_dir }}/config"
 sentry_virtualenv_path: "{{ sentry_home_dir }}/sentry_app"
-
+sentry_workers_count: 8
 
 # SNUBA 
 snuba_version: 20.6.0

--- a/src/commcare_cloud/ansible/roles/sentry/templates/sentry.conf.py.j2
+++ b/src/commcare_cloud/ansible/roles/sentry/templates/sentry.conf.py.j2
@@ -103,5 +103,5 @@ KAFKA_CLUSTERS["default"] = DEFAULT_KAFKA_OPTIONS
 SENTRY_WEB_HOST = '{{ sentry_web_host }}'
 SENTRY_WEB_PORT = {{ sentry_web_port }}
 SENTRY_WEB_OPTIONS = {
-    'workers': 4,
+    'workers': {{ sentry_workers_count }},
 }


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
sometimes sentry stops processing altogether because of too many requests, this has happened a few times. if this fix doesn't work we have to apply quota limit instead.
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
ICDS