### PR TITLE
Remove unused formplayer formplayer restart code from deploy

### DIFF
--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -731,7 +731,6 @@ def silent_services_restart(use_current_release=False):
     """
     execute(db.set_in_progress_flag, use_current_release)
     if not env.is_monolith:
-        execute(supervisor.restart_formplayer_if_it_is_running_from_old_release_location)
         execute(supervisor.restart_all_except_webworkers)
     execute(supervisor.restart_webworkers)
 

--- a/src/commcare_cloud/fab/operations/supervisor.py
+++ b/src/commcare_cloud/fab/operations/supervisor.py
@@ -107,15 +107,6 @@ def restart_formplayer():
     _services_restart()
 
 
-@roles(ROLES_FORMPLAYER)
-def restart_formplayer_if_it_is_running_from_old_release_location():
-    from commcare_cloud.fab.operations.formplayer import \
-        formplayer_is_running_from_old_release_location
-
-    if formplayer_is_running_from_old_release_location():
-        _services_restart()
-
-
 def _services_restart():
     """Stop and restart all supervisord services"""
     supervisor_command('stop all')


### PR DESCRIPTION
This was a bridge during the transition, but enough time has passed
and the condition is no longer ever fulfilled.

Just something I came across

##### ENVIRONMENTS AFFECTED
all (but it's no change other than being faster)
