### PR TITLE
set ownership and mode on release directory

### DIFF
--- a/src/commcare_cloud/fab/operations/release.py
+++ b/src/commcare_cloud/fab/operations/release.py
@@ -352,8 +352,8 @@ def create_code_dir(full_cluster=True):
     @parallel
     def create():
         sudo('mkdir -p {}'.format(env.code_root))
-        sudo('chown cchq:cchq {}'.format(env.code_root))
-        sudo('chmod 0755 {}'.format(env.code_root))
+        sudo('chown cchq:cchq {}'.format(env.code_root), user="root")
+        sudo('chmod 0755 {}'.format(env.code_root), user="root")
 
     return create
 

--- a/src/commcare_cloud/fab/operations/release.py
+++ b/src/commcare_cloud/fab/operations/release.py
@@ -352,6 +352,8 @@ def create_code_dir(full_cluster=True):
     @parallel
     def create():
         sudo('mkdir -p {}'.format(env.code_root))
+        sudo('chown cchq:cchq {}'.format(env.code_root))
+        sudo('chmod 0755 {}'.format(env.code_root))
 
     return create
 


### PR DESCRIPTION
Currently the deploy depends on the ability to read files (or at
least check for their existence) inside the releases folder without
using 'sudo'.

Depending on the system defaults files may be created without the
necessary permissions and ownership.

##### ENVIRONMENTS AFFECTED
all

@shyamkumarlchauhan this should fix the icds-sandbox deploy (I'm testing it now)