### PR TITLE
Secrets backend with abstract base class

### DIFF
--- a/src/commcare_cloud/commands/ansible/ansible_playbook.py
+++ b/src/commcare_cloud/commands/ansible/ansible_playbook.py
@@ -140,7 +140,7 @@ def run_ansible_playbook(
         return subprocess.call(cmd_parts, env=env_vars)
 
     def run_check():
-        with environment.secrets_backend.suppress_vault_loaded_event():
+        with environment.secrets_backend.suppress_datadog_event():
             return ansible_playbook(environment, playbook, '--check', *unknown_args)
 
     def run_apply():

--- a/src/commcare_cloud/commands/ansible/run_module.py
+++ b/src/commcare_cloud/commands/ansible/run_module.py
@@ -92,7 +92,7 @@ class RunAnsibleModule(CommandBase):
             )
 
         def run_check():
-            with environment.secrets_backend.suppress_vault_loaded_event():
+            with environment.secrets_backend.suppress_datadog_event():
                 return _run_ansible(args, '--check', *unknown_args)
 
         def run_apply():

--- a/src/commcare_cloud/environment/secrets/backends/abstract_backend.py
+++ b/src/commcare_cloud/environment/secrets/backends/abstract_backend.py
@@ -1,0 +1,31 @@
+import abc
+from contextlib import contextmanager
+
+import six
+
+
+@six.add_metaclass(abc.ABCMeta)
+class AbstractSecretsBackend(object):
+    @staticmethod
+    def prompt_user_input():
+        pass
+
+    @staticmethod
+    def get_extra_ansible_args():
+        return ()
+
+    @staticmethod
+    def get_extra_ansible_env_vars():
+        return {}
+
+    @abc.abstractmethod
+    def get_generated_variables(self):
+        pass
+
+    @abc.abstractmethod
+    def get_secret(self, var):
+        pass
+
+    @contextmanager
+    def suppress_datadog_event(self):
+        yield

--- a/src/commcare_cloud/environment/secrets/backends/ansible_vault/main.py
+++ b/src/commcare_cloud/environment/secrets/backends/ansible_vault/main.py
@@ -11,10 +11,11 @@ from memoized import memoized
 from six.moves import shlex_quote
 
 from commcare_cloud.environment.paths import ANSIBLE_DIR
+from commcare_cloud.environment.secrets.backends.abstract_backend import AbstractSecretsBackend
 from commcare_cloud.environment.secrets.secrets_schema import get_known_secret_specs
 
 
-class AnsibleVaultSecretsBackend(object):
+class AnsibleVaultSecretsBackend(AbstractSecretsBackend):
     def __init__(self, name, vault_file_path, record_to_datadog=False):
         self.name = name
         self.vault_file_path = vault_file_path

--- a/src/commcare_cloud/environment/secrets/backends/ansible_vault/main.py
+++ b/src/commcare_cloud/environment/secrets/backends/ansible_vault/main.py
@@ -132,7 +132,7 @@ class AnsibleVaultSecretsBackend(object):
             )
 
     @contextmanager
-    def suppress_vault_loaded_event(self):
+    def suppress_datadog_event(self):
         """Prevent "run event" from being sent to datadog
 
         This is only effective if `self.get_vault_variables()` has not

--- a/src/commcare_cloud/environment/secrets/backends/ansible_vault/main.py
+++ b/src/commcare_cloud/environment/secrets/backends/ansible_vault/main.py
@@ -65,11 +65,11 @@ class AnsibleVaultSecretsBackend(object):
         This method has a side-effect: it records a Datadog event with
         the commcare-cloud command that is currently being run.
         """
-        self.get_vault_variables()
+        self._get_vault_variables_and_record()
         return self._get_ansible_vault_password()
 
     @memoized
-    def get_vault_variables(self):
+    def _get_vault_variables_and_record(self):
         """Get ansible vault variables
 
         This method has a side-effect: it records a Datadog event with
@@ -108,7 +108,7 @@ class AnsibleVaultSecretsBackend(object):
 
     def get_secret(self, var):
         path = var.split('.')
-        context = self.get_vault_variables()
+        context = self._get_vault_variables_and_record()
         for node in path:
             context = context[node]
         return context

--- a/src/commcare_cloud/manage_commcare_cloud/list_vault_keys.py
+++ b/src/commcare_cloud/manage_commcare_cloud/list_vault_keys.py
@@ -31,7 +31,7 @@ class ListVaultKeys(CommandBase):
             environment = get_environment(env)
             passwd = environment.secrets_backend._get_ansible_vault_password()
             if passwd:
-                var_keys[env] = dict(get_flat_list_of_keys(environment.secrets_backend.get_vault_variables()))
+                var_keys[env] = dict(get_flat_list_of_keys(environment.secrets_backend._get_vault_variables_and_record()))
 
         headers = ["key"] + [env for env in envs if env in var_keys]
 


### PR DESCRIPTION
Some small updates to https://github.com/dimagi/commcare-cloud/pull/4114 based on Simon's insightful feedback.
- Clean up the interface a bit
- Make `AnsibleVaultSecretsBackend` inherit from an abstract base class with a clean interface that's generic (and not vault-specific. The only things a sub class is forced to define are (1) `get_secret` (the central capability of a secrets backend) and (2) `get_generated_variables` (which defines how the backend fetches secrets and assigns them to ansible variables).

##### ENVIRONMENTS AFFECTED
all, but it's a no-op