### PR TITLE
add cloudwatch_log role and deploys

### DIFF
--- a/src/commcare_cloud/ansible/deploy_cloudwatch_logs.yml
+++ b/src/commcare_cloud/ansible/deploy_cloudwatch_logs.yml
@@ -1,0 +1,118 @@
+
+- name: formplayer
+  hosts: formplayer
+  become: true
+  roles:
+    - role: cloudwatch_logs
+      vars:
+        log_files_collect_list:
+          - file_path: "/home/cchq/www/{{ deploy_env }}/log/formplayer**.log"
+            log_group_name: "formplayer"
+            log_stream_name_suffix: ""
+      tags:
+        - formplayer
+        - cloudwatch_logs
+
+- name: webworkers
+  hosts: webworkers
+  become: true
+  roles:
+    - role: cloudwatch_logs
+      vars:
+        log_files_collect_list:
+          - file_path: "/home/cchq/www/{{ deploy_env }}/log/**.log"
+            log_group_name: "webworkers"
+            log_stream_name_suffix: ""
+      tags:
+        - webworkers
+        - cloudwatch_logs
+
+- name: elasticsearch
+  hosts: elasticsearch
+  become: true
+  roles:
+    - role: cloudwatch_logs
+      vars:
+        log_files_collect_list:
+          - file_path: "/opt/data/elasticsearch-2.4.6/logs/**es.log**"
+            log_group_name: "elasticsearch"
+            log_stream_name_suffix: "{{ deploy_env }}_es"
+          - file_path: "/opt/data/elasticsearch-2.4.6/logs/**es_index_search_slowlog.log**"
+            log_group_name: "elasticsearch"
+            log_stream_name_suffix: "{{ deploy_env }}_es_index_search_slowlog"
+      tags:
+        - elasticsearch
+        - cloudwatch_logs
+
+- name: couchdb2_proxy
+  hosts: couchdb2_proxy
+  become: true
+  roles:
+    - role: cloudwatch_logs
+      vars:
+        log_files_collect_list:
+          - file_path: "/home/cchq/www/{{ deploy_env }}/log/**-nginx_access.log**"
+            log_group_name: "couchdb2_proxy"
+            log_stream_name_suffix: "nginx_access"
+          - file_path: "/home/cchq/www/{{ deploy_env }}/log/**-nginx_error.log**"
+            log_group_name: "couchdb2_proxy"
+            log_stream_name_suffix: "nginx_error"
+      tags:
+        - couchdb2_proxy
+        - cloudwatch_logs
+
+- name: couchdb2
+  hosts: couchdb2
+  become: true
+  roles:
+    - role: cloudwatch_logs
+      vars:
+        log_files_collect_list:
+          - file_path: "/home/cchq/www/{{ deploy_env }}/log/couchdb.stderr**"
+            log_group_name: "couchdb"
+            log_stream_name_suffix: "stderr"
+      tags:
+        - couchdb2
+        - cloudwatch_logs
+
+- name: celery
+  hosts: celery
+  become: true
+  roles:
+    - role: cloudwatch_logs
+      vars:
+        log_files_collect_list:
+          - file_path: "/home/cchq/www/{{ deploy_env }}/log/**.log**"
+            log_group_name: "celery"
+            log_stream_name_suffix: ""
+      tags:
+        - celery
+        - cloudwatch_logs
+
+- name: pillowtop
+  hosts: pillowtop
+  become: true
+  roles:
+    - role: cloudwatch_logs
+      vars:
+        log_files_collect_list:
+          - file_path: "/home/cchq/www/{{ deploy_env }}/log/**.log**"
+            log_group_name: "pillowtop"
+            log_stream_name_suffix: ""
+      tags:
+        - pillowtop
+        - cloudwatch_logs
+
+- name: proxy
+  hosts: proxy
+  become: true
+  roles:
+    - role: cloudwatch_logs
+      vars:
+        log_files_collect_list:
+          - file_path: "/home/cchq/www/{{ deploy_env }}/log/**.log**"
+            log_group_name: "proxy"
+            log_stream_name_suffix: ""
+      tags:
+        - proxy
+        - cloudwatch_logs

--- a/src/commcare_cloud/ansible/deploy_cloudwatch_logs.yml
+++ b/src/commcare_cloud/ansible/deploy_cloudwatch_logs.yml
@@ -6,7 +6,7 @@
     - role: cloudwatch_logs
       vars:
         log_files_collect_list:
-          - file_path: "/home/cchq/www/{{ deploy_env }}/log/formplayer**.log"
+          - file_path: "/home/cchq/www/{{ deploy_env }}/log/formplayer*.log"
             log_group_name: "formplayer"
             log_stream_name_suffix: ""
       tags:
@@ -20,7 +20,7 @@
     - role: cloudwatch_logs
       vars:
         log_files_collect_list:
-          - file_path: "/home/cchq/www/{{ deploy_env }}/log/**.log"
+          - file_path: "/home/cchq/www/{{ deploy_env }}/log/*.log"
             log_group_name: "webworkers"
             log_stream_name_suffix: ""
       tags:
@@ -34,10 +34,10 @@
     - role: cloudwatch_logs
       vars:
         log_files_collect_list:
-          - file_path: "/opt/data/elasticsearch-2.4.6/logs/**es.log**"
+          - file_path: "/opt/data/elasticsearch-2.4.6/logs/*es.log*"
             log_group_name: "elasticsearch"
             log_stream_name_suffix: "{{ deploy_env }}_es"
-          - file_path: "/opt/data/elasticsearch-2.4.6/logs/**es_index_search_slowlog.log**"
+          - file_path: "/opt/data/elasticsearch-2.4.6/logs/*es_index_search_slowlog.log*"
             log_group_name: "elasticsearch"
             log_stream_name_suffix: "{{ deploy_env }}_es_index_search_slowlog"
       tags:
@@ -51,10 +51,10 @@
     - role: cloudwatch_logs
       vars:
         log_files_collect_list:
-          - file_path: "/home/cchq/www/{{ deploy_env }}/log/**-nginx_access.log**"
+          - file_path: "/home/cchq/www/{{ deploy_env }}/log/*-nginx_access.log*"
             log_group_name: "couchdb2_proxy"
             log_stream_name_suffix: "nginx_access"
-          - file_path: "/home/cchq/www/{{ deploy_env }}/log/**-nginx_error.log**"
+          - file_path: "/home/cchq/www/{{ deploy_env }}/log/*-nginx_error.log*"
             log_group_name: "couchdb2_proxy"
             log_stream_name_suffix: "nginx_error"
       tags:
@@ -68,7 +68,7 @@
     - role: cloudwatch_logs
       vars:
         log_files_collect_list:
-          - file_path: "/home/cchq/www/{{ deploy_env }}/log/couchdb.stderr**"
+          - file_path: "/home/cchq/www/{{ deploy_env }}/log/couchdb.stderr*"
             log_group_name: "couchdb"
             log_stream_name_suffix: "stderr"
       tags:
@@ -82,7 +82,7 @@
     - role: cloudwatch_logs
       vars:
         log_files_collect_list:
-          - file_path: "/home/cchq/www/{{ deploy_env }}/log/**.log**"
+          - file_path: "/home/cchq/www/{{ deploy_env }}/log/*.log*"
             log_group_name: "celery"
             log_stream_name_suffix: ""
       tags:
@@ -96,7 +96,7 @@
     - role: cloudwatch_logs
       vars:
         log_files_collect_list:
-          - file_path: "/home/cchq/www/{{ deploy_env }}/log/**.log**"
+          - file_path: "/home/cchq/www/{{ deploy_env }}/log/*.log*"
             log_group_name: "pillowtop"
             log_stream_name_suffix: ""
       tags:
@@ -110,7 +110,7 @@
     - role: cloudwatch_logs
       vars:
         log_files_collect_list:
-          - file_path: "/home/cchq/www/{{ deploy_env }}/log/**.log**"
+          - file_path: "/home/cchq/www/{{ deploy_env }}/log/*.log*"
             log_group_name: "proxy"
             log_stream_name_suffix: ""
       tags:

--- a/src/commcare_cloud/ansible/deploy_cloudwatch_logs.yml
+++ b/src/commcare_cloud/ansible/deploy_cloudwatch_logs.yml
@@ -7,8 +7,7 @@
       vars:
         log_files_collect_list:
           - file_path: "/home/cchq/www/{{ deploy_env }}/log/formplayer*.log"
-            log_group_name: "formplayer"
-            log_stream_name_suffix: ""
+            log_group_name_suffix: "formplayer"
       tags:
         - formplayer
         - cloudwatch_logs
@@ -21,8 +20,7 @@
       vars:
         log_files_collect_list:
           - file_path: "/home/cchq/www/{{ deploy_env }}/log/*.log"
-            log_group_name: "webworkers"
-            log_stream_name_suffix: ""
+            log_group_name_suffix: "webworkers"
       tags:
         - webworkers
         - cloudwatch_logs
@@ -35,10 +33,10 @@
       vars:
         log_files_collect_list:
           - file_path: "/opt/data/elasticsearch-2.4.6/logs/*es.log*"
-            log_group_name: "elasticsearch"
+            log_group_name_suffix: "elasticsearch"
             log_stream_name_suffix: "{{ deploy_env }}_es"
           - file_path: "/opt/data/elasticsearch-2.4.6/logs/*es_index_search_slowlog.log*"
-            log_group_name: "elasticsearch"
+            log_group_name_suffix: "elasticsearch"
             log_stream_name_suffix: "{{ deploy_env }}_es_index_search_slowlog"
       tags:
         - elasticsearch
@@ -52,10 +50,10 @@
       vars:
         log_files_collect_list:
           - file_path: "/home/cchq/www/{{ deploy_env }}/log/*-nginx_access.log*"
-            log_group_name: "couchdb2_proxy"
+            log_group_name_suffix: "couchdb2_proxy"
             log_stream_name_suffix: "nginx_access"
           - file_path: "/home/cchq/www/{{ deploy_env }}/log/*-nginx_error.log*"
-            log_group_name: "couchdb2_proxy"
+            log_group_name_suffix: "couchdb2_proxy"
             log_stream_name_suffix: "nginx_error"
       tags:
         - couchdb2_proxy
@@ -69,7 +67,7 @@
       vars:
         log_files_collect_list:
           - file_path: "/home/cchq/www/{{ deploy_env }}/log/couchdb.stderr*"
-            log_group_name: "couchdb"
+            log_group_name_suffix: "couchdb2"
             log_stream_name_suffix: "stderr"
       tags:
         - couchdb2
@@ -83,8 +81,7 @@
       vars:
         log_files_collect_list:
           - file_path: "/home/cchq/www/{{ deploy_env }}/log/*.log*"
-            log_group_name: "celery"
-            log_stream_name_suffix: ""
+            log_group_name_suffix: "celery"
       tags:
         - celery
         - cloudwatch_logs
@@ -97,8 +94,7 @@
       vars:
         log_files_collect_list:
           - file_path: "/home/cchq/www/{{ deploy_env }}/log/*.log*"
-            log_group_name: "pillowtop"
-            log_stream_name_suffix: ""
+            log_group_name_suffix: "pillowtop"
       tags:
         - pillowtop
         - cloudwatch_logs
@@ -111,8 +107,7 @@
       vars:
         log_files_collect_list:
           - file_path: "/home/cchq/www/{{ deploy_env }}/log/*.log*"
-            log_group_name: "proxy"
-            log_stream_name_suffix: ""
+            log_group_name_suffix: "proxy"
       tags:
         - proxy
         - cloudwatch_logs

--- a/src/commcare_cloud/ansible/deploy_stack.yml
+++ b/src/commcare_cloud/ansible/deploy_stack.yml
@@ -19,3 +19,4 @@
 - import_playbook: migrate_on_fresh_install.yml
 - import_playbook: deploy_http_proxy.yml
 - import_playbook: deploy_logstash.yml
+- import_playbook: deploy_cloudwatch_logs.yml

--- a/src/commcare_cloud/ansible/roles/cloudwatch_logs/defaults/main.yml
+++ b/src/commcare_cloud/ansible/roles/cloudwatch_logs/defaults/main.yml
@@ -1,0 +1,1 @@
+log_files_collect_list: []

--- a/src/commcare_cloud/ansible/roles/cloudwatch_logs/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/cloudwatch_logs/tasks/main.yml
@@ -1,0 +1,30 @@
+- name: Check if cloudwatch-agent-ctl exists
+  shell: /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a status
+  become: yes
+  register: ctl_status
+  when: log_files_collect_list | length
+  tags: cloudwatch-logs
+
+- name: Configure and start cloudwatch agent
+  block:
+  - name: Create cloudwatch logs config
+    template:
+      src: "cloudwatch_logs.json.j2"
+      dest: "/opt/aws/amazon-cloudwatch-agent/etc/cloudwatch_logs.json"
+      group: cwagent
+      owner: cwagent
+      mode: 0644
+    become: yes
+    register: cloudwatch_logs_conf
+
+  - name: Reload cloudwatch agent if changed
+    shell: /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a append-config -m ec2 -s
+      -c file:/opt/aws/amazon-cloudwatch-agent/etc/cloudwatch_logs.json
+    become: yes
+    when: cloudwatch_logs_conf.changed
+
+  - name: Ensure cloudwatch agent enabled
+    shell: /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a start
+    become: yes
+  when:  log_files_collect_list | length
+  tags: cloudwatch-logs

--- a/src/commcare_cloud/ansible/roles/cloudwatch_logs/templates/cloudwatch_logs.json.j2
+++ b/src/commcare_cloud/ansible/roles/cloudwatch_logs/templates/cloudwatch_logs.json.j2
@@ -7,8 +7,8 @@
                 {% for cfg in log_files_collect_list -%}
                 {
                     "file_path": "{{ cfg.file_path }}",
-                    "log_group_name": "{{ cfg.log_group_name }}",
-                    "log_stream_name": "{instance_id}-{local_hostname}-{{ cfg.log_stream_name_suffix }}"
+                    "log_group_name": "{{ deploy_env }}-{{ cfg.log_group_name_suffix }}",
+                    "log_stream_name": "{instance_id}-{local_hostname}{%- if 'log_stream_name_suffix' in cfg %}-{{ cfg.log_stream_name_suffix }}{% endif %}"
                 }
                 {%- if not loop.last %}, {% endif %}
                 {%- endfor %}

--- a/src/commcare_cloud/ansible/roles/cloudwatch_logs/templates/cloudwatch_logs.json.j2
+++ b/src/commcare_cloud/ansible/roles/cloudwatch_logs/templates/cloudwatch_logs.json.j2
@@ -1,0 +1,19 @@
+{
+    "logs":
+    {
+        "logs_collected": {
+            "files": {
+                "collect_list": [
+                {% for cfg in log_files_collect_list -%}
+                {
+                    "file_path": "{{ cfg.file_path }}",
+                    "log_group_name": "{{ cfg.log_group_name }}",
+                    "log_stream_name": "{instance_id}-{{ cfg.log_stream_name_suffix }}"
+                }
+                {%- if not loop.last %}, {% endif %}
+                {%- endfor %}
+               ]
+           }
+        }
+    }
+}

--- a/src/commcare_cloud/ansible/roles/cloudwatch_logs/templates/cloudwatch_logs.json.j2
+++ b/src/commcare_cloud/ansible/roles/cloudwatch_logs/templates/cloudwatch_logs.json.j2
@@ -8,7 +8,7 @@
                 {
                     "file_path": "{{ cfg.file_path }}",
                     "log_group_name": "{{ cfg.log_group_name }}",
-                    "log_stream_name": "{instance_id}-{{ cfg.log_stream_name_suffix }}"
+                    "log_stream_name": "{instance_id}-{local_hostname}-{{ cfg.log_stream_name_suffix }}"
                 }
                 {%- if not loop.last %}, {% endif %}
                 {%- endfor %}


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-11088

`cloudwatch_logs` role creates log config json and loads it to the cloudwatch agent. Creates something like

<img width="1231" alt="Screen Shot 2020-08-20 at 1 54 49 PM" src="https://user-images.githubusercontent.com/615126/90807638-c300f300-e2ec-11ea-8f04-df0ad8226ebf.png">

Note: Not all of these have been applied to staging. 

TODO: 
- Right now for some log dirs, we just glob them altogether but a finer grain separation might be desired
- The simplest approach seemed to be to pass the var into the ansible call e.g.

```
      vars:
        log_files_collect_list:
          - file_path: "/home/cchq/www/{{ deploy_env }}/log/**.log**"
            log_group_name: "proxy"
            log_stream_name_suffix: ""
```
Mainly because I didn't know how to pass in a single entry from a global dict var. But we might want to do that and use terraform to create the [log groups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) if we wish to have different retention and encryption settings. 

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Staging, Prod, India