### PR TITLE
clean up npm and bower commands on deploy and always default to yarn

### DIFF
--- a/src/commcare_cloud/ansible/roles/nodejs/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/nodejs/tasks/main.yml
@@ -9,7 +9,7 @@
 
 - name: Add git nodejs repo
   apt_repository:
-    repo: 'deb https://deb.nodesource.com/node_8.x bionic main'
+    repo: 'deb https://deb.nodesource.com/node_12.x bionic main'
     state: present
   become: yes
   when: ansible_distribution_version == '18.04'

--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -799,8 +799,6 @@ ONLINE_DEPLOY_COMMANDS = [
     db.ensure_preindex_completion,
     db.ensure_checkpoints_safe,
     staticfiles.yarn_install,
-    staticfiles.bower_install,
-    staticfiles.npm_install,
     staticfiles.version_static,     # run after any new bower code has been installed
     staticfiles.collectstatic,
     staticfiles.compress,

--- a/src/commcare_cloud/fab/operations/staticfiles.py
+++ b/src/commcare_cloud/fab/operations/staticfiles.py
@@ -38,45 +38,8 @@ def version_static():
 
 
 @parallel
-@roles(set(ROLES_STATIC + ROLES_DJANGO))
-def bower_install():
-    yarn_lock = os.path.join(env.code_root, YARN_LOCK)
-    if files.exists(yarn_lock):
-        return
-
-    with cd(env.code_root):
-        config = {
-            'interactive': 'false',
-        }
-        if env.http_proxy:
-            config.update({
-                    'proxy': "http://{}".format(env.http_proxy),
-                    'https-proxy': "http://{}".format(env.http_proxy)
-            })
-        bower_command('prune', production=True, config=config)
-        bower_command('update', production=True, config=config)
-
-
-@parallel
-@roles(ROLES_STATIC + ROLES_DJANGO + ROLES_CELERY)
-def npm_install():
-    yarn_lock = os.path.join(env.code_root, YARN_LOCK)
-    if files.exists(yarn_lock):
-        return
-
-    with cd(env.code_root):
-        sudo('npm prune --production')
-        sudo('npm install --production')
-        sudo('npm update --production')
-
-
-@parallel
 @roles(ROLES_STATIC + ROLES_DJANGO + ROLES_CELERY)
 def yarn_install():
-    yarn_lock = os.path.join(env.code_root, YARN_LOCK)
-    if not files.exists(yarn_lock):
-        return
-
     with cd(env.code_root):
         sudo('yarn install --production')
 


### PR DESCRIPTION
A fresh environment sometimes tries to install js packages with npm instead of yarn, which causes errors.

##### ENVIRONMENTS AFFECTED
this affects deploy on all environments
