### PR TITLE
Change production compaction settings

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -79,7 +79,7 @@ couchdb2:
   password: "{{ COUCH_PASSWORD }}"
 
 couchdb_compaction_settings:
-  _default: '[{db_fragmentation, "6%"}, {view_fragmentation, "6%"}, {parallel_view_compaction, true}]'
+  _default: '[{db_fragmentation, "20%"}, {view_fragmentation, "20%"}, {parallel_view_compaction, true}]'
 
 
 couchdb2_client_max_body_size: 100M


### PR DESCRIPTION
We have a routine issue where ever couple weeks couch disk usage goes about 80% and I can resolve it by manually running compaction. Compaction is automatically running continuously which makes that really confusing. Last week I tested a hypothesis that the threshold, set at 6% fragmentation, was too low, and thus too many view and data files were being targeted for compaction at once, resulting in the compaction process not picking the most useful files to start with and not being able to keep up with the queue of things presumably needing compaction. To test this, I set couch14's threshold to 20% instead of 6%, telling it to focus on files with a higher bang for the buck. (If I set that too high, it'll wait too long to compact, so I still believe there's a sweet spot.)

The results were pretty conclusive, with couch14 immediately showing better disk usage than the other two machines and better able to maintain a flat level of disk usage over time once it reached equilibrium:
<img width="602" alt="Screen Shot 2020-08-24 at 10 18 43 AM" src="https://user-images.githubusercontent.com/137212/91063158-39ef0200-e5f3-11ea-9a1a-5b88bcd301d1.png">

This PR applies that change to all 3 production couch machines.

##### ENVIRONMENTS AFFECTED
production