### PR TITLE
Add 'secrets' command for working with secrets values

### DIFF
--- a/docs/commcare-cloud/commands/index.md
+++ b/docs/commcare-cloud/commands/index.md
@@ -11,7 +11,7 @@ All `commcare-cloud` commands take the following form:
 ```
 commcare-cloud [--control]
                <env>
-               {bootstrap-users,ansible-playbook,django-manage,aps,aws-sign-in,tmux,ap,validate-environment-settings,pillow-topic-assignments,openvpn-activate-user,deploy-stack,export-sentry-events,service,update-supervisor-confs,update-users,ping,migrate_couchdb,lookup,run-module,update-config,copy-files,couchdb-cluster-info,deploy,mosh,list-postgresql-dbs,after-reboot,ssh,downtime,fab,update-local-known-hosts,send-datadog-event,pillow-resource-report,aws-list,aws-fill-inventory,migrate-couchdb,terraform,openvpn-claim-user,celery-resource-report,run-shell-command,terraform-migrate-state}
+               {bootstrap-users,ansible-playbook,django-manage,aps,aws-sign-in,tmux,ap,validate-environment-settings,pillow-topic-assignments,openvpn-activate-user,deploy-stack,export-sentry-events,service,update-supervisor-confs,update-users,ping,migrate_couchdb,lookup,run-module,update-config,copy-files,couchdb-cluster-info,deploy,mosh,list-postgresql-dbs,after-reboot,ssh,downtime,fab,update-local-known-hosts,send-datadog-event,pillow-resource-report,aws-list,aws-fill-inventory,migrate-couchdb,terraform,secrets,openvpn-claim-user,celery-resource-report,run-shell-command,terraform-migrate-state}
                ...
 ```
 
@@ -629,6 +629,22 @@ Output as CSV
 ### Operational
 
 ---
+#### `secrets`
+
+View and edit secrets through the CLI
+
+```
+commcare-cloud <env> secrets {view,edit} secret_name
+```
+
+##### Positional Arguments
+
+###### `{view,edit}`
+
+###### `secret_name`
+
+---
+
 #### `ping`
 
 Ping specified or all machines to see if they have been provisioned yet.

--- a/src/commcare_cloud/commands/ansible/downtime.py
+++ b/src/commcare_cloud/commands/ansible/downtime.py
@@ -186,7 +186,7 @@ def initialize_datadog(environment):
     datadog_enabled = environment.public_vars.get('DATADOG_ENABLED', False)
     if datadog_enabled:
         datadog.initialize(
-            environment.get_secret('secrets.DATADOG_API_KEY'),
-            environment.get_secret('secrets.DATADOG_APP_KEY')
+            environment.get_secret('DATADOG_API_KEY'),
+            environment.get_secret('DATADOG_APP_KEY')
         )
         return True

--- a/src/commcare_cloud/commands/ansible/ops_tool.py
+++ b/src/commcare_cloud/commands/ansible/ops_tool.py
@@ -239,12 +239,12 @@ def get_couch_config(environment, nodes=None):
         control_node_ip=couch_nodes[0],
         control_node_port=15984,
         control_node_local_port=15986,
-        username=environment.get_secret('localsettings_private.COUCH_USERNAME'),
+        username=environment.get_secret('COUCH_USERNAME'),
         aliases={
             'couchdb@{}'.format(node): get_machine_alias(environment, node) for node in couch_nodes
         }
     )
-    config.set_password(environment.get_secret('localsettings_private.COUCH_PASSWORD'))
+    config.set_password(environment.get_secret('COUCH_PASSWORD'))
     return config
 
 

--- a/src/commcare_cloud/commands/ansible/run_module.py
+++ b/src/commcare_cloud/commands/ansible/run_module.py
@@ -203,12 +203,13 @@ class SendDatadogEvent(CommandBase):
     def run(self, args, unknown_args):
         args.module = 'datadog_event'
         environment = get_environment(args.env_name)
-        vault = environment.get_secret('secrets')
+        datadog_api_key = environment.get_secret('DATADOG_API_KEY')
+        datadog_app_key = environment.get_secret('DATADOG_APP_KEY')
         tags = "environment:{}".format(args.env_name)
         args.module_args = "api_key={api_key} app_key={app_key} " \
             "tags='{tags}' text='{text}' title='{title}' aggregation_key={agg}".format(
-                api_key=vault['DATADOG_API_KEY'],
-                app_key=vault['DATADOG_APP_KEY'],
+                api_key=datadog_api_key,
+                app_key=datadog_app_key,
                 tags=tags,
                 text=args.event_text,
                 title=args.event_title,

--- a/src/commcare_cloud/commands/secrets.py
+++ b/src/commcare_cloud/commands/secrets.py
@@ -1,0 +1,38 @@
+import getpass
+
+import six
+import yaml
+
+from commcare_cloud.commands.command_base import CommandBase, Argument
+from commcare_cloud.environment.main import get_environment
+
+
+class Secrets(CommandBase):
+    command = 'secrets'
+    help = (
+        "View and edit secrets through the CLI"
+    )
+
+    arguments = (
+        Argument(dest='subcommand', choices=['view', 'edit']),
+        Argument(dest='secret_name'),
+    )
+
+    def run(self, args, unknown_args):
+        environment = get_environment(args.env_name)
+        if args.subcommand == 'view':
+            return self._secrets_view(environment, args.secret_name)
+        if args.subcommand == 'edit':
+            return self._secrets_edit(environment, args.secret_name)
+
+    def _secrets_view(self, environment, secret_name):
+        secret = environment.get_secret(secret_name)
+        if isinstance(secret, six.string_types):
+            print(secret)
+        else:
+            print(yaml.safe_dump(secret))
+
+    def _secrets_edit(self, environment, secret_name):
+        environment.secrets_backend.prompt_user_input()
+        secret_value = getpass.getpass("New value for '{}' secret '{}': ".format(environment.name, secret_name))
+        environment.secrets_backend.set_secret(secret_name, secret_value)

--- a/src/commcare_cloud/commands/terraform/terraform.py
+++ b/src/commcare_cloud/commands/terraform/terraform.py
@@ -75,7 +75,7 @@ class Terraform(CommandBase):
 
         if not args.skip_secrets and unknown_args and unknown_args[0] in ('plan', 'apply'):
             rds_password = (
-                environment.get_secret('secrets.POSTGRES_USERS.root.password')
+                environment.get_secret('POSTGRES_USERS.root.password')
                 if environment.terraform_config.rds_instances
                 else ''
             )

--- a/src/commcare_cloud/commcare_cloud.py
+++ b/src/commcare_cloud/commcare_cloud.py
@@ -16,6 +16,7 @@ from commcare_cloud.commands.ansible.downtime import Downtime
 from commcare_cloud.commands.deploy import Deploy
 from commcare_cloud.commands.migrations.couchdb import MigrateCouchdb
 from commcare_cloud.commands.migrations.copy_files import CopyFiles
+from commcare_cloud.commands.secrets import Secrets
 from commcare_cloud.commands.sentry import ExportSentryEvents
 from commcare_cloud.commands.terraform.aws import AwsList, AwsFillInventory, AwsSignIn
 from commcare_cloud.commands.terraform.openvpn import OpenvpnActivateUser, OpenvpnClaimUser
@@ -60,6 +61,7 @@ COMMAND_GROUPS = OrderedDict([
         PillowTopicAssignments,
     ]),
     ('operational', [
+        Secrets,
         Ping,
         AnsiblePlaybook,
         DeployStack,

--- a/src/commcare_cloud/environment/secrets/backends/abstract_backend.py
+++ b/src/commcare_cloud/environment/secrets/backends/abstract_backend.py
@@ -57,6 +57,10 @@ class AbstractSecretsBackend(object):
     def get_secret(self, var):
         pass
 
+    @abc.abstractmethod
+    def set_secret(self, var, value):
+        pass
+
     @contextmanager
     def suppress_datadog_event(self):
         yield

--- a/src/commcare_cloud/environment/secrets/backends/ansible_vault/main.py
+++ b/src/commcare_cloud/environment/secrets/backends/ansible_vault/main.py
@@ -129,6 +129,9 @@ class AnsibleVaultSecretsBackend(AbstractSecretsBackend):
             context = context[node]
         return context
 
+    def set_secret(self, var, value):
+        raise NotImplementedError
+
     def _record_vault_loaded_event(self, secrets):
         if (
             self.should_send_vault_loaded_event and

--- a/src/commcare_cloud/manage_commcare_cloud/datadog_monitors.py
+++ b/src/commcare_cloud/manage_commcare_cloud/datadog_monitors.py
@@ -198,8 +198,8 @@ def get_data_to_update(monitor, keys_to_update):
 def initialize_datadog(config):
     env = get_environment(config.env_with_datadog_auth)
     initialize(
-        api_key=env.get_secret('secrets.DATADOG_API_KEY'),
-        app_key=env.get_secret('secrets.DATADOG_APP_KEY')
+        api_key=env.get_secret('DATADOG_API_KEY'),
+        app_key=env.get_secret('DATADOG_APP_KEY')
     )
 
 


### PR DESCRIPTION
Example usage:
```
cchq production secrets view POSTGRES_USERS.commcare.password
```

Currently the `set_secrets` method on the only currently existing secrets backend isn't implemented, so the `edit` command isn't useful yet. It's a little tricky to implement for vault without reformatting the vault file each time (and getting rid of comments) so I decided to punt for now. Will be useful for the new backend I'm working on though.

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
