### PR TITLE
Control NO_DEVICE_LOG_ENVS with new DEVICE_LOGS_ENABLED setting

### DIFF
--- a/environments/icds-cas/public.yml
+++ b/environments/icds-cas/public.yml
@@ -272,6 +272,7 @@ localsettings:
     - custom.icds.data_management.urls
   DAYS_TO_KEEP_DEVICE_LOGS: 45
   DEPLOY_MACHINE_NAME: "{{ alt_hostname|default(ansible_hostname) }}"
+  DEVICE_LOGS_ENABLED: no
   EMAIL_SMTP_HOST: relay.sendermile.com
   EMAIL_SMTP_PORT: 26
   EMAIL_USE_TLS: yes

--- a/environments/india/public.yml
+++ b/environments/india/public.yml
@@ -108,6 +108,7 @@ localsettings:
   COUCH_USERNAME: "{{ COUCH_USERNAME }}"
   COUCH_PASSWORD: "{{ COUCH_PASSWORD }}"
   DEPLOY_MACHINE_NAME: "{{ inventory_hostname }}"
+  DEVICE_LOGS_ENABLED: no
   EMAIL_SMTP_HOST: email-smtp.us-east-1.amazonaws.com
   EMAIL_SMTP_PORT: 587
   EMAIL_USE_TLS: yes

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -129,6 +129,7 @@ localsettings:
   COUCH_REINDEX_SCHEDULE: {'timedelta': {'minutes': 20}}
   CUSTOM_SYNCLOGS_DB: "synclogs_2017-11-01"
   DEPLOY_MACHINE_NAME: "{{ ansible_hostname }}"
+  DEVICE_LOGS_ENABLED: no
   EULA_COMPLIANCE: True
   EMAIL_SMTP_HOST: email-smtp.us-east-1.amazonaws.com
   EMAIL_SMTP_PORT: 587

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -1053,3 +1053,9 @@ LOCAL_REPEATER_CLASSES = json.loads('{{ localsettings.LOCAL_REPEATER_CLASSES|to_
 {% if localsettings.COMMCARE_EXTENSIONS is defined %}
 COMMCARE_EXTENSIONS = json.loads('{{ localsettings.COMMCARE_EXTENSIONS|to_json }}')
 {% endif %}
+
+{% if localsettings.DEVICE_LOGS_ENABLED|default(True) %}
+NO_DEVICE_LOG_ENVS = []
+{% else %}
+NO_DEVICE_LOG_ENVS = [{{ env_monitoring_id|to_json }}]
+{% endif %}


### PR DESCRIPTION
This lets us control whether device logs are enabled from the commcare-cloud environment rather than a global setting in `commmcare-hq/settings.py`.

This also adds india to that list

##### ENVIRONMENTS AFFECTED
india
