### PR TITLE
Making the airflow repo private

### DIFF
--- a/src/commcare_cloud/ansible/roles/airflow/defaults/main.yml
+++ b/src/commcare_cloud/ansible/roles/airflow/defaults/main.yml
@@ -1,6 +1,6 @@
 airflow_code_dir: "{{ airflow_home }}/pipes"
 airflow_dag_dir: "{{ airflow_home }}/dags"
 airflow_version: "master"
-airflow_repository: https://github.com/dimagi/pipes.git
+airflow_repository: git@github.com:dimagi/pipes.git
 airflow_dag_concurrency: 16
 airflow_parallelism: 32

--- a/src/commcare_cloud/ansible/roles/airflow/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/airflow/tasks/main.yml
@@ -10,6 +10,17 @@
     - "{{ airflow_home }}"
     - "{{ airflow_code_dir }}"
 
+- name: add deploy keys
+  become: yes
+  copy:
+    src: "{{ env_files_dir }}/{{ item.key }}"
+    dest: "{{ cchq_home }}/.ssh/{{ item.value }}"
+    owner: "{{ cchq_user }}"
+    group: "{{ cchq_user }}"
+    mode: 0600
+  loop: "{{ deploy_keys|dict2items }}"
+  when: deploy_keys is defined
+
 - name: Pull full Airflow source
   git:
     repo: "{{ airflow_repository }}"
@@ -18,6 +29,8 @@
     recursive: yes
     accept_hostkey: yes
     update: yes
+    deploy_key: deploy_key.pem
+    is_private: true
   become: yes
   become_user: "{{ cchq_user }}"
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Since we are more moving icds code private so the same, pipes repo (ariflow) is also turned private which in turns needs change in the deploy process to pull the private pipes repo.

##### ENVIRONMENTS AFFECTED
 - icds-staging
 - icds
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
