### PR TITLE
Add command to update a single user's public key

### DIFF
--- a/src/commcare_cloud/ansible/roles/bootstrap-users/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/bootstrap-users/tasks/main.yml
@@ -51,6 +51,8 @@
   authorized_key: user="{{ item }}" state=present key="{{ lookup('file', authorized_keys_dir ~ item ~ '.pub') }}" exclusive=yes
   with_items: '{{ dev_users.present }}'
   ignore_errors: "{{ ansible_check_mode }}"
+  tags:
+    - pubkey
 
 - name: Remove public key for cchq user  # todo: remove after applied to all envs
   become: yes

--- a/src/commcare_cloud/commands/ansible/ansible_playbook.py
+++ b/src/commcare_cloud/commands/ansible/ansible_playbook.py
@@ -334,6 +334,22 @@ class UpdateUsers(_AnsiblePlaybookAlias):
         return AnsiblePlaybook(self.parser).run(args, unknown_args)
 
 
+class UpdateUserPublicKey(_AnsiblePlaybookAlias):
+    command = 'update-user-key'
+    help = "Update a single user's public key (because update-users takes forever)."
+    arguments = _AnsiblePlaybookAlias.arguments + (
+        Argument("username", help="username who owns the public key"),
+    )
+
+    def run(self, args, unknown_args):
+        args.playbook = 'deploy_stack.yml'
+        unknown_args += (
+            '--tags=pubkey',
+            '--extra-vars={{"dev_users": {{"present": [{}]}}}}'.format(args.username),
+        )
+        return AnsiblePlaybook(self.parser).run(args, unknown_args)
+
+
 class UpdateSupervisorConfs(_AnsiblePlaybookAlias):
     command = 'update-supervisor-confs'
     help = """

--- a/src/commcare_cloud/commcare_cloud.py
+++ b/src/commcare_cloud/commcare_cloud.py
@@ -28,7 +28,7 @@ from .argparse14 import ArgumentParser, RawTextHelpFormatter
 from .commands.ansible.ansible_playbook import (
     AnsiblePlaybook,
     UpdateConfig, AfterReboot, BootstrapUsers, DeployStack,
-    UpdateUsers, UpdateSupervisorConfs,
+    UpdateUsers, UpdateUserPublicKey, UpdateSupervisorConfs,
 )
 from commcare_cloud.commands.ansible.service import Service
 from .commands.ansible.run_module import RunAnsibleModule, RunShellCommand, Ping, SendDatadogEvent
@@ -69,6 +69,7 @@ COMMAND_GROUPS = OrderedDict([
         AfterReboot,
         BootstrapUsers,
         UpdateUsers,
+        UpdateUserPublicKey,
         UpdateSupervisorConfs,
         Fab,
         Deploy,


### PR DESCRIPTION
This saves a lot of time when a user's public key changes. The `update-users` command, by comparison, takes much much longer to run.

Usage: `cchq <env> update-user-key <username>`
