### PR TITLE
update kafka log config

### DIFF
--- a/src/commcare_cloud/ansible/deploy_kafka.yml
+++ b/src/commcare_cloud/ansible/deploy_kafka.yml
@@ -32,21 +32,12 @@
   roles:
     - role: kernel_tune
  
-- name: Kafka system logs rolling configurations
+- name: cleanup
   hosts: kafka
   become: true
-  roles:
-    - role: ansible-logrotate
-      logrotate_scripts:
-        - name: "{{ deploy_env }}_kafka"
-          paths:
-            - "{{ kafka_log_dir | default('/var/log/kafka')}}/*.log.????-??-??-??"
-            - "{{ kafka_log_dir | default('/var/log/kafka') }}/*.out.*"
-          options:
-            - daily
-            - rotate 4
-            - missingok
-            - compress
-            - nocreate
-            - notifempty
-  tags: testit
+  tasks:
+    - name: remove legacy logrotate configs
+      file:
+        path: "/etc/logrotate.d/{{ deploy_env }}_kafka"
+        state: absent
+  tags: cleanup

--- a/src/commcare_cloud/ansible/roles/kafka/files/log4j_2.4.1.properties
+++ b/src/commcare_cloud/ansible/roles/kafka/files/log4j_2.4.1.properties
@@ -4,41 +4,53 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
 
-log4j.appender.kafkaAppender=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.kafkaAppender.DatePattern='.'yyyy-MM-dd-HH
+log4j.appender.kafkaAppender=org.apache.log4j.RollingFileAppender
 log4j.appender.kafkaAppender.File=${kafka.logs.dir}/server.log
 log4j.appender.kafkaAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.kafkaAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+log4j.appender.kafkaAppender.Append=true
+log4j.appender.kafkaAppender.MaxBackupIndex=10
+log4j.appender.kafkaAppender.MaxFileSize=50MB
 
-log4j.appender.stateChangeAppender=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.stateChangeAppender.DatePattern='.'yyyy-MM-dd-HH
+log4j.appender.stateChangeAppender=org.apache.log4j.RollingFileAppender
 log4j.appender.stateChangeAppender.File=${kafka.logs.dir}/state-change.log
 log4j.appender.stateChangeAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.stateChangeAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+log4j.appender.stateChangeAppender.Append=true
+log4j.appender.stateChangeAppender.MaxBackupIndex=10
+log4j.appender.stateChangeAppender.MaxFileSize=50MB
 
-log4j.appender.requestAppender=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.requestAppender.DatePattern='.'yyyy-MM-dd-HH
+log4j.appender.requestAppender=org.apache.log4j.RollingFileAppender
 log4j.appender.requestAppender.File=${kafka.logs.dir}/kafka-request.log
 log4j.appender.requestAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.requestAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+log4j.appender.requestAppender.Append=true
+log4j.appender.requestAppender.MaxBackupIndex=10
+log4j.appender.requestAppender.MaxFileSize=50MB
 
-log4j.appender.cleanerAppender=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.cleanerAppender.DatePattern='.'yyyy-MM-dd-HH
+log4j.appender.cleanerAppender=org.apache.log4j.RollingFileAppender
 log4j.appender.cleanerAppender.File=${kafka.logs.dir}/log-cleaner.log
 log4j.appender.cleanerAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.cleanerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+log4j.appender.cleanerAppender.Append=true
+log4j.appender.cleanerAppender.MaxBackupIndex=10
+log4j.appender.cleanerAppender.MaxFileSize=50MB
 
-log4j.appender.controllerAppender=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.controllerAppender.DatePattern='.'yyyy-MM-dd-HH
+log4j.appender.controllerAppender=org.apache.log4j.RollingFileAppender
 log4j.appender.controllerAppender.File=${kafka.logs.dir}/controller.log
 log4j.appender.controllerAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.controllerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+log4j.appender.controllerAppender.Append=true
+log4j.appender.controllerAppender.MaxBackupIndex=10
+log4j.appender.controllerAppender.MaxFileSize=50MB
 
-log4j.appender.authorizerAppender=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.authorizerAppender.DatePattern='.'yyyy-MM-dd-HH
+log4j.appender.authorizerAppender=org.apache.log4j.RollingFileAppender
 log4j.appender.authorizerAppender.File=${kafka.logs.dir}/kafka-authorizer.log
 log4j.appender.authorizerAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.authorizerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+log4j.appender.authorizerAppender.Append=true
+log4j.appender.authorizerAppender.MaxBackupIndex=10
+log4j.appender.authorizerAppender.MaxFileSize=50MB
 
 # Change the line below to adjust ZK client logging
 log4j.logger.org.apache.zookeeper=INFO


### PR DESCRIPTION
DailyRollingFileAppender has been observed to exhibit synchronization issues and data loss.

In addition to that it makes it very hard to use in conjunction with logrotate. 

This PR updates the Kafka logging configuration to use a vanilla `RollingFileAppender` which will also take care of cleaning up old logs.

##### ENVIRONMENTS AFFECTED
all
