### PR TITLE
only enable cloudwatch logs on certain environments

### DIFF
--- a/environments/india/public.yml
+++ b/environments/india/public.yml
@@ -224,3 +224,5 @@ kinesis_endpoint: "kinesis.ap-south-1.amazonaws.com"
 kinesis_flows:
   - file_pattern: "/opt/data/formplayer/log/request_response.*log"
     delivery_stream: "formplayer-request-response-logs-india"
+
+enable_cloudwatch_logs: true

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -188,3 +188,5 @@ commcare_cloud_pem: ~/.ssh/id_rsa
 kinesis_flows:
   - file_pattern: "/opt/data/formplayer/log/request_response.*log"
     delivery_stream: "formplayer-request-response-logs-production"
+
+enable_cloudwatch_logs: true

--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -149,3 +149,5 @@ commcare_cloud_pem: ~/.ssh/id_rsa
 kinesis_flows:
   - file_pattern: "/opt/data/formplayer/log/request_response.*log"
     delivery_stream: "formplayer-request-response-logs-staging"
+
+enable_cloudwatch_logs: true

--- a/src/commcare_cloud/ansible/roles/cloudwatch_logs/defaults/main.yml
+++ b/src/commcare_cloud/ansible/roles/cloudwatch_logs/defaults/main.yml
@@ -1,1 +1,2 @@
 log_files_collect_list: []
+enable_cloudwatch_logs: false

--- a/src/commcare_cloud/ansible/roles/cloudwatch_logs/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/cloudwatch_logs/tasks/main.yml
@@ -1,12 +1,10 @@
-- name: Check if cloudwatch-agent-ctl exists
-  shell: /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a status
-  become: yes
-  register: ctl_status
-  when: log_files_collect_list | length
-  tags: cloudwatch-logs
-
 - name: Configure and start cloudwatch agent
   block:
+  - name: Check if cloudwatch-agent-ctl exists
+    shell: /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a status
+    become: yes
+    register: ctl_status
+
   - name: Create cloudwatch logs config
     template:
       src: "cloudwatch_logs.json.j2"
@@ -26,5 +24,5 @@
   - name: Ensure cloudwatch agent enabled
     shell: /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a start
     become: yes
-  when:  log_files_collect_list | length
+  when: enable_cloudwatch_logs and log_files_collect_list | length
   tags: cloudwatch-logs


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Previous introduction of cloudwatch logs did not isolate environments. This isolates it to staging, production, and india. 

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Staging, Production, India