### PR TITLE
Use suggested max file descriptors for ES

### DIFF
--- a/src/commcare_cloud/ansible/roles/elasticsearch/templates/systemd/elasticsearch.service.j2
+++ b/src/commcare_cloud/ansible/roles/elasticsearch/templates/systemd/elasticsearch.service.j2
@@ -34,7 +34,7 @@ RestartSec=10
 StandardError=inherit
 
 # Specifies the maximum file descriptor number that can be opened by this process
-LimitNOFILE=32000
+LimitNOFILE=65536
 
 # Disable timeout logic and wait until process is stopped
 TimeoutStopSec=0


### PR DESCRIPTION
Found the following in ES log output:

> max file descriptors [32000] for elasticsearch process likely too low, consider increasing to at least [65536]


##### ENVIRONMENTS AFFECTED
all