### PR TITLE
Increase pgsynclog0-production max_storage

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -508,7 +508,7 @@ rds_instances:
   - identifier: "pgsynclog0-production"
     instance_type: "db.t3.2xlarge"
     storage: 1000
-    max_storage: 10000
+    max_storage: 20000
     multi_az: true
     engine_version: 9.6.15
     params:


### PR DESCRIPTION
It has been growing for about 8 weeks and our retention period is 9 weeks
so I think there is a chance it will level out at a new steady state
in a week or two. If it does not, then we will really need to investigate
the cause and make some optimizations before the disk becomes an even more major expense

<!--- Provide a link to the ticket or document which prompted this change -->

##### ENVIRONMENTS AFFECTED
production