### PR TITLE
added formplayer purge property

### DIFF
--- a/src/commcare_cloud/ansible/roles/formplayer/templates/application.properties.j2
+++ b/src/commcare_cloud/ansible/roles/formplayer/templates/application.properties.j2
@@ -55,3 +55,5 @@ management.port: 8081
 {% if formplayer_sensitive_data_logging %}
 sensitiveData.enableLogging=true
 {% endif %}
+
+commcare.formplayer.scheduledTasks.purge.cron=0 0 0 * * *


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-11257

Property file associated with https://github.com/dimagi/formplayer/pull/761 to schedule the purge task at midnight each night.  Does not alter the default `lockAtLeastFor` = `1h` and `lockAtMostFor` = `5h`.

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
all environments