### PR TITLE
Remove defunct prove-deploy build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,21 +10,11 @@ env:
     - TRAVIS_TEST=1
   matrix:
     - TEST=main
-    - TEST=prove-deploy
 
 matrix:
   fast_finish: true
 
 before_install:
-  # The next line exits out of the prove-deploy test if
-  #   - the test is not running from a cron event
-  #   - the last commit that was merged in doesn't contain [prove-deploy]
-  - |
-    if [[ $TEST = 'prove-deploy' && $TRAVIS_EVENT_TYPE != 'cron' ]] &&
-    echo $(git log --pretty=format:'%s %b' -n1 HEAD^2) | grep -iv '\[prove-deploy\]'
-    then
-      exit 0
-    fi
   # Make sure everything's up to date.
   - sudo apt-get clean
   - sudo apt-get update -qq
@@ -34,21 +24,6 @@ install:
   # Note: the installs must be done in the following order, otherwise the installation of commcare-cloud
   # tries to install from the commcare-cloud-bootstrap.egg_info directory
   - "pip install -e .[test]"
-  - mkdir ~/.aws
-  - touch ~/.aws/config
-  - touch ~/.aws/credentials
-  - touch ~/.ssh/commcarehq_testing.pem
-  - |
-    if [[ $TEST = 'prove-deploy' ]]
-    then
-      echo $VAULT_PASSWORD | ansible-vault --vault-password-file=/bin/cat decrypt .travis/secrets/.aws/config --output=~/.aws/config
-      echo $VAULT_PASSWORD | ansible-vault --vault-password-file=/bin/cat decrypt .travis/secrets/.aws/credentials --output=~/.aws/credentials
-      echo $VAULT_PASSWORD | ansible-vault --vault-password-file=/bin/cat decrypt .travis/secrets/.ssh/commcarehq_testing.pem --output=~/.ssh/commcarehq_testing.pem
-      pip install -e commcare-cloud-bootstrap
-    fi
 
 script:
   - ".travis/tests.sh"
-
-after_script:
-  - "if [[ $TEST = 'prove-deploy' ]]; then commcare-cloud-bootstrap terminate hq-${TRAVIS_COMMIT}; fi"

--- a/.travis/tests.sh
+++ b/.travis/tests.sh
@@ -38,24 +38,4 @@ then
     test_dimagi_environments
     nosetests -v
     test_autogen_docs
-
-elif [[ ${TEST} = 'prove-deploy' ]]
-then
-    bootstrap() {
-        ssh-keygen -f ~/.ssh/id_rsa -N "" -q
-        cp ~/.ssh/id_rsa.pub .travis/environments/_authorized_keys/travis.pub
-        (COMMCARE_CLOUD_ENVIRONMENTS=.travis/environments \
-            timeout 45m \
-            bash commcare-cloud-bootstrap/bootstrap.sh hq-${TRAVIS_COMMIT} ${BRANCH} .travis/spec.yml) || {
-                rc=$?
-                if [[ "${rc}" = 124 ]]
-                then
-                    echo "The bootstrapping process ran successfully for 45 minutes before being killed."
-                    echo "For now, for the purposes of this test, we're calling that a success"
-                else
-                    exit ${rc}
-                fi
-            }
-    }
-    bootstrap
 fi


### PR DESCRIPTION
The best little idea that never came to be. This build has sadly never passed, and we aren't able to get any value out of it. Rather than hold on, I think it's finally time to let it go. Any solution to the same problem (and I hear there's some work outside of SaaS on it) will likely end up being done differently anyway.

:(


##### ENVIRONMENTS AFFECTED
none