### PR TITLE
Allow configuration of Forwarding Header Processing

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -60,6 +60,7 @@ filebeat_inputs:
 
 formplayer_purge_time_spec: '5d'
 formplayer_sensitive_data_logging: true
+formplayer_forward_ip_proxy: true
 
 KSPLICE_ACTIVE: yes
 

--- a/src/commcare_cloud/ansible/roles/formplayer/templates/application.properties.j2
+++ b/src/commcare_cloud/ansible/roles/formplayer/templates/application.properties.j2
@@ -55,3 +55,7 @@ management.port: 8081
 {% if formplayer_sensitive_data_logging %}
 sensitiveData.enableLogging=true
 {% endif %}
+
+{% if formplayer_forward_ip_proxy %}
+server.forward-headers-strategy=NATIVE
+{% endif %}

--- a/src/commcare_cloud/ansible/roles/formplayer/vars/main.yml
+++ b/src/commcare_cloud/ansible/roles/formplayer/vars/main.yml
@@ -15,3 +15,7 @@ _formplayer_target_dir: "{{
   else formplayer_release_dir
 }}"
 formplayer_sensitive_data_logging: false
+
+# Instructs Spring Boot to process X-FORWARDED-FOR headers. Should be set if behind a 
+# trusted load balancer which forwards the original IP in headers.
+formplayer_forward_ip_proxy: false


### PR DESCRIPTION
Allows environments to direct Spring Boot to natively process `X-Forwarded-For` headers as provided by load balancers or proxies. 