### PR TITLE
Fix X-Forwarded-For with set_real_ip_from

### DIFF
--- a/environments/india/proxy.yml
+++ b/environments/india/proxy.yml
@@ -5,7 +5,5 @@ J2ME_SITE_HOST: 'j2me-india.commcarehq.org'
 tableau_server: 'tableau2.internal.commcarehq.org'
 TABLEAU_HOST: 'icds.commcarehq.org'
 primary_ssl_env: "india"
-
-# Nginx only accepts on cert, so cat the site cert and chain:
-# $ cat india.commcarehq.org.crt intermediate.crt > india.commcarehq.org.combined.crt
-letsencrypt_cchq_ssl: True
+trusted_proxies:
+  - 10.203.0.0/16

--- a/environments/production/proxy.yml
+++ b/environments/production/proxy.yml
@@ -4,6 +4,8 @@ NO_WWW_SITE_HOST: 'commcarehq.org'
 J2ME_SITE_HOST: 'j2mewww.commcarehq.org'
 # This sets production_commcare as the default endpoint for ssl connections
 primary_ssl_env: "production"
+trusted_proxies:
+  - 10.202.0.0/16
 
 nginx_hsts_max_age: 300 # 5 minutes
 nginx_ssl_protocols: "TLSv1.2"

--- a/environments/staging/proxy.yml
+++ b/environments/staging/proxy.yml
@@ -3,4 +3,5 @@ SITE_HOST: 'staging.commcarehq.org'
 J2ME_SITE_HOST: 'j2mestaging.commcarehq.org'
 primary_ssl_env: "staging"
 
-letsencrypt_cchq_ssl: True
+trusted_proxies:
+  - 10.201.0.0/16

--- a/src/commcare_cloud/ansible/roles/nginx/templates/site.j2
+++ b/src/commcare_cloud/ansible/roles/nginx/templates/site.j2
@@ -48,6 +48,10 @@ proxy_cache_path {{ cache.path }} levels=1:2 keys_zone={{ cache.name }}:10m
 
 server {
 {% if trusted_proxies %}
+  # These lines change the value of $remote_addr
+  # to first IP address travelling backwards in the incoming X-Forwarded-For
+  # that isn't in the ranges provided by trusted_proxies,
+  # i.e. the real client IP address
   real_ip_header X-Forwarded-For;
   {% for trusted_proxy in trusted_proxies %}
   set_real_ip_from {{ trusted_proxy }};

--- a/src/commcare_cloud/ansible/roles/nginx/templates/site.j2
+++ b/src/commcare_cloud/ansible/roles/nginx/templates/site.j2
@@ -47,6 +47,13 @@ proxy_cache_path {{ cache.path }} levels=1:2 keys_zone={{ cache.name }}:10m
 {% endfor %}
 
 server {
+{% if trusted_proxies %}
+  real_ip_header X-Forwarded-For;
+  {% for trusted_proxy in trusted_proxies %}
+  set_real_ip_from {{ trusted_proxy }};
+  {% endfor %}
+  real_ip_recursive on;
+{% endif %}
 
 {% for ip in nginx_block_ips %}
   deny {{ ip }};

--- a/src/commcare_cloud/ansible/roles/nginx/vars/cchq_ssl.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/cchq_ssl.yml
@@ -29,7 +29,7 @@ nginx_sites:
    proxy_max_temp_file_size: 5120m
    proxy_set_headers:
    - "Host $host"
-   - "X-Forwarded-For $proxy_add_x_forwarded_for"
+   - "X-Forwarded-For $remote_addr"
    - "X-Forwarded-Protocol  $scheme"
    access_log: "{{ log_home }}/{{ deploy_env }}-timing.log timing"
    add_header: X-XSS-Protection "1; mode=block"

--- a/src/commcare_cloud/ansible/roles/nginx/vars/cchq_ssl.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/cchq_ssl.yml
@@ -29,6 +29,9 @@ nginx_sites:
    proxy_max_temp_file_size: 5120m
    proxy_set_headers:
    - "Host $host"
+   # if trusted_proxies is used, $remote_addr is set by
+   # real_ip_header, set_real_ip_from, real_ip_recursive directives in site.j2
+   # to the the real client IP address (and not just an upstream proxy)
    - "X-Forwarded-For $remote_addr"
    - "X-Forwarded-Protocol  $scheme"
    access_log: "{{ log_home }}/{{ deploy_env }}-timing.log timing"

--- a/src/commcare_cloud/environment/schemas/proxy.py
+++ b/src/commcare_cloud/environment/schemas/proxy.py
@@ -18,6 +18,7 @@ class ProxyConfig(jsonobject.JsonObject):
     letsencrypt_cchq_ssl = jsonobject.BooleanProperty(default=False)
     letsencrypt_cas_ssl = jsonobject.BooleanProperty(default=False)
     primary_ssl_env = jsonobject.StringProperty()
+    trusted_proxies = jsonobject.ListProperty(str)
 
     special_sites = jsonobject.ListProperty(str)
     


### PR DESCRIPTION
This adds a variable, trusted_proxies, to proxy.yml, and then uses it to configure nginx to set the `X-Forwarded-For` to the real client IP address as opposed to either (1) the full chain including whatever the user passed in or (2) just the upstream proxy's IP address.

https://dimagi-dev.atlassian.net/browse/SAAS-11335

##### ENVIRONMENTS AFFECTED
production, staging, india