### PR TITLE
known port setting for Erlang couchdb cluster

### DIFF
--- a/src/commcare_cloud/ansible/roles/couchdb2/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/couchdb2/tasks/main.yml
@@ -9,6 +9,26 @@
     mode: 0644
   notify: restart couchdb2
 
+- name: Ensure that the Erlang VM listens on a known minimum port no.
+  become: yes
+  lineinfile:
+    dest: "{{ couchdb_dir }}/etc/vm.args"
+    line: "-kernel inet_dist_listen_min {{ couchdb_cluster_port }}"
+    line: "-kernel inet_dist_listen_max {{ couchdb_cluster_port }}"
+    insertafter: '^-sasl sasl_error_logger false'   
+    state: present
+  when: couchdb_cluster_port is defined
+
+- name: Ensure that the Erlang VM listens on a known maximum port no.
+  become: yes
+  lineinfile:
+    dest: "{{ couchdb_dir }}/etc/vm.args"
+    line: "-kernel inet_dist_listen_max {{ couchdb_cluster_port }}"
+    insertafter: '^-kernel inet_dist_listen_min {{ couchdb_cluster_port }}'
+    state: present
+  when: couchdb_cluster_port is defined
+  notify: restart couchdb2
+
 - meta: flush_handlers
 
 - name: Add nodes


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

Known port required for setting up couchdb cluster  on ICDS-SANDBOX due to NIC infrastructure port issue.

##### ENVIRONMENTS AFFECTED
ICDS-SANDBOX
