### PR TITLE
Fix tests and eliminate deprecation warning

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import
+from mock import patch
+
+from commcare_cloud.commands.terraform.aws import StringIsGuess
+
+
+def setup_package():
+    global patches
+    patches = [
+        patch.dict("os.environ", COMMCARE_CLOUD_DEFAULT_USERNAME=""),
+        # handle memoized decorator (in case get_default_username has already been called)
+        patch(
+            "commcare_cloud.commands.inventory_lookup.getinventory.get_default_username",
+            lambda: StringIsGuess("", is_guess=True),
+        ),
+
+    ]
+    for patch_ in patches:
+        patch_.start()
+
+
+def teardown_package():
+    for patch_ in patches:
+        patch_.stop()

--- a/tests/test_couch_migration.py
+++ b/tests/test_couch_migration.py
@@ -7,7 +7,7 @@ import yaml
 from couchdb_cluster_admin.doc_models import ShardAllocationDoc
 from mock.mock import patch
 from nose.tools import assert_equal
-from nose_parameterized import parameterized
+from parameterized import parameterized
 
 from commcare_cloud.commands.migrations.config import CouchMigration, PRUNE_PLAYBOOK_NAME, COUCH_SHARD_PLAN
 from commcare_cloud.commands.migrations.couchdb import generate_rsync_lists, \

--- a/tests/test_csv_inventory.py
+++ b/tests/test_csv_inventory.py
@@ -1,6 +1,6 @@
 import os
 
-from nose_parameterized import parameterized
+from parameterized import parameterized
 
 from commcare_cloud.environment.main import Environment
 from commcare_cloud.environment.paths import DefaultPaths

--- a/tests/test_getinventory.py
+++ b/tests/test_getinventory.py
@@ -2,7 +2,7 @@ import os
 
 from mock import patch
 from nose.tools import assert_equal, assert_raises
-from nose_parameterized import parameterized
+from parameterized import parameterized
 
 from commcare_cloud.commands.inventory_lookup.getinventory import (
     HostMatchException, HostPattern, get_server_address, split_host_group)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 
 from nose.tools import assert_equal, assert_dict_equal
-from nose_parameterized import parameterized
+from parameterized import parameterized
 
 from commcare_cloud.commands.ansible.helpers import ProcessDescriptor
 from commcare_cloud.commands.ansible.service import get_managed_service_options, get_processes_by_host, \


### PR DESCRIPTION
Tests were failing because of `COMMCARE_CLOUD_DEFAULT_USERNAME` in my environment.