### PR TITLE
Modernize Python code in preparation for upgrade to Python 3

### DIFF
--- a/.travis/tests.sh
+++ b/.travis/tests.sh
@@ -12,11 +12,13 @@ then
     cp .travis/environments/travis/private.yml .travis/environments/travis/vault.yml
 
     test_syntax() {
-        COMMCARE_CLOUD_ENVIRONMENTS=.travis/environments commcare-cloud travis deploy-stack --branch=${BRANCH}  --skip-check --quiet --syntax-check
+        COMMCARE_CLOUD_ENVIRONMENTS=.travis/environments \
+        commcare-cloud travis deploy-stack --branch=${BRANCH}  --skip-check --quiet --syntax-check
     }
 
     test_localsettings() {
-        COMMCARE_CLOUD_ENVIRONMENTS=.travis/environments commcare-cloud travis deploy-stack --branch=${BRANCH}  --skip-check --quiet --tags=py3,commcarehq
+        COMMCARE_CLOUD_ENVIRONMENTS=.travis/environments \
+        commcare-cloud travis deploy-stack --branch=${BRANCH}  --skip-check --quiet --tags=py3,commcarehq
         sudo python -m py_compile /home/cchq/www/travis/current/localsettings.py
     }
 
@@ -29,13 +31,9 @@ then
         COMMCARE_CLOUD_ENVIRONMENTS=commcare-environments ./tests/test_autogen_environments.sh
     }
 
-    test_autogen_docs() {
-        ./tests/test_autogen_docs.sh
-    }
-
     test_syntax
     test_localsettings
     test_dimagi_environments
     nosetests -v
-    test_autogen_docs
+    ./tests/test_autogen_docs.sh
 fi

--- a/.travis/tests.sh
+++ b/.travis/tests.sh
@@ -36,4 +36,5 @@ then
     test_dimagi_environments
     nosetests -v
     ./tests/test_autogen_docs.sh
+    ./tests/test_modernize.sh
 fi

--- a/commcare-cloud-bootstrap/commcare_cloud_bootstrap.py
+++ b/commcare-cloud-bootstrap/commcare_cloud_bootstrap.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from __future__ import absolute_import
 import argparse
 import json
 import os
@@ -16,6 +17,10 @@ import yaml
 import jsonobject
 
 from commcare_cloud.environment.main import get_environment
+import six
+from six.moves import range
+from six.moves import zip
+from six.moves import input
 
 TEMPLATE_DIR = os.path.join(os.path.dirname(__file__), 'environment')
 j2 = jinja2.Environment(loader=jinja2.FileSystemLoader(TEMPLATE_DIR))
@@ -98,7 +103,7 @@ class Host(StrictJsonObject):
 
 class Group(StrictJsonObject):
     name = jsonobject.StringProperty()
-    host_names = jsonobject.ListProperty(unicode)
+    host_names = jsonobject.ListProperty(six.text_type)
     vars = jsonobject.DictProperty()
 
 
@@ -206,7 +211,7 @@ def bootstrap_inventory(spec, env_name):
 def ask_aws_for_instances(env_name, aws_config, count):
     cache_file = '{env}-aws-new-instances.json'.format(env=env_name)
     if os.path.exists(cache_file):
-        cache_file_response = raw_input("\n{} already exists. Enter: "
+        cache_file_response = input("\n{} already exists. Enter: "
                                         "\n(d) to delete the file AND environment directory containing it, and"
                                         " terminate the existing aws instances or "
                                         "\n(anything) to continue using this file and these instances."
@@ -228,7 +233,7 @@ def ask_aws_for_instances(env_name, aws_config, count):
         cmd_parts = [
             'aws', 'ec2', 'run-instances',
             '--image-id', aws_config.ami,
-            '--count', unicode(int(count)),
+            '--count', six.text_type(int(count)),
             '--instance-type', aws_config.type,
             '--key-name', aws_config.key_name,
             '--security-group-ids', aws_config.security_group_id,

--- a/commcare-cloud-bootstrap/commcare_cloud_bootstrap.py
+++ b/commcare-cloud-bootstrap/commcare_cloud_bootstrap.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import argparse
 import json
 import os
@@ -109,7 +110,7 @@ class Group(StrictJsonObject):
 
 def provision_machines(spec, env_name=None, create_machines=True):
     if env_name is None:
-        env_name = u'hq-{}'.format(
+        env_name = 'hq-{}'.format(
             ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in range(7))
         )
     environment = get_environment(env_name)

--- a/commcare-cloud-bootstrap/generate_vault_passwords.py
+++ b/commcare-cloud-bootstrap/generate_vault_passwords.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import argparse
 import commcare_cloud_bootstrap as ccb
 

--- a/commcare-cloud-bootstrap/generate_vault_passwords.py
+++ b/commcare-cloud-bootstrap/generate_vault_passwords.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import argparse
 import commcare_cloud_bootstrap as ccb
 

--- a/commcare-cloud-bootstrap/setup.py
+++ b/commcare-cloud-bootstrap/setup.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from setuptools import setup, find_packages
 
 setup(

--- a/commcare-cloud-bootstrap/setup.py
+++ b/commcare-cloud-bootstrap/setup.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from setuptools import setup, find_packages
 
 setup(

--- a/fabfile.py
+++ b/fabfile.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 from sys import argv
 from time import sleep
 

--- a/fabfile.py
+++ b/fabfile.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import print_function
 from sys import argv
 from time import sleep
 

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup, find_packages
 
 test_deps = [
     'mock>=2.0.0',
+    'modernize',
     'nose>=1.3.7',
     'parameterized>=0.6.1',
 ]

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from setuptools import setup, find_packages
 
 test_deps = [

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from setuptools import setup, find_packages
 
 test_deps = [

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import unicode_literals
 from setuptools import setup, find_packages
 
 test_deps = [

--- a/src/commcare_cloud/alias.py
+++ b/src/commcare_cloud/alias.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import six
 
 
@@ -6,12 +7,12 @@ def _encode_args(*args, **kwargs):
 
     def encode_string(value):
         if isinstance(value, six.string_types + six.integer_types):
-            return unicode(value).encode('utf-8')
+            return six.text_type(value).encode('utf-8')
         else:
             TypeError("Do not know how to interpret type {} as a command-line argument: {}"
                       .format(type(value), value))
     for arg in args:
-        argv.append(unicode(arg).encode('utf-8'))
+        argv.append(six.text_type(arg).encode('utf-8'))
     for key, value in kwargs.items():
         if value is False or value is None:
             continue

--- a/src/commcare_cloud/alias.py
+++ b/src/commcare_cloud/alias.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import six
 
 

--- a/src/commcare_cloud/ansible/plugins/inventory/csv.py
+++ b/src/commcare_cloud/ansible/plugins/inventory/csv.py
@@ -1,5 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 
+from __future__ import unicode_literals
 import csv
 import json
 import os

--- a/src/commcare_cloud/ansible/plugins/lookup/cchq_aws_secret.py
+++ b/src/commcare_cloud/ansible/plugins/lookup/cchq_aws_secret.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import json
 import logging
 import os
-import six.moves.cPickle
+import six.moves.cPickle as pickle
 import time
 
 from ansible.plugins.lookup import aws_secret
@@ -76,8 +76,8 @@ class LookupModule(aws_secret.LookupModule):
                         # wait a short while and then try again from the top of the while True loop
                         time.sleep(.100)
                         continue
-                    return six.moves.cPickle.loads(Fernet(self._encryption_key()).decrypt(contents))
-            except (IOError, InvalidToken, six.moves.cPickle.UnpicklingError):
+                    return pickle.loads(Fernet(self._encryption_key()).decrypt(contents))
+            except (IOError, InvalidToken, pickle.UnpicklingError):
                 with open(self._secrets_cache_filename(term, inventory_dir=inventory_dir), 'wb') as f:
                     f.write(LOOKUP_IN_PROGRESS_ON_ANOTHER_FORK)
                 return Ellipsis
@@ -90,7 +90,7 @@ class LookupModule(aws_secret.LookupModule):
     def set_cache(self, term, value, inventory_dir):
         try:
             with open(self._secrets_cache_filename(term, inventory_dir=inventory_dir), 'wb') as f:
-                f.write(Fernet(self._encryption_key()).encrypt(six.moves.cPickle.dumps(value)))
+                f.write(Fernet(self._encryption_key()).encrypt(pickle.dumps(value)))
         except Exception as e:
             logging.warn('There was an error caching the secret {}'.format(e))
             raise

--- a/src/commcare_cloud/ansible/plugins/lookup/cchq_aws_secret.py
+++ b/src/commcare_cloud/ansible/plugins/lookup/cchq_aws_secret.py
@@ -1,7 +1,8 @@
+from __future__ import absolute_import
 import json
 import logging
 import os
-import cPickle
+import six.moves.cPickle
 import time
 
 from ansible.plugins.lookup import aws_secret
@@ -74,8 +75,8 @@ class LookupModule(aws_secret.LookupModule):
                         # wait a short while and then try again from the top of the while True loop
                         time.sleep(.100)
                         continue
-                    return cPickle.loads(Fernet(self._encryption_key()).decrypt(contents))
-            except (IOError, InvalidToken, cPickle.UnpicklingError):
+                    return six.moves.cPickle.loads(Fernet(self._encryption_key()).decrypt(contents))
+            except (IOError, InvalidToken, six.moves.cPickle.UnpicklingError):
                 with open(self._secrets_cache_filename(term, inventory_dir=inventory_dir), 'wb') as f:
                     f.write(LOOKUP_IN_PROGRESS_ON_ANOTHER_FORK)
                 return Ellipsis
@@ -88,7 +89,7 @@ class LookupModule(aws_secret.LookupModule):
     def set_cache(self, term, value, inventory_dir):
         try:
             with open(self._secrets_cache_filename(term, inventory_dir=inventory_dir), 'wb') as f:
-                f.write(Fernet(self._encryption_key()).encrypt(cPickle.dumps(value)))
+                f.write(Fernet(self._encryption_key()).encrypt(six.moves.cPickle.dumps(value)))
         except Exception as e:
             logging.warn('There was an error caching the secret {}'.format(e))
             raise

--- a/src/commcare_cloud/ansible/plugins/lookup/cchq_aws_secret.py
+++ b/src/commcare_cloud/ansible/plugins/lookup/cchq_aws_secret.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import json
 import logging
 import os

--- a/src/commcare_cloud/argparse14.py
+++ b/src/commcare_cloud/argparse14.py
@@ -10,6 +10,7 @@ rather than inlining this manual import magic.
 """
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import pkgutil
 from distutils.sysconfig import get_python_lib
 

--- a/src/commcare_cloud/cli_utils.py
+++ b/src/commcare_cloud/cli_utils.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import re
 import subprocess
 

--- a/src/commcare_cloud/colors.py
+++ b/src/commcare_cloud/colors.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+from __future__ import absolute_import
 from clint.textui import colored
 
 

--- a/src/commcare_cloud/commands/ansible/ansible_playbook.py
+++ b/src/commcare_cloud/commands/ansible/ansible_playbook.py
@@ -1,4 +1,6 @@
 # coding=utf-8
+from __future__ import absolute_import
+from __future__ import print_function
 import os
 import re
 import subprocess

--- a/src/commcare_cloud/commands/ansible/ansible_playbook.py
+++ b/src/commcare_cloud/commands/ansible/ansible_playbook.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 import os
 import re
 import subprocess

--- a/src/commcare_cloud/commands/ansible/downtime.py
+++ b/src/commcare_cloud/commands/ansible/downtime.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import inspect
 import os
 import time

--- a/src/commcare_cloud/commands/ansible/downtime.py
+++ b/src/commcare_cloud/commands/ansible/downtime.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+from __future__ import absolute_import
 import inspect
 import os
 import time

--- a/src/commcare_cloud/commands/ansible/helpers.py
+++ b/src/commcare_cloud/commands/ansible/helpers.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+from __future__ import absolute_import
 import itertools
 import os
 from collections import namedtuple, defaultdict
@@ -10,6 +11,7 @@ from commcare_cloud.cli_utils import has_arg, ask
 from commcare_cloud.colors import color_error, color_success
 from commcare_cloud.environment.paths import ANSIBLE_DIR, ANSIBLE_ROLES_PATH, ANSIBLE_COLLECTIONS_PATHS
 from six.moves import shlex_quote
+from six.moves import range
 
 DEPRECATED_ANSIBLE_ARGS = []
 

--- a/src/commcare_cloud/commands/ansible/helpers.py
+++ b/src/commcare_cloud/commands/ansible/helpers.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import itertools
 import os
 from collections import namedtuple, defaultdict
@@ -133,11 +134,11 @@ def run_action_with_check_mode(run_check, run_apply, skip_check, quiet=False, al
             # this means there was an error before ansible was able to start running
             return exit_code
         elif exit_code == 0:
-            puts(color_success(u"✓ Check completed with status code {}".format(exit_code)))
+            puts(color_success("✓ Check completed with status code {}".format(exit_code)))
             user_wants_to_apply = ask('Do you want to apply these changes?',
                                       quiet=quiet)
         else:
-            puts(color_error(u"✗ Check failed with status code {}".format(exit_code)))
+            puts(color_error("✗ Check failed with status code {}".format(exit_code)))
             user_wants_to_apply = ask('Do you want to try to apply these changes anyway?',
                                       quiet=quiet)
 
@@ -145,9 +146,9 @@ def run_action_with_check_mode(run_check, run_apply, skip_check, quiet=False, al
     if user_wants_to_apply:
         exit_code = run_apply()
         if exit_code == 0:
-            puts(color_success(u"✓ Apply completed with status code {}".format(exit_code)))
+            puts(color_success("✓ Apply completed with status code {}".format(exit_code)))
         else:
-            puts(color_error(u"✗ Apply failed with status code {}".format(exit_code)))
+            puts(color_error("✗ Apply failed with status code {}".format(exit_code)))
 
     return exit_code
 

--- a/src/commcare_cloud/commands/ansible/ops_tool.py
+++ b/src/commcare_cloud/commands/ansible/ops_tool.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 import collections
 import csv
 import subprocess
@@ -220,14 +221,14 @@ class CouchDBClusterInfo(CommandBase):
         environment = get_environment(args.env_name)
         couch_config = get_couch_config(environment)
 
-        puts(u'\nMembership')
+        puts('\nMembership')
         with indent():
             puts(get_membership(couch_config).get_printable())
 
-        puts(u'\nDB Info')
+        puts('\nDB Info')
         print_db_info(couch_config)
 
-        puts(u'\nShard allocation')
+        puts('\nShard allocation')
         print_shard_table([
             get_shard_allocation(couch_config, db_name)
             for db_name in sorted(get_db_list(couch_config.get_control_node()))

--- a/src/commcare_cloud/commands/ansible/ops_tool.py
+++ b/src/commcare_cloud/commands/ansible/ops_tool.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import print_function
 import collections
 import csv
 import subprocess

--- a/src/commcare_cloud/commands/ansible/run_module.py
+++ b/src/commcare_cloud/commands/ansible/run_module.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+from __future__ import absolute_import
 import os
 import subprocess
 from six.moves import shlex_quote

--- a/src/commcare_cloud/commands/ansible/run_module.py
+++ b/src/commcare_cloud/commands/ansible/run_module.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import os
 import subprocess
 from six.moves import shlex_quote

--- a/src/commcare_cloud/commands/ansible/service.py
+++ b/src/commcare_cloud/commands/ansible/service.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 import re
 from abc import ABCMeta, abstractmethod, abstractproperty
 from collections import defaultdict, OrderedDict

--- a/src/commcare_cloud/commands/ansible/service.py
+++ b/src/commcare_cloud/commands/ansible/service.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import print_function
 import re
 from abc import ABCMeta, abstractmethod, abstractproperty
 from collections import defaultdict, OrderedDict

--- a/src/commcare_cloud/commands/command_base.py
+++ b/src/commcare_cloud/commands/command_base.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import abc
 import inspect
 

--- a/src/commcare_cloud/commands/command_base.py
+++ b/src/commcare_cloud/commands/command_base.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import abc
 import inspect
 

--- a/src/commcare_cloud/commands/deploy.py
+++ b/src/commcare_cloud/commands/deploy.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 import sys
 from textwrap import dedent
 

--- a/src/commcare_cloud/commands/deploy.py
+++ b/src/commcare_cloud/commands/deploy.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import print_function
 import sys
 from textwrap import dedent
 

--- a/src/commcare_cloud/commands/fab.py
+++ b/src/commcare_cloud/commands/fab.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from __future__ import absolute_import
 import os
 import re
 import subprocess

--- a/src/commcare_cloud/commands/fab.py
+++ b/src/commcare_cloud/commands/fab.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import os
 import re
 import subprocess

--- a/src/commcare_cloud/commands/inventory_lookup/getinventory.py
+++ b/src/commcare_cloud/commands/inventory_lookup/getinventory.py
@@ -3,6 +3,7 @@ Utilities to get server hostname or IP address from an inventory file and group.
 """
 from __future__ import absolute_import, print_function
 
+from __future__ import unicode_literals
 import re
 
 import attr

--- a/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from __future__ import print_function
 
 import os

--- a/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import os
 import subprocess

--- a/src/commcare_cloud/commands/migrations/config.py
+++ b/src/commcare_cloud/commands/migrations/config.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import os
 
 import jsonobject

--- a/src/commcare_cloud/commands/migrations/config.py
+++ b/src/commcare_cloud/commands/migrations/config.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import os
 
 import jsonobject

--- a/src/commcare_cloud/commands/migrations/copy_files.py
+++ b/src/commcare_cloud/commands/migrations/copy_files.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import hashlib
 import os
 import shutil

--- a/src/commcare_cloud/commands/migrations/copy_files.py
+++ b/src/commcare_cloud/commands/migrations/copy_files.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import hashlib
 import os
 import shutil

--- a/src/commcare_cloud/commands/migrations/couchdb.py
+++ b/src/commcare_cloud/commands/migrations/couchdb.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 import difflib
 import json
 import os
@@ -308,21 +309,21 @@ def generate_shard_plan(migration):
 
 
 def describe(migration):
-    puts(u'\nMembership')
+    puts('\nMembership')
     with indent():
         puts(get_membership(migration.target_couch_config).get_printable())
-    puts(u'\nDB Info')
+    puts('\nDB Info')
     print_db_info(migration.target_couch_config)
 
-    puts(u'\nShard allocation')
+    puts('\nShard allocation')
     diff_with_db = None
     if os.path.exists(migration.shard_plan_path):
         diff_with_db = diff_plan(migration)
         if diff_with_db:
-            puts(color_highlight(u'DB allocation differs from plan:\n'))
-            puts(u"{}\n\n".format(diff_with_db))
+            puts(color_highlight('DB allocation differs from plan:\n'))
+            puts("{}\n\n".format(diff_with_db))
         else:
-            puts(color_success(u'DB allocation matches plan.'))
+            puts(color_success('DB allocation matches plan.'))
 
     if not diff_with_db:
         print_shard_table([
@@ -330,7 +331,7 @@ def describe(migration):
             for db_name in sorted(get_db_list(migration.target_couch_config.get_control_node()))
         ])
 
-    puts(u'\nShard count by node')
+    puts('\nShard count by node')
     print_shard_allocation_by_node([
         get_shard_allocation(migration.target_couch_config, db_name)
         for db_name in sorted(get_db_list(migration.target_couch_config.get_control_node()))

--- a/src/commcare_cloud/commands/migrations/couchdb.py
+++ b/src/commcare_cloud/commands/migrations/couchdb.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import print_function
 import difflib
 import json
 import os
@@ -29,6 +31,8 @@ from commcare_cloud.commands.migrations.copy_files import SourceFiles, prepare_f
     copy_scripts_to_target_host, execute_file_copy_scripts
 from commcare_cloud.commands.utils import render_template
 from commcare_cloud.environment.main import get_environment
+from six.moves import map
+from six.moves import zip
 
 TEMPLATE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'templates')
 PLAY_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'plays')
@@ -350,7 +354,7 @@ def print_shard_allocation_by_node(shard_allocation_docs):
         for node in nodes:
             row.append(len(by_node[node].get(db_name, [])))
         rows.append(row)
-    rows.append(["TOTAL"] + map(sum, zip(*rows)[1:]))
+    rows.append(["TOTAL"] + list(map(sum, zip(*rows))[1:]))
     print(tabulate(rows, headers=headers, tablefmt='simple'))
 
 

--- a/src/commcare_cloud/commands/secrets.py
+++ b/src/commcare_cloud/commands/secrets.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import print_function
 import getpass
 
 import six

--- a/src/commcare_cloud/commands/secrets.py
+++ b/src/commcare_cloud/commands/secrets.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 import getpass
 
 import six

--- a/src/commcare_cloud/commands/sentry.py
+++ b/src/commcare_cloud/commands/sentry.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 import json
 import sys
 

--- a/src/commcare_cloud/commands/sentry.py
+++ b/src/commcare_cloud/commands/sentry.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import print_function
 import json
 import sys
 

--- a/src/commcare_cloud/commands/shared_args.py
+++ b/src/commcare_cloud/commands/shared_args.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import os
 
 from commcare_cloud.commands.command_base import Argument

--- a/src/commcare_cloud/commands/shared_args.py
+++ b/src/commcare_cloud/commands/shared_args.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import os
 
 from commcare_cloud.commands.command_base import Argument

--- a/src/commcare_cloud/commands/terraform/aws.py
+++ b/src/commcare_cloud/commands/terraform/aws.py
@@ -2,6 +2,7 @@
 from __future__ import print_function
 
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import getpass
 import json
 import os
@@ -484,7 +485,7 @@ def _aws_sign_in_with_iam(aws_profile, duration_minutes=DEFAULT_SIGN_IN_DURATION
     mfa_token = input("Enter your MFA token: ")
     generate_session_profile(aws_profile, username, mfa_token, duration_minutes)
 
-    puts(color_success(u"✓ Sign in accepted"))
+    puts(color_success("✓ Sign in accepted"))
     puts("You will be able to use AWS from the command line for the next {} minutes."
          .format(duration_minutes))
     puts(color_notice(

--- a/src/commcare_cloud/commands/terraform/aws.py
+++ b/src/commcare_cloud/commands/terraform/aws.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 from __future__ import print_function
 
+from __future__ import absolute_import
 import getpass
 import json
 import os
@@ -613,6 +614,6 @@ def _iter_files_in_dir(directory):
             yield filepath
 
 
-def _ensure_all_dirs(path, mode=0700):
+def _ensure_all_dirs(path, mode=0o700):
     if not os.path.exists(path):
         os.makedirs(path, mode=mode)

--- a/src/commcare_cloud/commands/terraform/constants.py
+++ b/src/commcare_cloud/commands/terraform/constants.py
@@ -3,6 +3,7 @@
 #   ./manage.py list_waf_allow_patterns
 #
 # to replace the contents of the multiline string
+from __future__ import unicode_literals
 COMMCAREHQ_XML_POST_URLS_REGEX = r"""
 ^/a/([\w\.:-]+)/api/v([\d\.]+)/form/$
 ^/a/([\w\.:-]+)/apps/([\w-]+)/multimedia/uploaded/app_logo/([\w\-]+)/$

--- a/src/commcare_cloud/commands/terraform/migrations/0000_example.py
+++ b/src/commcare_cloud/commands/terraform/migrations/0000_example.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 def get_new_resource_address(environment, old_resource_address):
     """
     Specify migration by specifying for a given old address what the new address should be

--- a/src/commcare_cloud/commands/terraform/migrations/0001_make_more_things_root.py
+++ b/src/commcare_cloud/commands/terraform/migrations/0001_make_more_things_root.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 def get_new_resource_address(environment, old_resource_address):
     prefix = 'module.commcarehq.'
     if old_resource_address.startswith(prefix):

--- a/src/commcare_cloud/commands/terraform/migrations/0002_name_servers.py
+++ b/src/commcare_cloud/commands/terraform/migrations/0002_name_servers.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 def get_new_resource_address(environment, old_resource_address):
     import re
     server_matcher = re.compile(r'^module.servers.aws_instance.server\[(\d+)\]$')

--- a/src/commcare_cloud/commands/terraform/migrations/0002_name_servers.py
+++ b/src/commcare_cloud/commands/terraform/migrations/0002_name_servers.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 def get_new_resource_address(environment, old_resource_address):
     import re
     server_matcher = re.compile(r'^module.servers.aws_instance.server\[(\d+)\]$')

--- a/src/commcare_cloud/commands/terraform/migrations/0003_make_proxy_server_like_others.py
+++ b/src/commcare_cloud/commands/terraform/migrations/0003_make_proxy_server_like_others.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 def get_new_resource_address(environment, old_resource_address):
     import re
     server_matcher = re.compile(r'^module\.proxy_server__([\w-]+)\.aws_instance\.server$')

--- a/src/commcare_cloud/commands/terraform/migrations/0003_make_proxy_server_like_others.py
+++ b/src/commcare_cloud/commands/terraform/migrations/0003_make_proxy_server_like_others.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 def get_new_resource_address(environment, old_resource_address):
     import re
     server_matcher = re.compile(r'^module\.proxy_server__([\w-]+)\.aws_instance\.server$')

--- a/src/commcare_cloud/commands/terraform/migrations/0004_name_rds_instances.py
+++ b/src/commcare_cloud/commands/terraform/migrations/0004_name_rds_instances.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 def get_new_resource_address(environment, old_resource_address):
     import re
     server_matcher = re.compile(r'module\.postgresql-(\d+)\.(.*)$')

--- a/src/commcare_cloud/commands/terraform/migrations/0004_name_rds_instances.py
+++ b/src/commcare_cloud/commands/terraform/migrations/0004_name_rds_instances.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 def get_new_resource_address(environment, old_resource_address):
     import re
     server_matcher = re.compile(r'module\.postgresql-(\d+)\.(.*)$')

--- a/src/commcare_cloud/commands/terraform/migrations/0005_move_s3_log_bucket_to_logshipping.py
+++ b/src/commcare_cloud/commands/terraform/migrations/0005_move_s3_log_bucket_to_logshipping.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 def get_new_resource_address(environment, old_resource_address):
     if old_resource_address == 'module.ga_alb_waf.aws_s3_bucket.front_end_alb_logs':
         return 'module.logshipping.aws_s3_bucket.log_bucket'

--- a/src/commcare_cloud/commands/terraform/migrations/0006_create_firehose_stream_module_in_logshipping.py
+++ b/src/commcare_cloud/commands/terraform/migrations/0006_create_firehose_stream_module_in_logshipping.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 def get_new_resource_address(environment, old_resource_address):
     if old_resource_address == 'module.ga_alb_waf.aws_iam_role.firehose_role':
         return 'module.ga_alb_waf.module.firehose_stream.aws_iam_role.firehose_role'

--- a/src/commcare_cloud/commands/terraform/openvpn.py
+++ b/src/commcare_cloud/commands/terraform/openvpn.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from commcare_cloud.commands.ansible.ansible_playbook import run_ansible_playbook, \
     AnsiblePlaybook, _AnsiblePlaybookAlias
 from commcare_cloud.commands.command_base import CommandBase, Argument

--- a/src/commcare_cloud/commands/terraform/openvpn.py
+++ b/src/commcare_cloud/commands/terraform/openvpn.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from commcare_cloud.commands.ansible.ansible_playbook import run_ansible_playbook, \
     AnsiblePlaybook, _AnsiblePlaybookAlias
 from commcare_cloud.commands.command_base import CommandBase, Argument

--- a/src/commcare_cloud/commands/terraform/postgresql_units.py
+++ b/src/commcare_cloud/commands/terraform/postgresql_units.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import re
 
 import six

--- a/src/commcare_cloud/commands/terraform/postgresql_units.py
+++ b/src/commcare_cloud/commands/terraform/postgresql_units.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import re
 
 import six

--- a/src/commcare_cloud/commands/terraform/terraform.py
+++ b/src/commcare_cloud/commands/terraform/terraform.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import json
 import os
 import subprocess

--- a/src/commcare_cloud/commands/terraform/terraform.py
+++ b/src/commcare_cloud/commands/terraform/terraform.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+from __future__ import absolute_import
 import json
 import os
 import subprocess

--- a/src/commcare_cloud/commands/terraform/terraform_migrate_state.py
+++ b/src/commcare_cloud/commands/terraform/terraform_migrate_state.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import json
 import sys
 import tempfile

--- a/src/commcare_cloud/commands/terraform/terraform_migrate_state.py
+++ b/src/commcare_cloud/commands/terraform/terraform_migrate_state.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from __future__ import absolute_import
 import json
 import sys
 import tempfile
@@ -211,7 +212,7 @@ class _SimulatedState(object):
         return self._address_to_resource[address]
 
     def list(self):
-        return self._address_to_resource.keys()
+        return list(self._address_to_resource.keys())
 
     def address_is_free(self, address):
         return address not in self._address_to_resource

--- a/src/commcare_cloud/commands/terraform/tests/test_postgresql_units.py
+++ b/src/commcare_cloud/commands/terraform/tests/test_postgresql_units.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from nose.tools import assert_equal, assert_raises
 from parameterized.test import assert_contains
 

--- a/src/commcare_cloud/commands/terraform/tests/test_postgresql_units.py
+++ b/src/commcare_cloud/commands/terraform/tests/test_postgresql_units.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from nose.tools import assert_equal, assert_raises
 from parameterized.test import assert_contains
 

--- a/src/commcare_cloud/commands/terraform/tests/test_terraform_migrations.py
+++ b/src/commcare_cloud/commands/terraform/tests/test_terraform_migrations.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import re
 from collections import namedtuple
 

--- a/src/commcare_cloud/commands/terraform/tests/test_terraform_migrations.py
+++ b/src/commcare_cloud/commands/terraform/tests/test_terraform_migrations.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import re
 from collections import namedtuple
 
@@ -5,6 +6,7 @@ from nose.tools import assert_equal
 
 from commcare_cloud.commands.terraform.terraform_migrate_state import get_migrations, \
     Migration, make_migration_plans, MigrationPlan
+from six.moves import range
 
 
 def test_numbering():

--- a/src/commcare_cloud/commands/utils.py
+++ b/src/commcare_cloud/commands/utils.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import os
 
 from jinja2 import Environment, FileSystemLoader

--- a/src/commcare_cloud/commands/utils.py
+++ b/src/commcare_cloud/commands/utils.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import os
 
 from jinja2 import Environment, FileSystemLoader

--- a/src/commcare_cloud/commands/validate_environment_settings.py
+++ b/src/commcare_cloud/commands/validate_environment_settings.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from clint.textui import puts
 
 from commcare_cloud.colors import color_error, color_success
@@ -21,7 +22,7 @@ class ValidateEnvironmentSettings(CommandBase):
         try:
             environment.check()
         except Exception:
-            puts(color_error(u"✗ The environment has the following error:"))
+            puts(color_error("✗ The environment has the following error:"))
             raise
         else:
-            puts(color_success(u"✓ The environment configuration is valid."))
+            puts(color_success("✓ The environment configuration is valid."))

--- a/src/commcare_cloud/commands/validate_environment_settings.py
+++ b/src/commcare_cloud/commands/validate_environment_settings.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+from __future__ import absolute_import
 from clint.textui import puts
 
 from commcare_cloud.colors import color_error, color_success

--- a/src/commcare_cloud/commcare_cloud.py
+++ b/src/commcare_cloud/commcare_cloud.py
@@ -2,6 +2,7 @@
 from __future__ import print_function
 from __future__ import absolute_import
 
+from __future__ import unicode_literals
 import inspect
 import os
 import sys

--- a/src/commcare_cloud/environment/constants.py
+++ b/src/commcare_cloud/environment/constants.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import jsonobject
 
 

--- a/src/commcare_cloud/environment/constants.py
+++ b/src/commcare_cloud/environment/constants.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import jsonobject
 
 

--- a/src/commcare_cloud/environment/main.py
+++ b/src/commcare_cloud/environment/main.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import os
 import re
 

--- a/src/commcare_cloud/environment/main.py
+++ b/src/commcare_cloud/environment/main.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import os
 import re
 
@@ -24,6 +25,7 @@ from commcare_cloud.environment.schemas.proxy import ProxyConfig
 from commcare_cloud.environment.schemas.terraform import TerraformConfig
 from commcare_cloud.environment.schemas.prometheus import PrometheusConfig
 from commcare_cloud.environment.users import UsersConfig
+from six.moves import map
 
 
 class Environment(object):

--- a/src/commcare_cloud/environment/paths.py
+++ b/src/commcare_cloud/environment/paths.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import print_function
 import os
 import sys
 from distutils.sysconfig import get_python_lib

--- a/src/commcare_cloud/environment/paths.py
+++ b/src/commcare_cloud/environment/paths.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 import os
 import sys
 from distutils.sysconfig import get_python_lib

--- a/src/commcare_cloud/environment/schemas/app_processes.py
+++ b/src/commcare_cloud/environment/schemas/app_processes.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from collections import Counter, namedtuple
 
 import jsonobject

--- a/src/commcare_cloud/environment/schemas/app_processes.py
+++ b/src/commcare_cloud/environment/schemas/app_processes.py
@@ -1,11 +1,13 @@
 from __future__ import print_function
 
+from __future__ import absolute_import
 from collections import Counter, namedtuple
 
 import jsonobject
 from clint.textui import puts, indent
 
 from commcare_cloud.colors import color_warning
+import six
 
 IpAddressProperty = jsonobject.StringProperty
 IpAddressAndPortProperty = jsonobject.StringProperty
@@ -45,7 +47,7 @@ class AppProcessesConfig(jsonobject.JsonObject):
     datadog_pythonagent = jsonobject.BooleanProperty()
     additional_no_proxy_hosts = CommaSeparatedStrings()
 
-    service_blacklist = jsonobject.ListProperty(unicode)
+    service_blacklist = jsonobject.ListProperty(six.text_type)
     management_commands = jsonobject.DictProperty(jsonobject.DictProperty())
     celery_processes = jsonobject.DictProperty(jsonobject.DictProperty(CeleryOptions))
     pillows = jsonobject.DictProperty(jsonobject.DictProperty(PillowOptions))

--- a/src/commcare_cloud/environment/schemas/aws.py
+++ b/src/commcare_cloud/environment/schemas/aws.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import jsonobject
 
 

--- a/src/commcare_cloud/environment/schemas/aws.py
+++ b/src/commcare_cloud/environment/schemas/aws.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import jsonobject
 
 

--- a/src/commcare_cloud/environment/schemas/elasticsearch.py
+++ b/src/commcare_cloud/environment/schemas/elasticsearch.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import jsonobject
 
 

--- a/src/commcare_cloud/environment/schemas/elasticsearch.py
+++ b/src/commcare_cloud/environment/schemas/elasticsearch.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import jsonobject
 
 

--- a/src/commcare_cloud/environment/schemas/fab_settings.py
+++ b/src/commcare_cloud/environment/schemas/fab_settings.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 import jsonobject
 
 from commcare_cloud.colors import color_notice, color_code

--- a/src/commcare_cloud/environment/schemas/fab_settings.py
+++ b/src/commcare_cloud/environment/schemas/fab_settings.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import print_function
 import jsonobject
 
 from commcare_cloud.colors import color_notice, color_code

--- a/src/commcare_cloud/environment/schemas/meta.py
+++ b/src/commcare_cloud/environment/schemas/meta.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import re
 
 import jsonobject

--- a/src/commcare_cloud/environment/schemas/meta.py
+++ b/src/commcare_cloud/environment/schemas/meta.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import re
 
 import jsonobject
@@ -8,6 +9,7 @@ from commcare_cloud.environment.exceptions import EnvironmentException
 from commcare_cloud.environment.secrets.backends import all_secrets_backends_by_name
 from commcare_cloud.environment.secrets.backends.abstract_backend import AbstractSecretsBackend
 from commcare_cloud.fab.utils import get_github_credentials
+import six
 
 
 @memoized
@@ -57,13 +59,13 @@ class MetaConfig(jsonobject.JsonObject):
     deploy_env = jsonobject.StringProperty(required=True)
     always_deploy_formplayer = jsonobject.BooleanProperty(default=False)
     env_monitoring_id = jsonobject.StringProperty(required=True)
-    users = jsonobject.ListProperty(unicode, required=True)
+    users = jsonobject.ListProperty(six.text_type, required=True)
     slack_alerts_channel = jsonobject.StringProperty()
     bare_non_cchq_environment = jsonobject.BooleanProperty(default=False)
     git_repositories = jsonobject.ListProperty(GitRepository)
-    deploy_keys = jsonobject.DictProperty(unicode)
+    deploy_keys = jsonobject.DictProperty(six.text_type)
     secrets_backend = jsonobject.StringProperty(
-        choices=all_secrets_backends_by_name.keys(),
+        choices=list(all_secrets_backends_by_name),
         default='ansible-vault',
     )
 

--- a/src/commcare_cloud/environment/schemas/postgresql.py
+++ b/src/commcare_cloud/environment/schemas/postgresql.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import copy
 from collections import defaultdict
 

--- a/src/commcare_cloud/environment/schemas/postgresql.py
+++ b/src/commcare_cloud/environment/schemas/postgresql.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import copy
 from collections import defaultdict
 
@@ -9,6 +10,7 @@ import six
 from commcare_cloud.environment.constants import constants
 from commcare_cloud.environment.exceptions import PGConfigException
 from commcare_cloud.environment.schemas.role_defaults import get_defaults_jsonobject
+from six.moves import range
 
 PostgresqlOverride = get_defaults_jsonobject(
     'postgresql_base',
@@ -210,11 +212,11 @@ class PostgresqlConfig(jsonobject.JsonObject):
                 db.name = all_dbs_by_alias[db.master].name
 
     def generate_postgresql_dbs(self):
-        return filter(None, [
+        return [_f for _f in [
             self.dbs.main, self.dbs.synclogs,
         ] + (
             self.dbs.form_processing.get_db_list() if self.dbs.form_processing else []
-        ) + [self.dbs.ucr, self.dbs.formplayer] + self.dbs.custom + self.dbs.standby)
+        ) + [self.dbs.ucr, self.dbs.formplayer] + self.dbs.custom + self.dbs.standby if _f]
 
     def _check_reporting_databases(self):
         referenced_django_aliases = set()
@@ -297,7 +299,7 @@ class DBOptions(jsonobject.JsonObject):
     port = jsonobject.IntegerProperty(default=None)
     user = jsonobject.StringProperty()
     password = jsonobject.StringProperty()
-    options = jsonobject.DictProperty(unicode)
+    options = jsonobject.DictProperty(six.text_type)
     django_alias = jsonobject.StringProperty()
     django_migrate = jsonobject.BooleanProperty(default=True)
     query_stats = jsonobject.BooleanProperty(default=False)

--- a/src/commcare_cloud/environment/schemas/prometheus.py
+++ b/src/commcare_cloud/environment/schemas/prometheus.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import jsonobject
 
 

--- a/src/commcare_cloud/environment/schemas/proxy.py
+++ b/src/commcare_cloud/environment/schemas/proxy.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import jsonobject
 
 

--- a/src/commcare_cloud/environment/schemas/proxy.py
+++ b/src/commcare_cloud/environment/schemas/proxy.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import jsonobject
 
 

--- a/src/commcare_cloud/environment/schemas/role_defaults.py
+++ b/src/commcare_cloud/environment/schemas/role_defaults.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import jsonobject
 from commcare_cloud.environment.paths import get_role_defaults
 

--- a/src/commcare_cloud/environment/schemas/role_defaults.py
+++ b/src/commcare_cloud/environment/schemas/role_defaults.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import jsonobject
 from commcare_cloud.environment.paths import get_role_defaults
 

--- a/src/commcare_cloud/environment/schemas/role_defaults.py
+++ b/src/commcare_cloud/environment/schemas/role_defaults.py
@@ -18,8 +18,10 @@ def get_defaults_jsonobject(role, **kwargs):
     :return: The new JsonObject subclass.
     """
     cls = type(jsonobject.JsonObject)(
-        '{}_Defaults'.format(role), (jsonobject.JsonObject,),
-        dict(get_role_defaults(role), _allow_dynamic_properties=False, **kwargs))
+        str('{}_Defaults'.format(role)),  # bytes in Python 2, text in Python 3
+        (jsonobject.JsonObject,),
+        dict(get_role_defaults(role), _allow_dynamic_properties=False, **kwargs),
+    )
 
     # exclude from to_json if set to the default value
     def exclude(self, value):

--- a/src/commcare_cloud/environment/schemas/terraform.py
+++ b/src/commcare_cloud/environment/schemas/terraform.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import jsonobject
 from clint.textui import puts
 from commcare_cloud.colors import color_warning

--- a/src/commcare_cloud/environment/schemas/terraform.py
+++ b/src/commcare_cloud/environment/schemas/terraform.py
@@ -1,6 +1,8 @@
+from __future__ import absolute_import
 import jsonobject
 from clint.textui import puts
 from commcare_cloud.colors import color_warning
+from six.moves import range
 
 
 class TerraformConfig(jsonobject.JsonObject):

--- a/src/commcare_cloud/environment/schemas/tests/test_terraform_schema.py
+++ b/src/commcare_cloud/environment/schemas/tests/test_terraform_schema.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from commcare_cloud.environment.schemas.terraform import ServerConfig
 
 

--- a/src/commcare_cloud/environment/schemas/tests/test_terraform_schema.py
+++ b/src/commcare_cloud/environment/schemas/tests/test_terraform_schema.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from commcare_cloud.environment.schemas.terraform import ServerConfig
 
 

--- a/src/commcare_cloud/environment/secrets/backends/__init__.py
+++ b/src/commcare_cloud/environment/secrets/backends/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from commcare_cloud.environment.secrets.backends.ansible_vault.main import AnsibleVaultSecretsBackend
 from commcare_cloud.environment.secrets.backends.aws_secrets.main import AwsSecretsBackend
 

--- a/src/commcare_cloud/environment/secrets/backends/abstract_backend.py
+++ b/src/commcare_cloud/environment/secrets/backends/abstract_backend.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import abc
 from contextlib import contextmanager
 

--- a/src/commcare_cloud/environment/secrets/backends/abstract_backend.py
+++ b/src/commcare_cloud/environment/secrets/backends/abstract_backend.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import abc
 from contextlib import contextmanager
 

--- a/src/commcare_cloud/environment/secrets/backends/ansible_vault/main.py
+++ b/src/commcare_cloud/environment/secrets/backends/ansible_vault/main.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 import getpass
 import os
 import sys

--- a/src/commcare_cloud/environment/secrets/backends/ansible_vault/main.py
+++ b/src/commcare_cloud/environment/secrets/backends/ansible_vault/main.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import print_function
 import getpass
 import os
 import sys

--- a/src/commcare_cloud/environment/secrets/backends/ansible_vault/tests/test_secrets_list.py
+++ b/src/commcare_cloud/environment/secrets/backends/ansible_vault/tests/test_secrets_list.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import os
 
 import yaml

--- a/src/commcare_cloud/environment/secrets/backends/ansible_vault/tests/test_secrets_list.py
+++ b/src/commcare_cloud/environment/secrets/backends/ansible_vault/tests/test_secrets_list.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import os
 
 import yaml

--- a/src/commcare_cloud/environment/secrets/backends/aws_secrets/main.py
+++ b/src/commcare_cloud/environment/secrets/backends/aws_secrets/main.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import json
 import sys
 

--- a/src/commcare_cloud/environment/secrets/backends/aws_secrets/main.py
+++ b/src/commcare_cloud/environment/secrets/backends/aws_secrets/main.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import json
 import sys
 

--- a/src/commcare_cloud/environment/secrets/backends/aws_secrets/tests/test_secrets_list.py
+++ b/src/commcare_cloud/environment/secrets/backends/aws_secrets/tests/test_secrets_list.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import os
 
 import yaml

--- a/src/commcare_cloud/environment/secrets/backends/aws_secrets/tests/test_secrets_list.py
+++ b/src/commcare_cloud/environment/secrets/backends/aws_secrets/tests/test_secrets_list.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import os
 
 import yaml

--- a/src/commcare_cloud/environment/secrets/secrets_schema.py
+++ b/src/commcare_cloud/environment/secrets/secrets_schema.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import os
 
 import jsonobject

--- a/src/commcare_cloud/environment/secrets/secrets_schema.py
+++ b/src/commcare_cloud/environment/secrets/secrets_schema.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import os
 
 import jsonobject

--- a/src/commcare_cloud/environment/secrets/utils.py
+++ b/src/commcare_cloud/environment/secrets/utils.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import difflib
 
 import yaml

--- a/src/commcare_cloud/environment/secrets/utils.py
+++ b/src/commcare_cloud/environment/secrets/utils.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import difflib
 
 import yaml

--- a/src/commcare_cloud/environment/users.py
+++ b/src/commcare_cloud/environment/users.py
@@ -1,4 +1,6 @@
+from __future__ import absolute_import
 import jsonobject
+import six
 
 
 class UsersConfig(jsonobject.JsonObject):
@@ -7,5 +9,5 @@ class UsersConfig(jsonobject.JsonObject):
 
 
 class DevUsers(jsonobject.JsonObject):
-    present = jsonobject.ListProperty(unicode)
-    absent = jsonobject.ListProperty(unicode)
+    present = jsonobject.ListProperty(six.text_type)
+    absent = jsonobject.ListProperty(six.text_type)

--- a/src/commcare_cloud/fab/checks/check_servers.py
+++ b/src/commcare_cloud/fab/checks/check_servers.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 from fabric.api import roles, env, sudo, run, hide
 from fabric.context_managers import cd
 from fabric.decorators import runs_once

--- a/src/commcare_cloud/fab/const.py
+++ b/src/commcare_cloud/fab/const.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import os
 
 PROJECT_ROOT = os.path.dirname(__file__)

--- a/src/commcare_cloud/fab/exceptions.py
+++ b/src/commcare_cloud/fab/exceptions.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 class PreindexNotFinished(Exception):
     """Thrown when a preindex of the database is not finished in a certain time period"""
 

--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -27,6 +27,7 @@ Server layout:
 """
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 import datetime
 import functools
 import os

--- a/src/commcare_cloud/fab/operations/airflow.py
+++ b/src/commcare_cloud/fab/operations/airflow.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from __future__ import unicode_literals
 import os
 
 from fabric.api import roles, sudo, env

--- a/src/commcare_cloud/fab/operations/db.py
+++ b/src/commcare_cloud/fab/operations/db.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import datetime
 import time
 

--- a/src/commcare_cloud/fab/operations/formplayer.py
+++ b/src/commcare_cloud/fab/operations/formplayer.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import datetime
 import os
 

--- a/src/commcare_cloud/fab/operations/offline.py
+++ b/src/commcare_cloud/fab/operations/offline.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 import os
 from datetime import datetime
 

--- a/src/commcare_cloud/fab/operations/release.py
+++ b/src/commcare_cloud/fab/operations/release.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+from __future__ import unicode_literals
 import functools
 import os
 import posixpath

--- a/src/commcare_cloud/fab/operations/staticfiles.py
+++ b/src/commcare_cloud/fab/operations/staticfiles.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from __future__ import unicode_literals
 import os
 
 from fabric.api import roles, parallel, sudo, env

--- a/src/commcare_cloud/fab/operations/supervisor.py
+++ b/src/commcare_cloud/fab/operations/supervisor.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 import time
 from contextlib import contextmanager
 

--- a/src/commcare_cloud/fab/utils.py
+++ b/src/commcare_cloud/fab/utils.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+from __future__ import unicode_literals
 import datetime
 import os
 import pickle
@@ -230,7 +231,7 @@ def _retrieve_cached(filename):
 def traceback_string():
     exc_type, exc, tb = sys.exc_info()
     trace = "".join(traceback.format_tb(tb))
-    return u"Traceback:\n{trace}{type}: {exc}".format(
+    return "Traceback:\n{trace}{type}: {exc}".format(
         trace=trace,
         type=exc_type.__name__,
         exc=exc,

--- a/src/commcare_cloud/fabfile.py
+++ b/src/commcare_cloud/fabfile.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import sys
 import os
 

--- a/src/commcare_cloud/manage_commcare_cloud/__init__.py
+++ b/src/commcare_cloud/manage_commcare_cloud/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from .manage_commcare_cloud import main
 
 

--- a/src/commcare_cloud/manage_commcare_cloud/configure.py
+++ b/src/commcare_cloud/manage_commcare_cloud/configure.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import print_function
 import os
 import textwrap
 from six.moves import shlex_quote

--- a/src/commcare_cloud/manage_commcare_cloud/configure.py
+++ b/src/commcare_cloud/manage_commcare_cloud/configure.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 import os
 import textwrap
 from six.moves import shlex_quote

--- a/src/commcare_cloud/manage_commcare_cloud/datadog_monitors.py
+++ b/src/commcare_cloud/manage_commcare_cloud/datadog_monitors.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 import difflib
 import os
 import re

--- a/src/commcare_cloud/manage_commcare_cloud/datadog_monitors.py
+++ b/src/commcare_cloud/manage_commcare_cloud/datadog_monitors.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import print_function
 import difflib
 import os
 import re

--- a/src/commcare_cloud/manage_commcare_cloud/get.py
+++ b/src/commcare_cloud/manage_commcare_cloud/get.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from __future__ import absolute_import
 from commcare_cloud.commands.command_base import CommandBase
 from commcare_cloud.environment.paths import ANSIBLE_DIR, get_available_envs
 

--- a/src/commcare_cloud/manage_commcare_cloud/get.py
+++ b/src/commcare_cloud/manage_commcare_cloud/get.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from commcare_cloud.commands.command_base import CommandBase
 from commcare_cloud.environment.paths import ANSIBLE_DIR, get_available_envs
 

--- a/src/commcare_cloud/manage_commcare_cloud/install.py
+++ b/src/commcare_cloud/manage_commcare_cloud/install.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import os
 import subprocess
 from six.moves import shlex_quote

--- a/src/commcare_cloud/manage_commcare_cloud/install.py
+++ b/src/commcare_cloud/manage_commcare_cloud/install.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import os
 import subprocess
 from six.moves import shlex_quote

--- a/src/commcare_cloud/manage_commcare_cloud/list_vault_keys.py
+++ b/src/commcare_cloud/manage_commcare_cloud/list_vault_keys.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-
+from __future__ import absolute_import
 from collections import defaultdict
 from itertools import chain
 

--- a/src/commcare_cloud/manage_commcare_cloud/list_vault_keys.py
+++ b/src/commcare_cloud/manage_commcare_cloud/list_vault_keys.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from collections import defaultdict
 from itertools import chain
 

--- a/src/commcare_cloud/manage_commcare_cloud/make_changelog.py
+++ b/src/commcare_cloud/manage_commcare_cloud/make_changelog.py
@@ -115,4 +115,4 @@ class MakeChangelog(CommandBase):
         template = j2.get_template('changelog.md.j2')
 
         text = template.render(changelog_entry=changelog_entry, ordinal=ordinal)
-        print(text.rstrip().encode("utf-8").replace('{{', "{{ '{{' }}"))
+        print(text.rstrip().replace('{{', "{{ '{{' }}").encode("utf-8"))

--- a/src/commcare_cloud/manage_commcare_cloud/make_changelog.py
+++ b/src/commcare_cloud/manage_commcare_cloud/make_changelog.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 from __future__ import absolute_import
 
+from __future__ import unicode_literals
 import jsonobject
 
 import jinja2

--- a/src/commcare_cloud/manage_commcare_cloud/make_docs.py
+++ b/src/commcare_cloud/manage_commcare_cloud/make_docs.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import cgi
 import inspect
 import os

--- a/src/commcare_cloud/manage_commcare_cloud/make_docs.py
+++ b/src/commcare_cloud/manage_commcare_cloud/make_docs.py
@@ -6,7 +6,7 @@ import cgi
 import inspect
 import os
 import textwrap
-from StringIO import StringIO
+from io import StringIO
 
 import jinja2
 

--- a/src/commcare_cloud/manage_commcare_cloud/make_docs.py
+++ b/src/commcare_cloud/manage_commcare_cloud/make_docs.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+from __future__ import absolute_import
 import cgi
 import inspect
 import os
@@ -13,6 +14,7 @@ from gettext import gettext as _
 
 from commcare_cloud.commands.command_base import CommandBase
 from commcare_cloud.commcare_cloud import make_command_parser, COMMAND_GROUPS
+from six.moves import range
 
 
 class _Section(RawTextHelpFormatter._Section):

--- a/src/commcare_cloud/manage_commcare_cloud/manage_commcare_cloud.py
+++ b/src/commcare_cloud/manage_commcare_cloud/manage_commcare_cloud.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from __future__ import unicode_literals
 from commcare_cloud.manage_commcare_cloud.datadog_monitors import UpdateDatadogMonitors, ListDatadogMonitors
 from commcare_cloud.manage_commcare_cloud.test_environments import TestEnvironments
 from ..argparse14 import ArgumentParser

--- a/src/commcare_cloud/manage_commcare_cloud/test_environments.py
+++ b/src/commcare_cloud/manage_commcare_cloud/test_environments.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from __future__ import absolute_import
 from commcare_cloud.commands.command_base import CommandBase
 
 

--- a/src/commcare_cloud/manage_commcare_cloud/test_environments.py
+++ b/src/commcare_cloud/manage_commcare_cloud/test_environments.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from commcare_cloud.commands.command_base import CommandBase
 
 

--- a/src/commcare_cloud/manage_commcare_cloud/tests/test_environments.py
+++ b/src/commcare_cloud/manage_commcare_cloud/tests/test_environments.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+from __future__ import absolute_import
 import pickle
 from ipaddress import ip_address
 from parameterized import parameterized

--- a/src/commcare_cloud/manage_commcare_cloud/tests/test_environments.py
+++ b/src/commcare_cloud/manage_commcare_cloud/tests/test_environments.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import pickle
 from ipaddress import ip_address
 from parameterized import parameterized

--- a/src/commcare_cloud/manage_commcare_cloud/yaml_representers.py
+++ b/src/commcare_cloud/manage_commcare_cloud/yaml_representers.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import collections
 
 import yaml

--- a/src/commcare_cloud/manage_commcare_cloud/yaml_representers.py
+++ b/src/commcare_cloud/manage_commcare_cloud/yaml_representers.py
@@ -1,10 +1,12 @@
+from __future__ import absolute_import
 import collections
 
 import yaml
 from yaml.representer import SafeRepresenter
+import six
 
 
-class LiteralUnicode(unicode):
+class LiteralUnicode(six.text_type):
     pass
 
 

--- a/src/commcare_cloud/parse_help.py
+++ b/src/commcare_cloud/parse_help.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from collections import namedtuple
 import os
 import subprocess

--- a/src/commcare_cloud/parse_help.py
+++ b/src/commcare_cloud/parse_help.py
@@ -1,8 +1,10 @@
 from __future__ import print_function
+from __future__ import absolute_import
 from collections import namedtuple
 import os
 import subprocess
 import sys
+from six.moves import range
 
 ANSIBLE_HELP_OPTIONS_PREFIX='optional arguments:'
 _HELP_CACHE = os.path.join(os.path.dirname(__file__), 'help_cache')

--- a/src/commcare_cloud/patch_environ.py
+++ b/src/commcare_cloud/patch_environ.py
@@ -2,6 +2,7 @@
 from __future__ import print_function
 from __future__ import absolute_import
 
+from __future__ import unicode_literals
 import os
 import sys
 from clint.textui import puts

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from mock import patch
 
 from commcare_cloud.commands.terraform.aws import StringIsGuess

--- a/tests/test_couch_migration.py
+++ b/tests/test_couch_migration.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+from __future__ import absolute_import
 import os
 import shutil
 

--- a/tests/test_couch_migration.py
+++ b/tests/test_couch_migration.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import os
 import shutil
 

--- a/tests/test_csv_inventory.py
+++ b/tests/test_csv_inventory.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import os
 
 from parameterized import parameterized

--- a/tests/test_csv_inventory.py
+++ b/tests/test_csv_inventory.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import os
 
 from parameterized import parameterized

--- a/tests/test_file_migration.py
+++ b/tests/test_file_migration.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import os
 import shutil
 

--- a/tests/test_file_migration.py
+++ b/tests/test_file_migration.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import os
 import shutil
 

--- a/tests/test_getinventory.py
+++ b/tests/test_getinventory.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import os
 
 from mock import patch

--- a/tests/test_getinventory.py
+++ b/tests/test_getinventory.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import os
 
 from mock import patch

--- a/tests/test_jinja_templates.py
+++ b/tests/test_jinja_templates.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import fnmatch
 import os
 

--- a/tests/test_jinja_templates.py
+++ b/tests/test_jinja_templates.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import fnmatch
 import os
 

--- a/tests/test_modernize.sh
+++ b/tests/test_modernize.sh
@@ -1,0 +1,23 @@
+#! /bin/bash
+# Verify that python-modernize is a no-op
+#
+# The python-modernize command below should be updated each time a new
+# modernizer fix is applied to the codebase.
+#
+# undo-modernizations.diff may need to be updated if new lines are added
+# that would be, but should not be modernized.
+set -e
+function do_diff() {
+    git --no-pager diff --quiet || echo -e "\nERROR: $1"
+    git --no-pager diff --exit-code
+}
+
+do_diff "Unexpected diff before modernize"
+# use find to exclude python3 scripts
+find . -name '*.py' \
+    ! -path ./scripts/aws/derive_ses_smtp_password.py \
+    ! -path ./scripts/es_snapshot.py \
+    ! -path ./src/commcare_cloud/ansible/roles/pg_repack/files/pg_repack.py \
+    -exec python-modernize --no-diffs -wnf default --future-unicode {} +
+git apply tests/undo-superfluous-modernizations.diff
+do_diff "Unexpected diff after modernize"

--- a/tests/test_postgresql_config.py
+++ b/tests/test_postgresql_config.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import os
 from unittest import SkipTest
 

--- a/tests/test_postgresql_config.py
+++ b/tests/test_postgresql_config.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+from __future__ import absolute_import
 import os
 from unittest import SkipTest
 
@@ -24,7 +25,7 @@ def test_postgresql_config(env_name):
 
     with open(env.paths.generated_yml) as f:
         generated = yaml.safe_load(f)
-        assert generated.keys() == ['postgresql_dbs']
+        assert list(generated.keys()) == ['postgresql_dbs']
 
     expected_json = generated['postgresql_dbs']
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+from __future__ import absolute_import
 import itertools
 import os
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import itertools
 import os
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+from __future__ import absolute_import
 from nose.tools import assert_equal, assert_dict_equal
 from parameterized import parameterized
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 from __future__ import absolute_import
+from __future__ import unicode_literals
 from nose.tools import assert_equal, assert_dict_equal
 from parameterized import parameterized
 

--- a/tests/test_ssh.py
+++ b/tests/test_ssh.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import os
 import subprocess
 

--- a/tests/test_ssh.py
+++ b/tests/test_ssh.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import os
 import subprocess
 

--- a/tests/undo-superfluous-modernizations.diff
+++ b/tests/undo-superfluous-modernizations.diff
@@ -1,0 +1,110 @@
+diff --git a/commcare-cloud-bootstrap/commcare_cloud_bootstrap.py b/commcare-cloud-bootstrap/commcare_cloud_bootstrap.py
+index b4076b012..978f3af03 100644
+--- a/commcare-cloud-bootstrap/commcare_cloud_bootstrap.py
++++ b/commcare-cloud-bootstrap/commcare_cloud_bootstrap.py
+@@ -127,7 +127,7 @@ def provision_machines(spec, env_name=None, create_machines=True):
+ 
+     hosts_by_name = {}
+ 
+-    for host, (public_ip, private_ip) in zip(inventory.all_hosts, list(instance_ip_addresses.values())):
++    for host, (public_ip, private_ip) in zip(inventory.all_hosts, instance_ip_addresses.values()):
+         host.public_ip = public_ip
+         host.private_ip = private_ip
+         host.vars['hostname'] = host.name
+@@ -170,7 +170,7 @@ def alphanumeric_sort_key(key):
+ 
+ 
+ def bootstrap_inventory(spec, env_name):
+-    incomplete = dict(list(spec.allocations.items()))
++    incomplete = dict(spec.allocations.items())
+ 
+     inventory = Inventory()
+ 
+diff --git a/src/commcare_cloud/commands/ansible/ops_tool.py b/src/commcare_cloud/commands/ansible/ops_tool.py
+index 430e17f9a..7d1af83b0 100644
+--- a/src/commcare_cloud/commands/ansible/ops_tool.py
++++ b/src/commcare_cloud/commands/ansible/ops_tool.py
+@@ -128,7 +128,7 @@ class CeleryResourceReport(CommandBase):
+         if args.show_workers:
+             headers.append('Worker Hosts')
+         rows = []
+-        for queue_name, stats in sorted(list(by_queue.items()), key=itemgetter(0)):
++        for queue_name, stats in sorted(by_queue.items(), key=itemgetter(0)):
+             workers = stats['num_workers']
+             concurrency_ = stats['concurrency']
+             row = [list(stats['pooling'])[0], '`{}`'.format(queue_name), workers, concurrency_, concurrency_ // workers]
+@@ -168,7 +168,7 @@ class PillowResourceReport(CommandBase):
+         headers = ['Pillow', 'Processes']
+         rows = [
+             [queue_name, stats['num_processes']]
+-            for queue_name, stats in sorted(list(by_process.items()), key=itemgetter(0))
++            for queue_name, stats in sorted(by_process.items(), key=itemgetter(0))
+         ]
+ 
+         print_table(headers, rows, args.csv)
+diff --git a/src/commcare_cloud/commands/ansible/service.py b/src/commcare_cloud/commands/ansible/service.py
+index 848051193..c8c0c1c52 100644
+--- a/src/commcare_cloud/commands/ansible/service.py
++++ b/src/commcare_cloud/commands/ansible/service.py
+@@ -576,7 +576,7 @@ def optimize_process_operations(all_processes_by_host, process_host_mapping):
+ 
+     processes_by_hosts = {}
+     # group hosts together so we do less calls to ansible
+-    items = sorted(list(processes_by_host.items()), key=lambda hp: hp[1])
++    items = sorted(processes_by_host.items(), key=lambda hp: hp[1])
+     for processes, group in groupby(items, key=lambda hp: hp[1]):
+         hosts = tuple(sorted([host_processes[0] for host_processes in group]))
+         processes_by_hosts[hosts] = processes
+diff --git a/src/commcare_cloud/environment/main.py b/src/commcare_cloud/environment/main.py
+index 7e091c705..8bff10977 100644
+--- a/src/commcare_cloud/environment/main.py
++++ b/src/commcare_cloud/environment/main.py
+@@ -350,7 +350,7 @@ class Environment(object):
+             ),
+             'new_release_name': datetime.utcnow().strftime('%Y-%m-%d_%H.%M'),
+             'git_repositories': [repo.to_generated_variables() for repo in self.meta_config.git_repositories],
+-            'deploy_keys': dict(list(self.meta_config.deploy_keys.items())),
++            'deploy_keys': dict(self.meta_config.deploy_keys.items()),
+         }
+         if not self.meta_config.bare_non_cchq_environment:
+             generated_variables.update(self.app_processes_config.to_generated_variables())
+diff --git a/src/commcare_cloud/environment/schemas/postgresql.py b/src/commcare_cloud/environment/schemas/postgresql.py
+index 77b02363e..c3fcabe1d 100644
+--- a/src/commcare_cloud/environment/schemas/postgresql.py
++++ b/src/commcare_cloud/environment/schemas/postgresql.py
+@@ -349,7 +349,7 @@ class FormProcessingConfig(jsonobject.JsonObject):
+         return (
+             [self.proxy]
+             + ([self.proxy_standby] if self.proxy_standby.host else [])
+-            + sorted(list(self.partitions.values()), key=lambda db: alphanum_key(db.django_alias))
++            + sorted(self.partitions.values(), key=lambda db: alphanum_key(db.django_alias))
+         )
+ 
+ 
+diff --git a/src/commcare_cloud/manage_commcare_cloud/list_vault_keys.py b/src/commcare_cloud/manage_commcare_cloud/list_vault_keys.py
+index c4821e8df..2e0eff6a2 100644
+--- a/src/commcare_cloud/manage_commcare_cloud/list_vault_keys.py
++++ b/src/commcare_cloud/manage_commcare_cloud/list_vault_keys.py
+@@ -37,7 +37,7 @@ class ListVaultKeys(CommandBase):
+         headers = ["key"] + [env for env in envs if env in var_keys]
+ 
+         rows = []
+-        for key in sorted(set(chain.from_iterable(list(var_keys.values())))):
++        for key in sorted(set(chain.from_iterable(var_keys.values()))):
+             row = ['.'.join(part if part is not None else '*' for part in key)]
+             by_var = defaultdict(set)
+             for env in envs:
+diff --git a/tests/test_schemas.py b/tests/test_schemas.py
+index c8881058f..36dcc370e 100644
+--- a/tests/test_schemas.py
++++ b/tests/test_schemas.py
+@@ -18,7 +18,7 @@ TEST_ENVIRONMENTS_DIR = os.path.join(os.path.dirname(__file__), 'test_envs')
+ def test_get_machine_alias():
+     env = get_environment('small_cluster')
+ 
+-    all_hosts = set(itertools.chain.from_iterable(list(env.groups.values())))
++    all_hosts = set(itertools.chain.from_iterable(env.groups.values()))
+     assert_equal(all_hosts, {'172.19.3.0', '172.19.3.1', '172.19.3.2', '172.19.3.3'})
+     aliases = set([get_machine_alias(env, host) for host in all_hosts])
+     assert_equal(aliases, {'demo_server0', 'demo_server1', 'demo_server2', 'demo_server3'})
+\ No newline at end of file

--- a/tests/undo-superfluous-modernizations.diff
+++ b/tests/undo-superfluous-modernizations.diff
@@ -20,6 +20,16 @@ index b4076b012..978f3af03 100644
  
      inventory = Inventory()
  
+diff --git a/setup.py b/setup.py
+index 5d3084fdb..0f12ba186 100644
+--- a/setup.py
++++ b/setup.py
+@@ -1,5 +1,4 @@
+ from __future__ import absolute_import
+-from __future__ import unicode_literals
+ from setuptools import setup, find_packages
+ 
+ test_deps = [
 diff --git a/src/commcare_cloud/commands/ansible/ops_tool.py b/src/commcare_cloud/commands/ansible/ops_tool.py
 index 430e17f9a..7d1af83b0 100644
 --- a/src/commcare_cloud/commands/ansible/ops_tool.py

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,5 @@
 
+from __future__ import unicode_literals
 def get_file_contents(path):
     with open(path, 'r') as f:
         return f.read()


### PR DESCRIPTION
This is the first step in the process of upgrading commcare-cloud to Python 3. A test has been added to verify that new PRs conform to the new modernization standard, which means that all new Python modules should have the `__future__` imports and use `six` where applicable to ensure forward compatibility with Python 3.

```py
from __future__ import absolute_import
from __future__ import print_function  # if the module uses `print`
from __future__ import unicode_literals
```

#### Porting guidelines

We will follow [Django’s guide for porting to Python 3](https://docs.djangoproject.com/en/1.11/topics/python3/) (as was done when [upgrading commcare-hq](https://github.com/dimagi/commcare-hq/pull/18373#discussion_r148927632)), which lists tips and best practices including very important sections on handling [Unicode literals](https://docs.djangoproject.com/en/1.11/topics/python3/#unicode-literals) and [strings](https://docs.djangoproject.com/en/1.11/topics/python3/#string-handling). We will use the most recent version of [six](https://pypi.org/project/six/) on PyPI (currently 1.15.0), _not_ Django’s customized version of six.

More details can be found in [this doc](https://docs.google.com/document/d/17QQu5BAAwle5KHTMawTlsf4o78ZRXElIKlrBdHjrU8M/edit).

FYI @dimagi/team-commcare-hq 

##### ENVIRONMENTS AFFECTED
None yet. This change should have no affect on how the tool works, and should be completely backward-compatible with Python 2.7.

Review by commit :blowfish: 
