### PR TITLE
Update Contributing readme for zsh users

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,7 @@ To run tests, first install the test dependencies
 ```
 pip install -e .[test]
 ```
+- if running on zsh `pip install -e '.[test]'`
 
 and then run
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Zsh uses square brackets for pattern matching, so when passing as part of an argument, the argument needs quotations. Made this clear in the Contributing readme.

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
