### PR TITLE
adding cron job entries to kill celery tasks after 36h

### DIFF
--- a/src/commcare_cloud/ansible/deploy_commcarehq.yml
+++ b/src/commcare_cloud/ansible/deploy_commcarehq.yml
@@ -139,4 +139,3 @@
   tasks:
     - include_tasks: roles/commcarehq/tasks/celery_cron.yml
   tags: services
-  

--- a/src/commcare_cloud/ansible/deploy_commcarehq.yml
+++ b/src/commcare_cloud/ansible/deploy_commcarehq.yml
@@ -133,3 +133,10 @@
       with_items: "{{ contents.stdout_lines }}"
       when: item not in supervisor_files|sum(start=[])
   tags: services
+
+- name: Celery tasks cleanup Cron job
+  hosts: celery
+  tasks:
+    - include_tasks: roles/commcarehq/tasks/celery_cron.yml
+  tags: services
+  

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/celery_cron.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/celery_cron.yml
@@ -1,0 +1,27 @@
+# To remove celery tasks that are running for more than 36 hours.
+#
+- name: Celery cron jobs for soft kill tasks running from last 36h
+  become: true
+  cron:
+    name: "Sending SIGTERM to celery processes running morethan 36h"
+    job: "kill -15 $(ps -eo comm,pid,etimes | awk '/celeryd:/ {if ($4 > 129599) { print $3 }}')"
+    minute: 15
+    hour: "*"
+    weekday: "0,1,2,3,4,5,6"
+    user: root
+    cron_file: celery_sigterm
+  tags:
+    - cron
+
+- name: Cron job to Kill Celery tasks running from last 46h
+  become: true
+  cron:
+    name: "Sending SIGTERM to celery processes running morethan 46h"
+    job: "kill -9 $(ps -eo comm,pid,etimes | awk '/celeryd:/ {if ($4 > 165599) { print $3 }}')"
+    minute: 0
+    hour: "*"
+    weekday: "0,1,2,3,4,5,6"
+    user: root
+    cron_file: celery_sigkill
+  tags:
+    - cron

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/celery_cron.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/celery_cron.yml
@@ -4,7 +4,7 @@
   become: true
   cron:
     name: "Sending SIGTERM to celery processes running morethan 36h"
-    job: "kill -15 $(ps -eo comm,pid,etimes | awk '/celeryd:/ {if ($4 > 129599) { print $3 }}')"
+    job: "kill -15 $(ps -eo comm,pid,etimes | awk '/celeryd:/ {if ($4 > 36*60*60) { print $3 }}')"
     minute: 15
     hour: "*"
     weekday: "0,1,2,3,4,5,6"
@@ -17,7 +17,7 @@
   become: true
   cron:
     name: "Sending SIGTERM to celery processes running morethan 46h"
-    job: "kill -9 $(ps -eo comm,pid,etimes | awk '/celeryd:/ {if ($4 > 165599) { print $3 }}')"
+    job: "kill -9 $(ps -eo comm,pid,etimes | awk '/celeryd:/ {if ($4 > 46*60*60) { print $3 }}')"
     minute: 0
     hour: "*"
     weekday: "0,1,2,3,4,5,6"

--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -398,7 +398,7 @@ def setup_release(keep_days=0):
     _setup_release(parse_int_or_exit(keep_days), full_cluster=True)
 
 
-def _setup_release(keep_days=0, full_cluster=True):
+def _setup_release(keep_days=2, full_cluster=True):
     """
     Setup a release in the releases directory with the most recent code.
     Useful for running management commands. These releases will automatically


### PR DESCRIPTION
Celery tasks
- soft kill > 36h
- kill immediately > 46h. 

Increased previous release folders retention period to 48 hours by default. 

<!--- Provide a link to the ticket or document which prompted this change -->

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
