### PR TITLE
Shlex quote ssh options

### DIFF
--- a/src/commcare_cloud/commands/ansible/helpers.py
+++ b/src/commcare_cloud/commands/ansible/helpers.py
@@ -13,6 +13,7 @@ from commcare_cloud.colors import color_error, color_success
 from commcare_cloud.environment.paths import ANSIBLE_DIR, ANSIBLE_ROLES_PATH, ANSIBLE_COLLECTIONS_PATHS
 from six.moves import shlex_quote
 from six.moves import range
+from six.moves import map
 
 DEPRECATED_ANSIBLE_ARGS = []
 

--- a/src/commcare_cloud/commands/ansible/helpers.py
+++ b/src/commcare_cloud/commands/ansible/helpers.py
@@ -11,6 +11,7 @@ from clint.textui import puts
 from commcare_cloud.cli_utils import has_arg, ask
 from commcare_cloud.colors import color_error, color_success
 from commcare_cloud.environment.paths import ANSIBLE_DIR, ANSIBLE_ROLES_PATH, ANSIBLE_COLLECTIONS_PATHS
+from six.moves import shlex_quote
 from six.moves import range
 
 DEPRECATED_ANSIBLE_ARGS = []
@@ -58,7 +59,7 @@ def get_common_ssh_args(environment, use_factory_auth=False):
     common_ssh_args.extend(get_default_ssh_options_as_cmd_parts(environment))
 
     if common_ssh_args:
-        cmd_parts_with_common_ssh_args += ('--ssh-common-args={}'.format(' '.join(common_ssh_args)),)
+        cmd_parts_with_common_ssh_args += ('--ssh-common-args={}'.format(' '.join(map(shlex_quote, common_ssh_args))),)
     return cmd_parts_with_common_ssh_args
 
 

--- a/src/commcare_cloud/commands/ansible/helpers.py
+++ b/src/commcare_cloud/commands/ansible/helpers.py
@@ -11,7 +11,6 @@ from clint.textui import puts
 from commcare_cloud.cli_utils import has_arg, ask
 from commcare_cloud.colors import color_error, color_success
 from commcare_cloud.environment.paths import ANSIBLE_DIR, ANSIBLE_ROLES_PATH, ANSIBLE_COLLECTIONS_PATHS
-from six.moves import shlex_quote
 from six.moves import range
 
 DEPRECATED_ANSIBLE_ARGS = []
@@ -56,8 +55,7 @@ def get_common_ssh_args(environment, use_factory_auth=False):
         cmd_parts_with_common_ssh_args += auth_cmd_parts
         common_ssh_args.extend(auth_ssh_args)
 
-    for option_name, default_option_value in get_default_ssh_options(environment):
-        common_ssh_args.extend(["-o", '{}={}'.format(option_name, default_option_value)])
+    common_ssh_args.extend(get_default_ssh_options_as_cmd_parts(environment))
 
     if common_ssh_args:
         cmd_parts_with_common_ssh_args += ('--ssh-common-args={}'.format(' '.join(common_ssh_args)),)
@@ -76,6 +74,14 @@ def get_default_ssh_options(environment):
         default_ssh_options.append(('UserKnownHostsFile', known_hosts_filepath))
 
     return default_ssh_options
+
+
+def get_default_ssh_options_as_cmd_parts(environment, original_ssh_args=()):
+    ssh_args = []
+    for option_name, default_option_value in get_default_ssh_options(environment):
+        if not any(a.startswith(('{}='.format(option_name), "-o{}=".format(option_name))) for a in original_ssh_args):
+            ssh_args.extend(["-o", '{}={}'.format(option_name, default_option_value)])
+    return ssh_args
 
 
 def add_factory_auth_cmd(environment):

--- a/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import os
 import subprocess
 import sys
 
@@ -12,7 +11,7 @@ from six.moves import shlex_quote
 from commcare_cloud.cli_utils import print_command
 from commcare_cloud.commands.command_base import Argument, CommandBase
 from commcare_cloud.environment.main import get_environment
-from ..ansible.helpers import get_default_ssh_options
+from ..ansible.helpers import get_default_ssh_options_as_cmd_parts
 
 from ...colors import color_error
 from .getinventory import (get_monolith_address, get_server_address,
@@ -86,9 +85,7 @@ class Ssh(_Ssh):
             ssh_args = ['-A'] + ssh_args
 
         environment = get_environment(args.env_name)
-        for option_name, default_option_value in get_default_ssh_options(environment):
-            if not any(a.startswith(('{}='.format(option_name), "-o{}=".format(option_name))) for a in ssh_args):
-                ssh_args = ["-o", '{}={}'.format(option_name, default_option_value)] + ssh_args
+        ssh_args = get_default_ssh_options_as_cmd_parts(environment, original_ssh_args=ssh_args) + ssh_args
         return super(Ssh, self).run(args, ssh_args)
 
 

--- a/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -87,7 +87,7 @@ class Ssh(_Ssh):
 
         environment = get_environment(args.env_name)
         for option_name, default_option_value in get_default_ssh_options(environment):
-            if not any(a.startswith(('{}='.format(option_name), "-o{}=" + option_name)) for a in ssh_args):
+            if not any(a.startswith(('{}='.format(option_name), "-o{}=".format(option_name))) for a in ssh_args):
                 ssh_args = ["-o", '{}={}'.format(option_name, default_option_value)] + ssh_args
         return super(Ssh, self).run(args, ssh_args)
 


### PR DESCRIPTION
Review commit-by-commit. The third commit is the only behavior change. Typical of escaping, we never noticed this because we so far haven't used ssh options that require escaping (due to presence of ` `, `'`, `"`, etc), and so by accident the escaped and unescaped versions are the same. This fixes it to work for ssh option values that contain those characters.

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
