### PR TITLE
update staging es machines

### DIFF
--- a/environments/staging/inventory.ini
+++ b/environments/staging/inventory.ini
@@ -125,7 +125,6 @@ redis2
 
 [elasticsearch:children]
 # Amazon EC2
-# Amazon EC2
 # ES v7.9.1 hosts
 es4
 es5

--- a/environments/staging/inventory.ini
+++ b/environments/staging/inventory.ini
@@ -125,12 +125,13 @@ redis2
 
 [elasticsearch:children]
 # Amazon EC2
-# old ES v2 hosts
-# es4
-# es5
-# ES v7 hosts
-es6
-es7
+# Amazon EC2
+# ES v7.9.1 hosts
+es4
+es5
+# ES v7.6.2 hosts
+# es6
+# es7
 
 [shared_dir_host:children]
 redis2

--- a/environments/staging/inventory.ini.j2
+++ b/environments/staging/inventory.ini.j2
@@ -105,12 +105,12 @@ redis2
 
 [elasticsearch:children]
 # Amazon EC2
-# old ES v2 hosts
-# es4
-# es5
-# ES v7 hosts
-es6
-es7
+# ES v7.9.1 hosts
+es4
+es5
+# ES v7.6.2 hosts
+# es6
+# es7
 
 [shared_dir_host:children]
 redis2


### PR DESCRIPTION
I have upgraded ES to 7.9.1 using the es4 and es5 machines. I have already rolled this out. 

We can now delete the es6 and es7 machines. @dannyroberts @sanjay2916 