### PR TITLE
Make scripts/example-apply-terraform-to-single-server-and-bring-back-up.sh accept multiple hosts

### DIFF
--- a/scripts/example-apply-terraform-to-single-server-and-bring-back-up.sh
+++ b/scripts/example-apply-terraform-to-single-server-and-bring-back-up.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
-
-bash example-apply-terraform-to-single-server-and-bring-back-up.sh production couch3 master
+# Example usage:
+#   bash scripts/example-apply-terraform-to-single-server-and-bring-back-up.sh production couch3 master
 
 env=$1
-host=$2
+hosts=$2
 branch=$3
 
 read -rsp "Vault Password for '${env}': " vault_password
 
-cchq ${env} terraform apply --skip-secrets -target module.server__${host}-${env}.aws_instance.server &&
+targets_args=""
+for host in $(echo ${hosts} | sed 's/:/ /g')
+do
+  targets_args="${targets_args} -target module.server__${host}-${env}.aws_instance.server"
+done
+
+cchq ${env} terraform apply --skip-secrets ${targets_args} &&
 until cchq production ping ${host}
 do
     sleep 5


### PR DESCRIPTION
I use these scripts as a starting point for some operations, and this is a generally useful change I made during a recent rollout.

##### ENVIRONMENTS AFFECTED
none