### PR TITLE
parse secret as json before storing

### DIFF
--- a/src/commcare_cloud/commands/secrets.py
+++ b/src/commcare_cloud/commands/secrets.py
@@ -2,10 +2,12 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 import getpass
+import json
 
 import six
 import yaml
 from clint.textui import puts
+from six.moves import input
 
 from commcare_cloud.colors import color_error
 from commcare_cloud.commands.command_base import CommandBase, Argument
@@ -42,6 +44,10 @@ class Secrets(CommandBase):
     def _secrets_edit(self, environment, secret_name):
         environment.secrets_backend.prompt_user_input()
         secret_value = getpass.getpass("New value for '{}' secret '{}': ".format(environment.name, secret_name))
+        try:
+            secret_value = json.loads(secret_value)
+        except ValueError:
+            pass
         environment.secrets_backend.set_secret(secret_name, secret_value)
 
 


### PR DESCRIPTION
This was necessary to make a change to the POSTGRES_USERS secret.

I needed to change the path `POSTGRES_USERS.userX.privs.0.objs`:

```yaml
userX:
  privs:
  - objs: userY
    type: group
  username: username
```

`cchq <env> secrets edit POSTGRES_USERS.userX.privs.0.objs` failed this error:
```
Traceback (most recent call last):
  File "/home/skelly/.commcare-cloud/bin/cchq", line 11, in <module>
    load_entry_point('commcare-cloud', 'console_scripts', 'cchq')()
  File "/home/skelly/commcare-cloud/src/commcare_cloud/commcare_cloud.py", line 183, in main
    exit_code = call_commcare_cloud()
  File "/home/skelly/commcare-cloud/src/commcare_cloud/commcare_cloud.py", line 174, in call_commcare_cloud
    exit_code = commands[args.command].run(args, unknown_args)
  File "/home/skelly/commcare-cloud/src/commcare_cloud/commands/secrets.py", line 31, in run
    return self._secrets_view(environment, args.secret_name)
  File "/home/skelly/commcare-cloud/src/commcare_cloud/commands/secrets.py", line 36, in _secrets_view
    secret = environment.get_secret(secret_name)
  File "/home/skelly/commcare-cloud/src/commcare_cloud/environment/main.py", line 91, in get_secret
    return self.secrets_backend.get_secret(var)
  File "/home/skelly/commcare-cloud/src/commcare_cloud/environment/secrets/backends/abstract_backend.py", line 64, in get_secret
    value = value[node]
TypeError: list indices must be integers, not unicode
```

**General feedback**
In general I found this process a bit tricky and had to dig into the code to try and figure out exactly what input I should be giving to the `edit` command. After seeing the YAML output from `view POSTGRES_USERS` I assumed I could just past an edited version of that to the `edit` command but that didn't work since `getpass` only takes a single line of input. 

Some quick thoughts on this:
1. Consider using jsonpath for the expressions
2. There should be a way to take the output of `view` and pass it back as the input to `edit`. Perhaps reading from stdin if there is no TTY would work? I think this would be necessary if you wanted to do something like add a DB user.