### PR TITLE
check monit status of entire group

### DIFF
--- a/src/commcare_cloud/commands/ansible/service.py
+++ b/src/commcare_cloud/commands/ansible/service.py
@@ -198,7 +198,7 @@ class SupervisorService(SubServicesMixin, ServiceBase):
 
 def _service_status_helper(service_name):
     if service_name in MONIT_MANAGED_SERVICES:
-        return 'monit status {}'.format(service_name)
+        return 'monit status -g {}'.format(service_name)
 
     return 'service {} status'.format(service_name)
 


### PR DESCRIPTION
In rare instances where multiple servers are running on a single machine e.g. duration an upgrade, it's useful to see the status of all services in the group. In the case that there is only one service this will output exactly the same as what it does now.

This also has the benefit of being able to define the service names distinctly for different versions: https://github.com/dimagi/commcare-cloud/pull/4233