### PR TITLE
allow either ',' or ':' to be used in limit patterns

### DIFF
--- a/src/commcare_cloud/commands/ansible/ansible_playbook.py
+++ b/src/commcare_cloud/commands/ansible/ansible_playbook.py
@@ -95,12 +95,12 @@ def run_ansible_playbook(
     def get_limit():
         limit_parts = []
         if limit:
-            limit_parts.append(limit)
+            limit_parts = re.split('[,:]', limit)
         if 'ansible_skip' in environment.sshable_hostnames_by_group and respect_ansible_skip:
             limit_parts.append('!ansible_skip')
 
         if limit_parts:
-            return '--limit', ':'.join(limit_parts)
+            return '--limit', ','.join(limit_parts)
         else:
             return ()
 


### PR DESCRIPTION
Also standardise pattern using ',' (people generally understand what a ',' does better than a ':' for separating lists of items)
