### PR TITLE
add prometheus group vars

### DIFF
--- a/src/commcare_cloud/ansible/group_vars/alertmanager.yml
+++ b/src/commcare_cloud/ansible/group_vars/alertmanager.yml
@@ -1,0 +1,5 @@
+prometheus_alertmanager_config:
+  - scheme: http
+      path_prefix: /alertmanager
+      static_configs:
+        - targets: "{{ groups['alertmanager'] | map('regex_replace', '$', ':9093') | list  }}"

--- a/src/commcare_cloud/ansible/group_vars/alertmanager.yml
+++ b/src/commcare_cloud/ansible/group_vars/alertmanager.yml
@@ -1,5 +1,5 @@
 prometheus_alertmanager_config:
   - scheme: http
-      path_prefix: /alertmanager
-      static_configs:
-        - targets: "{{ groups['alertmanager'] | map('regex_replace', '$', ':9093') | list  }}"
+    path_prefix: '/alertmanager'
+    static_configs:
+      - targets: "{{ groups['alertmanager'] | map('regex_replace', '$', ':9093') | list  }}"

--- a/src/commcare_cloud/ansible/group_vars/prometheus.yml
+++ b/src/commcare_cloud/ansible/group_vars/prometheus.yml
@@ -1,0 +1,60 @@
+prometheus_global:
+  evaluation_interval: 30s
+  scrape_interval: 20s
+  scrape_timeout: 20s
+
+prometheus_external_labels:
+  environment: "{{ prometheus_monitoring_env }}"
+
+prometheus_alert_rules: []  # rule files stored in role
+prometheus_static_targets_files: []  # targets defined in role
+prometheus_targets: {}  # targets defined in role
+
+_prometheus_scrape_configs:
+  - job_name: "prometheus"
+    metrics_path: "{{ prometheus_metrics_path }}"
+    static_configs:
+      - targets:
+          - "{{ ansible_fqdn | default(ansible_host) | default('localhost') }}:9090"
+        labels:
+          environment: "{{ prometheus_monitoring_env }}"
+  - job_name: "node"
+    file_sd_configs:
+      - files:
+          - "{{ prometheus_config_dir }}/file_sd/node.yml"
+    relabel_configs:
+      - source_labels: [ '__address__' ]
+        separator: ':'
+        regex: '(.*):.*'
+        target_label: 'instance'
+        replacement: '${1}'
+
+http_probe_scrape:
+  - job_name: blackbox
+    metrics_path: /probe
+    params:
+      module: [http_prometheus]
+    static_configs:
+      - targets: "{{ prometheus_http_probe_urls|default([]) }}"
+        labels:
+          environment: "{{ prometheus_monitoring_env }}"
+    relabel_configs:
+      - source_labels: [ __address__ ]
+        target_label: __param_target
+      - source_labels: [ __param_target ]
+        target_label: instance
+      - target_label: __address__
+        replacement: "{{ ansible_default_ipv4.address }}:9115"
+
+federation_scrape:
+  - job_name: 'federate'
+    scrape_interval: 15s
+    honor_labels: true
+    metrics_path: '/prometheus/federate'
+    params:
+      match[]:
+        - '{__name__=~".+"}' #scrape everything
+    static_configs:
+      - targets: "{{ prometheus_federation_endpoints|default([]) }}"
+
+prometheus_scrape_configs: "{{ _prometheus_scrape_configs + (federation_scrape if prometheus_federation_endpoints|default(None) else []) + (http_probe_scrape if prometheus_http_probe_urls|default(None) else []) }}"

--- a/src/commcare_cloud/environment/main.py
+++ b/src/commcare_cloud/environment/main.py
@@ -10,6 +10,8 @@ from datetime import datetime
 import yaml
 from ansible.inventory.manager import InventoryManager
 from ansible.parsing.dataloader import DataLoader
+from ansible.parsing.utils.yaml import from_yaml
+from ansible.parsing.yaml.dumper import AnsibleDumper
 from ansible.vars.manager import VariableManager
 from memoized import memoized, memoized_property
 
@@ -101,7 +103,7 @@ class Environment(object):
     def public_vars(self):
         """contents of public.yml, as a dict"""
         with open(self.paths.public_yml) as f:
-            return yaml.safe_load(f)
+            return from_yaml(f)
 
     @memoized_property
     def _disallowed_public_variables(self):
@@ -112,13 +114,13 @@ class Environment(object):
     @memoized_property
     def meta_config(self):
         with open(self.paths.meta_yml) as f:
-            meta_json = yaml.safe_load(f)
+            meta_json = from_yaml(f)
         return MetaConfig.wrap(meta_json)
 
     @memoized_property
     def postgresql_config(self):
         with open(self.paths.postgresql_yml) as f:
-            postgresql_json = yaml.safe_load(f)
+            postgresql_json = from_yaml(f)
         postgresql_config = PostgresqlConfig.wrap(postgresql_json)
         postgresql_config.replace_hosts(self)
         postgresql_config.check()
@@ -128,7 +130,7 @@ class Environment(object):
     def elasticsearch_config(self):
         try:
             with open(self.paths.elasticsearch_yml) as f:
-                elasticsearch_json = yaml.safe_load(f)
+                elasticsearch_json = from_yaml(f)
         except IOError:
             # It's fine to omit this file
             elasticsearch_json = {}
@@ -141,7 +143,7 @@ class Environment(object):
     @memoized_property
     def proxy_config(self):
         with open(self.paths.proxy_yml) as f:
-            proxy_json = yaml.safe_load(f)
+            proxy_json = from_yaml(f)
         proxy_config = ProxyConfig.wrap(proxy_json)
         proxy_config.check()
         return proxy_config
@@ -150,7 +152,7 @@ class Environment(object):
     def prometheus_config(self):
         try:
             with open(self.paths.prometheus_yml) as f:
-                prometheus_json = yaml.safe_load(f)
+                prometheus_json = from_yaml(f)
         except IOError:
             return None
         return PrometheusConfig.wrap(prometheus_json)
@@ -162,7 +164,7 @@ class Environment(object):
         present_users = []
         for user_group_from_yml in user_groups_from_yml:
             with open(self.paths.get_users_yml(user_group_from_yml)) as f:
-                user_group_json = yaml.safe_load(f)
+                user_group_json = from_yaml(f)
             present_users += user_group_json['dev_users']['present']
             absent_users += user_group_json['dev_users']['absent']
         self.check_user_group_absent_present_overlaps(absent_users, present_users)
@@ -173,7 +175,7 @@ class Environment(object):
     def terraform_config(self):
         try:
             with open(self.paths.terraform_yml) as f:
-                config_yml = yaml.safe_load(f)
+                config_yml = from_yaml(f)
         except IOError:
             return None
         config_yml['environment'] = config_yml.get('environment', self.meta_config.env_monitoring_id)
@@ -183,7 +185,7 @@ class Environment(object):
     def aws_config(self):
         try:
             with open(self.paths.aws_yml) as f:
-                config_yml = yaml.safe_load(f)
+                config_yml = from_yaml(f)
         except IOError:
             config_yml = {}
         return AwsConfig.wrap(config_yml)
@@ -207,9 +209,9 @@ class Environment(object):
         includes environmental-defaults/app-processes.yml as well as <env>/app-processes.yml
         """
         with open(self.paths.app_processes_yml_default) as f:
-            app_processes_json = yaml.safe_load(f)
+            app_processes_json = from_yaml(f)
         with open(self.paths.app_processes_yml) as f:
-            app_processes_json.update(yaml.safe_load(f))
+            app_processes_json.update(from_yaml(f))
 
         raw_app_processes_config = AppProcessesConfig.wrap(app_processes_json)
         raw_app_processes_config.check()
@@ -230,9 +232,9 @@ class Environment(object):
         includes environmental-defaults/fab-settings.yml as well as <env>/fab-settings.yml
         """
         with open(self.paths.fab_settings_yml_default) as f:
-            fab_settings_json = yaml.safe_load(f)
+            fab_settings_json = from_yaml(f)
         with open(self.paths.fab_settings_yml) as f:
-            fab_settings_json.update(yaml.safe_load(f) or {})
+            fab_settings_json.update(from_yaml(f) or {})
 
         fab_settings_config = FabSettingsConfig.wrap(fab_settings_json)
         return fab_settings_config
@@ -367,7 +369,7 @@ class Environment(object):
         generated_variables.update(self.secrets_backend.get_generated_variables())
 
         with open(self.paths.generated_yml, 'w') as f:
-            f.write(yaml.safe_dump(generated_variables))
+            f.write(yaml.dump(generated_variables, Dumper=AnsibleDumper))
 
     def translate_host(self, host, filename_for_error):
         if host == 'None' or host in self.inventory_manager.hosts:

--- a/src/commcare_cloud/environment/main.py
+++ b/src/commcare_cloud/environment/main.py
@@ -11,7 +11,6 @@ import yaml
 from ansible.inventory.manager import InventoryManager
 from ansible.parsing.dataloader import DataLoader
 from ansible.parsing.utils.yaml import from_yaml
-from ansible.parsing.yaml.dumper import AnsibleDumper
 from ansible.vars.manager import VariableManager
 from memoized import memoized, memoized_property
 
@@ -29,6 +28,8 @@ from commcare_cloud.environment.schemas.terraform import TerraformConfig
 from commcare_cloud.environment.schemas.prometheus import PrometheusConfig
 from commcare_cloud.environment.users import UsersConfig
 from six.moves import map
+
+from commcare_cloud.yaml import PreserveUnsafeDumper
 
 
 class Environment(object):
@@ -369,7 +370,7 @@ class Environment(object):
         generated_variables.update(self.secrets_backend.get_generated_variables())
 
         with open(self.paths.generated_yml, 'w') as f:
-            f.write(yaml.dump(generated_variables, Dumper=AnsibleDumper))
+            f.write(yaml.dump(generated_variables, Dumper=PreserveUnsafeDumper))
 
     def translate_host(self, host, filename_for_error):
         if host == 'None' or host in self.inventory_manager.hosts:

--- a/src/commcare_cloud/yaml.py
+++ b/src/commcare_cloud/yaml.py
@@ -1,0 +1,23 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from ansible.parsing.yaml.dumper import AnsibleDumper
+from ansible.utils.unsafe_proxy import AnsibleUnsafeText
+
+
+def represent_unsafe_unicode(dumper, data):
+    return dumper.represent_scalar('!unsafe', data)
+
+
+class PreserveUnsafeDumper(AnsibleDumper):
+    """YAML Dumper that preserves the '!unsafe' tag for unsafe values.
+
+    See https://docs.ansible.com/ansible/latest/user_guide/playbooks_advanced_syntax.html#unsafe-or-raw-strings
+    """
+    pass
+
+
+PreserveUnsafeDumper.add_representer(
+    AnsibleUnsafeText,
+    represent_unsafe_unicode,
+)


### PR DESCRIPTION
https://github.com/dimagi/commcare-prometheus/pull/36

Changes to YAML loading are required to preserve the `unsafe` tag for any vars which are used in [icds prometheus config](https://github.com/dimagi/icds-commcare-environments/blob/master/environments/icds-cas/prometheus.yml#L26)