### PR TITLE
 increased UpdateUserSyncHistoryPillow processes from 2 to 4

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -104,7 +104,7 @@ pillows:
     UCLAPatientFluffPillow:
       num_processes: 1
     UpdateUserSyncHistoryPillow:
-      num_processes: 2
+      num_processes: 4
     UserCacheInvalidatePillow:
       num_processes: 1
     UserGroupsDbKafkaPillow:


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
# Production UpdateUserSyncHistoryPillow Pillows
1. added 2 more kafka paritions to the topic=synclog-sql. Total: 4 now
2.  increased UpdateUserSyncHistoryPillow processes from 2 to 4. 