### PR TITLE
Increase production postgres connection limit

### DIFF
--- a/environments/production/postgresql.yml
+++ b/environments/production/postgresql.yml
@@ -1,13 +1,13 @@
 postgres_override:
   allow_dump_from_pgstandby: yes
-  postgresql_max_connections: 300
+  postgresql_max_connections: 500
   postgresql_version: '9.6'
   postgresql_checkpoint_completion_target: '0.7'
   postgresql_wal_buffers: 16MB
   postgresql_max_wal_size: 2GB
 
 pgbouncer_override:
-  pgbouncer_default_pool: 290
+  pgbouncer_default_pool: 490
   pgbouncer_max_connections: 10000
   pgbouncer_pool_mode: transaction
   pgbouncer_pool_timeout: 1

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -490,7 +490,7 @@ proxy_servers:
 
 rds_instances:
   - identifier: "pgmain0-production"
-    instance_type: "db.t3.2xlarge"
+    instance_type: "db.m5.4xlarge"
     storage: 500
     max_storage: 5000
     multi_az: true


### PR DESCRIPTION
- raise postgres connection limit 300 => 500
- increase size of pgmain0

I was tempted to also change these settings to match [pgtune](https://pgtune.leopard.in.ua/#/) recommendations, but I chose not to hold off since changing any of these could conceivably have a _negative_ effect on performance. (Before we do, we should at least understand what the current/default values are in RDS/postgres.)
```
      shared_buffers: 16GB
      effective_cache_size: 48GB
      maintenance_work_mem: 2GB
      default_statistics_target: 100
      random_page_cost: 1.1
      effective_io_concurrency: 200
      work_mem: 20971kB
      min_wal_size: 1GB
      max_wal_size: 4GB
      max_worker_processes: 16
      max_parallel_workers_per_gather: 4
```

##### ENVIRONMENTS AFFECTED
production