### PR TITLE
Have terraform ignore manual changes to the IP deny list

### DIFF
--- a/src/commcare_cloud/terraform/modules/ga_alb_waf/main.tf
+++ b/src/commcare_cloud/terraform/modules/ga_alb_waf/main.tf
@@ -52,6 +52,9 @@ resource "aws_wafv2_ip_set" "permanent_block" {
   ip_address_version = "IPV4"
   description        = "Manually Added IPs for denial"
   addresses          = ["195.54.160.21/32", "64.39.99.208/32"]
+  lifecycle {
+    ignore_changes = ["addresses"]
+  }
 
   tags = {
   }

--- a/src/commcare_cloud/terraform/modules/ga_alb_waf/main.tf
+++ b/src/commcare_cloud/terraform/modules/ga_alb_waf/main.tf
@@ -51,7 +51,7 @@ resource "aws_wafv2_ip_set" "permanent_block" {
   scope              = "REGIONAL"
   ip_address_version = "IPV4"
   description        = "Manually Added IPs for denial"
-  addresses          = ["195.54.160.21/32", "64.39.99.208/32"]
+  addresses          = []
   lifecycle {
     ignore_changes = ["addresses"]
   }


### PR DESCRIPTION
This PR is basically acknowledging that an IP deny list is a more dynamic thing than we want to hard code in a setting in a git repo

##### ENVIRONMENTS AFFECTED
saas aws envs