### PR TITLE
specify pg version in monit and handlers

### DIFF
--- a/src/commcare_cloud/ansible/roles/postgresql_base/handlers/main.yml
+++ b/src/commcare_cloud/ansible/roles/postgresql_base/handlers/main.yml
@@ -1,15 +1,21 @@
 ---
 - name: Start postgres
   become: yes
-  action: service name=postgresql args="{{ postgresql_version }}" state=started
+  service:
+    name: "postgresql@{{ postgresql_version }}-main"
+    state: started
 
 - name: Restart postgres
   become: yes
-  action: service name=postgresql args="{{ postgresql_version }}" state=restarted
+  service:
+    name: "postgresql@{{ postgresql_version }}-main"
+    state: restarted
 
 - name: Reload postgres
   become: yes
-  action: service name=postgresql args="{{ postgresql_version }}" state=reloaded
+  service:
+    name: "postgresql@{{ postgresql_version }}-main"
+    state: reloaded
 
 - name: reload systemd
   become: yes

--- a/src/commcare_cloud/ansible/roles/postgresql_base/templates/monit.postgresql.j2
+++ b/src/commcare_cloud/ansible/roles/postgresql_base/templates/monit.postgresql.j2
@@ -1,6 +1,6 @@
  check process postgresql_{{ postgresql_version }} with pidfile {{ postgresql_pid_file }}
    group database
    group postgresql
-   start program = "/etc/init.d/postgresql start {{ postgresql_version }}"
-   stop program = "/etc/init.d/postgresql stop {{ postgresql_version }}"
+   start program = "systemctl start postgresql@{{ postgresql_version }}-main"
+   stop program = "systemctl stop postgresql@{{ postgresql_version }}-main"
    if failed host {{ inventory_hostname }} port {{ postgresql_port }} then restart


### PR DESCRIPTION
Although the version was specified already it was being ignored (note from the docs "While using remote hosts with systemd this setting will be ignored.")

Also the `init.d` script that monit was using doesn't work since it gets redirected to using systemd.