### PR TITLE
Saas-11380/pg_repack installation in staging pg_bouncer

### DIFF
--- a/environments/staging/postgresql.yml
+++ b/environments/staging/postgresql.yml
@@ -13,6 +13,10 @@ pgbouncer_override:
   pgbouncer_max_connections: 1600
   pgbouncer_default_pool: 290
 
+pg_repack:
+  pgproxy2:
+    - database: commcarehq_synclogs
+
 dbs:
   main:
     pgbouncer_host: pgproxy2

--- a/src/commcare_cloud/ansible/group_vars/postgresql.yml
+++ b/src/commcare_cloud/ansible/group_vars/postgresql.yml
@@ -2,3 +2,4 @@ datadog_integration_pgbouncer: true
 datadog_integration_postgres: true
 is_pg_standby: false
 is_pg_master: true
+pg_repack_version: 1.4.3

--- a/src/commcare_cloud/ansible/roles/pg_repack/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/pg_repack/tasks/main.yml
@@ -46,7 +46,7 @@
       ansible_ssh_pipelining: true
     postgresql_ext:
       name: pg_repack
-      db: "{{ item }}"
+      db: "{{ item.database }}"
       port: "{{ postgresql_port }}"
       version: "{{ pg_repack_version }}"
     loop: "{{ pg_repack.get(inventory_hostname, []) }}"
@@ -64,10 +64,10 @@
 - name: Create pg_repack cron
   become: yes
   cron:
-    name: "pg_repack {{ item }}"
+    name: "pg_repack {{ item.database }}"
     job: "{{ pg_repack_script_path }} --pg-repack {{ postgres_install_dir }}/bin/pg_repack --dead-tup-ratio {{ item.ratio|default(0.05) }} -d {{ item.database }}{% if item.tables|default(None) %} --tables {{ item.tables|join(' ') }}{% endif %}"
     minute: "30"
     hour: "{{ nadir_hour + 2 }}"
     user: postgres
-    cron_file: "pg_repack_{{ item }}"
+    cron_file: "pg_repack_{{ item.database }}"
   loop: "{{ pg_repack.get(inventory_hostname, []) }}"


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

Installed pg_repack 1.4.3 version on staging pg_bouncer server to add an extension on the staging commcarehq_synclog database. 
Faced some issues in pg_repack tasks/main.yml due to recent changes {{ item }}. Fixed it. 

Need some help with below syntaxes and cron job entry. due to recent changes made to the tasks/main.yml and below syntax the cron task is failing. 
```
Syntax #1
pg_repack:
  pg<host>:
    - database: <databasename>
    - tables:
        - <table1>
        - <table2>

syntax #2:
pg_repack:
  pg<host>:
    - <databasename>

```
