### PR TITLE
adding task to remove particular user pubkey from ansible user

### DIFF
--- a/src/commcare_cloud/ansible/roles/bootstrap-users/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/bootstrap-users/tasks/main.yml
@@ -64,21 +64,22 @@
   tags:
     - new_ansible_sudo_pass
 
-- name: Authorize current devs to login as ansible
-  become: yes
-  authorized_key: user=ansible state=present key="{{ lookup('file', authorized_keys_dir ~ item ~ '.pub') }}"
+- name: remove key using username
+  lineinfile:
+    dest: /home/ansible/.ssh/authorized_keys
+    state: absent
+    regexp: "username={{ item }}"
+  when: reset_user | default(False)
   with_items: '{{ dev_users.present }}'
   tags:
     - pubkey
 
-# task is remove old pubkey of particular devs from ansible and update with new pubkey
-- name: UnAuthorize current devs to login as ansible
+- name: Authorize current devs to login as ansible
   become: yes
-  authorized_key: user=ansible state=absent key="{{ lookup('file', authorized_keys_dir ~ item ~ '.pub') }}"
-  with_items: '{{ user }}'
+  authorized_key: user=ansible state=present key="{{ lookup('file', authorized_keys_dir ~ item ~ '.pub') }}" key_options=environment="username={{ item }}"
+  with_items: '{{ dev_users.present }}'
   tags:
-    - remove_pubkey
-  when: user is defined
+    - pubkey
 
 - import_tasks: remove_users.yml
   when: dev_users.absent

--- a/src/commcare_cloud/ansible/roles/bootstrap-users/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/bootstrap-users/tasks/main.yml
@@ -77,8 +77,7 @@
 
 - name: capturing username
   pause:
-    prompt: "Please enter your dimagi username"
-    seconds: 30
+    prompt: "Please enter your Dimagi username"
   register: username_input
 
 - fail: msg="The given username is not defined or empty or not a valid dev_user"

--- a/src/commcare_cloud/ansible/roles/bootstrap-users/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/bootstrap-users/tasks/main.yml
@@ -72,8 +72,8 @@
   register: ssh_pubkeys_results_list
 
 - name: iterate over ssh_pubkeys_list and join into a string
-    set_fact:
-      ssh_pubkeys_string: "{{ ssh_pubkeys_results_list.results | map(attribute='ansible_facts.ssh_pubkeys_list') | list | join('\n') }}"
+  set_fact:
+    ssh_pubkeys_string: "{{ ssh_pubkeys_results_list.results | map(attribute='ansible_facts.ssh_pubkeys_list') | list | join('\n') }}"
 
 - name: Authorize current devs to login as ansible
   become: yes

--- a/src/commcare_cloud/ansible/roles/bootstrap-users/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/bootstrap-users/tasks/main.yml
@@ -64,19 +64,20 @@
   tags:
     - new_ansible_sudo_pass
 
-- name: remove key using username
-  lineinfile:
-    dest: /home/ansible/.ssh/authorized_keys
-    state: absent
-    regexp: "username={{ item }}"
-  when: reset_user | default(False)
-  with_items: '{{ dev_users.present }}'
-  tags:
-    - pubkey
+- name: lookup ssh pubkeys from authorized_keys_dir and create ssh_pubkeys_list
+  set_fact:
+    ssh_pubkeys_list: "{{ lookup('file', authorized_keys_dir ~ item ~ '.pub') }}"
+  with_items:
+    "{{ dev_users.present }}"
+  register: ssh_pubkeys_results_list
+
+- name: iterate over ssh_pubkeys_list and join into a string
+    set_fact:
+      ssh_pubkeys_string: "{{ ssh_pubkeys_results_list.results | map(attribute='ansible_facts.ssh_pubkeys_list') | list | join('\n') }}"
 
 - name: Authorize current devs to login as ansible
   become: yes
-  authorized_key: user=ansible state=present key="{{ lookup('file', authorized_keys_dir ~ item ~ '.pub') }}" key_options=environment="username={{ item }}"
+  authorized_key: user=ansible state=present key="{{ ssh_pubkeys_string }}" exclusive=yes
   with_items: '{{ dev_users.present }}'
   tags:
     - pubkey

--- a/src/commcare_cloud/ansible/roles/bootstrap-users/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/bootstrap-users/tasks/main.yml
@@ -70,26 +70,42 @@
   with_items:
     "{{ dev_users.present }}"
   register: ssh_pubkeys_results_list
+  tags:
+    - pubkey
 
 - name: iterate over ssh_pubkeys_list and join into a string
   set_fact:
     ssh_pubkeys_string: "{{ ssh_pubkeys_results_list.results | map(attribute='ansible_facts.ssh_pubkeys_list') | list | join('\n') }}"
+  tags:
+    - pubkey
 
 - name: capturing username
   pause:
     prompt: "Please enter your Dimagi username"
   register: username_input
+  tags:
+    - capture-userinfo
+    - pubkey
 
 - fail: msg="The given username is not defined or empty or not a valid dev_user"
   when: (username_input.user_input == "" ) or (username_input.user_input|length == 0) or (username_input.user_input not in "{{ dev_users.present }}")
+  tags:
+    - capture-userinfo
+    - pubkey
 
 - debug:
     msg: "Entered username: {{ username_input.user_input }}"
+  tags:
+    - capture-userinfo
+    - pubkey
 
 - name: "Verifying {{ username_input.user_input }} user key in the ssh_pubkeys_string list"
   assert:
     that:
       - '"{{ lookup("file", authorized_keys_dir ~ username_input.user_input ~ ".pub" ) }}" in ssh_pubkeys_string'
+  tags:
+    - capture-userinfo
+    - pubkey
 
 - name: Authorize current devs to login as ansible
   become: yes

--- a/src/commcare_cloud/ansible/roles/bootstrap-users/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/bootstrap-users/tasks/main.yml
@@ -75,10 +75,22 @@
   set_fact:
     ssh_pubkeys_string: "{{ ssh_pubkeys_results_list.results | map(attribute='ansible_facts.ssh_pubkeys_list') | list | join('\n') }}"
 
-- name: "Verifying ansible user key in the ssh_pubkeys_string list"
+- name: capturing username
+  pause:
+    prompt: "Please enter your dimagi username"
+    seconds: 30
+  register: username_input
+
+- fail: msg="The given username is not defined or empty or not a valid dev_user"
+  when: (username_input.user_input == "" ) or (username_input.user_input|length == 0) or (username_input.user_input not in "{{ dev_users.present }}")
+
+- debug:
+    msg: "Entered username: {{ username_input.user_input }}"
+
+- name: "Verifying {{ username_input.user_input }} user key in the ssh_pubkeys_string list"
   assert:
-  that:
-    - '"{{ lookup("file", authorized_keys_dir ~ "ansible.pub" ) }}" in ssh_pubkeys_string'
+    that:
+      - '"{{ lookup("file", authorized_keys_dir ~ username_input.user_input ~ ".pub" ) }}" in ssh_pubkeys_string'
 
 - name: Authorize current devs to login as ansible
   become: yes

--- a/src/commcare_cloud/ansible/roles/bootstrap-users/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/bootstrap-users/tasks/main.yml
@@ -75,6 +75,11 @@
   set_fact:
     ssh_pubkeys_string: "{{ ssh_pubkeys_results_list.results | map(attribute='ansible_facts.ssh_pubkeys_list') | list | join('\n') }}"
 
+- name: "Verifying ansible user key in the ssh_pubkeys_string list"
+  assert:
+  that:
+    - '"{{ lookup("file", authorized_keys_dir ~ "ansible.pub" ) }}" in ssh_pubkeys_string'
+
 - name: Authorize current devs to login as ansible
   become: yes
   authorized_key: user=ansible state=present key="{{ ssh_pubkeys_string }}" exclusive=yes

--- a/src/commcare_cloud/ansible/roles/bootstrap-users/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/bootstrap-users/tasks/main.yml
@@ -71,6 +71,15 @@
   tags:
     - pubkey
 
+# task is remove old pubkey of particular devs from ansible and update with new pubkey
+- name: UnAuthorize current devs to login as ansible
+  become: yes
+  authorized_key: user=ansible state=absent key="{{ lookup('file', authorized_keys_dir ~ item ~ '.pub') }}"
+  with_items: '{{ user }}'
+  tags:
+    - remove_pubkey
+  when: user is defined
+
 - import_tasks: remove_users.yml
   when: dev_users.absent
 

--- a/src/commcare_cloud/commands/ansible/ansible_playbook.py
+++ b/src/commcare_cloud/commands/ansible/ansible_playbook.py
@@ -314,7 +314,7 @@ class BootstrapUsers(_AnsiblePlaybookAlias):
         args.playbook = 'deploy_stack.yml'
         args.use_factory_auth = True
         public_vars = environment.public_vars
-        unknown_args += ('--tags=bootstrap-users',) + get_user_arg(public_vars, unknown_args, use_factory_auth=True)
+        unknown_args += ('--tags=bootstrap-users', '--skip-tags=capture-userinfo',) + get_user_arg(public_vars, unknown_args, use_factory_auth=True)
 
         if not public_vars.get('commcare_cloud_pem'):
             unknown_args += ('--ask-pass',)


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

Adding task to remove particular user pubkey from _ansible_ user. 

command: 
cchq <env> django-manage update-users --tags=remove_pubkey -e '{"user":["username"]}' 

This is one of the approaches we can use to remove a particular a user from the ansible authorized_keys file. Please let me know your suggestions.