### PR TITLE
get correct version from DB to fix postgresql_ext bug

### DIFF
--- a/src/commcare_cloud/ansible/roles/citusdb/tasks/setup_cordinator.yml
+++ b/src/commcare_cloud/ansible/roles/citusdb/tasks/setup_cordinator.yml
@@ -1,19 +1,26 @@
 ---
- - name: Add Citus Extension on Coordinator Database
-   become: yes
-   become_user: postgres
-   postgresql_ext:
-     name: citus
-     db: "{{ item.name }}"
-     version: "{{ citus_version }}"
-   with_items: "{{ postgresql_dbs.all }}"
-   when: item.host == inventory_hostname
+# postgresql_ext bug https://github.com/ansible-collections/community.general/pull/1078
+- name: Get available citus version
+  become: yes
+  become_user: postgres
+  shell: psql postgres -q  -t -c "select version from pg_available_extension_versions where name = 'citus' and version >= '{{ citus_version }}' order by version desc limit 1;"
+  register: citus_version_available
 
- - name: Add Workers Nodes to the Cordinator
-   become: yes
-   become_user: postgres
-   shell: psql {{ item.0.name }} -c "SELECT * from master_add_node( '{{item.1|ipaddr}}' , 6432) ; "
-   with_nested: 
-    - "{{ postgresql_dbs.all }}"
-    - "{{ groups['citusdb_worker'] | difference(groups['pg_standby']) }}"
-   when: item.0.host in groups.citusdb_master
+- name: Add Citus Extension on Coordinator Database
+  become: yes
+  become_user: postgres
+  postgresql_ext:
+    name: citus
+    db: "{{ item.name }}"
+    version: "{{ citus_version_available.stdout | default(citus_version) | trim }}"
+  with_items: "{{ postgresql_dbs.all }}"
+  when: item.host == inventory_hostname
+
+- name: Add Workers Nodes to the Cordinator
+  become: yes
+  become_user: postgres
+  shell: psql {{ item.0.name }} -c "SELECT * from master_add_node( '{{item.1|ipaddr}}' , 6432);"
+  with_nested:
+  - "{{ postgresql_dbs.all }}"
+  - "{{ groups['citusdb_worker'] | difference(groups['pg_standby']) }}"
+  when: item.0.host in groups.citusdb_master

--- a/src/commcare_cloud/ansible/roles/citusdb/tasks/setup_worker.yml
+++ b/src/commcare_cloud/ansible/roles/citusdb/tasks/setup_worker.yml
@@ -15,12 +15,19 @@
   when: item.create and item.host in groups.citusdb_master
   with_items: "{{ postgresql_dbs.all }}"
 
+# postgresql_ext bug https://github.com/ansible-collections/community.general/pull/1078
+- name: Get available citus version
+  become: yes
+  become_user: postgres
+  shell: psql postgres -q  -t -c "select version from pg_available_extension_versions where name = 'citus' and version >= '{{ citus_version }}' order by version desc limit 1;"
+  register: citus_version_available
+
 - name: Add Citus Extension on Worker Database
   become: yes
   become_user: postgres
   postgresql_ext:
     name: citus
     db: "{{ item.name }}"
-    version: "{{ citus_version }}"
+    version: "{{ citus_version_available.stdout | default(citus_version) | trim }}"
   with_items: "{{ postgresql_dbs.all }}"
   when: item.host in groups.citusdb_master


### PR DESCRIPTION
There are two issues that make this necessary.

1. The version of the citus extension does not match the version of the package (the package does not include the 'patch' version). This works OK for installing the extension the first time but after that the `postgresql_ext` ansible module will complain that `9.4 < 9.4.1`. 

2. The `postgresql_ext` ansible module does not correctly sort available versions. To work around the 1st point you can set the version to `latest` but a bug in the Ansible module where it's not sorting the versions means that the version it tries to install is somewhat random: https://github.com/ansible-collections/community.general/pull/1078

This change queries the DB for the latest available version that is >= the specified version and uses that as the input to the `postgresql_ext` module.