### PR TITLE
Revoke access for fission warehouse

### DIFF
--- a/environments/_users/fission-warehouse.yml
+++ b/environments/_users/fission-warehouse.yml
@@ -1,8 +1,8 @@
 dev_users:
   present:
-    - nteja
     - amohammed
+  absent:
+    - nteja
     - asamaddar
     - sbaig
     - dgadiraju
-  absent: []


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
The only environment to include fission-warehouse users is staging. Adil still works with USH so will maintain access to staging. 
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Staging