### PR TITLE
Sk/pg standby

### DIFF
--- a/src/commcare_cloud/ansible/roles/postgresql_base/templates/pg_hba.conf.j2
+++ b/src/commcare_cloud/ansible/roles/postgresql_base/templates/pg_hba.conf.j2
@@ -12,6 +12,12 @@ local   replication     postgres                                peer
 {{ entry.contype|default('host') }}    {{ entry.databases|default('all') }}    {{ entry.users|default('all') }}    {% if entry.contype != 'local' %}{{ entry.netmask }}{% endif %}    {{ entry.method|default('md5') }}
 {% endfor %}
 
+{% for standby in groups.get('pg_standby', []) %}
+{% if hostvars[standby].hot_standby_master|default(None) == inventory_hostname %}
+host replication    {{ postgres_users.replication.username|default('hqrepl') }}     {{ standby }}   md5
+{% endif %}
+{% endfor %}
+
 {% if inventory_hostname in groups.get('citusdb_worker', []) %}
 # Allow trust from localhost for pgbouncer
 host    all             all             127.0.0.1/32            trust 

--- a/src/commcare_cloud/ansible/setup_pg_standby.yml
+++ b/src/commcare_cloud/ansible/setup_pg_standby.yml
@@ -13,6 +13,12 @@
     - include_vars:
         file: roles/citusdb/defaults/main.yml
       when: "'citusdb' in groups"
+
+    - set_fact:
+        postgresql_version: "{{ citus_postgresql_version }}"
+        postgresql_port: "{{ citus_postgresql_port }}"
+      when: "'citusdb' in groups"
+
     - assert:
         that:
           - "hot_standby_master is defined"


### PR DESCRIPTION
Fixes for PostgreSQL standby setup:

1. Ensure that replication is permitted from primary to standby
2. Use correct vars when setting up CitusDB
