### PR TITLE
pg_repack extension created for staging commcarehq_synclog

### DIFF
--- a/environments/staging/postgresql.yml
+++ b/environments/staging/postgresql.yml
@@ -16,6 +16,10 @@ pgbouncer_override:
 pg_repack:
   pgproxy2:
     - database: commcarehq_synclogs
+      username: "{{ postgres_users.root.username }}"
+      password: "{{ postgres_users.root.password }}"
+      port: 6432
+      skip_superuser_check: True
 
 dbs:
   main:

--- a/environments/staging/postgresql.yml
+++ b/environments/staging/postgresql.yml
@@ -13,6 +13,10 @@ pgbouncer_override:
   pgbouncer_max_connections: 1600
   pgbouncer_default_pool: 290
 
+pg_repack:
+  pgproxy2:
+    - database: commcarehq_synclogs
+
 dbs:
   main:
     pgbouncer_host: pgproxy2

--- a/environments/staging/postgresql.yml
+++ b/environments/staging/postgresql.yml
@@ -19,7 +19,7 @@ pg_repack:
       username: "{{ postgres_users.root.username }}"
       password: "{{ postgres_users.root.password }}"
       port: 6432
-      skip_superuser_check: True
+      skip_superuser_check: False
 
 dbs:
   main:

--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -25,6 +25,9 @@ backup_postgres: plain
 backup_es_s3: False
 postgres_s3: False
 
+# pg_repack
+pg_repack_version: 1.4.3
+
 filebeat_inputs:
   - path: "{{ log_home }}/{{ deploy_env }}-timing.log"
     tags: nginx-timing

--- a/src/commcare_cloud/ansible/deploy_postgres.yml
+++ b/src/commcare_cloud/ansible/deploy_postgres.yml
@@ -83,9 +83,10 @@
     - role: kernel_tune 
 
 - name: Install and configure pg_repack
-  hosts: "{{ pg_repack|list }}"
+  hosts: postgresql
   become: true
   roles:
     - role: pg_repack
+      when: inventory_hostname in pg_repack
   tags:
     pg_repack

--- a/src/commcare_cloud/ansible/group_vars/postgresql.yml
+++ b/src/commcare_cloud/ansible/group_vars/postgresql.yml
@@ -2,4 +2,3 @@ datadog_integration_pgbouncer: true
 datadog_integration_postgres: true
 is_pg_standby: false
 is_pg_master: true
-pg_repack_version: 1.4.3

--- a/src/commcare_cloud/ansible/group_vars/postgresql.yml
+++ b/src/commcare_cloud/ansible/group_vars/postgresql.yml
@@ -2,3 +2,4 @@ datadog_integration_pgbouncer: true
 datadog_integration_postgres: true
 is_pg_standby: false
 is_pg_master: true
+pg_repack_version: 1.4.3

--- a/src/commcare_cloud/ansible/roles/pg_repack/defaults/main.yml
+++ b/src/commcare_cloud/ansible/roles/pg_repack/defaults/main.yml
@@ -1,5 +1,5 @@
 pg_repack_version: 1.4.5
 pg_repack_source: "http://api.pgxn.org/dist/pg_repack/{{pg_repack_version}}/pg_repack-{{pg_repack_version}}.zip"
 pg_repack_script_path: /usr/local/bin/pg_repack.py
-nadir_hour: 2
-pg_bouncer_port: 6432
+pg_repack_skip_superuser_check: no
+pg_repack_nadir_hour: 2

--- a/src/commcare_cloud/ansible/roles/pg_repack/defaults/main.yml
+++ b/src/commcare_cloud/ansible/roles/pg_repack/defaults/main.yml
@@ -1,3 +1,5 @@
 pg_repack_version: 1.4.5
 pg_repack_source: "http://api.pgxn.org/dist/pg_repack/{{pg_repack_version}}/pg_repack-{{pg_repack_version}}.zip"
 pg_repack_script_path: /usr/local/bin/pg_repack.py
+nadir_hour: 2
+pg_bouncer_port: 6432

--- a/src/commcare_cloud/ansible/roles/pg_repack/files/pg_repack.py
+++ b/src/commcare_cloud/ansible/roles/pg_repack/files/pg_repack.py
@@ -128,7 +128,7 @@ def main():
     parser.add_argument('-p', '--port', help='Port number')
     parser.add_argument('-U', '--username', help='Name of the user')
     parser.add_argument('-W', '--password', help='Password of the user')
-    parser.add_argument('-k', '--no-superuser-check', help='skip superuser checks in client', action='store_true')
+    parser.add_argument('-k', '--no-superuser-check', dest='no_superuser_check', help='skip superuser checks in client', action='store_true')
 
     args = parser.parse_args()
 
@@ -151,9 +151,17 @@ def main():
     for table in tables:
         logger.debug('\t%s', table)
 
-    repack_command = [
-        args.pg_repack, '--no-order', '--wait-timeout=30', '-k' , f'--dbname={args.database}'
-    ] + [f'--port={args.port}'] + [f'--host={args.host}'] + [f'--username={args.username}'] + [f'--table={table}' for table in table_names]
+    repack_command = [args.pg_repack, '--no-order', '--wait-timeout=30', f'--dbname={args.database}' ] + [f'--table={table}' for table in table_names]
+
+    additional_args = {'port':args.port,'username':args.username, 'host':args.host}
+
+    for key, value in additional_args.items():
+        if additional_args[key]:
+           add_params = f'--{key}={value}'
+           repack_command.append(add_params)
+
+    if args.no_superuser_check:
+        repack_command.append('-k')
 
     try:
         cpu_count = multiprocessing.cpu_count()

--- a/src/commcare_cloud/ansible/roles/pg_repack/files/pg_repack.py
+++ b/src/commcare_cloud/ansible/roles/pg_repack/files/pg_repack.py
@@ -64,9 +64,9 @@ def fetchall_as_namedtuple(cursor):
     return (Result(*row) for row in cursor)
 
 
-def get_table_info(dbname, table_names=None):
+def get_table_info(dbname, table_names=None, host='127.0.0.1', port=5432, username=None, password=None):
     tables = defaultdict(dict)
-    connection = psycopg2.connect(connection_factory=LoggingConnection, dbname=dbname)
+    connection = psycopg2.connect(connection_factory=LoggingConnection, dbname=dbname, host=host, port=port, user=username, password=password)
     connection.initialize(logger)
     try:
         with connection.cursor() as cursor:
@@ -121,9 +121,14 @@ def main():
     parser.add_argument('--dead-tup-ratio', dest='dead_tup_ratio_limit', type=float, default=0.1,
                         help='Only consider tables with a ratio of live tuples to dead tuples above this limit')
     parser.add_argument('--pg-repack', help='Path to pg_repack', required=True)
-    parser.add_argument('-d', '--database', help='Name fo the database', required=True)
+    parser.add_argument('-d', '--database', help='Name of the database', required=True)
     parser.add_argument('-v', dest='verbosity', help="Verbose logging. Specify multiple times (up to 3).", action='count', default=0)
     parser.add_argument('--dry-run', action='store_true')
+    parser.add_argument('--host', help='Name of the host')
+    parser.add_argument('-p', '--port', help='Port number')
+    parser.add_argument('-U', '--username', help='Name of the user')
+    parser.add_argument('-W', '--password', help='Password of the user')
+    parser.add_argument('-k', '--no-superuser-check', help='skip superuser checks in client', action='store_true')
 
     args = parser.parse_args()
 
@@ -133,7 +138,7 @@ def main():
 
     size_limit_bytes = args.size_limit * GB
     tables = [
-        table for table in get_table_info(args.database, args.tables)
+        table for table in get_table_info(dbname=args.database, table_names=args.tables, host=args.host, port=args.port, username=args.username, password=args.password)
         if table.should_repack(size_limit_bytes, args.dead_tup_ratio_limit)
     ]
     table_names = [table.table_name for table in tables]
@@ -147,8 +152,8 @@ def main():
         logger.debug('\t%s', table)
 
     repack_command = [
-        args.pg_repack, '--no-order', '--wait-timeout=30', f'--dbname={args.database}'
-    ] + [f'--table={table}' for table in table_names]
+        args.pg_repack, '--no-order', '--wait-timeout=30', '-k' , f'--dbname={args.database}'
+    ] + [f'--port={args.port}'] + [f'--host={args.host}'] + [f'--username={args.username}'] + [f'--table={table}' for table in table_names]
 
     try:
         cpu_count = multiprocessing.cpu_count()
@@ -172,7 +177,7 @@ def main():
 
     logger.info('\nSTDOUT:\n%s\nSTDERR:\n%s', output.decode(), error_output.decode())
     post_tables = [
-        table for table in get_table_info(args.database)
+        table for table in get_table_info(dbname=args.database, host=args.host, port=args.port, username=args.username, password=args.password)
         if table.table_name in table_names
     ]
 

--- a/src/commcare_cloud/ansible/roles/pg_repack/files/pg_repack.py
+++ b/src/commcare_cloud/ansible/roles/pg_repack/files/pg_repack.py
@@ -153,10 +153,10 @@ def main():
 
     repack_command = [args.pg_repack, '--no-order', '--wait-timeout=30', f'--dbname={args.database}' ] + [f'--table={table}' for table in table_names]
 
-    additional_args = {'port':args.port,'username':args.username, 'host':args.host}
+    additional_args = {'port': args.port, 'username': args.username, 'host': args.host}
 
     for key, value in additional_args.items():
-        if additional_args[key]:
+        if value:
            add_params = f'--{key}={value}'
            repack_command.append(add_params)
 

--- a/src/commcare_cloud/ansible/roles/pg_repack/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/pg_repack/tasks/main.yml
@@ -71,12 +71,12 @@
       --host {{ item.host|default('localhost') }}
       --port {{ item.port|default(5432) }}
       -d {{ item.database }}
-      {% if item.tables|default(None) %} --tables {{ item.tables|join(' ') }}{% endif %}"
+      {% if item.tables|default(None) %} --tables {{ item.tables|join(' ') }}{% endif %}
       --table-size-limit {{ item.table_size|default(10) }}
       --dead-tup-ratio {{ item.ratio|default(0.05) }}
       {% if item.username|default(None) %} -U {{ item.username }}{% endif %}
       {% if item.password|default(None) %} -W {{ item.password }}{% endif %}
-      {% if item.skip_superuser_check|default(pg_repack_skip_superuser_check) %} -k{% endif %}
+      {% if item.skip_superuser_check|default(pg_repack_skip_superuser_check) %} -k{% endif %}"
     minute: "30"
     hour: "{{ pg_repack_nadir_hour + 2 }}"
     user: postgres

--- a/src/commcare_cloud/ansible/roles/pg_repack/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/pg_repack/tasks/main.yml
@@ -47,10 +47,12 @@
     postgresql_ext:
       name: pg_repack
       db: "{{ item.database }}"
-      port: "{{ postgresql_port }}"
+      port: "{{ pg_bouncer_port|default(5432) }}"
+      login_user: "{{ postgres_users.root.username }}"
+      login_password: "{{ postgres_users.root.password }}"
       version: "{{ pg_repack_version }}"
     loop: "{{ pg_repack.get(inventory_hostname, []) }}"
-  when: pg_repack_stat.stat.exists == False or pg_repack_installed_version.stdout.split()[1] != pg_repack_version
+  when: pg_repack_stat.stat.exists == False or pg_repack_installed_version.stdout.split()[1] == pg_repack_version
 
 - name: Create pg_repack script
   become: yes
@@ -65,7 +67,7 @@
   become: yes
   cron:
     name: "pg_repack {{ item.database }}"
-    job: "{{ pg_repack_script_path }} --pg-repack {{ postgres_install_dir }}/bin/pg_repack --dead-tup-ratio {{ item.ratio|default(0.05) }} -d {{ item.database }}{% if item.tables|default(None) %} --tables {{ item.tables|join(' ') }}{% endif %}"
+    job: "{{ pg_repack_script_path }} --pg-repack {{ postgres_install_dir }}/bin/pg_repack --host {{ item.host|default('localhost') }} --port {{ pg_repack_port|default(5432) }} -U {{ postgres_users.root.username|default(None) }} -W {{ postgres_users.root.password|default(None) }} -k --table-size-limit {{ item.table_size|default(10) }} --dead-tup-ratio {{ item.ratio|default(0.05) }} -d {{ item.database }}{% if item.tables|default(None) %} --tables {{ item.tables|join(' ') }}{% endif %}"
     minute: "30"
     hour: "{{ nadir_hour + 2 }}"
     user: postgres

--- a/src/commcare_cloud/ansible/roles/pg_repack/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/pg_repack/tasks/main.yml
@@ -46,7 +46,7 @@
       ansible_ssh_pipelining: true
     postgresql_ext:
       name: pg_repack
-      db: "{{ item }}"
+      db: "{{ item.database }}"
       port: "{{ postgresql_port }}"
       version: "{{ pg_repack_version }}"
     loop: "{{ pg_repack.get(inventory_hostname, []) }}"
@@ -64,10 +64,10 @@
 - name: Create pg_repack cron
   become: yes
   cron:
-    name: "pg_repack {{ item }}"
+    name: "pg_repack {{ item.database }}"
     job: "{{ pg_repack_script_path }} --pg-repack {{ postgres_install_dir }}/bin/pg_repack --dead-tup-ratio {{ item.ratio|default(0.05) }} -d {{ item.database }}{% if item.tables|default(None) %} --tables {{ item.tables|join(' ') }}{% endif %}"
     minute: "30"
     hour: "{{ nadir_hour + 2 }}"
     user: postgres
-    cron_file: "pg_repack_{{ item }}"
+    cron_file: "pg_repack_{{ item.database }}"
   loop: "{{ pg_repack.get(inventory_hostname, []) }}"

--- a/src/commcare_cloud/ansible/roles/pg_repack/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/pg_repack/tasks/main.yml
@@ -47,12 +47,11 @@
     postgresql_ext:
       name: pg_repack
       db: "{{ item.database }}"
-      port: "{{ pg_bouncer_port|default(5432) }}"
-      login_user: "{{ postgres_users.root.username }}"
-      login_password: "{{ postgres_users.root.password }}"
+      port: "{{ item.port|default(5432) }}"
+      login_user: "{{ item.username|default(None) }}"
+      login_password: "{{ item.password|default(None) }}"
       version: "{{ pg_repack_version }}"
     loop: "{{ pg_repack.get(inventory_hostname, []) }}"
-  when: pg_repack_stat.stat.exists == False or pg_repack_installed_version.stdout.split()[1] == pg_repack_version
 
 - name: Create pg_repack script
   become: yes
@@ -67,9 +66,19 @@
   become: yes
   cron:
     name: "pg_repack {{ item.database }}"
-    job: "{{ pg_repack_script_path }} --pg-repack {{ postgres_install_dir }}/bin/pg_repack --host {{ item.host|default('localhost') }} --port {{ pg_repack_port|default(5432) }} -U {{ postgres_users.root.username|default(None) }} -W {{ postgres_users.root.password|default(None) }} -k --table-size-limit {{ item.table_size|default(10) }} --dead-tup-ratio {{ item.ratio|default(0.05) }} -d {{ item.database }}{% if item.tables|default(None) %} --tables {{ item.tables|join(' ') }}{% endif %}"
+    job: >
+      "{{ pg_repack_script_path }} --pg-repack {{ postgres_install_dir }}/bin/pg_repack
+      --host {{ item.host|default('localhost') }}
+      --port {{ item.port|default(5432) }}
+      -d {{ item.database }}
+      {% if item.tables|default(None) %} --tables {{ item.tables|join(' ') }}{% endif %}"
+      --table-size-limit {{ item.table_size|default(10) }}
+      --dead-tup-ratio {{ item.ratio|default(0.05) }}
+      {% if item.username|default(None) %} -U {{ item.username }}{% endif %}
+      {% if item.password|default(None) %} -W {{ item.password }}{% endif %}
+      {% if item.skip_superuser_check|default(pg_repack_skip_superuser_check) %} -k{% endif %}
     minute: "30"
-    hour: "{{ nadir_hour + 2 }}"
+    hour: "{{ pg_repack_nadir_hour + 2 }}"
     user: postgres
     cron_file: "pg_repack_{{ item.database }}"
   loop: "{{ pg_repack.get(inventory_hostname, []) }}"


### PR DESCRIPTION
Installed pg_repack 1.4.3 version on staging pg_bouncer server to add an extension on the staging commcarehq_synclog database. Faced some issues in pg_repack tasks/main.yml with the item variable. Fixed it. 
- Updated pg_repack script to connect to the remote database. 
- we need superuser (root) credentials to allow repacking on the databases/tables. 

Please review my changes related pg_repack.py. If looks good will apply the changes in staging env first. thanks.