### PR TITLE
Use db.t3.* in production to align with RIs

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -516,7 +516,7 @@ rds_instances:
       shared_preload_libraries: pg_stat_statements
       log_min_duration_statement: 1000
   - identifier: "pgshard2-production"
-    instance_type: "db.m5.2xlarge"
+    instance_type: "db.t3.2xlarge"
     storage: 500
     max_storage: 2500
     multi_az: true
@@ -525,7 +525,7 @@ rds_instances:
       shared_preload_libraries: pg_stat_statements
       log_min_duration_statement: 1000
   - identifier: "pgshard3-production"
-    instance_type: "db.m5.2xlarge"
+    instance_type: "db.t3.2xlarge"
     storage: 500
     max_storage: 2500
     multi_az: true
@@ -534,7 +534,7 @@ rds_instances:
       shared_preload_libraries: pg_stat_statements
       log_min_duration_statement: 1000
   - identifier: "pgshard4-production"
-    instance_type: "db.m5.2xlarge"
+    instance_type: "db.t3.2xlarge"
     storage: 500
     max_storage: 2500
     multi_az: true
@@ -543,7 +543,7 @@ rds_instances:
       shared_preload_libraries: pg_stat_statements
       log_min_duration_statement: 1000
   - identifier: "pgshard5-production"
-    instance_type: "db.m5.2xlarge"
+    instance_type: "db.t3.2xlarge"
     storage: 500
     max_storage: 2500
     multi_az: true


### PR DESCRIPTION
When firefighting yesterday I made a small oversight that results in something super cost-inefficient: paying for db.m5's when we've already prepaid for db.t3's that we now aren't using. This PR switches the pgshard machines back to db.t3 while keeping the current "size" of RAM and CPU. I expect this to have no effect on performance and a ton of effect on cost (versus staying the course we set yesterday).

##### ENVIRONMENTS AFFECTED
production