### PR TITLE
Do the same to pgshard1-production as the rest of the shards

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -507,7 +507,7 @@ rds_instances:
     engine_version: 9.6.15
 
   - identifier: "pgshard1-production"
-    instance_type: "db.m5.2xlarge"
+    instance_type: "db.t3.2xlarge"
     storage: 500
     max_storage: 2500
     multi_az: true


### PR DESCRIPTION
This was an oversight from https://github.com/dimagi/commcare-cloud/pull/4284 I found only after merging it.