### PR TITLE
Use new monitoring_interval rds setting

### DIFF
--- a/src/commcare_cloud/terraform/modules/postgresql/main.tf
+++ b/src/commcare_cloud/terraform/modules/postgresql/main.tf
@@ -45,6 +45,7 @@ module "postgresql" {
 
   # DB option group
   major_engine_version = "9.6"
+  monitoring_interval = "${var.rds_instance["monitoring_interval"]}"
 
   # Snapshot name upon DB deletion
   final_snapshot_identifier = "final-snapshot-${var.rds_instance["identifier"]}"


### PR DESCRIPTION
added in https://github.com/dimagi/commcare-cloud/pull/4283 but inadvertently not actually used
