### PR TITLE
option to dump current couchdb shard allocation

### DIFF
--- a/docs/commcare-cloud/commands/index.md
+++ b/docs/commcare-cloud/commands/index.md
@@ -1310,8 +1310,14 @@ Output table as CSV
 Output information about the CouchDB cluster
 
 ```
-commcare-cloud <env> couchdb-cluster-info
+commcare-cloud <env> couchdb-cluster-info [--raw]
 ```
+
+##### Optional Arguments
+
+###### `--raw`
+
+Output raw shard allocations as YAML instead of printing tables.
 
 ---
 


### PR DESCRIPTION
This can be useful when doing migrations (using the `migrate-couchdb` command) when the source cluster is no longer available (docs etc. still to be worked out).
