### PR TITLE
fix syntax warning

### DIFF
--- a/src/commcare_cloud/commcare_cloud.py
+++ b/src/commcare_cloud/commcare_cloud.py
@@ -181,7 +181,7 @@ def call_commcare_cloud(input_argv=sys.argv):
 
 def main():
     exit_code = call_commcare_cloud()
-    if exit_code is not 0:
+    if exit_code != 0:
         exit(exit_code)
 
 


### PR DESCRIPTION
```
src/commcare_cloud/commcare_cloud.py:184: SyntaxWarning: "is not" with a literal. Did you mean "!="?
```