### PR TITLE
remove es7 nodes from staging

### DIFF
--- a/environments/staging/terraform.yml
+++ b/environments/staging/terraform.yml
@@ -39,28 +39,6 @@ servers:
     group: webworkers
     os: ubuntu_pro_bionic
 
-  - server_name: "es4-staging"
-    server_instance_type: "t3.medium"
-    network_tier: "db-private"
-    az: "a"
-    volume_size: 30
-    volume_encrypted: yes
-    block_device:
-      volume_size: 80
-      encrypted: true
-    group: "elasticsearch"
-    os: ubuntu_pro_bionic
-  - server_name: "es5-staging"
-    server_instance_type: "t3.medium"
-    network_tier: "db-private"
-    az: "a"
-    volume_size: 30
-    volume_encrypted: yes
-    block_device:
-      volume_size: 80
-      encrypted: true
-    group: "elasticsearch"
-    os: ubuntu_pro_bionic
   - server_name: "es6-staging"
     server_instance_type: "t3.medium"
     network_tier: "db-private"


### PR DESCRIPTION
Staging has been rolled back to ES2 using the original ES2 nodes. These ES7 nodes are no longer in use.

I tried running `terraform plan` but got permission denied errors on a number of resources so someone else will have to roll this out.

##### ENVIRONMENTS AFFECTED
staging
