### PR TITLE
Change default aws sso_role_name to match online configuration

### DIFF
--- a/src/commcare_cloud/commands/terraform/aws.py
+++ b/src/commcare_cloud/commands/terraform/aws.py
@@ -567,7 +567,7 @@ def _write_profile_for_sso(
     config.set(section, 'sso_start_url', sso_start_url)
     config.set(section, 'sso_region', sso_region)
     config.set(section, 'sso_account_id', sso_account_id)
-    config.set(section, 'sso_role_name', 'AWSPowerUserAccess')
+    config.set(section, 'sso_role_name', 'PowerUserAccessPlus')
     config.set(section, 'region', region)
     config.set(section, 'output', 'json')
     with open(AWS_CONFIG_PATH, 'w') as f:


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-11451. I also updated the commcare-india account role settings in the console to have the same configuration as production, staging, so that now this default is right for all of them.

##### ENVIRONMENTS AFFECTED
saas aws envs