### PR TITLE
create new update-user command for when update-users is slow AF

### DIFF
--- a/docs/commcare-cloud/commands/index.md
+++ b/docs/commcare-cloud/commands/index.md
@@ -11,7 +11,7 @@ All `commcare-cloud` commands take the following form:
 ```
 commcare-cloud [--control]
                <env>
-               {after-reboot,ansible-playbook,ap,aws-fill-inventory,aws-list,aws-sign-in,bootstrap-users,celery-resource-report,copy-files,couchdb-cluster-info,deploy,deploy-stack,aps,django-manage,downtime,export-sentry-events,fab,list-postgresql-dbs,lookup,migrate-couchdb,migrate_couchdb,migrate-secrets,mosh,openvpn-activate-user,openvpn-claim-user,pillow-resource-report,pillow-topic-assignments,ping,run-module,run-shell-command,secrets,send-datadog-event,service,ssh,terraform,terraform-migrate-state,tmux,update-config,update-local-known-hosts,update-supervisor-confs,update-user-key,update-users,validate-environment-settings}
+               {after-reboot,ansible-playbook,ap,aws-fill-inventory,aws-list,aws-sign-in,bootstrap-users,celery-resource-report,copy-files,couchdb-cluster-info,deploy,deploy-stack,aps,django-manage,downtime,export-sentry-events,fab,list-postgresql-dbs,lookup,migrate-couchdb,migrate_couchdb,migrate-secrets,mosh,openvpn-activate-user,openvpn-claim-user,pillow-resource-report,pillow-topic-assignments,ping,run-module,run-shell-command,secrets,send-datadog-event,service,ssh,terraform,terraform-migrate-state,tmux,update-config,update-local-known-hosts,update-supervisor-confs,add-new-user,update-user-key,update-users,validate-environment-settings}
                ...
 ```
 
@@ -924,6 +924,16 @@ up to date.
 ###### `--use-factory-auth`
 
 authenticate using the pem file (or prompt for root password if there is no pem file)
+
+---
+
+#### `add-new-user`
+
+Adds a single user to machines for a given username and group (because update-users takes forever).
+
+```
+commcare-cloud <env> add-new-user [--use-factory-auth] username dev_group
+```
 
 ---
 

--- a/docs/commcare-cloud/commands/index.md
+++ b/docs/commcare-cloud/commands/index.md
@@ -11,7 +11,7 @@ All `commcare-cloud` commands take the following form:
 ```
 commcare-cloud [--control]
                <env>
-               {after-reboot,ansible-playbook,ap,aws-fill-inventory,aws-list,aws-sign-in,bootstrap-users,celery-resource-report,copy-files,couchdb-cluster-info,deploy,deploy-stack,aps,django-manage,downtime,export-sentry-events,fab,list-postgresql-dbs,lookup,migrate-couchdb,migrate_couchdb,migrate-secrets,mosh,openvpn-activate-user,openvpn-claim-user,pillow-resource-report,pillow-topic-assignments,ping,run-module,run-shell-command,secrets,send-datadog-event,service,ssh,terraform,terraform-migrate-state,tmux,update-config,update-local-known-hosts,update-supervisor-confs,add-new-user,update-user-key,update-users,validate-environment-settings}
+               {after-reboot,ansible-playbook,ap,aws-fill-inventory,aws-list,aws-sign-in,bootstrap-users,celery-resource-report,copy-files,couchdb-cluster-info,deploy,deploy-stack,aps,django-manage,downtime,export-sentry-events,fab,list-postgresql-dbs,lookup,migrate-couchdb,migrate_couchdb,migrate-secrets,mosh,openvpn-activate-user,openvpn-claim-user,pillow-resource-report,pillow-topic-assignments,ping,run-module,run-shell-command,secrets,send-datadog-event,service,ssh,terraform,terraform-migrate-state,tmux,update-config,update-local-known-hosts,update-supervisor-confs,update-user-key,update-users,validate-environment-settings}
                ...
 ```
 
@@ -924,16 +924,6 @@ up to date.
 ###### `--use-factory-auth`
 
 authenticate using the pem file (or prompt for root password if there is no pem file)
-
----
-
-#### `add-new-user`
-
-Adds a single user to machines for a given username and group (because update-users takes forever).
-
-```
-commcare-cloud <env> add-new-user [--use-factory-auth] username dev_group
-```
 
 ---
 

--- a/src/commcare_cloud/ansible/roles/bootstrap-users/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/bootstrap-users/tasks/main.yml
@@ -46,7 +46,7 @@
   user: name="{{ item }}" state=present shell=/bin/bash groups={{ dev_group }}
   with_items: '{{ dev_users.present }}'
   tags:
-    - new_user
+    - update_user
 
 - name: Add public keys for current devs
   become: yes
@@ -54,6 +54,7 @@
   with_items: '{{ dev_users.present }}'
   ignore_errors: "{{ ansible_check_mode }}"
   tags:
+    - update_user
     - pubkey
 
 - name: Remove public key for cchq user  # todo: remove after applied to all envs
@@ -71,6 +72,7 @@
   authorized_key: user=ansible state=present key="{{ lookup('file', authorized_keys_dir ~ item ~ '.pub') }}"
   with_items: '{{ dev_users.present }}'
   tags:
+    - update_user
     - pubkey
 
 - import_tasks: remove_users.yml
@@ -82,12 +84,16 @@
   register: users_pw_valid
   loop: "{{ dev_users.present }} + ['ansible', '{{ cchq_user }}']"
   changed_when: False
+  tags:
+    - update_user
 
 - name: clear users password valid time
   become: yes
   shell: chage -M -1 "{{ item['item'] }}"
   loop: "{{ users_pw_valid.results }}"
   when: item.stdout is defined and item.stdout != ''
+  tags:
+    - update_user
 
 
 # This must be the last task in the file
@@ -97,4 +103,5 @@
   become: yes
   template: src=sudoers.j2 dest=/etc/sudoers.d/cchq validate='visudo -cf %s' owner=root group=root mode=0440
   tags:
+    - update_user
     - sudoers

--- a/src/commcare_cloud/ansible/roles/bootstrap-users/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/bootstrap-users/tasks/main.yml
@@ -45,6 +45,8 @@
   become: yes
   user: name="{{ item }}" state=present shell=/bin/bash groups={{ dev_group }}
   with_items: '{{ dev_users.present }}'
+  tags:
+    - new_user
 
 - name: Add public keys for current devs
   become: yes

--- a/src/commcare_cloud/commands/ansible/ansible_playbook.py
+++ b/src/commcare_cloud/commands/ansible/ansible_playbook.py
@@ -337,6 +337,27 @@ class UpdateUsers(_AnsiblePlaybookAlias):
         return AnsiblePlaybook(self.parser).run(args, unknown_args)
 
 
+class AddNewUser(_AnsiblePlaybookAlias):
+    command = 'add-new-user'
+    help = ("Adds a single user to machines for a given username "
+            "and group (because update-users takes forever).")
+    arguments = _AnsiblePlaybookAlias.arguments + (
+        Argument("username", help="username of the user needing to be added"),
+        Argument("dev_group", help="name of the dev group the user is in"),
+    )
+
+    def run(self, args, unknown_args):
+        args.playbook = 'deploy_stack.yml'
+        unknown_args += (
+            '--tags=new_user',
+            '--extra-vars={{"dev_users": {{"present": [{}]}}, "dev_group": "{}"}}'.format(
+                args.username,
+                args.dev_group
+            ),
+        )
+        return AnsiblePlaybook(self.parser).run(args, unknown_args)
+
+
 class UpdateUserPublicKey(_AnsiblePlaybookAlias):
     command = 'update-user-key'
     help = "Update a single user's public key (because update-users takes forever)."

--- a/src/commcare_cloud/commands/ansible/ansible_playbook.py
+++ b/src/commcare_cloud/commands/ansible/ansible_playbook.py
@@ -337,39 +337,32 @@ class UpdateUsers(_AnsiblePlaybookAlias):
         return AnsiblePlaybook(self.parser).run(args, unknown_args)
 
 
-class AddNewUser(_AnsiblePlaybookAlias):
-    command = 'add-new-user'
-    help = ("Adds a single user to machines for a given username "
-            "and group (because update-users takes forever).")
+class UpdateUser(_AnsiblePlaybookAlias):
+    command = 'update-user'
+    help = """
+    Brings a single user up to date with the current CommCare Cloud settings.
+    Use this when `update-users` takes forever.
+    """
     arguments = _AnsiblePlaybookAlias.arguments + (
         Argument("username", help="username of the user needing to be added"),
-        Argument("dev_group", help="name of the dev group the user is in"),
+        Argument('--dev-group', default='dimagidev', help=(
+            "name of the dev group the user is in"
+        )),
+        Argument('--ssh-key-only', action='store_true', default=False, help=(
+            "only update the ssh key"
+        )),
     )
 
     def run(self, args, unknown_args):
         args.playbook = 'deploy_stack.yml'
         unknown_args += (
-            '--tags=new_user',
-            '--extra-vars={{"dev_users": {{"present": [{}]}}, "dev_group": "{}"}}'.format(
+            '--tags={}'.format('pubkey' if args.ssh_key_only else 'update_user'),
+            '--extra-vars={{"dev_users": {{"present": [{}]}}, '
+            '"dev_group": "{}", '
+            '"single_user_only": True }}'.format(
                 args.username,
-                args.dev_group
+                args.dev_group,
             ),
-        )
-        return AnsiblePlaybook(self.parser).run(args, unknown_args)
-
-
-class UpdateUserPublicKey(_AnsiblePlaybookAlias):
-    command = 'update-user-key'
-    help = "Update a single user's public key (because update-users takes forever)."
-    arguments = _AnsiblePlaybookAlias.arguments + (
-        Argument("username", help="username who owns the public key"),
-    )
-
-    def run(self, args, unknown_args):
-        args.playbook = 'deploy_stack.yml'
-        unknown_args += (
-            '--tags=pubkey',
-            '--extra-vars={{"dev_users": {{"present": [{}]}}}}'.format(args.username),
         )
         return AnsiblePlaybook(self.parser).run(args, unknown_args)
 

--- a/src/commcare_cloud/commcare_cloud.py
+++ b/src/commcare_cloud/commcare_cloud.py
@@ -29,8 +29,7 @@ from .argparse14 import ArgumentParser, RawTextHelpFormatter
 from .commands.ansible.ansible_playbook import (
     AnsiblePlaybook,
     UpdateConfig, AfterReboot, BootstrapUsers, DeployStack,
-    UpdateUsers, UpdateUserPublicKey, UpdateSupervisorConfs,
-    AddNewUser,
+    UpdateUsers, UpdateUser, UpdateSupervisorConfs,
 )
 from commcare_cloud.commands.ansible.service import Service
 from .commands.ansible.run_module import RunAnsibleModule, RunShellCommand, Ping, SendDatadogEvent
@@ -72,8 +71,7 @@ COMMAND_GROUPS = OrderedDict([
         AfterReboot,
         BootstrapUsers,
         UpdateUsers,
-        AddNewUser,
-        UpdateUserPublicKey,
+        UpdateUser,
         UpdateSupervisorConfs,
         Fab,
         Deploy,

--- a/src/commcare_cloud/commcare_cloud.py
+++ b/src/commcare_cloud/commcare_cloud.py
@@ -30,6 +30,7 @@ from .commands.ansible.ansible_playbook import (
     AnsiblePlaybook,
     UpdateConfig, AfterReboot, BootstrapUsers, DeployStack,
     UpdateUsers, UpdateUserPublicKey, UpdateSupervisorConfs,
+    AddNewUser,
 )
 from commcare_cloud.commands.ansible.service import Service
 from .commands.ansible.run_module import RunAnsibleModule, RunShellCommand, Ping, SendDatadogEvent
@@ -71,6 +72,7 @@ COMMAND_GROUPS = OrderedDict([
         AfterReboot,
         BootstrapUsers,
         UpdateUsers,
+        AddNewUser,
         UpdateUserPublicKey,
         UpdateSupervisorConfs,
         Fab,


### PR DESCRIPTION
`update-users` takes a really long time to run on environments like prod. 

this introduces the `add-new-user` command which can be used in combination with `update-user-key`

##### ENVIRONMENTS AFFECTED
all
