### PR TITLE
pg_repack installation on production commcarehq_synclog db

### DIFF
--- a/environments/production/postgresql.yml
+++ b/environments/production/postgresql.yml
@@ -13,6 +13,14 @@ pgbouncer_override:
   pgbouncer_pool_timeout: 1
   pgbouncer_reserve_pool: 5
 
+# pg_repack settings
+pg_repack:
+  pgbouncer3:
+    - database: commcarehq_synclogs
+      username: "{{ postgres_users.root.username }}"
+      password: "{{ postgres_users.root.password }}"
+      port: 6432
+      skip_superuser_check: True
 
 # We're temporarily disabling read replicas
 # and will revisit after migration to RDS

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -104,6 +104,9 @@ rabbitmq_version: 3.8.5-1
 #RabbitMQ Broker URL
 BROKER_URL: 'amqp://{{ AMQP_USER }}:{{ AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }};amqp://{{ AMQP_USER }}:{{ AMQP_PASSWORD }}@{{ groups.rabbitmq.1 }}:5672/{{ AMQP_NAME }}'
 
+# pg_repack
+pg_repack_version: 1.4.3
+
 s3_blob_db_enabled: yes
 s3_blob_db_url: "https://s3.amazonaws.com"
 s3_blob_db_s3_bucket: 'dimagi-commcare-production-blobdb'


### PR DESCRIPTION
Please review my changes and let me know if you have any suggestions.

Steps to deploy pg_repack :
 cchq <env> deploy-stack --tags=pg_repack --branch=<branch_name>
#In cron.d a new file will be added with below line will.
2. /usr/lib/postgresql/9.6/bin/pg_repack --no-order --wait-timeout=30 -k --dbname=commcarehq_synclogs --port=6432 --username=root --table=table1 --table=table2