### PR TITLE
remove main citus cluster from india

### DIFF
--- a/environments/india/inventory.ini
+++ b/environments/india/inventory.ini
@@ -72,18 +72,18 @@ es_data
 pgmain0-india.ccqpd1xrju8m.ap-south-1.rds.amazonaws.com
 
 [citusdb_worker:children]
-;citusworker0
-;citusworker1
-;citusworker2
+citusworker0
+citusworker1
+citusworker2
 
 [citusdb_master:children]
-;citusmaster0
+citusmaster0
 
 [citusdb:children]
-;citusmaster0
-;citusworker0
-;citusworker1
-;citusworker2
+citusmaster0
+citusworker0
+citusworker1
+citusworker2
 
 [pg_standby:children]
 # empty

--- a/environments/india/inventory.ini
+++ b/environments/india/inventory.ini
@@ -6,16 +6,6 @@
 10.203.10.48 hostname=web0-india ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-041a554f3e4ac5d9b
 [web1]
 10.203.10.146 hostname=web1-india ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-09f05906332021832
-[citus0]
-10.203.10.77 hostname=citus0-india ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-02df9617c533d67ba
-[citus1]
-10.203.10.74 hostname=citus1-india ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-09b97890b94b99b23
-[citus2]
-10.203.10.190 hostname=citus2-india ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-01d3a813f449ef321
-[citus2standby]
-10.203.10.105 hostname=citus2standby-india ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-0e1bd37fa4288cb05
-[citus1standby]
-10.203.10.220 hostname=citus1standby-india ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-097e43aea9f77c954
 [airflow1]
 10.203.10.63 hostname=airflow1-india ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-09c34ee118d43f4de
 [celery1]
@@ -82,48 +72,21 @@ es_data
 pgmain0-india.ccqpd1xrju8m.ap-south-1.rds.amazonaws.com
 
 [citusdb_worker:children]
-citus1
-citus2
-citus1standby
-citus2standby
 ;citusworker0
 ;citusworker1
 ;citusworker2
 
 [citusdb_master:children]
-citus0
 ;citusmaster0
 
 [citusdb:children]
-citus0
-citus1
-citus2
-citus1standby
-citus2standby
 ;citusmaster0
 ;citusworker0
 ;citusworker1
 ;citusworker2
 
 [pg_standby:children]
-citus1standby
-citus2standby
-
-[citus1:vars]
-postgresql_replication_slots=['standby0']
-hot_standby_server=10.203.10.220
-
-[citus2:vars]
-postgresql_replication_slots=['standby0']
-hot_standby_server=10.203.10.105
-
-[citus1standby:vars]
-replication_slot=standby0
-hot_standby_master=10.203.10.74
-
-[citus2standby:vars]
-replication_slot=standby0
-hot_standby_master=10.203.10.190
+# empty
 
 [proxy:children]
 proxy1

--- a/environments/india/inventory.ini.j2
+++ b/environments/india/inventory.ini.j2
@@ -2,11 +2,6 @@
 {{ __djangomanage0__ }}
 {{ __web0__ }}
 {{ __web1__ }}
-{{ __citus0__ }}
-{{ __citus1__ }}
-{{ __citus2__ }}
-{{ __citus2standby__ }}
-{{ __citus1standby__ }}
 {{ __airflow1__ }}
 {{ __celery1__ }} swap_size=4G
 {{ __celery2__ }} swap_size=4G
@@ -50,48 +45,21 @@ es_data
 {{ __rds_pgmain0__ }}
 
 [citusdb_worker:children]
-citus1
-citus2
-citus1standby
-citus2standby
 ;citusworker0
 ;citusworker1
 ;citusworker2
 
 [citusdb_master:children]
-citus0
 ;citusmaster0
 
 [citusdb:children]
-citus0
-citus1
-citus2
-citus1standby
-citus2standby
 ;citusmaster0
 ;citusworker0
 ;citusworker1
 ;citusworker2
 
 [pg_standby:children]
-citus1standby
-citus2standby
-
-[citus1:vars]
-postgresql_replication_slots=['standby0']
-hot_standby_server=10.203.10.220
-
-[citus2:vars]
-postgresql_replication_slots=['standby0']
-hot_standby_server=10.203.10.105
-
-[citus1standby:vars]
-replication_slot=standby0
-hot_standby_master=10.203.10.74
-
-[citus2standby:vars]
-replication_slot=standby0
-hot_standby_master=10.203.10.190
+# empty
 
 [proxy:children]
 proxy1

--- a/environments/india/inventory.ini.j2
+++ b/environments/india/inventory.ini.j2
@@ -45,18 +45,18 @@ es_data
 {{ __rds_pgmain0__ }}
 
 [citusdb_worker:children]
-;citusworker0
-;citusworker1
-;citusworker2
+citusworker0
+citusworker1
+citusworker2
 
 [citusdb_master:children]
-;citusmaster0
+citusmaster0
 
 [citusdb:children]
-;citusmaster0
-;citusworker0
-;citusworker1
-;citusworker2
+citusmaster0
+citusworker0
+citusworker1
+citusworker2
 
 [pg_standby:children]
 # empty

--- a/environments/india/postgresql.yml
+++ b/environments/india/postgresql.yml
@@ -2,7 +2,6 @@ DEFAULT_POSTGRESQL_HOST: rds_pgmain0
 REPORTING_DATABASES:
   ucr: ucr
   aaa-data: aaa-data
-#  icds-ucr-citus: ucr
 
 pgbouncer_override:
   pgbouncer_default_pool: 290
@@ -53,15 +52,6 @@ dbs:
         shards: [820, 1023]
         pgbouncer_host: pgbouncer0
   custom:
-    # remove citus from django
-    # django_alias: icds-ucr-citus
-    - name: icds-ucr-citus
-      django_migrate: False
-      host: citus0
-      pgbouncer_host: pgbouncer0
-      pg_config:
-        - name: citus.shard_count
-          value: 32
     - django_alias: aaa-data
       name: aaa-data
       django_migrate: True  # AAA dashboard models are stored here

--- a/environments/india/terraform.yml
+++ b/environments/india/terraform.yml
@@ -50,30 +50,6 @@ servers:
     volume_encrypted: no
     group: control
     os: bionic
-  - server_name: "citus0-india"
-    server_instance_type: "c5.xlarge"
-    network_tier: "app-private"
-    az: "a"
-    volume_size: 150
-    volume_encrypted: no
-    group: citusdb_master
-    os: bionic
-  - server_name: "citus1-india"
-    server_instance_type: "c5.xlarge"
-    network_tier: "app-private"
-    az: "a"
-    volume_size: 150
-    volume_encrypted: no
-    group: citusdb_worker
-    os: bionic
-  - server_name: "citus2-india"
-    server_instance_type: "c5.xlarge"
-    network_tier: "app-private"
-    az: "a"
-    volume_size: 150
-    volume_encrypted: no
-    group: citusdb_worker
-    os: bionic
   - server_name: "citusmaster0-india"
     server_instance_type: "c5.xlarge"
     network_tier: "app-private"
@@ -99,22 +75,6 @@ servers:
     group: citusdb_worker
     os: bionic
   - server_name: "citusworker2-india"
-    server_instance_type: "c5.xlarge"
-    network_tier: "app-private"
-    az: "a"
-    volume_size: 150
-    volume_encrypted: no
-    group: citusdb_worker
-    os: bionic
-  - server_name: "citus1standby-india"
-    server_instance_type: "c5.xlarge"
-    network_tier: "app-private"
-    az: "a"
-    volume_size: 150
-    volume_encrypted: no
-    group: citusdb_worker
-    os: bionic
-  - server_name: "citus2standby-india"
     server_instance_type: "c5.xlarge"
     network_tier: "app-private"
     az: "a"


### PR DESCRIPTION
This cluster is not longer used. It has already been (removed from localsettings](https://github.com/dimagi/commcare-cloud/pull/3907).

We are still keeping the 'test' cluster for now while we continue to test the rebalancing tool.

##### ENVIRONMENTS AFFECTED
`india`
