### PR TITLE
bump memory on india's control machine due to OOMs

### DIFF
--- a/environments/india/terraform.yml
+++ b/environments/india/terraform.yml
@@ -19,7 +19,7 @@ external_routes: []
 
 servers:
   - server_name: "control0-india"
-    server_instance_type: "t3.small"
+    server_instance_type: "t3.medium"
     network_tier: "app-private"
     az: "a"
     volume_size: 80


### PR DESCRIPTION
india's control machine is constantly OOMing when running `update-users`. see
https://app.datadoghq.com/dashboard/nbz-bie-nip/host-groups?from_ts=1604072511418&live=false&to_ts=1604074311418&tpl_var_environment=india

##### ENVIRONMENTS AFFECTED
india
