### PR TITLE
Add simple task to preview PRs about to be deployed

### DIFF
--- a/docs/commcare-cloud/commands/index.md
+++ b/docs/commcare-cloud/commands/index.md
@@ -1005,6 +1005,7 @@ Use `-l` instead of a command to see the full list of commands.
     pillowtop
     preindex_views             Creates a new release that runs preindex_every...
     prepare_offline_deploy
+    preview_deploy             Display the PRs that will be deployed
     reset_mvp_pillows
     restart_services
     restart_webworkers

--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -851,6 +851,11 @@ def deploy_airflow():
     execute(airflow.update_airflow)
 
 
+@task
+def preview_deploy():
+    env.deploy_metadata.diff.warn_of_migrations()
+
+
 def make_tasks_for_envs(available_envs):
     tasks = {}
     for env_name in available_envs:

--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -853,6 +853,7 @@ def deploy_airflow():
 
 @task
 def preview_deploy():
+    """Display the PRs that will be deployed"""
     env.deploy_metadata.diff.warn_of_migrations()
 
 


### PR DESCRIPTION
Little utility that can be run with
```
$ cchq production fab preview_deploy
```

##### ENVIRONMENTS AFFECTED
None
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
