### PR TITLE
bump max_storage of pgsynclog0-production from 20TB to 30TB

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -555,7 +555,7 @@ rds_instances:
   - identifier: "pgsynclog0-production"
     instance_type: "db.t3.2xlarge"
     storage: 1000
-    max_storage: 20000
+    max_storage: 30000
     multi_az: true
     engine_version: 9.6.15
     params:


### PR DESCRIPTION
`pgsynclog0-production` triggered the 90% disk usage threshold today. 

##### ENVIRONMENTS AFFECTED
production
