### PR TITLE
check for prefix instead of full match

### DIFF
--- a/src/commcare_cloud/commands/ansible/service.py
+++ b/src/commcare_cloud/commands/ansible/service.py
@@ -198,14 +198,14 @@ class SupervisorService(SubServicesMixin, ServiceBase):
 
 
 def _service_status_helper(service_name):
-    if service_name in MONIT_MANAGED_SERVICES:
+    if any(service_name.startswith(prefix) for prefix in MONIT_MANAGED_SERVICES):
         return 'monit status {}'.format(service_name)
 
     return 'service {} status'.format(service_name)
 
 
 def _ansible_module_helper(service_name):
-    if service_name in MONIT_MANAGED_SERVICES:
+    if any(service_name.startswith(prefix) for prefix in MONIT_MANAGED_SERVICES):
         return 'monit'
 
     return 'service'


### PR DESCRIPTION
After changing the PosgreSQL service to be version
specific the 'monit' check broke since it was
looking for exact matches.