### PR TITLE
Use kafka-topics.sh --list to get topics for kafka data wipe

### DIFF
--- a/docs/howto/wipe_persistent_data.md
+++ b/docs/howto/wipe_persistent_data.md
@@ -37,11 +37,10 @@ How To Wipe Persistent Data
 
        $ cchq monolith ap wipe_kafka.yml
 
-   You can check they have been removed by confirming that
-   "__consumer_offsets" is the only topic remaining:
+   You can check they have been removed by confirming that the following shows
+   no output:
 
        $ kafka-topics.sh --zookeeper localhost:2181 --list
-       __consumer_offsets
 
 
 Rebuilding environment

--- a/src/commcare_cloud/ansible/wipe_kafka.yml
+++ b/src/commcare_cloud/ansible/wipe_kafka.yml
@@ -24,25 +24,9 @@
       include_vars: roles/kafka/defaults/main.yml
 
     - name: Get Kafka topics
-      # django_manage does not support check mode, and this task does not
-      # change the system. Force this task to run in normal mode even when
-      # check mode is on:
-      check_mode: no
-      django_manage:
-        command: 'list_kafka_topics'
-        app_path: "{{ code_home }}"
-        virtualenv: "{{ py3_virtualenv_home }}"
+      command: "/opt/kafka/bin/kafka-topics.sh --list --zookeeper localhost:{{ zookeeper_client_port }}"
       register: topics_result
-      # topics_result does not have `stdout` or `stdout_lines`. Use
-      # `out.split()` instead. e.g.
-      #    {
-      #        "changed": false,
-      #        "failed": false,
-      #        "out": "case\ncase-sql\ncommcare-user\ndomain\nform\nform-sql\n"
-      #               "group\nledger\nmeta\nsms\nweb-user\napp\nlocation\n"
-      #               "synclog-sql\n",
-      #        # ...
-      #    }
+      check_mode: no
 
     - name: Allow Kafka server to delete topics
       lineinfile:
@@ -58,7 +42,7 @@
         state: restarted
 
     - name: Delete topics
-      loop: "{{ topics_result.out.split() }}"
+      loop: "{{ topics_result.stdout_lines }}"
       command: "/opt/kafka/bin/kafka-topics.sh
         --delete
         --zookeeper localhost:{{ zookeeper_client_port }}


### PR DESCRIPTION
Fetch the list of topics from kafka itself, rather than django.  On a multi-server environment, kafka is often on a machine that doesn't have a django environment setup, so you can't run management commands directly.

##### ENVIRONMENTS AFFECTED

This only affects environments where we're wiping all data in preparation for restore from backups or data dumps - it shouldn't affect any production environment.
