### PR TITLE
Use bionic image on Travis since most (all?) envs are now on 18.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "2.7"
   - "3.6"
 os: linux
-dist: trusty
+dist: bionic
 
 env:
   global:


### PR DESCRIPTION
This may be the reason why Ansible uses pip2 instead of pip3 on Travis (unlike our production machines).

##### ENVIRONMENTS AFFECTED
travis (tests only)
