### PR TITLE
Switch back to apt-managed supervisor

### DIFF
--- a/src/commcare_cloud/ansible/roles/supervisor/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/supervisor/tasks/main.yml
@@ -1,21 +1,13 @@
 ---
 
-- name: remove supervisor 3.0b
-  apt: name=supervisor state=absent
+- name: pip uninstall supervisor
+  # can be removed when all envs have been swiched to the apt-managed supervisor
+  pip: name=supervisor state=absent
   become: yes
 
-- name: install supervisor 4.0.4
-  pip: name=supervisor state=present version=4.0.4
+- name: install supervisor
+  apt: name=supervisor state=present
   become: yes
-
-- name: link supervisor
-  file:
-    path: /usr/bin/{{ item }}
-    state: link
-    src: /usr/local/bin/{{ item }}
-  with_items:
-    - supervisord
-    - supervisorctl
 
 - name: find supervisord path
   shell: 'which supervisord'


### PR DESCRIPTION
This should be safe since we have upgraded from Ubuntu 14.04. Using the apt-managed version means security patches will be applied by the system, which is better than having the version hard-coded in an Ansible role.

I will roll this out on all SaaS-managed environments when it has been approved and merged.

##### ENVIRONMENTS AFFECTED
all

Deployed to
- [x] staging
- [ ] production
- [ ] india
- [ ] swiss