### PR TITLE
Explicitly use io.open in scripts directory files

### DIFF
--- a/scripts/es_snapshot.py
+++ b/scripts/es_snapshot.py
@@ -12,11 +12,14 @@ import logging
 import os
 import subprocess
 from datetime import datetime
-from textwrap import indent
 from functools import wraps
+from io import open
+from textwrap import indent
 
 import requests
 from requests import HTTPError, Timeout
+
+from commcare_cloud.python_migration_utils import open_for_json_dump
 
 logger = logging.getLogger(__name__)
 
@@ -444,7 +447,7 @@ class DownloadSnapshotVersion(object):
             return 1
 
         if not self.dry_run:
-            with open(os.path.join(self.download_path, 'index'), 'w') as fp:
+            with open_for_json_dump(os.path.join(self.download_path, 'index')) as fp:
                 json.dump({'snapshots': [self.snapshot_version]}, fp)
 
         total_bytes = 0

--- a/src/commcare_cloud/python_migration_utils.py
+++ b/src/commcare_cloud/python_migration_utils.py
@@ -1,5 +1,8 @@
-import six
+from __future__ import absolute_import
+
 from io import open
+
+import six
 
 
 def open_for_json_dump(path):

--- a/src/commcare_cloud/python_migration_utils.py
+++ b/src/commcare_cloud/python_migration_utils.py
@@ -1,0 +1,13 @@
+import six
+from io import open
+
+
+def open_for_json_dump(path):
+    """
+    This ensures compatible file write modes based on Python versions
+    Python 2 json.dump(s) returns a bytes object
+    Python 3 json.dump(s) returns a str object
+    """
+    if six.PY2:
+        return open(path, "wb")
+    return open(path, "w", encoding="utf-8")

--- a/src/commcare_cloud/python_migration_utils.py
+++ b/src/commcare_cloud/python_migration_utils.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 from io import open
 

--- a/src/commcare_cloud/python_migration_utils.py
+++ b/src/commcare_cloud/python_migration_utils.py
@@ -8,8 +8,8 @@ import six
 def open_for_json_dump(path):
     """
     This ensures compatible file write modes based on Python versions
-    Python 2 json.dump(s) returns a bytes object
-    Python 3 json.dump(s) returns a str object
+    Python 2 json.dump and json.dumps create a bytes object
+    Python 3 json.dump and json.dumps create a str object
     """
     if six.PY2:
         return open(path, "wb")


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
[Prepare for Python 3 Compatibility](https://dimagi-dev.atlassian.net/browse/SAAS-11366)

Also added a util method for properly handling `json.dump(s)` conflicting behaviors on Python 2 and 3.
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None