### PR TITLE
Enable commcare-cloud --control with python3

### DIFF
--- a/control/init.sh
+++ b/control/init.sh
@@ -104,9 +104,9 @@ if [ -z "$(which manage-commcare-cloud)" ]; then
     # first time install need requirements installed in serial
     # installs strictly what's in requirements.txt, so versions are pre-pinned
     cd ${COMMCARE_CLOUD_REPO}
-    pip install --quiet --upgrade pip-tools
-    pip-sync --quiet $REQUIREMENTS
-    pip install --quiet --editable .
+    pip install --upgrade pip-tools
+    pip-sync $REQUIREMENTS
+    pip install --editable .
     cd -
 else
     {

--- a/control/init.sh
+++ b/control/init.sh
@@ -20,8 +20,8 @@ if [ -z ${TRAVIS_TEST} ]; then
     if [ "$CCHQ_PYTHON" == 3 ]; then
         if [ ! -f $VENV/bin/activate ]; then
             # use virtualenv because `python3 -m venv` is broken on Ubuntu 18.04
-            python3 -m pip install --quiet --user --upgrade virtualenv
-            python3 -m virtualenv --quiet $VENV
+            python3 -m pip install --user --upgrade virtualenv
+            python3 -m virtualenv $VENV
         fi
         source $VENV/bin/activate
     elif ! hash virtualenvwrapper.sh 2>/dev/null; then

--- a/src/commcare_cloud/commcare_cloud.py
+++ b/src/commcare_cloud/commcare_cloud.py
@@ -100,15 +100,21 @@ COMMAND_TYPES = sorted(
 
 
 def run_on_control_instead(args, sys_argv):
-    argv = [arg for arg in sys_argv][1:]
+    argv = sys_argv[1:]
     argv.remove('--control')
     executable = 'commcare-cloud'
     branch = getattr(args, 'branch', 'master')
+    venv = os.environ.get("CCHQ_VIRTUALENV")
     cmd_parts = [
         executable, args.env_name, 'ssh', 'control[0]', '-t',
-        'cd ~/commcare-cloud && git fetch --prune && git checkout {branch} '
+        '{env}cd ~/commcare-cloud && git fetch --prune && git checkout {branch} '
         '&& git reset --hard origin/{branch} && source ~/init-ansible && {cchq} {cchq_args}'
-        .format(branch=branch, cchq=executable, cchq_args=' '.join([shlex_quote(arg) for arg in argv]))
+        .format(
+            env=('export CCHQ_VIRTUALENV=%s; ' % venv if venv else ''),
+            branch=branch,
+            cchq=executable,
+            cchq_args=' '.join(shlex_quote(arg) for arg in argv),
+        )
     ]
 
     print_command(' '.join([shlex_quote(part) for part in cmd_parts]))


### PR DESCRIPTION
Set the environment variable `CCHQ_VIRTUALENV` to `cchq` (or anything other than `ansible`) when running `commcore-cloud --control` commands to cause the virtualenv with that name to be used on the control machine. The virtualenv with will be created with python3 if it does not exist. Example:

```sh
CCHQ_VIRTUALENV=cchq commcare-cloud <env> --control ...
```

Use of virtualenvwrapper by init.sh will be phased out with Python 2.

<!--- Provide a link to the ticket or document which prompted this change -->

##### ENVIRONMENTS AFFECTED
None. This is currently for testing only. Running `commcare-cloud` with Python 3 is still in development.
