### PR TITLE
switched from import_tasks to import_roles

### DIFF
--- a/src/commcare_cloud/ansible/deploy_commcarehq.yml
+++ b/src/commcare_cloud/ansible/deploy_commcarehq.yml
@@ -130,4 +130,8 @@
 - name: Celery tasks cleanup Cron job
   hosts: celery
   tasks:
-    - {import_tasks: 'roles/commcarehq/tasks/celery_cron.yml', tags: ['services']}
+    - import_role:
+        name: commcarehq
+        tasks_from: celery_cron.yml
+      tags:
+        - services


### PR DESCRIPTION
Fixed the template not found issue by switching from import_tasks to import_role. Tested in staging and did work.
Please review. thanks