### PR TITLE
add shard document counts to "couchdb-cluster-info" command output

### DIFF
--- a/docs/commcare-cloud/commands/index.md
+++ b/docs/commcare-cloud/commands/index.md
@@ -1308,10 +1308,18 @@ Output table as CSV
 
 #### `couchdb-cluster-info`
 
-Output information about the CouchDB cluster
+Output information about the CouchDB cluster.
 
 ```
-commcare-cloud <env> couchdb-cluster-info [--raw]
+commcare-cloud <env> couchdb-cluster-info [--raw] [--shard-counts] [--database DATABASE] [--couch-port COUCH_PORT]
+                                          [--couch-local-port COUCH_LOCAL_PORT]
+```
+
+##### Shard counts are displayed as follows
+```
+* a single number if all nodes have the same count
+* the count on the first node followed by the difference in each following node
+  e.g. 2000,+1,-2 indicates that the counts are 2000,2001,1998
 ```
 
 ##### Optional Arguments
@@ -1319,6 +1327,22 @@ commcare-cloud <env> couchdb-cluster-info [--raw]
 ###### `--raw`
 
 Output raw shard allocations as YAML instead of printing tables.
+
+###### `--shard-counts`
+
+Include document counts for each shard
+
+###### `--database DATABASE`
+
+Only show output for this database
+
+###### `--couch-port COUCH_PORT`
+
+CouchDB port. Defaults to 15984
+
+###### `--couch-local-port COUCH_LOCAL_PORT`
+
+CouchDB node local port. Defaults to 15986
 
 ---
 

--- a/src/commcare_cloud/commands/ansible/couch_utils.py
+++ b/src/commcare_cloud/commands/ansible/couch_utils.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from operator import attrgetter
 
 from couchdb_cluster_admin.suggest_shard_allocation import get_db_info
-from six.moves import urllib_parse, zip_longest
+from six.moves import urllib_parse, zip_longest, map
 
 import jsonobject
 from couchdb_cluster_admin.utils import do_node_local_request, get_membership, NodeDetails, humansize
@@ -78,7 +78,7 @@ def print_shard_table(shard_allocation_docs, shard_details):
     tables = defaultdict(list)
     for shard_allocation_doc in shard_allocation_docs:
         if not shard_allocation_doc.validate_allocation():
-            print(u"In this allocation by_node and by_range are inconsistent:", repr(shard_allocation_doc))
+            print("In this allocation by_node and by_range are inconsistent:", repr(shard_allocation_doc))
             continue
 
         db_shard_details = shards_by_db.get(shard_allocation_doc.db_name)
@@ -105,7 +105,7 @@ def get_shard_table_rows(shard_doc, shard_details):
     rows, shard_row = [], []
     shard_row.append(shard_doc.db_name)
     for shard, nodes in sorted(shard_doc.by_range.items()):
-        shard_row.append(u','.join(map(shard_doc.config.format_node_name, nodes)))
+        shard_row.append(','.join(map(shard_doc.config.format_node_name, nodes)))
     rows.append(shard_row)
 
     if shard_details:
@@ -118,7 +118,7 @@ def get_shard_table_rows(shard_doc, shard_details):
         def format_counts(counts):
             if len(set(counts)) == 1:
                 return counts[0]
-            return u','.join([
+            return ','.join([
                 str(cnt) if i == 0 else '{0:+}'.format(cnt)
                 for i, cnt in enumerate(counts)
             ])

--- a/src/commcare_cloud/commands/ansible/couch_utils.py
+++ b/src/commcare_cloud/commands/ansible/couch_utils.py
@@ -44,11 +44,15 @@ def get_shard_details(node_details, shard_name):
 def _get_db_name(shard_name):
     return shard_name.split("/")[-1].split(".")[0]
 
+
 def get_nodes(config):
-    config.get_control_node()
     node_details = []
-    for member in get_membership(config).cluster_nodes:
+    nodes = get_membership(config).cluster_nodes
+    for member in nodes:
         address = member.split('@')[1]
+        if address in ("localhost", "127.0.0.1"):
+            assert len(nodes) == 1
+            address = config.control_node_ip
         node_details.append(NodeDetails(
             address,
             config.control_node_port,

--- a/src/commcare_cloud/commands/ansible/couch_utils.py
+++ b/src/commcare_cloud/commands/ansible/couch_utils.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from operator import attrgetter
 
 from couchdb_cluster_admin.suggest_shard_allocation import get_db_info
-from six.moves import urllib_parse
+from six.moves import urllib_parse, zip_longest
 
 import jsonobject
 from couchdb_cluster_admin.utils import do_node_local_request, get_membership, NodeDetails, humansize
@@ -87,7 +87,7 @@ def print_shard_table(shard_allocation_docs, shard_details):
     if single_db:
         headers, rows = list(tables.items())[0]
         data = [("",) + headers] + rows
-        transposed = list(map(list, itertools.izip_longest(*data, fillvalue=None)))
+        transposed = list(map(list, zip_longest(*data, fillvalue=None)))
         print(tabulate(transposed[1:], headers=["Shard", "Nodes", "Doc Counts", "Doc Deletion Counts"]))
     else:
         for header, rows in tables.items():

--- a/src/commcare_cloud/commands/ansible/couch_utils.py
+++ b/src/commcare_cloud/commands/ansible/couch_utils.py
@@ -1,0 +1,141 @@
+import itertools
+from collections import defaultdict
+from operator import attrgetter
+from six.moves import urllib_parse
+
+import jsonobject
+from couchdb_cluster_admin.utils import do_node_local_request, get_membership, NodeDetails
+
+
+def get_cluster_shard_details(config):
+    nodes = get_nodes(config)
+    return list(itertools.chain.from_iterable(get_node_shard_details(node_details) for node_details in nodes))
+
+
+def get_node_shard_details(node_details):
+    shards = get_node_shards(node_details)
+    return [get_shard_details(node_details, shard) for shard in shards]
+
+
+def get_node_shards(node_details):
+    return [
+        local_db for local_db in do_node_local_request(node_details, "_all_dbs")
+        if local_db.startswith("shards")
+    ]
+
+
+def get_shard_details(node_details, shard_name):
+    data = do_node_local_request(node_details, urllib_parse.quote(shard_name, safe=""))
+    data["node"] = "couchdb@{}".format(node_details.ip)
+    data["shard_name"] = data["db_name"]
+    data["db_name"] = shard_name.split("/")[-1].split(".")[0]
+    return ShardDetails(data)
+
+
+def get_nodes(config):
+    config.get_control_node()
+    node_details = []
+    for member in get_membership(config).cluster_nodes:
+        address = member.split('@')[1]
+        node_details.append(NodeDetails(
+            address,
+            config.control_node_port,
+            config.control_node_local_port,
+            config.username,
+            config._password,
+            None
+        ))
+    return node_details
+
+
+def print_shard_table(shard_allocation_docs, shard_details):
+    last_header = None
+    db_names = [shard_allocation_doc.db_name for shard_allocation_doc in shard_allocation_docs]
+    max_db_name_len = max(list(map(len, db_names)))
+
+    shard_details = sorted(shard_details, key=attrgetter('db_name'))
+    shards_by_db = {
+        group: list(shards)
+        for group, shards in itertools.groupby(shard_details, key=attrgetter('db_name'))
+    }
+
+    for shard_allocation_doc in shard_allocation_docs:
+        if not shard_allocation_doc.validate_allocation():
+            print("error")
+            continue
+
+        db_shard_details = shards_by_db[shard_allocation_doc.db_name]
+        this_header = sorted(shard_allocation_doc.by_range)
+        print(get_printable(
+            shard_allocation_doc,
+            db_shard_details,
+            include_shard_names=(last_header != this_header),
+            db_name_len=max_db_name_len
+        ))
+        last_header = this_header
+
+
+def get_printable(shard_doc, shard_details, include_shard_names, db_name_len=20):
+    parts = []
+    first_column = u'{{: <{}}}  '.format(db_name_len)
+    other_columns = u'{: ^20s}  '
+    if include_shard_names:
+        parts.append(first_column.format(u''))
+        for shard in sorted(shard_doc.by_range):
+            parts.append(other_columns.format(shard))
+        parts.append(u'\n')
+    parts.append(first_column.format(shard_doc.db_name))
+    for shard, nodes in sorted(shard_doc.by_range.items()):
+        parts.append(other_columns.format(u','.join(map(shard_doc.config.format_node_name, nodes))))
+    parts.append(u'\n')
+
+    shards_by_shard_name = defaultdict(list)
+    for shard_detail in shard_details:
+        shards_by_shard_name[shard_detail.shard_name_short].append(shard_detail)
+
+    for shard_name, nodes in sorted(shard_doc.by_range.items()):
+        shards = {shard.node: shard for shard in shards_by_shard_name[shard_name]}
+        doc_counts = {
+            "doc_count": None,
+            "doc_del_count": None
+        }
+        for node in nodes:
+            shard = shards[node]
+            if doc_counts["doc_count"] is None:
+                doc_counts["doc_count"] = [shard.doc_count]
+                doc_counts["doc_del_count"] = [shard.doc_del_count]
+            else:
+                first_doc_count, first_doc_del_count = doc_counts["doc_count"][0], doc_counts["doc_del_count"][0]
+                doc_counts["doc_count"].append(shard.doc_count - first_doc_count)
+                doc_counts["doc_del_count"].append(shard.doc_del_count - first_doc_del_count)
+        parts.append(other_columns.format(u','.join(['{0:+}'.format(c) for c in doc_counts["doc_count"]])))
+        parts.append(u'\n')
+        parts.append(other_columns.format(u','.join(['{0:+}'.format(c) for c in doc_counts["doc_del_count"]])))
+
+    return ''.join(parts)
+
+
+class ShardDetails(jsonobject.JsonObject):
+    node = jsonobject.StringProperty()
+    db_name = jsonobject.StringProperty()
+
+    # shards/c0000000-dfffffff/commcarehq.1541009837
+    shard_name = jsonobject.StringProperty()
+    engine = jsonobject.StringProperty()
+    doc_count = jsonobject.IntegerProperty()
+    doc_del_count = jsonobject.IntegerProperty()
+    purge_seq = jsonobject.IntegerProperty()
+    compact_running = jsonobject.BooleanProperty()
+    sizes = jsonobject.DictProperty()
+    disk_size = jsonobject.IntegerProperty()
+    data_size = jsonobject.IntegerProperty()
+    other = jsonobject.DictProperty()
+    instance_start_time = jsonobject.StringProperty()
+    disk_format_version = jsonobject.IntegerProperty()
+    committed_update_seq = jsonobject.IntegerProperty()
+    compacted_seq = jsonobject.IntegerProperty()
+    uuid = jsonobject.StringProperty()
+
+    @property
+    def shard_name_short(self):
+        return self.shard_name.split('/')[1]

--- a/src/commcare_cloud/commands/ansible/couch_utils.py
+++ b/src/commcare_cloud/commands/ansible/couch_utils.py
@@ -148,8 +148,10 @@ def print_db_info(config, databases=None):
     ]
     if len(rows) == 1:
         # swap
-        headers, rows = rows, headers
-    tabulate(rows, headers)
+        data = [headers] + rows
+        print(tabulate(list(map(list, zip_longest(*data, fillvalue=None)))))
+    else:
+        print(tabulate(rows, headers))
 
 
 class ShardDetails(jsonobject.JsonObject):

--- a/src/commcare_cloud/commands/ansible/couch_utils.py
+++ b/src/commcare_cloud/commands/ansible/couch_utils.py
@@ -91,7 +91,7 @@ def print_shard_table(shard_allocation_docs, shard_details):
         print(tabulate(transposed[1:], headers=["Shard", "Nodes", "Doc Counts", "Doc Deletion Counts"]))
     else:
         for header, rows in tables.items():
-            print(tabulate(rows, header))
+            print(tabulate(rows, header, numalign="left"))
 
 
 def get_shard_table_rows(shard_doc, shard_details):
@@ -109,6 +109,8 @@ def get_shard_table_rows(shard_doc, shard_details):
             shards_by_shard_name[shard_detail.shard_name_short].append(shard_detail)
 
         def format_counts(counts):
+            if len(set(counts)) == 1:
+                return counts[0]
             return u','.join([
                 str(cnt) if i == 0 else '{0:+}'.format(cnt)
                 for i, cnt in enumerate(counts)

--- a/src/commcare_cloud/commands/ansible/ops_tool.py
+++ b/src/commcare_cloud/commands/ansible/ops_tool.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 import collections
 import csv
+import inspect
 import itertools
 import json
 import subprocess
@@ -216,7 +217,14 @@ def _get_pillow_resources_by_name(environment):
 
 class CouchDBClusterInfo(CommandBase):
     command = 'couchdb-cluster-info'
-    help = "Output information about the CouchDB cluster"
+    help = inspect.cleandoc("""
+    Output information about the CouchDB cluster.
+
+    Shard counts are displayed as follows:
+    * a single number if all nodes have the same count
+    * the count on the first node followed by the difference in each following node
+      e.g. 2000,+1,-2 indicates that the counts are 2000,2001,1998
+    """)
 
     arguments = (
         Argument("--raw", action="store_true", help="Output raw shard allocations as YAML instead of printing tables."),

--- a/src/commcare_cloud/commands/ansible/ops_tool.py
+++ b/src/commcare_cloud/commands/ansible/ops_tool.py
@@ -230,11 +230,13 @@ class CouchDBClusterInfo(CommandBase):
         Argument("--raw", action="store_true", help="Output raw shard allocations as YAML instead of printing tables."),
         Argument("--shard-counts", action="store_true", help="Include document counts for each shard"),
         Argument("--database", help="Only show output for this database"),
+        Argument("--couch-port", default=15984, type=int),
+        Argument("--couch-local-port", default=15986, type=int),
     )
 
     def run(self, args, unknown_args):
         environment = get_environment(args.env_name)
-        couch_config = get_couch_config(environment)
+        couch_config = get_couch_config(environment, port=args.couch_port, local_port=args.couch_local_port)
 
         db_list = sorted(get_db_list(couch_config.get_control_node()))
         if args.database:
@@ -276,12 +278,12 @@ class CouchDBClusterInfo(CommandBase):
         return 0
 
 
-def get_couch_config(environment, nodes=None):
+def get_couch_config(environment, nodes=None, port=15984, local_port=15986):
     couch_nodes = nodes or environment.groups['couchdb2']
     config = Config(
         control_node_ip=couch_nodes[0],
-        control_node_port=15984,
-        control_node_local_port=15986,
+        control_node_port=port,
+        control_node_local_port=local_port,
         username=environment.get_secret('COUCH_USERNAME'),
         aliases={
             'couchdb@{}'.format(node): get_machine_alias(environment, node) for node in couch_nodes

--- a/src/commcare_cloud/commands/ansible/ops_tool.py
+++ b/src/commcare_cloud/commands/ansible/ops_tool.py
@@ -230,8 +230,8 @@ class CouchDBClusterInfo(CommandBase):
         Argument("--raw", action="store_true", help="Output raw shard allocations as YAML instead of printing tables."),
         Argument("--shard-counts", action="store_true", help="Include document counts for each shard"),
         Argument("--database", help="Only show output for this database"),
-        Argument("--couch-port", default=15984, type=int),
-        Argument("--couch-local-port", default=15986, type=int),
+        Argument("--couch-port", default=15984, type=int, help="CouchDB port. Defaults to 15984"),
+        Argument("--couch-local-port", default=15986, type=int, help="CouchDB node local port. Defaults to 15986"),
     )
 
     def run(self, args, unknown_args):


### PR DESCRIPTION
Add document counts to `couchdb-cluster-info` output:

**--shard-counts**
```
Shard allocation
                  00000000-1fffffff    20000000-3fffffff    40000000-5fffffff    60000000-7fffffff    80000000-9fffffff    a0000000-bfffffff    c0000000-dfffffff    e0000000-ffffffff
----------------  -------------------  -------------------  -------------------  -------------------  -------------------  -------------------  -------------------  -------------------
commcarehq        c1,c2,c3             c1,c2,c3             c1,c2,c3             c1,c2,c3             c1,c2,c3             c1,c2,c3             c1,c2,c3             c1,c2,c3
...doc_count      20203549,+637,-1302  20209048,+1050,-951  20205735,+969,-1415  20207806,+1035,-886  20205643,+901,-1019  20208597,+895,-1137  20207946,+990,-1080  20205598,+1167,-932
...doc_del_count  737525,+0,+0         719676,+0,+0         714452,+0,+0         664236,+0,+0         729924,+0,+0         869472,+0,+0         727183,+0,+0         872446,+0,+0
```

**For a single database**
```

Shard              Nodes     Doc Counts           Doc Deletion Counts
-----------------  --------  -------------------  ---------------------
00000000-1fffffff  c1,c2,c3  20203549,+637,-1302  737525,+0,+0
20000000-3fffffff  c1,c2,c3  20209048,+1050,-951  719676,+0,+0
40000000-5fffffff  c1,c2,c3  20205735,+969,-1415  714452,+0,+0
60000000-7fffffff  c1,c2,c3  20207806,+1035,-886  664236,+0,+0
80000000-9fffffff  c1,c2,c3  20205643,+901,-1019  729924,+0,+0
a0000000-bfffffff  c1,c2,c3  20208597,+895,-1137  869472,+0,+0
c0000000-dfffffff  c1,c2,c3  20207946,+990,-1080  727183,+0,+0
e0000000-ffffffff  c1,c2,c3  20205598,+1167,-932  872446,+0,+0

```