### PR TITLE
Explicitly use io.open in environments directory

### DIFF
--- a/src/commcare_cloud/environment/main.py
+++ b/src/commcare_cloud/environment/main.py
@@ -1,11 +1,10 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
+
 import os
 import re
-
 from collections import Counter
 from datetime import datetime
-
+from io import open
 
 import yaml
 from ansible.inventory.manager import InventoryManager
@@ -13,22 +12,24 @@ from ansible.parsing.dataloader import DataLoader
 from ansible.parsing.utils.yaml import from_yaml
 from ansible.vars.manager import VariableManager
 from memoized import memoized, memoized_property
+from six.moves import map
 
 from commcare_cloud.environment.constants import constants
 from commcare_cloud.environment.exceptions import EnvironmentException
 from commcare_cloud.environment.paths import DefaultPaths, get_role_defaults
 from commcare_cloud.environment.schemas.app_processes import AppProcessesConfig
 from commcare_cloud.environment.schemas.aws import AwsConfig
-from commcare_cloud.environment.schemas.elasticsearch import ElasticsearchConfig
+from commcare_cloud.environment.schemas.elasticsearch import (
+    ElasticsearchConfig,
+)
 from commcare_cloud.environment.schemas.fab_settings import FabSettingsConfig
 from commcare_cloud.environment.schemas.meta import MetaConfig
 from commcare_cloud.environment.schemas.postgresql import PostgresqlConfig
+from commcare_cloud.environment.schemas.prometheus import PrometheusConfig
 from commcare_cloud.environment.schemas.proxy import ProxyConfig
 from commcare_cloud.environment.schemas.terraform import TerraformConfig
-from commcare_cloud.environment.schemas.prometheus import PrometheusConfig
 from commcare_cloud.environment.users import UsersConfig
-from six.moves import map
-
+from commcare_cloud.python_migration_utils import open_for_yaml_dump
 from commcare_cloud.yaml import PreserveUnsafeDumper
 
 
@@ -75,7 +76,7 @@ class Environment(object):
             (hostname_to_sshable[host], self.hostname_map.get(host))
             for host in inventory_hostnames
         }
-        with open(self.paths.known_hosts) as f:
+        with open(self.paths.known_hosts, encoding='utf-8') as f:
             known_hosts_contents = f.read()
         missing_hosts = {
             (sshable, hostname) for sshable, hostname in expected_hosts
@@ -103,7 +104,7 @@ class Environment(object):
     @memoized_property
     def public_vars(self):
         """contents of public.yml, as a dict"""
-        with open(self.paths.public_yml) as f:
+        with open(self.paths.public_yml, encoding='utf-8') as f:
             return from_yaml(f)
 
     @memoized_property
@@ -114,13 +115,13 @@ class Environment(object):
 
     @memoized_property
     def meta_config(self):
-        with open(self.paths.meta_yml) as f:
+        with open(self.paths.meta_yml, encoding='utf-8') as f:
             meta_json = from_yaml(f)
         return MetaConfig.wrap(meta_json)
 
     @memoized_property
     def postgresql_config(self):
-        with open(self.paths.postgresql_yml) as f:
+        with open(self.paths.postgresql_yml, encoding='utf-8') as f:
             postgresql_json = from_yaml(f)
         postgresql_config = PostgresqlConfig.wrap(postgresql_json)
         postgresql_config.replace_hosts(self)
@@ -130,7 +131,7 @@ class Environment(object):
     @memoized_property
     def elasticsearch_config(self):
         try:
-            with open(self.paths.elasticsearch_yml) as f:
+            with open(self.paths.elasticsearch_yml, encoding='utf-8') as f:
                 elasticsearch_json = from_yaml(f)
         except IOError:
             # It's fine to omit this file
@@ -143,7 +144,7 @@ class Environment(object):
 
     @memoized_property
     def proxy_config(self):
-        with open(self.paths.proxy_yml) as f:
+        with open(self.paths.proxy_yml, encoding='utf-8') as f:
             proxy_json = from_yaml(f)
         proxy_config = ProxyConfig.wrap(proxy_json)
         proxy_config.check()
@@ -152,7 +153,7 @@ class Environment(object):
     @memoized_property
     def prometheus_config(self):
         try:
-            with open(self.paths.prometheus_yml) as f:
+            with open(self.paths.prometheus_yml, encoding='utf-8') as f:
                 prometheus_json = from_yaml(f)
         except IOError:
             return None
@@ -164,7 +165,7 @@ class Environment(object):
         absent_users = []
         present_users = []
         for user_group_from_yml in user_groups_from_yml:
-            with open(self.paths.get_users_yml(user_group_from_yml)) as f:
+            with open(self.paths.get_users_yml(user_group_from_yml), encoding='utf-8') as f:
                 user_group_json = from_yaml(f)
             present_users += user_group_json['dev_users']['present']
             absent_users += user_group_json['dev_users']['absent']
@@ -175,7 +176,7 @@ class Environment(object):
     @memoized_property
     def terraform_config(self):
         try:
-            with open(self.paths.terraform_yml) as f:
+            with open(self.paths.terraform_yml, encoding='utf-8') as f:
                 config_yml = from_yaml(f)
         except IOError:
             return None
@@ -185,14 +186,14 @@ class Environment(object):
     @memoized_property
     def aws_config(self):
         try:
-            with open(self.paths.aws_yml) as f:
+            with open(self.paths.aws_yml, encoding='utf-8') as f:
                 config_yml = from_yaml(f)
         except IOError:
             config_yml = {}
         return AwsConfig.wrap(config_yml)
 
     def get_authorized_key(self, user):
-        with open(self.paths.get_authorized_key_file(user)) as f:
+        with open(self.paths.get_authorized_key_file(user), encoding='utf-8') as f:
             return f.read()
 
     def check_user_group_absent_present_overlaps(self, absent_users, present_users):
@@ -209,9 +210,9 @@ class Environment(object):
 
         includes environmental-defaults/app-processes.yml as well as <env>/app-processes.yml
         """
-        with open(self.paths.app_processes_yml_default) as f:
+        with open(self.paths.app_processes_yml_default, encoding='utf-8') as f:
             app_processes_json = from_yaml(f)
-        with open(self.paths.app_processes_yml) as f:
+        with open(self.paths.app_processes_yml, encoding='utf-8') as f:
             app_processes_json.update(from_yaml(f))
 
         raw_app_processes_config = AppProcessesConfig.wrap(app_processes_json)
@@ -232,9 +233,9 @@ class Environment(object):
 
         includes environmental-defaults/fab-settings.yml as well as <env>/fab-settings.yml
         """
-        with open(self.paths.fab_settings_yml_default) as f:
+        with open(self.paths.fab_settings_yml_default, encoding='utf-8') as f:
             fab_settings_json = from_yaml(f)
-        with open(self.paths.fab_settings_yml) as f:
+        with open(self.paths.fab_settings_yml, encoding='utf-8') as f:
             fab_settings_json.update(from_yaml(f) or {})
 
         fab_settings_config = FabSettingsConfig.wrap(fab_settings_json)
@@ -369,7 +370,7 @@ class Environment(object):
 
         generated_variables.update(self.secrets_backend.get_generated_variables())
 
-        with open(self.paths.generated_yml, 'w') as f:
+        with open_for_yaml_dump(self.paths.generated_yml) as f:
             f.write(yaml.dump(generated_variables, Dumper=PreserveUnsafeDumper))
 
     def translate_host(self, host, filename_for_error):

--- a/src/commcare_cloud/environment/paths.py
+++ b/src/commcare_cloud/environment/paths.py
@@ -1,12 +1,12 @@
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
+
 import os
 import sys
 from distutils.sysconfig import get_python_lib
+from io import open
 
 import yaml
-from memoized import memoized_property, memoized
+from memoized import memoized, memoized_property
 
 from commcare_cloud.environment.exceptions import EnvironmentException
 
@@ -168,7 +168,7 @@ def get_role_defaults_yml(role):
 @memoized
 def get_role_defaults(role):
     """contents of a role's defaults/main.yml, as a dict"""
-    with open(get_role_defaults_yml(role)) as f:
+    with open(get_role_defaults_yml(role), encoding='utf-8') as f:
         return yaml.safe_load(f)
 
 

--- a/src/commcare_cloud/environment/secrets/backends/ansible_vault/main.py
+++ b/src/commcare_cloud/environment/secrets/backends/ansible_vault/main.py
@@ -1,10 +1,10 @@
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
+
 import getpass
 import os
 import sys
 from contextlib import contextmanager
+from io import open
 
 import datadog.api
 import yaml
@@ -14,9 +14,13 @@ from memoized import memoized
 from six.moves import shlex_quote
 
 from commcare_cloud.environment.paths import ANSIBLE_DIR
-from commcare_cloud.environment.secrets.backends.abstract_backend import AbstractSecretsBackend
-from commcare_cloud.environment.secrets.secrets_schema import get_generated_variables, \
-    get_known_secret_specs_by_name
+from commcare_cloud.environment.secrets.backends.abstract_backend import (
+    AbstractSecretsBackend,
+)
+from commcare_cloud.environment.secrets.secrets_schema import (
+    get_generated_variables,
+    get_known_secret_specs_by_name,
+)
 
 
 class AnsibleVaultSecretsBackend(AbstractSecretsBackend):
@@ -104,7 +108,7 @@ class AnsibleVaultSecretsBackend(AbstractSecretsBackend):
     @memoized
     def _get_vault_variables(self):
         # try unencrypted first for tests
-        with open(self.vault_file_path, 'r') as f:
+        with open(self.vault_file_path, 'r', encoding='utf-8') as f:
             vault_vars = yaml.safe_load(f)
         if isinstance(vault_vars, dict):
             return vault_vars
@@ -112,7 +116,7 @@ class AnsibleVaultSecretsBackend(AbstractSecretsBackend):
         while True:
             try:
                 vault = Vault(self._get_ansible_vault_password())
-                with open(self.vault_file_path, 'r') as vf:
+                with open(self.vault_file_path, 'r', encoding='utf-8') as vf:
                     return vault.load(vf.read())
             except AnsibleVaultError:
                 if os.environ.get('ANSIBLE_VAULT_PASSWORD'):

--- a/src/commcare_cloud/environment/secrets/backends/ansible_vault/tests/test_secrets_list.py
+++ b/src/commcare_cloud/environment/secrets/backends/ansible_vault/tests/test_secrets_list.py
@@ -1,15 +1,18 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
+
 import os
+from io import open
 
 import yaml
 
-from commcare_cloud.environment.secrets.backends.ansible_vault.main import AnsibleVaultSecretsBackend
+from commcare_cloud.environment.secrets.backends.ansible_vault.main import (
+    AnsibleVaultSecretsBackend,
+)
 from commcare_cloud.environment.secrets.utils import yaml_diff
 
 
 def test_generated_variables_as_expected():
-    with open(os.path.join(os.path.dirname(__file__), 'expected-generated-variables.yml')) as f:
+    with open(os.path.join(os.path.dirname(__file__), 'expected-generated-variables.yml'), encoding='utf-8') as f:
         expected_generated_variables = yaml.safe_load(f)
     generated_variables = AnsibleVaultSecretsBackend('a', 'b').get_generated_variables()
     assert generated_variables == expected_generated_variables, \

--- a/src/commcare_cloud/environment/secrets/backends/aws_secrets/tests/test_secrets_list.py
+++ b/src/commcare_cloud/environment/secrets/backends/aws_secrets/tests/test_secrets_list.py
@@ -1,15 +1,18 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
+
 import os
+from io import open
 
 import yaml
 
-from commcare_cloud.environment.secrets.backends.aws_secrets.main import AwsSecretsBackend
+from commcare_cloud.environment.secrets.backends.aws_secrets.main import (
+    AwsSecretsBackend,
+)
 from commcare_cloud.environment.secrets.utils import yaml_diff
 
 
 def test_generated_variables_as_expected():
-    with open(os.path.join(os.path.dirname(__file__), 'expected-generated-variables.yml')) as f:
+    with open(os.path.join(os.path.dirname(__file__), 'expected-generated-variables.yml'), encoding='utf-8') as f:
         expected_generated_variables = yaml.safe_load(f)
     generated_variables = AwsSecretsBackend('commcare-staging', environment=None).get_generated_variables()
     assert generated_variables == expected_generated_variables, \

--- a/src/commcare_cloud/environment/secrets/secrets_schema.py
+++ b/src/commcare_cloud/environment/secrets/secrets_schema.py
@@ -1,6 +1,7 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
+
 import os
+from io import open
 
 import jsonobject
 import yaml
@@ -55,7 +56,7 @@ class SecretSpec(jsonobject.JsonObject):
 
 
 def get_known_secret_specs():
-    with open(os.path.join(PACKAGE_BASE, 'environment', 'secrets', 'secrets.yml')) as f:
+    with open(os.path.join(PACKAGE_BASE, 'environment', 'secrets', 'secrets.yml'), encoding='utf-8') as f:
         return [SecretSpec.wrap(secret_spec) for secret_spec in yaml.safe_load(f)]
 
 

--- a/src/commcare_cloud/manage_commcare_cloud/tests/test_environments.py
+++ b/src/commcare_cloud/manage_commcare_cloud/tests/test_environments.py
@@ -23,6 +23,12 @@ def test_all(environment):
     environment.check()
 
 
+# useful for python 2 -> 3 migration
+@parameterized(commcare_envs)
+def test_authorized_key(environment):
+    environment.get_authorized_key('gherceg')
+
+
 @parameterized(commcare_envs)
 def test_hostnames(environment):
     missing_hostnames = set()

--- a/src/commcare_cloud/python_migration_utils.py
+++ b/src/commcare_cloud/python_migration_utils.py
@@ -18,9 +18,7 @@ def open_for_json_dump(path):
 
 def open_for_yaml_dump(path):
     """
-    This ensures compatible file write modes based on Python versions
-    Python 2 json.dump and json.dumps create a bytes object
-    Python 3 json.dump and json.dumps create a str object
+    This ensures compatible file write modes based on Python versions for yaml.dump/safe_dump calls
     """
     if six.PY2:
         return open(path, "wb")

--- a/src/commcare_cloud/python_migration_utils.py
+++ b/src/commcare_cloud/python_migration_utils.py
@@ -14,3 +14,14 @@ def open_for_json_dump(path):
     if six.PY2:
         return open(path, "wb")
     return open(path, "w", encoding="utf-8")
+
+
+def open_for_yaml_dump(path):
+    """
+    This ensures compatible file write modes based on Python versions
+    Python 2 json.dump and json.dumps create a bytes object
+    Python 3 json.dump and json.dumps create a str object
+    """
+    if six.PY2:
+        return open(path, "wb")
+    return open(path, "w", encoding="utf-8")


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
[Replace open with io.open](https://dimagi-dev.atlassian.net/browse/SAAS-11366)
A continuation of work done for this ticket. This addresses all of the uses of `open` in the `environments` directory.
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None