### PR TITLE
allow adding tags to datadog events

### DIFF
--- a/docs/commcare-cloud/commands/index.md
+++ b/docs/commcare-cloud/commands/index.md
@@ -470,7 +470,7 @@ authenticate using the pem file (or prompt for root password if there is no pem 
 Track an infrastructure maintainance event in Datadog
 
 ```
-commcare-cloud <env> send-datadog-event event_title event_text
+commcare-cloud <env> send-datadog-event [--tags [TAGS [TAGS ...]]] event_title event_text
 ```
 
 ##### Positional Arguments
@@ -482,6 +482,12 @@ Title of the datadog event.
 ###### `event_text`
 
 Text content of the datadog event.
+
+##### Optional Arguments
+
+###### `--tags [TAGS [TAGS ...]]`
+
+Additional tags e.g. host:web2
 
 ---
 

--- a/src/commcare_cloud/commands/ansible/run_module.py
+++ b/src/commcare_cloud/commands/ansible/run_module.py
@@ -200,6 +200,9 @@ class SendDatadogEvent(CommandBase):
         Argument('event_text', help="""
             Text content of the datadog event.
         """),
+        Argument('--tags', nargs="*", help="""
+            Additional tags e.g. host:web2
+        """),
     )
 
     def run(self, args, unknown_args):
@@ -207,12 +210,13 @@ class SendDatadogEvent(CommandBase):
         environment = get_environment(args.env_name)
         datadog_api_key = environment.get_secret('DATADOG_API_KEY')
         datadog_app_key = environment.get_secret('DATADOG_APP_KEY')
-        tags = "environment:{}".format(args.env_name)
+        tags = args.tags or []
+        tags.append("environment:{}".format(args.env_name))
         args.module_args = "api_key={api_key} app_key={app_key} " \
             "tags='{tags}' text='{text}' title='{title}' aggregation_key={agg}".format(
                 api_key=datadog_api_key,
                 app_key=datadog_app_key,
-                tags=tags,
+                tags=",".join(tags),
                 text=args.event_text,
                 title=args.event_title,
                 agg='commcare-cloud'


### PR DESCRIPTION
This allows adding arbitrary tags to events sent to Datadog such as the host or group the event is related to.