### PR TITLE
Explicitly use io.open in remaining commcare_cloud files

### DIFF
--- a/docs/commcare-cloud/commands/index.md
+++ b/docs/commcare-cloud/commands/index.md
@@ -1259,7 +1259,7 @@ commcare-cloud <env> list-postgresql-dbs [--compare]
 To list all database on a particular environment.
 
 ```
-commcare-cloud <ev> list-databases
+commcare-cloud <env> list-postgresql-dbs
 ```
 
 ##### Optional Arguments

--- a/scripts/es_snapshot.py
+++ b/scripts/es_snapshot.py
@@ -19,7 +19,7 @@ from textwrap import indent
 import requests
 from requests import HTTPError, Timeout
 
-from commcare_cloud.python_migration_utils import open_for_json_dump
+from commcare_cloud.python_migration_utils import open_for_write
 
 logger = logging.getLogger(__name__)
 
@@ -447,7 +447,7 @@ class DownloadSnapshotVersion(object):
             return 1
 
         if not self.dry_run:
-            with open_for_json_dump(os.path.join(self.download_path, 'index')) as fp:
+            with open_for_write(os.path.join(self.download_path, 'index')) as fp:
                 json.dump({'snapshots': [self.snapshot_version]}, fp)
 
         total_bytes = 0

--- a/src/commcare_cloud/ansible/plugins/inventory/csv.py
+++ b/src/commcare_cloud/ansible/plugins/inventory/csv.py
@@ -1,10 +1,19 @@
-from __future__ import (absolute_import, division, print_function)
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
-from __future__ import unicode_literals
 import csv
 import json
 import os
 import re
+from io import open
+
+from ansible.errors import AnsibleParserError
+from ansible.module_utils._text import to_bytes, to_text
+from ansible.plugins.inventory import BaseInventoryPlugin
 
 __metaclass__ = type
 
@@ -67,9 +76,6 @@ EXAMPLES = '''
 '''
 
 
-from ansible.errors import AnsibleParserError
-from ansible.module_utils._text import to_text, to_bytes
-from ansible.plugins.inventory import BaseInventoryPlugin
 
 
 TYPE_STRING = 'S'

--- a/src/commcare_cloud/ansible/plugins/lookup/cchq_aws_secret.py
+++ b/src/commcare_cloud/ansible/plugins/lookup/cchq_aws_secret.py
@@ -1,11 +1,12 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
+
 import json
 import logging
 import os
-import six.moves.cPickle as pickle
 import time
+from io import open
 
+import six.moves.cPickle as pickle
 from ansible.plugins.lookup import aws_secret
 from cryptography.fernet import Fernet, InvalidToken
 

--- a/src/commcare_cloud/cli_utils.py
+++ b/src/commcare_cloud/cli_utils.py
@@ -1,15 +1,16 @@
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
+
 import re
 import subprocess
-
 import sys
-from clint.textui import puts
+from io import open
 
-from commcare_cloud.colors import color_error, color_code
-from .environment.paths import ANSIBLE_DIR
+from clint.textui import puts
 from six.moves import input, shlex_quote
+
+from commcare_cloud.colors import color_code, color_error
+
+from .environment.paths import ANSIBLE_DIR
 
 
 def ask(message, strict=False, quiet=False):
@@ -60,7 +61,7 @@ def git_branch():
             "git status",
             cwd=ANSIBLE_DIR,
             shell=True,
-            stderr=open('/dev/null', 'w'),
+            stderr=open('/dev/null', 'w', encoding='utf-8'),
             universal_newlines=True,
         )
     except subprocess.CalledProcessError as e:

--- a/src/commcare_cloud/commands/ansible/ops_tool.py
+++ b/src/commcare_cloud/commands/ansible/ops_tool.py
@@ -1,6 +1,4 @@
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 import collections
 import csv
@@ -10,19 +8,43 @@ import json
 import subprocess
 import sys
 from collections import defaultdict
-from operator import itemgetter, attrgetter
+from io import open
+from operator import attrgetter, itemgetter
 
 import yaml
-from clint.textui import puts, indent
-from couchdb_cluster_admin.utils import get_membership, get_shard_allocation, get_db_list, Config
+from clint.textui import indent, puts
+from couchdb_cluster_admin.utils import (
+    Config,
+    get_db_list,
+    get_membership,
+    get_shard_allocation,
+)
 from tabulate import tabulate
 
-from commcare_cloud.colors import color_error, color_success, color_changed, color_added, color_removed
+from commcare_cloud.colors import (
+    color_added,
+    color_changed,
+    color_error,
+    color_removed,
+    color_success,
+)
 from commcare_cloud.commands import shared_args
-from commcare_cloud.commands.ansible.couch_utils import get_cluster_shard_details, print_shard_table, print_db_info
-from commcare_cloud.commands.command_base import CommandBase, Argument, CommandError
-from commcare_cloud.commands.inventory_lookup.getinventory import get_instance_group
-from commcare_cloud.commands.inventory_lookup.inventory_lookup import DjangoManage
+from commcare_cloud.commands.ansible.couch_utils import (
+    get_cluster_shard_details,
+    print_db_info,
+    print_shard_table,
+)
+from commcare_cloud.commands.command_base import (
+    Argument,
+    CommandBase,
+    CommandError,
+)
+from commcare_cloud.commands.inventory_lookup.getinventory import (
+    get_instance_group,
+)
+from commcare_cloud.commands.inventory_lookup.inventory_lookup import (
+    DjangoManage,
+)
 from commcare_cloud.commands.utils import PrivilegedCommand
 from commcare_cloud.environment.exceptions import EnvironmentException
 from commcare_cloud.environment.main import get_environment
@@ -38,7 +60,7 @@ class ListDatabases(CommandBase):
     To list all database on a particular environment.
 
     ```
-    commcare-cloud <ev> list-databases
+    commcare-cloud <env> list-postgresql-dbs
     ```
     """
 
@@ -314,7 +336,7 @@ class UpdateLocalKnownHosts(CommandBase):
         if limit:
             environment.inventory_manager.subset(limit)
 
-        with open(environment.paths.known_hosts, 'r') as known_hosts:
+        with open(environment.paths.known_hosts, 'r', encoding='utf-8') as known_hosts:
             original_keys_by_host = _get_host_key_map(
                 [line.strip() for line in known_hosts.readlines()]
             )
@@ -365,7 +387,7 @@ class UpdateLocalKnownHosts(CommandBase):
             if updated:
                 lines.append('{} {} {}'.format(host, key_type, updated))
 
-        with open(environment.paths.known_hosts, 'w') as known_hosts:
+        with open(environment.paths.known_hosts, 'w', encoding='utf-8') as known_hosts:
             known_hosts.write('\n'.join(sorted(lines)))
 
         try:

--- a/src/commcare_cloud/commands/migrations/config.py
+++ b/src/commcare_cloud/commands/migrations/config.py
@@ -1,6 +1,7 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
+
 import os
+from io import open
 
 import jsonobject
 import yaml
@@ -23,7 +24,7 @@ class CouchMigration(object):
 
     @memoized_property
     def plan(self):
-        with open(self.plan_path) as f:
+        with open(self.plan_path, encoding='utf-8') as f:
             plan = yaml.safe_load(f)
 
         return CouchMigrationPlan.wrap(plan)
@@ -83,7 +84,7 @@ class CouchMigration(object):
 
     @memoized_property
     def shard_plan(self):
-        with open(self.shard_plan_path) as f:
+        with open(self.shard_plan_path, encoding='utf-8') as f:
             plan = yaml.safe_load(f)
 
         return [

--- a/src/commcare_cloud/commands/migrations/copy_files.py
+++ b/src/commcare_cloud/commands/migrations/copy_files.py
@@ -1,19 +1,26 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
+
 import hashlib
 import os
 import shutil
+from io import open
 
 import attr
 import yaml
 
 from commcare_cloud.commands import shared_args
-from commcare_cloud.commands.ansible.helpers import AnsibleContext, run_action_with_check_mode
+from commcare_cloud.commands.ansible.helpers import (
+    AnsibleContext,
+    run_action_with_check_mode,
+)
 from commcare_cloud.commands.ansible.run_module import run_ansible_module
-from commcare_cloud.commands.command_base import CommandBase, Argument, CommandError
-from commcare_cloud.commands.utils import render_template, PrivilegedCommand
+from commcare_cloud.commands.command_base import (
+    Argument,
+    CommandBase,
+    CommandError,
+)
+from commcare_cloud.commands.utils import PrivilegedCommand, render_template
 from commcare_cloud.environment.main import get_environment
-
 
 FILE_MIGRATION_RSYNC_SCRIPT = 'file_migration_rsync.sh'
 TEMPLATE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'templates')
@@ -127,7 +134,8 @@ class CopyFiles(CommandBase):
 
 
 def read_plan(plan_path, target_env, limit=None):
-    with open(plan_path, 'r') as f:
+    with open(plan_path, 'r', encoding='utf-8') as f:
+        # PY2: yaml.safe_load always returns byte strings
         plan_dict = yaml.safe_load(f)
 
     source_env = None
@@ -185,7 +193,8 @@ def prepare_file_copy_scripts(target_host, source_file_configs, script_root):
         else:
             filename = get_file_list_filename(config)
             path = os.path.join(target_script_root, filename)
-            with open(path, 'w') as f:
+            with open(path, 'w', encoding='utf-8') as f:
+                # PY2: unicode literals will coerce bytes -> unicode on py2
                 f.write('{}\n'.format('\n'.join(files)))
 
             files_for_node.append((config, filename))
@@ -197,7 +206,7 @@ def prepare_file_copy_scripts(target_host, source_file_configs, script_root):
             'rsync_file_root': os.path.join('/tmp', REMOTE_MIGRATION_ROOT)
         }, TEMPLATE_DIR)
         rsync_script_path = os.path.join(target_script_root, FILE_MIGRATION_RSYNC_SCRIPT)
-        with open(rsync_script_path, 'w') as f:
+        with open(rsync_script_path, 'w', encoding='utf-8') as f:
             f.write(rsync_script_contents)
 
 

--- a/src/commcare_cloud/commands/migrations/copy_files.py
+++ b/src/commcare_cloud/commands/migrations/copy_files.py
@@ -135,7 +135,7 @@ class CopyFiles(CommandBase):
 
 def read_plan(plan_path, target_env, limit=None):
     with open(plan_path, 'r', encoding='utf-8') as f:
-        # PY2: yaml.safe_load always returns byte strings
+        # PY2: yaml.safe_load returns byte strings when the content is ASCII-only bytes
         plan_dict = yaml.safe_load(f)
 
     source_env = None

--- a/src/commcare_cloud/commands/migrations/couchdb.py
+++ b/src/commcare_cloud/commands/migrations/couchdb.py
@@ -58,7 +58,7 @@ from commcare_cloud.commands.migrations.copy_files import (
 )
 from commcare_cloud.commands.utils import render_template
 from commcare_cloud.environment.main import get_environment
-from commcare_cloud.python_migration_utils import open_python_dependent
+from commcare_cloud.python_migration_utils import open_for_write
 
 TEMPLATE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'templates')
 PLAY_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'plays')
@@ -244,7 +244,7 @@ def commit(migration, ansible_context):
 def assert_files(migration, alloc_docs_by_db, ansible_context):
     files_by_node = get_files_for_assertion(alloc_docs_by_db)
     expected_files_vars = os.path.abspath(os.path.join(migration.working_dir, 'assert_vars.yml'))
-    with open_python_dependent(expected_files_vars) as f:
+    with open_for_write(expected_files_vars) as f:
         yaml.safe_dump({
             'files_by_node': files_by_node,
             'couch_data_dir': migration.couchdb2_data_dir,
@@ -323,7 +323,7 @@ def generate_shard_plan(migration):
     shard_allocations = generate_shard_allocation(
         migration.source_couch_config, migration.plan.target_allocation
     )
-    with open_python_dependent(migration.shard_plan_path) as f:
+    with open_for_write(migration.shard_plan_path) as f:
         plan = {
             shard_allocation_doc.db_name: shard_allocation_doc.to_plan_json()
             for shard_allocation_doc in shard_allocations

--- a/src/commcare_cloud/commands/migrations/couchdb.py
+++ b/src/commcare_cloud/commands/migrations/couchdb.py
@@ -58,7 +58,7 @@ from commcare_cloud.commands.migrations.copy_files import (
 )
 from commcare_cloud.commands.utils import render_template
 from commcare_cloud.environment.main import get_environment
-from commcare_cloud.python_migration_utils import open_for_yaml_dump
+from commcare_cloud.python_migration_utils import open_python_dependent
 
 TEMPLATE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'templates')
 PLAY_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'plays')
@@ -244,7 +244,7 @@ def commit(migration, ansible_context):
 def assert_files(migration, alloc_docs_by_db, ansible_context):
     files_by_node = get_files_for_assertion(alloc_docs_by_db)
     expected_files_vars = os.path.abspath(os.path.join(migration.working_dir, 'assert_vars.yml'))
-    with open_for_yaml_dump(expected_files_vars) as f:
+    with open_python_dependent(expected_files_vars) as f:
         yaml.safe_dump({
             'files_by_node': files_by_node,
             'couch_data_dir': migration.couchdb2_data_dir,
@@ -323,7 +323,7 @@ def generate_shard_plan(migration):
     shard_allocations = generate_shard_allocation(
         migration.source_couch_config, migration.plan.target_allocation
     )
-    with open_for_yaml_dump(migration.shard_plan_path) as f:
+    with open_python_dependent(migration.shard_plan_path) as f:
         plan = {
             shard_allocation_doc.db_name: shard_allocation_doc.to_plan_json()
             for shard_allocation_doc in shard_allocations

--- a/src/commcare_cloud/commands/migrations/couchdb.py
+++ b/src/commcare_cloud/commands/migrations/couchdb.py
@@ -1,39 +1,64 @@
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
+
 import difflib
 import json
 import os
 from collections import defaultdict
 from contextlib import contextmanager
+from io import open
 
 import yaml
-from clint.textui import puts, indent
+from clint.textui import indent, puts
 from couchdb_cluster_admin.describe import print_shard_table
 from couchdb_cluster_admin.doc_models import ShardAllocationDoc
-from couchdb_cluster_admin.file_plan import get_missing_files_by_node_and_source, \
-    figure_out_what_you_can_and_cannot_delete
-from couchdb_cluster_admin.suggest_shard_allocation import get_shard_allocation_from_plan, generate_shard_allocation, \
-    print_db_info
-from couchdb_cluster_admin.utils import put_shard_allocation, get_shard_allocation, get_db_list, check_connection, \
-    get_membership
+from couchdb_cluster_admin.file_plan import (
+    figure_out_what_you_can_and_cannot_delete,
+    get_missing_files_by_node_and_source,
+)
+from couchdb_cluster_admin.suggest_shard_allocation import (
+    generate_shard_allocation,
+    get_shard_allocation_from_plan,
+    print_db_info,
+)
+from couchdb_cluster_admin.utils import (
+    check_connection,
+    get_db_list,
+    get_membership,
+    get_shard_allocation,
+    put_shard_allocation,
+)
+from six.moves import map, zip
 from tabulate import tabulate
 
 from commcare_cloud.cli_utils import ask
-from commcare_cloud.colors import color_warning, color_notice, color_summary, color_error, \
-    color_highlight, color_success
+from commcare_cloud.colors import (
+    color_error,
+    color_highlight,
+    color_notice,
+    color_success,
+    color_summary,
+    color_warning,
+)
 from commcare_cloud.commands import shared_args
-from commcare_cloud.commands.ansible.ansible_playbook import run_ansible_playbook
-from commcare_cloud.commands.ansible.helpers import AnsibleContext, run_action_with_check_mode
+from commcare_cloud.commands.ansible.ansible_playbook import (
+    run_ansible_playbook,
+)
+from commcare_cloud.commands.ansible.helpers import (
+    AnsibleContext,
+    run_action_with_check_mode,
+)
 from commcare_cloud.commands.ansible.run_module import run_ansible_module
-from commcare_cloud.commands.command_base import CommandBase, Argument
+from commcare_cloud.commands.command_base import Argument, CommandBase
 from commcare_cloud.commands.migrations.config import CouchMigration
-from commcare_cloud.commands.migrations.copy_files import SourceFiles, prepare_file_copy_scripts, \
-    copy_scripts_to_target_host, execute_file_copy_scripts
+from commcare_cloud.commands.migrations.copy_files import (
+    SourceFiles,
+    copy_scripts_to_target_host,
+    execute_file_copy_scripts,
+    prepare_file_copy_scripts,
+)
 from commcare_cloud.commands.utils import render_template
 from commcare_cloud.environment.main import get_environment
-from six.moves import map
-from six.moves import zip
+from commcare_cloud.python_migration_utils import open_for_yaml_dump
 
 TEMPLATE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'templates')
 PLAY_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'plays')
@@ -181,7 +206,7 @@ def generate_shard_prune_playbook(migration):
         'deletable_files_by_node': deletable_files_by_node,
         'couch_data_dir': migration.couchdb2_data_dir
     }, TEMPLATE_DIR)
-    with open(migration.prune_playbook_path, 'w') as f:
+    with open(migration.prune_playbook_path, 'w', encoding='utf-8') as f:
         f.write(prune_playbook)
 
     return list(deletable_files_by_node)
@@ -219,7 +244,7 @@ def commit(migration, ansible_context):
 def assert_files(migration, alloc_docs_by_db, ansible_context):
     files_by_node = get_files_for_assertion(alloc_docs_by_db)
     expected_files_vars = os.path.abspath(os.path.join(migration.working_dir, 'assert_vars.yml'))
-    with open(expected_files_vars, 'w') as f:
+    with open_for_yaml_dump(expected_files_vars) as f:
         yaml.safe_dump({
             'files_by_node': files_by_node,
             'couch_data_dir': migration.couchdb2_data_dir,
@@ -298,7 +323,7 @@ def generate_shard_plan(migration):
     shard_allocations = generate_shard_allocation(
         migration.source_couch_config, migration.plan.target_allocation
     )
-    with open(migration.shard_plan_path, 'w') as f:
+    with open_for_yaml_dump(migration.shard_plan_path) as f:
         plan = {
             shard_allocation_doc.db_name: shard_allocation_doc.to_plan_json()
             for shard_allocation_doc in shard_allocations

--- a/src/commcare_cloud/commands/terraform/aws.py
+++ b/src/commcare_cloud/commands/terraform/aws.py
@@ -23,7 +23,7 @@ from commcare_cloud.cli_utils import print_command
 from commcare_cloud.colors import color_notice, color_success
 from commcare_cloud.commands.command_base import Argument, CommandBase
 from commcare_cloud.environment.main import get_environment
-from commcare_cloud.python_migration_utils import open_python_dependent
+from commcare_cloud.python_migration_utils import open_for_write
 
 
 def check_output(cmd_parts, env, silent=False):
@@ -145,11 +145,11 @@ class AwsFillInventory(CommandBase):
 
         if not args.cached:
             resources = get_aws_resources(environment)
-            with open_python_dependent(environment.paths.aws_resources_yml) as f:
+            with open_for_write(environment.paths.aws_resources_yml) as f:
                 f.write(yaml.safe_dump(resources, default_flow_style=False))
         else:
             with open(environment.paths.aws_resources_yml, 'r', encoding='utf-8') as f:
-                # PY2: yaml.safe_load will return bytes regardless of read mode
+                # PY2: yaml.safe_load will return bytes when the content is ASCII-only bytes
                 resources = yaml.safe_load(f.read())
 
         with open(environment.paths.inventory_ini_j2, 'r', encoding='utf-8') as f:
@@ -532,7 +532,7 @@ def _write_credentials_to_aws_credentials(
     config.set(aws_profile, 'aws_secret_access_key', aws_secret_access_key)
     config.set(aws_profile, 'aws_session_token', aws_session_token)
     config.set(aws_profile, 'expiration', expiration.strftime("%Y-%m-%dT%H:%M:%SZ"))
-    with open_python_dependent(AWS_CREDENTIALS_PATH) as f:
+    with open_for_write(AWS_CREDENTIALS_PATH) as f:
         config.write(f)
 
 
@@ -570,7 +570,7 @@ def _write_profile_for_sso(
     config.set(section, 'sso_role_name', 'PowerUserAccessPlus')
     config.set(section, 'region', region)
     config.set(section, 'output', 'json')
-    with open_python_dependent(AWS_CONFIG_PATH) as f:
+    with open_for_write(AWS_CONFIG_PATH) as f:
         config.write(f)
 
 

--- a/src/commcare_cloud/commands/terraform/aws.py
+++ b/src/commcare_cloud/commands/terraform/aws.py
@@ -1,14 +1,13 @@
 # coding=utf-8
-from __future__ import print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
 import getpass
 import json
 import os
 import subprocess
 import textwrap
 from datetime import datetime
+from io import open
 
 import boto3
 import jinja2
@@ -18,14 +17,13 @@ import yaml
 from clint.textui import puts
 from memoized import memoized
 from simplejson import JSONDecodeError
-from six.moves import shlex_quote
-from six.moves import configparser
-from six.moves import input
+from six.moves import configparser, input, shlex_quote
 
 from commcare_cloud.cli_utils import print_command
-from commcare_cloud.colors import color_success, color_notice
-from commcare_cloud.commands.command_base import CommandBase, Argument
+from commcare_cloud.colors import color_notice, color_success
+from commcare_cloud.commands.command_base import Argument, CommandBase
 from commcare_cloud.environment.main import get_environment
+from commcare_cloud.python_migration_utils import open_python_dependent
 
 
 def check_output(cmd_parts, env, silent=False):
@@ -147,21 +145,23 @@ class AwsFillInventory(CommandBase):
 
         if not args.cached:
             resources = get_aws_resources(environment)
-            with open(environment.paths.aws_resources_yml, 'w') as f:
+            with open_python_dependent(environment.paths.aws_resources_yml) as f:
                 f.write(yaml.safe_dump(resources, default_flow_style=False))
         else:
-            with open(environment.paths.aws_resources_yml, 'r') as f:
+            with open(environment.paths.aws_resources_yml, 'r', encoding='utf-8') as f:
+                # PY2: yaml.safe_load will return bytes regardless of read mode
                 resources = yaml.safe_load(f.read())
 
-        with open(environment.paths.inventory_ini_j2) as f:
+        with open(environment.paths.inventory_ini_j2, 'r', encoding='utf-8') as f:
             inventory_ini_j2 = f.read()
 
-        with open(environment.paths.inventory_ini, 'w') as f:
+        with open(environment.paths.inventory_ini, 'w', encoding='utf-8') as f:
             # by putting this inside the with
             # we make sure that if the it fails, inventory.ini is made empty
             # reflecting that we were unable to create it
             out_string = AwsFillInventoryHelper(environment, inventory_ini_j2,
                                                 resources).render()
+            # PY2: out_string is unicode based on Jinja2 render method
             f.write(out_string)
 
 
@@ -410,7 +410,7 @@ def _sync_sso_to_v1_credentials(aws_session_profile):
     # with the credential format that terraform uses
 
     for filepath in _iter_files_in_dir(AWS_CLI_CACHE_DIR):
-        with open(filepath) as f:
+        with open(filepath, 'r', encoding='utf-8') as f:
             try:
                 data = json.load(f)
             except JSONDecodeError:
@@ -532,7 +532,7 @@ def _write_credentials_to_aws_credentials(
     config.set(aws_profile, 'aws_secret_access_key', aws_secret_access_key)
     config.set(aws_profile, 'aws_session_token', aws_session_token)
     config.set(aws_profile, 'expiration', expiration.strftime("%Y-%m-%dT%H:%M:%SZ"))
-    with open(AWS_CREDENTIALS_PATH, 'w') as f:
+    with open_python_dependent(AWS_CREDENTIALS_PATH) as f:
         config.write(f)
 
 
@@ -570,14 +570,14 @@ def _write_profile_for_sso(
     config.set(section, 'sso_role_name', 'PowerUserAccessPlus')
     config.set(section, 'region', region)
     config.set(section, 'output', 'json')
-    with open(AWS_CONFIG_PATH, 'w') as f:
+    with open_python_dependent(AWS_CONFIG_PATH) as f:
         config.write(f)
 
 
 def _has_valid_session_credentials_for_sso():
     for filepath in _iter_files_in_dir(AWS_SSO_CACHE_DIR):
         try:
-            with open(filepath, 'r') as f:
+            with open(filepath, 'r', encoding='utf-8') as f:
                 contents = json.load(f)
         except JSONDecodeError:
             continue

--- a/src/commcare_cloud/commands/terraform/terraform.py
+++ b/src/commcare_cloud/commands/terraform/terraform.py
@@ -1,25 +1,30 @@
-from __future__ import print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
 import json
 import os
 import subprocess
+from io import open
 
 from clint.textui import puts
 from six.moves import shlex_quote
 
 from commcare_cloud.cli_utils import print_command
 from commcare_cloud.colors import color_error
-from commcare_cloud.commands.command_base import CommandBase, Argument
+from commcare_cloud.commands.command_base import Argument, CommandBase
 from commcare_cloud.commands.terraform import postgresql_units
-from commcare_cloud.commands.terraform.aws import aws_sign_in, get_default_username, \
-    print_help_message_about_the_commcare_cloud_default_username_env_var
-from commcare_cloud.commands.terraform.constants import COMMCAREHQ_XML_POST_URLS_REGEX, \
-    COMMCAREHQ_XML_QUERYSTRING_URLS_REGEX
+from commcare_cloud.commands.terraform.aws import (
+    aws_sign_in,
+    get_default_username,
+    print_help_message_about_the_commcare_cloud_default_username_env_var,
+)
+from commcare_cloud.commands.terraform.constants import (
+    COMMCAREHQ_XML_POST_URLS_REGEX,
+    COMMCAREHQ_XML_QUERYSTRING_URLS_REGEX,
+)
 from commcare_cloud.commands.utils import render_template
 from commcare_cloud.environment.main import get_environment
 from commcare_cloud.environment.paths import TERRAFORM_DIR, get_role_defaults
+from commcare_cloud.python_migration_utils import open_python_dependent
 
 
 class Terraform(CommandBase):
@@ -87,7 +92,7 @@ class Terraform(CommandBase):
                 else ''
             )
 
-            with open(os.path.join(run_dir, 'secrets.auto.tfvars'), 'w') as f:
+            with open_python_dependent(os.path.join(run_dir, 'secrets.auto.tfvars')) as f:
                 print('rds_password = {}'.format(json.dumps(rds_password)), file=f)
 
         env_vars = {'AWS_PROFILE': aws_sign_in(environment)}
@@ -177,8 +182,8 @@ def generate_terraform_entrypoint(environment, key_name, run_dir, apply_immediat
             ('variables.tf.j2', 'variables.tf'),
             ('terraform.tfvars.j2', 'terraform.tfvars'),
     ):
-        with open(os.path.join(run_dir, output_file), 'w') as f:
-            f.write(render_template(template_file, context, template_root).encode('utf-8'))
+        with open(os.path.join(run_dir, output_file), 'w', encoding='utf-8') as f:
+            f.write(render_template(template_file, context, template_root))
 
 
 def compact_waf_regexes(patterns):

--- a/src/commcare_cloud/commands/terraform/terraform.py
+++ b/src/commcare_cloud/commands/terraform/terraform.py
@@ -24,7 +24,6 @@ from commcare_cloud.commands.terraform.constants import (
 from commcare_cloud.commands.utils import render_template
 from commcare_cloud.environment.main import get_environment
 from commcare_cloud.environment.paths import TERRAFORM_DIR, get_role_defaults
-from commcare_cloud.python_migration_utils import open_for_write
 
 
 class Terraform(CommandBase):
@@ -92,7 +91,7 @@ class Terraform(CommandBase):
                 else ''
             )
 
-            with open_for_write(os.path.join(run_dir, 'secrets.auto.tfvars')) as f:
+            with open(os.path.join(run_dir, 'secrets.auto.tfvars'), 'w', encoding='utf-8') as f:
                 print('rds_password = {}'.format(json.dumps(rds_password)), file=f)
 
         env_vars = {'AWS_PROFILE': aws_sign_in(environment)}

--- a/src/commcare_cloud/commands/terraform/terraform.py
+++ b/src/commcare_cloud/commands/terraform/terraform.py
@@ -24,7 +24,7 @@ from commcare_cloud.commands.terraform.constants import (
 from commcare_cloud.commands.utils import render_template
 from commcare_cloud.environment.main import get_environment
 from commcare_cloud.environment.paths import TERRAFORM_DIR, get_role_defaults
-from commcare_cloud.python_migration_utils import open_python_dependent
+from commcare_cloud.python_migration_utils import open_for_write
 
 
 class Terraform(CommandBase):
@@ -92,7 +92,7 @@ class Terraform(CommandBase):
                 else ''
             )
 
-            with open_python_dependent(os.path.join(run_dir, 'secrets.auto.tfvars')) as f:
+            with open_for_write(os.path.join(run_dir, 'secrets.auto.tfvars')) as f:
                 print('rds_password = {}'.format(json.dumps(rds_password)), file=f)
 
         env_vars = {'AWS_PROFILE': aws_sign_in(environment)}

--- a/src/commcare_cloud/commands/terraform/terraform_migrate_state.py
+++ b/src/commcare_cloud/commands/terraform/terraform_migrate_state.py
@@ -24,7 +24,7 @@ from commcare_cloud.commands.command_base import (
 )
 from commcare_cloud.commands.terraform.aws import aws_sign_in
 from commcare_cloud.environment.main import get_environment
-from commcare_cloud.python_migration_utils import open_python_dependent
+from commcare_cloud.python_migration_utils import open_for_write
 
 
 class TerraformMigrateState(CommandBase):
@@ -154,7 +154,7 @@ class RemoteMigrationStateManager(object):
         """
         temp_filename = tempfile.mktemp()
         try:
-            with open_python_dependent(temp_filename) as f:
+            with open_for_write(temp_filename) as f:
                 json.dump(remote_migration_state.to_json(), f)
 
             try:

--- a/src/commcare_cloud/commands/terraform/terraform_migrate_state.py
+++ b/src/commcare_cloud/commands/terraform/terraform_migrate_state.py
@@ -1,27 +1,30 @@
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import unicode_literals
-import json
-import sys
-import tempfile
-from copy import deepcopy
+from __future__ import absolute_import, print_function, unicode_literals
 
-import boto3
-import jsonobject
+import json
 import os
 import re
 import runpy
 import subprocess
-from collections import namedtuple, deque
+import sys
+import tempfile
+from collections import deque, namedtuple
+from io import open
 
+import boto3
+import jsonobject
 from botocore.exceptions import ClientError
 from memoized import memoized_property
 
 from commcare_cloud.alias import commcare_cloud
-from commcare_cloud.cli_utils import ask, print_command
-from commcare_cloud.commands.command_base import CommandBase, CommandError, Argument
+from commcare_cloud.cli_utils import ask
+from commcare_cloud.commands.command_base import (
+    Argument,
+    CommandBase,
+    CommandError,
+)
 from commcare_cloud.commands.terraform.aws import aws_sign_in
 from commcare_cloud.environment.main import get_environment
+from commcare_cloud.python_migration_utils import open_python_dependent
 
 
 class TerraformMigrateState(CommandBase):
@@ -134,7 +137,7 @@ class RemoteMigrationStateManager(object):
                     error_code = e.response.get('Error', {}).get('Code', 'Unknown')
                     raise CommandError('Request to S3 exited with code {}'.format(error_code))
             else:
-                with open(temp_filename) as f:
+                with open(temp_filename, 'r', encoding='utf-8') as f:
                     return RemoteMigrationState.wrap(json.load(f))
 
         finally:
@@ -151,7 +154,7 @@ class RemoteMigrationStateManager(object):
         """
         temp_filename = tempfile.mktemp()
         try:
-            with open(temp_filename, 'w') as f:
+            with open_python_dependent(temp_filename) as f:
                 json.dump(remote_migration_state.to_json(), f)
 
             try:

--- a/src/commcare_cloud/environment/main.py
+++ b/src/commcare_cloud/environment/main.py
@@ -29,7 +29,7 @@ from commcare_cloud.environment.schemas.prometheus import PrometheusConfig
 from commcare_cloud.environment.schemas.proxy import ProxyConfig
 from commcare_cloud.environment.schemas.terraform import TerraformConfig
 from commcare_cloud.environment.users import UsersConfig
-from commcare_cloud.python_migration_utils import open_for_yaml_dump
+from commcare_cloud.python_migration_utils import open_for_write
 from commcare_cloud.yaml import PreserveUnsafeDumper
 
 
@@ -370,7 +370,7 @@ class Environment(object):
 
         generated_variables.update(self.secrets_backend.get_generated_variables())
 
-        with open_for_yaml_dump(self.paths.generated_yml) as f:
+        with open_for_write(self.paths.generated_yml) as f:
             f.write(yaml.dump(generated_variables, Dumper=PreserveUnsafeDumper))
 
     def translate_host(self, host, filename_for_error):

--- a/src/commcare_cloud/fab/utils.py
+++ b/src/commcare_cloud/fab/utils.py
@@ -1,7 +1,5 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
-from __future__ import unicode_literals
 import datetime
 import os
 import pickle
@@ -10,15 +8,16 @@ import sys
 import traceback
 from collections import defaultdict
 from getpass import getpass
-
-from gevent.pool import Pool
-from github import Github, UnknownObjectException
-from memoized import memoized, memoized_property
+from io import open
 
 from fabric.api import env, execute, local
 from fabric.colors import blue, cyan, red, yellow
 from fabric.context_managers import cd, settings
 from fabric.operations import sudo
+from gevent.pool import Pool
+from github import Github, UnknownObjectException
+from memoized import memoized, memoized_property
+from six.moves import input
 
 from .const import (
     CACHED_DEPLOY_CHECKPOINT_FILENAME,
@@ -29,8 +28,6 @@ from .const import (
     RELEASE_RECORD,
 )
 
-from six.moves import input
-
 LABELS_TO_EXPAND = [
     "reindex/migration",
 ]
@@ -40,7 +37,7 @@ def execute_with_timing(fn, *args, **kwargs):
     start_time = datetime.datetime.utcnow()
     execute(fn, *args, **kwargs)
     if env.timing_log:
-        with open(env.timing_log, 'a') as timing_log:
+        with open(env.timing_log, 'a', encoding='utf-8') as timing_log:
             duration = datetime.datetime.utcnow() - start_time
             timing_log.write('{}: {}\n'.format(fn.__name__, duration.seconds))
 
@@ -202,9 +199,9 @@ def _get_env_filename():
 
 
 def cache_deploy_state(command_index):
-    with open(os.path.join(PROJECT_ROOT, _get_checkpoint_filename()), 'w') as f:
+    with open(os.path.join(PROJECT_ROOT, _get_checkpoint_filename()), 'wb') as f:
         pickle.dump(command_index, f)
-    with open(os.path.join(PROJECT_ROOT, _get_env_filename()), 'w') as f:
+    with open(os.path.join(PROJECT_ROOT, _get_env_filename()), 'wb') as f:
         pickle.dump(env, f)
 
 
@@ -224,7 +221,7 @@ def retrieve_cached_deploy_checkpoint():
 
 
 def _retrieve_cached(filename):
-    with open(filename, 'r') as f:
+    with open(filename, 'rb') as f:
         return pickle.load(f)
 
 

--- a/src/commcare_cloud/manage_commcare_cloud/configure.py
+++ b/src/commcare_cloud/manage_commcare_cloud/configure.py
@@ -1,17 +1,20 @@
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
+
 import os
 import textwrap
-from six.moves import shlex_quote
+from io import open
 
 from clint.textui import puts
+from six.moves import shlex_quote
 
 from commcare_cloud.cli_utils import ask
-from commcare_cloud.colors import color_summary, color_notice, color_code
+from commcare_cloud.colors import color_code, color_notice, color_summary
 from commcare_cloud.commands.command_base import CommandBase
-from commcare_cloud.environment.paths import DIMAGI_ENVIRONMENTS_DIR, get_virtualenv_bin_path, \
-    PACKAGE_BASE
+from commcare_cloud.environment.paths import (
+    DIMAGI_ENVIRONMENTS_DIR,
+    PACKAGE_BASE,
+    get_virtualenv_bin_path,
+)
 
 
 class Configure(CommandBase):
@@ -80,7 +83,7 @@ class Configure(CommandBase):
         load_config_file = os.path.expanduser("~/.commcare-cloud/load_config.sh")
         if not os.path.exists(load_config_file) or \
                 ask("Overwrite your ~/.commcare-cloud/load_config.sh?", quiet=quiet):
-            with open(load_config_file, 'w') as f:
+            with open(load_config_file, 'w', encoding='utf-8') as f:
                 f.write(textwrap.dedent("""
                     # auto-generated with `manage-commcare-cloud configure`:
                     export COMMCARE_CLOUD_ENVIRONMENTS={COMMCARE_CLOUD_ENVIRONMENTS}

--- a/src/commcare_cloud/parse_help.py
+++ b/src/commcare_cloud/parse_help.py
@@ -1,10 +1,10 @@
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import unicode_literals
-from collections import namedtuple
+from __future__ import absolute_import, print_function, unicode_literals
+
 import os
 import subprocess
-import sys
+from collections import namedtuple
+from io import open
+
 from six.moves import range
 
 ANSIBLE_HELP_OPTIONS_PREFIX='optional arguments:'
@@ -17,7 +17,7 @@ _AVAILABLE_HELP_CACHES = {
 
 def _get_help_text(command):
     if command in _AVAILABLE_HELP_CACHES:
-        with open(_AVAILABLE_HELP_CACHES[command]) as f:
+        with open(_AVAILABLE_HELP_CACHES[command], 'r', encoding='utf-8') as f:
             return f.read()
     else:
         return subprocess.check_output(command, shell=True)

--- a/src/commcare_cloud/python_migration_utils.py
+++ b/src/commcare_cloud/python_migration_utils.py
@@ -5,6 +5,19 @@ from io import open
 import six
 
 
+def open_python_dependent(path):
+    """
+    Used for cases where we cannot avoid having a bytes string in PY2 and text string in PY3
+    Some examples are:
+        - json.dump and json.dumps attempt to write byte strings on PY2, and text strings on PY3
+        - same for yaml.dump and yaml.safe_dump
+        - passing the file stream into a library that writes byte strings in PY2
+    """
+    if six.PY2:
+        return open(path, "wb")
+    return open(path, "w", encoding="utf-8")
+
+
 def open_for_json_dump(path):
     """
     This ensures compatible file write modes based on Python versions

--- a/src/commcare_cloud/python_migration_utils.py
+++ b/src/commcare_cloud/python_migration_utils.py
@@ -16,23 +16,3 @@ def open_for_write(path):
     if six.PY2:
         return open(path, "wb")
     return open(path, "w", encoding="utf-8")
-
-
-def open_for_json_dump(path):
-    """
-    This ensures compatible file write modes based on Python versions
-    Python 2 json.dump and json.dumps create a bytes object
-    Python 3 json.dump and json.dumps create a str object
-    """
-    if six.PY2:
-        return open(path, "wb")
-    return open(path, "w", encoding="utf-8")
-
-
-def open_for_yaml_dump(path):
-    """
-    This ensures compatible file write modes based on Python versions for yaml.dump/safe_dump calls
-    """
-    if six.PY2:
-        return open(path, "wb")
-    return open(path, "w", encoding="utf-8")

--- a/src/commcare_cloud/python_migration_utils.py
+++ b/src/commcare_cloud/python_migration_utils.py
@@ -5,7 +5,7 @@ from io import open
 import six
 
 
-def open_python_dependent(path):
+def open_for_write(path):
     """
     Used for cases where we cannot avoid having a bytes string in PY2 and text string in PY3
     Some examples are:


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
[Replace open with io.open](https://dimagi-dev.atlassian.net/browse/SAAS-11366)

Continuation of a list of PRs for this ticket. This fixes open calls that have yet to be addressed in the `src/commcare_cloud` directory.

The first new commit is https://github.com/dimagi/commcare-cloud/pull/4355/commits/f5f0b1e4c749a5ff4d6e6890d8b89f5b3e218e4e

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None