### PR TITLE
Explicitly use io.open in remaining files in src/commcare_cloud

### DIFF
--- a/src/commcare_cloud/ansible/plugins/inventory/csv.py
+++ b/src/commcare_cloud/ansible/plugins/inventory/csv.py
@@ -1,10 +1,19 @@
-from __future__ import (absolute_import, division, print_function)
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
-from __future__ import unicode_literals
 import csv
 import json
 import os
 import re
+from io import open
+
+from ansible.errors import AnsibleParserError
+from ansible.module_utils._text import to_bytes, to_text
+from ansible.plugins.inventory import BaseInventoryPlugin
 
 __metaclass__ = type
 
@@ -67,9 +76,6 @@ EXAMPLES = '''
 '''
 
 
-from ansible.errors import AnsibleParserError
-from ansible.module_utils._text import to_text, to_bytes
-from ansible.plugins.inventory import BaseInventoryPlugin
 
 
 TYPE_STRING = 'S'

--- a/src/commcare_cloud/ansible/plugins/lookup/cchq_aws_secret.py
+++ b/src/commcare_cloud/ansible/plugins/lookup/cchq_aws_secret.py
@@ -1,11 +1,12 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
+
 import json
 import logging
 import os
-import six.moves.cPickle as pickle
 import time
+from io import open
 
+import six.moves.cPickle as pickle
 from ansible.plugins.lookup import aws_secret
 from cryptography.fernet import Fernet, InvalidToken
 

--- a/src/commcare_cloud/cli_utils.py
+++ b/src/commcare_cloud/cli_utils.py
@@ -1,15 +1,16 @@
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
+
 import re
 import subprocess
-
 import sys
-from clint.textui import puts
+from io import open
 
-from commcare_cloud.colors import color_error, color_code
-from .environment.paths import ANSIBLE_DIR
+from clint.textui import puts
 from six.moves import input, shlex_quote
+
+from commcare_cloud.colors import color_code, color_error
+
+from .environment.paths import ANSIBLE_DIR
 
 
 def ask(message, strict=False, quiet=False):
@@ -60,7 +61,7 @@ def git_branch():
             "git status",
             cwd=ANSIBLE_DIR,
             shell=True,
-            stderr=open('/dev/null', 'w'),
+            stderr=open('/dev/null', 'w', encoding='utf-8'),
             universal_newlines=True,
         )
     except subprocess.CalledProcessError as e:

--- a/src/commcare_cloud/fab/utils.py
+++ b/src/commcare_cloud/fab/utils.py
@@ -1,7 +1,5 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
-from __future__ import unicode_literals
 import datetime
 import os
 import pickle
@@ -10,15 +8,16 @@ import sys
 import traceback
 from collections import defaultdict
 from getpass import getpass
-
-from gevent.pool import Pool
-from github import Github, UnknownObjectException
-from memoized import memoized, memoized_property
+from io import open
 
 from fabric.api import env, execute, local
 from fabric.colors import blue, cyan, red, yellow
 from fabric.context_managers import cd, settings
 from fabric.operations import sudo
+from gevent.pool import Pool
+from github import Github, UnknownObjectException
+from memoized import memoized, memoized_property
+from six.moves import input
 
 from .const import (
     CACHED_DEPLOY_CHECKPOINT_FILENAME,
@@ -29,8 +28,6 @@ from .const import (
     RELEASE_RECORD,
 )
 
-from six.moves import input
-
 LABELS_TO_EXPAND = [
     "reindex/migration",
 ]
@@ -40,7 +37,7 @@ def execute_with_timing(fn, *args, **kwargs):
     start_time = datetime.datetime.utcnow()
     execute(fn, *args, **kwargs)
     if env.timing_log:
-        with open(env.timing_log, 'a') as timing_log:
+        with open(env.timing_log, 'a', encoding='utf-8') as timing_log:
             duration = datetime.datetime.utcnow() - start_time
             timing_log.write('{}: {}\n'.format(fn.__name__, duration.seconds))
 
@@ -202,9 +199,9 @@ def _get_env_filename():
 
 
 def cache_deploy_state(command_index):
-    with open(os.path.join(PROJECT_ROOT, _get_checkpoint_filename()), 'w') as f:
+    with open(os.path.join(PROJECT_ROOT, _get_checkpoint_filename()), 'wb') as f:
         pickle.dump(command_index, f)
-    with open(os.path.join(PROJECT_ROOT, _get_env_filename()), 'w') as f:
+    with open(os.path.join(PROJECT_ROOT, _get_env_filename()), 'wb') as f:
         pickle.dump(env, f)
 
 
@@ -224,7 +221,7 @@ def retrieve_cached_deploy_checkpoint():
 
 
 def _retrieve_cached(filename):
-    with open(filename, 'r') as f:
+    with open(filename, 'rb') as f:
         return pickle.load(f)
 
 

--- a/src/commcare_cloud/parse_help.py
+++ b/src/commcare_cloud/parse_help.py
@@ -1,10 +1,10 @@
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import unicode_literals
-from collections import namedtuple
+from __future__ import absolute_import, print_function, unicode_literals
+
 import os
 import subprocess
-import sys
+from collections import namedtuple
+from io import open
+
 from six.moves import range
 
 ANSIBLE_HELP_OPTIONS_PREFIX='optional arguments:'
@@ -17,7 +17,7 @@ _AVAILABLE_HELP_CACHES = {
 
 def _get_help_text(command):
     if command in _AVAILABLE_HELP_CACHES:
-        with open(_AVAILABLE_HELP_CACHES[command]) as f:
+        with open(_AVAILABLE_HELP_CACHES[command], 'r', encoding='utf-8') as f:
             return f.read()
     else:
         return subprocess.check_output(command, shell=True)


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
[Replace open with io.open](https://dimagi-dev.atlassian.net/browse/SAAS-11366)

Continuation of the PRs to replace open calls in python 2/3 with io.open calls. 
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None