### PR TITLE
remove commcare-hq source from formplayer machines

### DIFF
--- a/src/commcare_cloud/fab/const.py
+++ b/src/commcare_cloud/fab/const.py
@@ -12,7 +12,6 @@ ROLES_ALL_SRC = [
     'django_app',
     'django_celery',
     'django_pillowtop',
-    'formplayer',
     'staticfiles',
     'airflow',
     'django_manage'

--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -272,7 +272,7 @@ def env_common():
     env.resume = False
     env.offline = False
     env.full_deploy = False
-    env.supervisor_roles = ROLES_ALL_SRC
+    env.supervisor_roles = ROLES_ALL_SERVICES
 
 
 @task


### PR DESCRIPTION
Removing 'formplayer' from the `ROLES_ALL_SRC` role means that the commcare-hq code
will not get deployed to these nodes. In the past formplayer was deployed inside the HQ code deploy structure
but that is no longer the case. There is no need to have the HQ code on formplayer machines.

##### ENVIRONMENTS AFFECTED
ALL
