### PR TITLE
Raise exception if /current release directory does not exist when deploying 

### DIFF
--- a/src/commcare_cloud/environment/exceptions.py
+++ b/src/commcare_cloud/environment/exceptions.py
@@ -1,4 +1,7 @@
 class EnvironmentException(Exception):
+    """
+    Used for any environment, configuration, general setup issues encountered
+    """
     pass
 
 

--- a/src/commcare_cloud/environment/exceptions.py
+++ b/src/commcare_cloud/environment/exceptions.py
@@ -1,3 +1,6 @@
+from __future__ import unicode_literals
+
+
 class EnvironmentException(Exception):
     """
     Used for any environment, configuration, general setup issues encountered

--- a/src/commcare_cloud/fab/operations/release.py
+++ b/src/commcare_cloud/fab/operations/release.py
@@ -303,9 +303,7 @@ def update_virtualenv(full_cluster=True):
             _clone_virtual_env(env.py3_virtualenv_current, env.py3_virtualenv_root)
         elif not exists(env.py3_virtualenv_current):
             raise EnvironmentException(
-                "{} cannot be found. This means there is no virtual environment available to clone from. "
-                "You will need to recreate the /current directory on this machine that symlinks to the most " 
-                "recent release in order to deploy successfully.".format(env.py3_virtualenv_current)
+                "Virtual environment not found: {}".format(env.py3_virtualenv_current)
             )
 
         requirements_files = [join("requirements", "prod-requirements.txt")]


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Discovered this issue when HQ code was removed from formplayer machines. The machines were unable to create a new virtual environment during deploy. This is ok behavior since an ansible command handles creating a virtualenv when first being setup, and we do not expect to remove the /current directory from any machine that needs it. This will make it easier to debug in the future if it ever comes up.
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None