### PR TITLE
Increased couchdb2_client_max_body_size on staging

### DIFF
--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -76,6 +76,7 @@ couch_dbs:
 couchdb2:
   username: "{{ COUCH_USERNAME }}"
   password: "{{ COUCH_PASSWORD }}"
+couchdb2_client_max_body_size: 100M
 couchdb_reduce_limit: False
 couchdb_cluster_settings:
   q: 8


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/USH-482

This now matches [the limit on prod](https://github.com/dimagi/commcare-cloud/blob/98b4f21d5b60043a289da00a93de9a957d1f7540/environments/production/public.yml#L86).

##### ENVIRONMENTS AFFECTED
staging
