### PR TITLE
Increase pgucr0-production RDS instance to make use of RIs

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -496,7 +496,7 @@ rds_instances:
       log_min_duration_statement: 1000
 
   - identifier: "pgucr0-production"
-    instance_type: "db.t3.large"
+    instance_type: "db.t3.2xlarge"  # increased from db.t3.large due to unused db.t3 RIs
     storage: 500
     max_storage: 5000
     multi_az: true


### PR DESCRIPTION
It hasn't been increased this year while the rest of the cluster expanded around it.
It's the only db.t3 we use in production and since the maintainance in the last couple weeks
we are no longer using all of our RIs. Based on those two things it seemed worth it to throw
more hardware at this instance since we are already committed to paying for that regardless.

<!--- Provide a link to the ticket or document which prompted this change -->

##### ENVIRONMENTS AFFECTED
production