### PR TITLE
Add more doc and link to setting up releases

### DIFF
--- a/src/commcare_cloud/fab/README.md
+++ b/src/commcare_cloud/fab/README.md
@@ -78,7 +78,7 @@ To set up a release based on a non-master branch, run:
 cchq <env> fab setup_release --set code_branch=<HQ BRANCH>
 ```
 
-For extensions, run:
+The same can be applied to set the branch for any additional repositories that have been configured. Use the variable `<name>_code_branch` where `name` is the name given to the repository in `meta.yml`:
 
 ```
 cchq <env> fab setup_release --set <env>_code_branch=<Extension HQ BRANCH>

--- a/src/commcare_cloud/fab/README.md
+++ b/src/commcare_cloud/fab/README.md
@@ -78,6 +78,12 @@ To set up a release based on a non-master branch, run:
 cchq <env> fab setup_release --set code_branch=<HQ BRANCH>
 ```
 
+For extensions, run:
+
+```
+cchq <env> fab setup_release --set <env>_code_branch=<Extension HQ BRANCH>
+```
+
 Upon deploys, releases like these are cleaned up by the deploy process. If you know you have a long running command, you can ensure that the release does not get removed by using the `keep_days` option:
 
 ```

--- a/src/commcare_cloud/fab/README.md
+++ b/src/commcare_cloud/fab/README.md
@@ -81,7 +81,7 @@ cchq <env> fab setup_release --set code_branch=<HQ BRANCH>
 The same can be applied to set the branch for any additional repositories that have been configured. Use the variable `<name>_code_branch` where `name` is the name given to the repository in `meta.yml`:
 
 ```
-cchq <env> fab setup_release --set <env>_code_branch=<Extension HQ BRANCH>
+cchq <env> fab setup_release --set <NAME>_code_branch=<BRANCH NAME>
 ```
 
 Upon deploys, releases like these are cleaned up by the deploy process. If you know you have a long running command, you can ensure that the release does not get removed by using the `keep_days` option:

--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -381,6 +381,7 @@ def setup_limited_release(keep_days=1):
 
     Example:
     fab <env> setup_limited_release:keep_days=10  # Makes a new release that will last for 10 days
+    fab <env> setup_limited_release --set code_branch=<HQ BRANCH>
     """
     _setup_release(parse_int_or_exit(keep_days), full_cluster=False)
 
@@ -404,6 +405,9 @@ def _setup_release(keep_days=2, full_cluster=True):
     Useful for running management commands. These releases will automatically
     be cleaned up at the finish of each deploy. To ensure that a release will
     last past a deploy use the `keep_days` param.
+
+    More options at
+    https://github.com/dimagi/commcare-cloud/blob/master/src/commcare_cloud/fab/README.md#private-releases
 
     :param keep_days: The number of days to keep this release before it will be purged
     :param full_cluster: If False, only setup on webworkers[0] where the command will be run


### PR DESCRIPTION
Found myself a little lost trying to setup a private release on icds-staging the other day with specific branches.
So
1. Added an example in code itself for quick reference
2. Adding an example in the README for extensions
3. Added a link to README's relevant section in the common method called for both deploy and private releases, where i think it is relevant, though we might then need to rename the README title to "Manage releases" instead of "Private releases" if that makes sense?

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None