### PR TITLE
Add RAM to pgbouncer3-production

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -373,7 +373,7 @@ servers:
     os: bionic
 
   - server_name: "pgbouncer3-production"
-    server_instance_type: m5.8xlarge
+    server_instance_type: r5.8xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 80


### PR DESCRIPTION
This is to avoid tomorrow morning the brownout we had earlier today due to pgbouncer getting too close to using all its memory https://app.datadoghq.com/dashboard/nbz-bie-nip/host-groups?from_ts=1607459910000&fullscreen_end_ts=1607472475285&fullscreen_paused=true&fullscreen_section=overview&fullscreen_start_ts=1607467785000&fullscreen_widget=274741947&live=true&to_ts=1607488710000&tpl_var_environment=production&tpl_var_host_group=postgresql.

##### ENVIRONMENTS AFFECTED
production