### PR TITLE
Add monit to formplayer to restart if OOM occurs

### DIFF
--- a/src/commcare_cloud/ansible/requirements.yml
+++ b/src/commcare_cloud/ansible/requirements.yml
@@ -32,3 +32,4 @@ roles:
 collections:
   - name: https://github.com/dimagi/commcare-logstash/releases/download/V0.9.2/dimagi-commcare_logstash-0.9.2.tar.gz
   - name: https://github.com/dimagi/commcare-prometheus/releases/download/V0.1.10/dimagi-commcare_prometheus-0.1.10.tar.gz
+  - name: community.general

--- a/src/commcare_cloud/ansible/roles/formplayer/defaults/main.yml
+++ b/src/commcare_cloud/ansible/roles/formplayer/defaults/main.yml
@@ -10,3 +10,4 @@ formplayer_purge_time_spec: '2d'
 # and is only meant to be used by update-config
 _should_update_formplayer_in_place: no
 formplayer_data_dir: "{{ encrypted_root }}/formplayer"
+use_monit_for_formplayer: false

--- a/src/commcare_cloud/ansible/roles/formplayer/meta/main.yml
+++ b/src/commcare_cloud/ansible/roles/formplayer/meta/main.yml
@@ -2,4 +2,6 @@
 dependencies:
   - role: java
   - {role: supervisor, tags: supervisor}
-  - role: monit
+
+collections:
+  - community.general.monit

--- a/src/commcare_cloud/ansible/roles/formplayer/meta/main.yml
+++ b/src/commcare_cloud/ansible/roles/formplayer/meta/main.yml
@@ -2,3 +2,4 @@
 dependencies:
   - role: java
   - {role: supervisor, tags: supervisor}
+  - role: monit

--- a/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
@@ -144,8 +144,8 @@
   tags:
     - localsettings
 
-# This should be the last task in the file
-# (and certainly the last one tagged with `formplayer_deploy`)
+# This should be the last task in the formplayer release process
+# (and the last one tagged with `formplayer_deploy`)
 # so that if setting up a release fails, `current` never gets linked to it
 # giving us nearly atomic formplayer deploys
 - name: Link formplayer jar

--- a/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
@@ -174,13 +174,16 @@
 
 - meta: flush_handlers
 
-- monit:
-    name: formplayer
-    state: monitored
-  tags: monit
-  ignore_errors: "{{ ansible_check_mode }}"
-  register: result
-  until: not result.failed or 'process not presently configured with monit' not in result.msg
-  retries: 5
-  delay: 20
+# NOTE: this check currently fails because of a bug in community.general.monit
+# A PR has been made to fix this, and we can uncomment this once that is merged/released
+# https://github.com/ansible-collections/community.general/pull/1532
+#- community.general.monit:
+#    name: formplayer
+#    state: monitored
+#  tags: monit
+#  ignore_errors: "{{ ansible_check_mode }}"
+#  register: result
+#  until: not result.failed or 'process not presently configured with monit' not in result.msg
+#  retries: 5
+#  delay: 20
 

--- a/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
@@ -183,3 +183,4 @@
   until: not result.failed or 'process not presently configured with monit' not in result.msg
   retries: 5
   delay: 20
+

--- a/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
@@ -161,19 +161,17 @@
     - formplayer_deploy
   when: not _should_update_formplayer_in_place
 
-- block:
 
-  - name: Formplayer monit config
-    become: yes
-    template:
-      src: "monit.formplayer.j2"
-      dest: "/etc/monit/conf.d/formplayer"
-      group: root
-      owner: root
-      mode: 0640
-    notify: reload monit
-    tags: monit
-
+- name: Formplayer monit config
+  become: yes
+  template:
+    src: "monit.formplayer.j2"
+    dest: "/etc/monit/conf.d/formplayer"
+    group: root
+    owner: root
+    mode: 0640
+  notify: reload monit
+  tags: monit
   when: use_monit_for_formplayer == true
 
 - meta: flush_handlers

--- a/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
@@ -160,3 +160,26 @@
   tags:
     - formplayer_deploy
   when: not _should_update_formplayer_in_place
+
+- name: Formplayer monit config
+  become: yes
+  template:
+    src: "monit.formplayer.j2"
+    dest: "/etc/monit/conf.d/formplayer"
+    group: root
+    owner: root
+    mode: 0640
+  notify: reload monit
+  tags: monit
+
+- meta: flush_handlers
+
+- monit:
+    name: formplayer
+    state: monitored
+  tags: monit
+  ignore_errors: "{{ ansible_check_mode }}"
+  register: result
+  until: not result.failed or 'process not presently configured with monit' not in result.msg
+  retries: 5
+  delay: 20

--- a/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
@@ -183,3 +183,4 @@
   until: not result.failed or 'process not presently configured with monit' not in result.msg
   retries: 5
   delay: 20
+  

--- a/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
@@ -83,7 +83,7 @@
 
 - name: Formplayer request-response logging directory
   file:
-    path: "{{ formplayer_service_log_dir }}"
+    path: "{{ formplayer_access_log_dir }}"
     state: directory
     owner: "{{ cchq_user }}"
     group: "{{ cchq_user }}"

--- a/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
@@ -161,16 +161,20 @@
     - formplayer_deploy
   when: not _should_update_formplayer_in_place
 
-- name: Formplayer monit config
-  become: yes
-  template:
-    src: "monit.formplayer.j2"
-    dest: "/etc/monit/conf.d/formplayer"
-    group: root
-    owner: root
-    mode: 0640
-  notify: reload monit
-  tags: monit
+- block:
+
+  - name: Formplayer monit config
+    become: yes
+    template:
+      src: "monit.formplayer.j2"
+      dest: "/etc/monit/conf.d/formplayer"
+      group: root
+      owner: root
+      mode: 0640
+    notify: reload monit
+    tags: monit
+
+  when: use_monit_for_formplayer == true
 
 - meta: flush_handlers
 

--- a/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
@@ -83,7 +83,7 @@
 
 - name: Formplayer request-response logging directory
   file:
-    path: "{{ formplayer_logging_dir }}"
+    path: "{{ formplayer_service_log_dir }}"
     state: directory
     owner: "{{ cchq_user }}"
     group: "{{ cchq_user }}"
@@ -183,4 +183,3 @@
   until: not result.failed or 'process not presently configured with monit' not in result.msg
   retries: 5
   delay: 20
-  

--- a/src/commcare_cloud/ansible/roles/formplayer/templates/logback-spring.xml.j2
+++ b/src/commcare_cloud/ansible/roles/formplayer/templates/logback-spring.xml.j2
@@ -8,10 +8,10 @@
 
     {% if formplayer_sensitive_data_logging -%}
     <appender name="requests" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>{{ formplayer_logging_dir }}/request_response.log</file>
+        <file>{{ formplayer_service_log_dir }}/request_response.log</file>
         <!-- Keep a fixed number of logs. -->
         <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>{{ formplayer_logging_dir }}/request_response.%i.log</fileNamePattern>
+            <fileNamePattern>{{ formplayer_service_log_dir }}/request_response.%i.log</fileNamePattern>
             <minIndex>1</minIndex>
             <maxIndex>3</maxIndex>
         </rollingPolicy>

--- a/src/commcare_cloud/ansible/roles/formplayer/templates/logback-spring.xml.j2
+++ b/src/commcare_cloud/ansible/roles/formplayer/templates/logback-spring.xml.j2
@@ -8,10 +8,10 @@
 
     {% if formplayer_sensitive_data_logging -%}
     <appender name="requests" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>{{ formplayer_service_log_dir }}/request_response.log</file>
+        <file>{{ formplayer_access_log_dir }}/request_response.log</file>
         <!-- Keep a fixed number of logs. -->
         <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>{{ formplayer_service_log_dir }}/request_response.%i.log</fileNamePattern>
+            <fileNamePattern>{{ formplayer_access_log_dir }}/request_response.%i.log</fileNamePattern>
             <minIndex>1</minIndex>
             <maxIndex>3</maxIndex>
         </rollingPolicy>

--- a/src/commcare_cloud/ansible/roles/formplayer/templates/monit.formplayer.j2
+++ b/src/commcare_cloud/ansible/roles/formplayer/templates/monit.formplayer.j2
@@ -1,5 +1,5 @@
- check file formplayer with path {{ formplayer_logging_dir }}/formplayer-spring.log
+ check file formplayer with path {{ formplayer_process_log_dir }}/formplayer-spring.log
   group formplayer
   start program = "supervisorctl start {{ project }}-{{ deploy_env }}-formsplayer-spring"
   stop program = "supervisorctl stop {{ project }}-{{ deploy_env }}-formsplayer-spring"
-  if content = "java.lang.OutOfMemoryError: GC overhead limit exceeded" then restart
+  if content = "^Caused by: java.lang.OutOfMemoryError: GC overhead limit exceeded" then restart

--- a/src/commcare_cloud/ansible/roles/formplayer/templates/monit.formplayer.j2
+++ b/src/commcare_cloud/ansible/roles/formplayer/templates/monit.formplayer.j2
@@ -3,3 +3,4 @@
   start program = "supervisorctl start {{ project }}-{{ deploy_env }}-formsplayer-spring"
   stop program = "supervisorctl stop {{ project }}-{{ deploy_env }}-formsplayer-spring"
   if content = "^Caused by: java.lang.OutOfMemoryError: GC overhead limit exceeded" then restart
+

--- a/src/commcare_cloud/ansible/roles/formplayer/templates/monit.formplayer.j2
+++ b/src/commcare_cloud/ansible/roles/formplayer/templates/monit.formplayer.j2
@@ -1,0 +1,5 @@
+ check file formplayer with path {{ formplayer_logging_dir }}/formplayer-spring.log
+  group formplayer
+  start program = "supervisorctl start {{ project }}-{{ deploy_env }}-formsplayer-spring"
+  stop program = "supervisorctl stop {{ project }}-{{ deploy_env }}-formsplayer-spring"
+  if content = "java.lang.OutOfMemoryError" then restart

--- a/src/commcare_cloud/ansible/roles/formplayer/templates/monit.formplayer.j2
+++ b/src/commcare_cloud/ansible/roles/formplayer/templates/monit.formplayer.j2
@@ -1,6 +1,6 @@
  check file formplayer with path {{ formplayer_process_log_dir }}/formplayer-spring.log
   group formplayer
-  start program = "supervisorctl start {{ project }}-{{ deploy_env }}-formsplayer-spring"
-  stop program = "supervisorctl stop {{ project }}-{{ deploy_env }}-formsplayer-spring"
+  start program = "/usr/bin/supervisorctl start {{ project }}-{{ deploy_env }}-formsplayer-spring"
+  stop program = "/usr/bin/supervisorctl stop {{ project }}-{{ deploy_env }}-formsplayer-spring"
   if content = "^Caused by: java.lang.OutOfMemoryError: GC overhead limit exceeded" then restart
 

--- a/src/commcare_cloud/ansible/roles/formplayer/templates/monit.formplayer.j2
+++ b/src/commcare_cloud/ansible/roles/formplayer/templates/monit.formplayer.j2
@@ -2,4 +2,4 @@
   group formplayer
   start program = "supervisorctl start {{ project }}-{{ deploy_env }}-formsplayer-spring"
   stop program = "supervisorctl stop {{ project }}-{{ deploy_env }}-formsplayer-spring"
-  if content = "java.lang.OutOfMemoryError" then restart
+  if content = "java.lang.OutOfMemoryError: GC overhead limit exceeded" then restart

--- a/src/commcare_cloud/ansible/roles/formplayer/vars/main.yml
+++ b/src/commcare_cloud/ansible/roles/formplayer/vars/main.yml
@@ -1,5 +1,6 @@
 formplayer_build_dir: "{{ www_home }}/formplayer_build"
-formplayer_logging_dir: "{{ encrypted_root }}/formplayer/log"
+formplayer_service_log_dir: "{{ encrypted_root }}/formplayer/log"
+formplayer_process_log_dir: "{{ www_home }}/log"
 # formplayer_sentry_dsn: ..defined in secret file
 # formplayer_db_name: ..defined in secret file
 formplayer_build_url: "{{

--- a/src/commcare_cloud/ansible/roles/formplayer/vars/main.yml
+++ b/src/commcare_cloud/ansible/roles/formplayer/vars/main.yml
@@ -1,5 +1,5 @@
 formplayer_build_dir: "{{ www_home }}/formplayer_build"
-formplayer_service_log_dir: "{{ encrypted_root }}/formplayer/log"
+formplayer_access_log_dir: "{{ encrypted_root }}/formplayer/log"
 formplayer_process_log_dir: "{{ www_home }}/log"
 # formplayer_sentry_dsn: ..defined in secret file
 # formplayer_db_name: ..defined in secret file


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
[Monit Investigation](https://dimagi-dev.atlassian.net/browse/SAAS-11555)

This is a solution to a symptom of recent formplayer issues, which is frequent OOMs that do not bring the entire formplayer process down. Similar to elasticsearch, the method here is to search the formplayer logs for an OOM and restart using supervisor if/when that occurs. 

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None