### PR TITLE
Remove commcare-hq src from formplayer (part 2)

### DIFF
--- a/src/commcare_cloud/ansible/deploy_commcarehq.yml
+++ b/src/commcare_cloud/ansible/deploy_commcarehq.yml
@@ -73,14 +73,14 @@
   tags: services
 
 - name: Management Command Supervisor Config
-  hosts: commcarehq:formplayer
+  hosts: commcarehq
   tasks:
     - include_vars: roles/commcarehq/vars/main.yml
     - include_tasks: roles/commcarehq/tasks/management_commands.yml
   tags: services
 
 - name: Prometheus Supervisor Config
-  hosts: commcarehq:formplayer
+  hosts: commcarehq
   tasks:
     - include_vars: roles/commcarehq/vars/main.yml
     - include_tasks: roles/commcarehq/tasks/prometheus.yml
@@ -88,7 +88,7 @@
   tags: services
 
 - name: Prometheus Django runner
-  hosts: commcarehq:formplayer
+  hosts: commcarehq
   tasks:
     - include_vars: roles/commcarehq/vars/main.yml
     - include_tasks: roles/commcarehq/tasks/prometheus_django_runner.yml

--- a/src/commcare_cloud/ansible/deploy_commcarehq.yml
+++ b/src/commcare_cloud/ansible/deploy_commcarehq.yml
@@ -73,14 +73,14 @@
   tags: services
 
 - name: Management Command Supervisor Config
-  hosts: commcarehq
+  hosts: commcarehq:formplayer
   tasks:
     - include_vars: roles/commcarehq/vars/main.yml
     - include_tasks: roles/commcarehq/tasks/management_commands.yml
   tags: services
 
 - name: Prometheus Supervisor Config
-  hosts: commcarehq
+  hosts: commcarehq:formplayer
   tasks:
     - include_vars: roles/commcarehq/vars/main.yml
     - include_tasks: roles/commcarehq/tasks/prometheus.yml
@@ -88,7 +88,7 @@
   tags: services
 
 - name: Prometheus Django runner
-  hosts: commcarehq
+  hosts: commcarehq:formplayer
   tasks:
     - include_vars: roles/commcarehq/vars/main.yml
     - include_tasks: roles/commcarehq/tasks/prometheus_django_runner.yml

--- a/src/commcare_cloud/ansible/host_group_aliases.yml
+++ b/src/commcare_cloud/ansible/host_group_aliases.yml
@@ -14,7 +14,6 @@
         groups: commcarehq
       with_items:
         - "{{ groups['webworkers']|default([]) }}"
-        - "{{ groups['formplayer']|default([]) }}"
         - "{{ groups['celery']|default([]) }}"
         - "{{ groups['proxy']|default([]) }}"
         - "{{ groups['pillowtop']|default([]) }}"


### PR DESCRIPTION
Followup to https://github.com/dimagi/commcare-cloud/pull/4361. This is both just nice cleanup and something that we found since that PR was merged blocks us from running `update-config`. Once a formplayer deploy has gone out, current/localsettings.py will no longer exist and a task that tries to update it fails.

##### ENVIRONMENTS AFFECTED
all