### PR TITLE
Use become to link supervisor binaries

### DIFF
--- a/src/commcare_cloud/ansible/roles/supervisor/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/supervisor/tasks/main.yml
@@ -16,6 +16,7 @@
   with_items:
     - supervisord
     - supervisorctl
+  become: yes
 
 - name: find supervisord path
   shell: 'which supervisord'


### PR DESCRIPTION
It is not super clear (1) how this worked before and (2) why it stopped working in some cases.
But it should be fine to use elevated permissions to do this step. @millerdev you suggested this as a possible solution the other day when we talked and I was too baffled to make a decision, but I looked again and it seems like a reasonable fix even if we don't know what made this change now

My guess is either that something changed the permissions of /usr/local/bin or /usr/bin, or the location of where supervisorctl was installed (?) or the permissions of the supervisor binaries after install. Not sure if that rings any bells for anyone but it doesn't for me.

##### ENVIRONMENTS AFFECTED
we've seen this on staging (not sure if it affects other environments, but I'd default to assuming so)