### PR TITLE
Allow switch between Py2/3 virtualenvs

### DIFF
--- a/control/init.sh
+++ b/control/init.sh
@@ -107,6 +107,7 @@ if [ -z "$(which manage-commcare-cloud)" ]; then
     pip install --upgrade pip-tools
     pip-sync $REQUIREMENTS
     pip install --editable .
+    rm src/commcare_cloud.egg-info/requires.txt  # HACK for Python 2+3
     cd -
 else
     {
@@ -115,6 +116,7 @@ else
         pip install --quiet --upgrade pip-tools
         pip-sync --quiet $REQUIREMENTS
         pip install --quiet --editable .
+        rm src/commcare_cloud.egg-info/requires.txt  # HACK for Python 2+3
         cd -
     } &
 fi


### PR DESCRIPTION
Prevents errors like

Python 2:
```
pkg_resources.DistributionNotFound: The 'importlib-metadata==3.1.0' distribution was not found and is required by commcare-cloud
```

Python 3
```
pkg_resources.DistributionNotFound: The 'ndg-httpsclient' distribution was not found and is required by commcare-cloud
```

Explanation: `pip install --editable .` writes package metadata, including a list of requirements, in the directory containing the "editable" dependency. This is a problem since requirements are different for Python 2 and 3. Errors happen when metadata for the opposite version of Python is present when running commcare-cloud commands. Removing requires.txt disables the run-time check of requirements by pkg_resources.

<!--- Provide a link to the ticket or document which prompted this change -->

##### ENVIRONMENTS AFFECTED
n/a (commcare-cloud on Python 3 is currently still being tested on staging)
