### PR TITLE
Enforce python 3 usage

### DIFF
--- a/src/commcare_cloud/commcare_cloud.py
+++ b/src/commcare_cloud/commcare_cloud.py
@@ -171,12 +171,23 @@ def make_command_parser(available_envs, formatter_class=RawTextHelpFormatter,
 
 
 def call_commcare_cloud(input_argv=sys.argv):
+    # make sure user aware they are running on python 2 env
+    force_python_2 = "--please-let-me-use-python2"
+    if sys.version_info[0] == 2:
+        if force_python_2 not in input_argv:
+            print('Error: you must upgrade to Python 3. If you really have to, you can use Python 2 with this option'
+                  ' {}'.format(force_python_2))
+            exit(-1)
+
     put_virtualenv_bin_on_the_path()
     parser, subparsers, commands = make_command_parser(available_envs=get_available_envs())
     args, unknown_args = parser.parse_known_args(input_argv[1:])
 
     if args.control:
         run_on_control_instead(args, input_argv)
+
+    # remove force_python_2 arg before running command
+    unknown_args.remove(force_python_2)
     try:
         exit_code = commands[args.command].run(args, unknown_args)
     except CommandError as e:

--- a/src/commcare_cloud/commcare_cloud.py
+++ b/src/commcare_cloud/commcare_cloud.py
@@ -173,7 +173,7 @@ def make_command_parser(available_envs, formatter_class=RawTextHelpFormatter,
 def call_commcare_cloud(input_argv=sys.argv):
     # make sure user aware they are running on python 2 env
     force_python_2 = "--please-let-me-use-python2"
-    if sys.version_info[0] == 2:
+    if not os.environ.get("TRAVIS_TEST") and sys.version_info[0] == 2:
         if force_python_2 not in input_argv:
             print('Error: you must upgrade to Python 3. If you really have to, you can use Python 2 with this option'
                   ' {}'.format(force_python_2))

--- a/src/commcare_cloud/commcare_cloud.py
+++ b/src/commcare_cloud/commcare_cloud.py
@@ -175,8 +175,18 @@ def call_commcare_cloud(input_argv=sys.argv):
     force_python_2 = "--force-commcare-cloud-to-use-python2"
     if not os.environ.get("TRAVIS_TEST") and sys.version_info[0] == 2:
         if force_python_2 not in input_argv:
-            print('Error: you must upgrade to Python 3. Though not desirable, if you really have to '
-                  'you can use Python 2 with this option {}'.format(force_python_2))
+            from textwrap import dedent
+            print(dedent("""
+                Error: you must upgrade to Python 3. Though not desirable, if you really have
+                to you can use Python 2 with this option {}
+                
+                Setup Python 3
+                - Create a new Python-3-based virtualenv
+                - pip install -r requirements3.txt
+                - rm -rf src/commcare_cloud.egg-info
+                - pip install -e .
+                - manage-commcare-cloud install
+                """.format(force_python_2)))
             exit(-1)
 
     put_virtualenv_bin_on_the_path()

--- a/src/commcare_cloud/commcare_cloud.py
+++ b/src/commcare_cloud/commcare_cloud.py
@@ -187,7 +187,9 @@ def call_commcare_cloud(input_argv=sys.argv):
         run_on_control_instead(args, input_argv)
 
     # remove force_python_2 arg before running command
-    unknown_args.remove(force_python_2)
+    if force_python_2 in unknown_args:
+        unknown_args.remove(force_python_2)
+
     try:
         exit_code = commands[args.command].run(args, unknown_args)
     except CommandError as e:

--- a/src/commcare_cloud/commcare_cloud.py
+++ b/src/commcare_cloud/commcare_cloud.py
@@ -172,11 +172,11 @@ def make_command_parser(available_envs, formatter_class=RawTextHelpFormatter,
 
 def call_commcare_cloud(input_argv=sys.argv):
     # make sure user aware they are running on python 2 env
-    force_python_2 = "--please-let-me-use-python2"
+    force_python_2 = "--force-commcare-cloud-to-use-python2"
     if not os.environ.get("TRAVIS_TEST") and sys.version_info[0] == 2:
         if force_python_2 not in input_argv:
-            print('Error: you must upgrade to Python 3. If you really have to, you can use Python 2 with this option'
-                  ' {}'.format(force_python_2))
+            print('Error: you must upgrade to Python 3. Though not desirable if you really have to, '
+                  'you can use Python 2 with this option {}'.format(force_python_2))
             exit(-1)
 
     put_virtualenv_bin_on_the_path()

--- a/src/commcare_cloud/commcare_cloud.py
+++ b/src/commcare_cloud/commcare_cloud.py
@@ -175,7 +175,7 @@ def call_commcare_cloud(input_argv=sys.argv):
     force_python_2 = "--force-commcare-cloud-to-use-python2"
     if not os.environ.get("TRAVIS_TEST") and sys.version_info[0] == 2:
         if force_python_2 not in input_argv:
-            print('Error: you must upgrade to Python 3. Though not desirable if you really have to, '
+            print('Error: you must upgrade to Python 3. Though not desirable, if you really have to '
                   'you can use Python 2 with this option {}'.format(force_python_2))
             exit(-1)
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
As part of the Python 3 migration on commcare-cloud, this change ensures users are aware they need to upgrade to Python 3. If they must use Python 2 they can still to do so, but this makes it slightly more difficult (must pass in `--force-commcare-cloud-to-use-python2`). We will merge this once we feel Python 3 is ready for use on all environments. 
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None