### PR TITLE
Fix terraform for configs without elasticache_cluster

### DIFF
--- a/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
@@ -155,6 +155,7 @@ module "Redis" {
 }
 {% endif %}
 
+{% if elasticache_cluster %}
 module "elasticache-module-base" {
   source                = "./modules/elasticache-cluster"
   namespace             = "${var.environment}-elasticache-cluster"
@@ -185,6 +186,7 @@ module "r53-private-zone-create" {
   route_names = {{ r53_private_zone.route_names|tojson }}
   records     = ["${module.elasticache-module-base.configuration_endpoint_address}"]
 }
+{% endif %}
 
 module "openvpn" {
   source = "./modules/openvpn"


### PR DESCRIPTION
A change made for https://dimagi-dev.atlassian.net/browse/SAAS-11511 wasn't backwards compatible, and this PR makes it backwards compatible.

##### ENVIRONMENTS AFFECTED
production, india (staging had a different config so wasn't hit by it)
