### PR TITLE
Formplayer deployment fixes

### DIFF
--- a/src/commcare_cloud/ansible/deploy_stack.yml
+++ b/src/commcare_cloud/ansible/deploy_stack.yml
@@ -2,8 +2,8 @@
 # deploy-stack.yml
 
 - import_playbook: update_apt_cache.yml
-- import_playbook: deploy_ebsnvme_mapping.yml
 - import_playbook: deploy_common.yml
+- import_playbook: deploy_ebsnvme_mapping.yml
 - import_playbook: deploy_lvm.yml
 - import_playbook: deploy_db.yml
 - import_playbook: deploy_commcarehq.yml

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/formplayer.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/formplayer.yml
@@ -9,6 +9,17 @@
   tags:
     - formplayer_deploy
 
+- name: create services home
+  become: yes
+  file:
+    path: "{{ service_home }}"
+    owner: "{{ cchq_user }}"
+    group: "{{ cchq_user }}"
+    mode: 0777
+    state: directory
+  tags:
+    - formplayer_deploy
+
 - name: define formplayer spring services
   become: yes
   template:


### PR DESCRIPTION
Following the process outlined [here](https://confluence.dimagi.com/pages/viewpage.action?spaceKey=internal&title=How+to+create+a+new+machine+in+an+AWS+environment) for a formplayer machine failed on 2 steps:
- an inability to find /dev/sd[x], because that device did not exist
- accessing a directory in formplayer which did not exist

The first seems to have been caused by the common mounting operations overriding the work of deploy_ebsnvme_mapping. The error encountered:
`
TASK [ecryptfs : Format block storage volume] *******************************************************************************************************************************
fatal: [10.201.10.118]: FAILED! => {“changed”: false, “msg”: “Device /dev/sdf not found.“}
`

The second is caused by referencing a folder that was expected to be created by another unrelated task.
The error encountered:
`
TASK [commcarehq : define formplayer spring services] **************************
failed: [10.201.10.238] (item={u'env_vars': {u'no_proxy': u'', u'https_proxy': u'', u'http_proxy': u'', u'TMPDIR': u'/opt/tmp'}}) => {"ansible_loop_var": "item", "changed": false, "checksum": "27597806eb5b832790fcf71a8d6d2e473cec1324", "item": {"env_vars": {"TMPDIR": "/opt/tmp", "http_proxy": "", "https_proxy": "", "no_proxy": ""}}, "msg": "Destination directory /home/cchq/www/staging/services does not exist"}
`