### PR TITLE
Enable monit for formplayer c023

### DIFF
--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -530,6 +530,12 @@ formplayer_c014
 [formplayer_c014:vars]
 extra_formplayer_args='-XX:+UseG1GC -XX:+UseStringDeduplication'
 
+[formplayer_with_monit:vars]
+use_monit_for_formplayer=true
+
+[formplayer_with_monit:children]
+formplayer_c023
+
 [redis0]
 10.202.40.233 hostname=redis0-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-055334f56a475b851 swap_size=1G
 

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -132,6 +132,12 @@ formplayer_c014
 [formplayer_c014:vars]
 extra_formplayer_args='-XX:+UseG1GC -XX:+UseStringDeduplication'
 
+[formplayer_with_monit:vars]
+use_monit_for_formplayer=true
+
+[formplayer_with_monit:children]
+formplayer_c023
+
 {{ __redis0__ }} swap_size=1G
 
 [redis:children]


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
[Use monit to restart if OOM due to GC occurs](https://github.com/dimagi/commcare-cloud/pull/4386)

This PR is the next step in using monit to restart formplayer machines if an OutOfMemory error due to garbage collection occurs. To be conservative, we will start by rolling this out to one machine that has exhibited issues and monitor the impact.
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production