### PR TITLE
Use a conditional check for monit that will actually work

### DIFF
--- a/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
@@ -172,7 +172,7 @@
     mode: 0640
   notify: reload monit
   tags: monit
-  when: use_monit_for_formplayer == true
+  when: use_monit_for_formplayer|bool
 
 - meta: flush_handlers
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
`<var> == true` does not work. The variable on its own errors due to a deprecation so `<var>|bool` seems to be correct and it works when tested on staging.
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
