### PR TITLE
Include monit handlers to have access to 'reload monit'

### DIFF
--- a/src/commcare_cloud/ansible/deploy_formplayer.yml
+++ b/src/commcare_cloud/ansible/deploy_formplayer.yml
@@ -23,3 +23,5 @@
       tags: formplayer
     - role: kinesis_agent
       tags: kinesis-agent
+  handlers:
+    - include: roles/monit/handlers/main.yml


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Properly include the monit reload handler to give the formplayer playbook access to it/the ability to run it. Tested by making no-op changes on c023 and verified that monit reloaded as expected.
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None