### PR TITLE
Elasticache-cluster terraform module update: support for Elasticache-cluster disabled ref. SAAS-11653 (after rebase)

### DIFF
--- a/environments/india/terraform.yml
+++ b/environments/india/terraform.yml
@@ -258,3 +258,9 @@ rds_instances:
     storage: 500
     multi_az: true
     engine_version: 9.6.9
+
+elasticache_cluster:
+  create: no
+
+r53_private_zone:
+  create: no

--- a/environments/india/terraform.yml
+++ b/environments/india/terraform.yml
@@ -264,3 +264,4 @@ elasticache_cluster:
 
 r53_private_zone:
   create: no
+  create_record: no

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -463,3 +463,4 @@ elasticache_cluster:
 
 r53_private_zone:
   create: no
+  create_record: no

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -457,3 +457,9 @@ rds_instances:
 
 elasticache:
   create: no
+
+elasticache_cluster:
+  create: no
+
+r53_private_zone:
+  create: no

--- a/environments/staging/terraform.yml
+++ b/environments/staging/terraform.yml
@@ -249,18 +249,20 @@ elasticache:
   create: no
 
 elasticache_cluster:
+  create: yes
   cache_node_type: "cache.t3.medium"
-  node_groups:  2
-  replicas_per_node: 1
   cache_engine_version: "4.0.10"
+  cache_prameter_group: "default.redis4.0"
   automatic_failover: true
   transit_encryption: false
   at_rest_encryption: true
   auto_minor_version: false
+  cluster_size: 2
   maintenance_window: "sun:03:30-sun:04:30"
   snapshot_retention: 7
   snapshot_window: "07:30-08:30"
 
 r53_private_zone:
+  create: yes
   domain_name:  "stg.dimagi.local"
   route_names:  "redis"

--- a/environments/staging/terraform.yml
+++ b/environments/staging/terraform.yml
@@ -264,5 +264,6 @@ elasticache_cluster:
 
 r53_private_zone:
   create: yes
-  domain_name:  "stg.dimagi.local"
+  domain_name:  "staging.commcare.local"
+  create_record: yes
   route_names:  "redis"

--- a/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
@@ -158,10 +158,9 @@ module "Redis" {
 {% if elasticache_cluster %}
 module "elasticache-module-base" {
   source                = "./modules/elasticache-cluster"
+  create               = "{{ elasticache_cluster.create|tojson }}"
   namespace             = "${var.environment}-elasticache-cluster"
   cluster_id            = "${var.environment}-elasticache-cluster"
-  node_groups           = {{ elasticache_cluster.node_groups|tojson }}
-  replicas_per_node     = {{ elasticache_cluster.replicas_per_node|tojson }}
   subnet_ids_cache      = ["${values(module.network.subnets-db-private)}"]
   securitygroup_id      = ["${module.network.db-private-sg}", "${module.network.ssh-sg}", "${module.network.vpn-connections-sg}"]
   cache_engine          = {{ elasticache_cluster.cache_engine|tojson }}
@@ -176,15 +175,19 @@ module "elasticache-module-base" {
   snapshot_retention    = {{ elasticache_cluster.snapshot_retention|tojson }}
   snapshot_window       = {{ elasticache_cluster.snapshot_window|tojson }}
   port_number           = 6379
+  cluster_size          = {{ elasticache_cluster.cluster_size|tojson }}
   replication_group_des = "${var.environment}-redis-cluster"
 }
+{% endif %}
 
+{% if r53_private_zone %}
 module "r53-private-zone-create" {
   source      = "./modules/r53-private-zone-create-update"
+  create      = "{{ r53_private_zone.create|tojson }}"
   zone_vpc_id = "${module.network.vpc-id}"
   domain_name = {{ r53_private_zone.domain_name|tojson }}
   route_names = {{ r53_private_zone.route_names|tojson }}
-  records     = ["${module.elasticache-module-base.configuration_endpoint_address}"]
+  records     = ["${module.elasticache-module-base.primary_configuration_endpoint_address}"]
 }
 {% endif %}
 

--- a/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
@@ -187,6 +187,7 @@ module "r53-private-zone-create" {
   zone_vpc_id = "${module.network.vpc-id}"
   domain_name = {{ r53_private_zone.domain_name|tojson }}
   route_names = {{ r53_private_zone.route_names|tojson }}
+  create_record      = "{{ r53_private_zone.create_record|tojson }}"
   records     = ["${module.elasticache-module-base.primary_configuration_endpoint_address}"]
 }
 {% endif %}

--- a/src/commcare_cloud/environment/schemas/terraform.py
+++ b/src/commcare_cloud/environment/schemas/terraform.py
@@ -177,4 +177,5 @@ class RoutePrivateZoneConfig(jsonobject.JsonObject):
     _allow_dynamic_properties = False
     create = jsonobject.BooleanProperty(default=True)
     domain_name = jsonobject.StringProperty()
+    create_record = jsonobject.BooleanProperty(default=True)
     route_names = jsonobject.StringProperty()

--- a/src/commcare_cloud/environment/schemas/terraform.py
+++ b/src/commcare_cloud/environment/schemas/terraform.py
@@ -159,21 +159,22 @@ class ElasticacheConfig(jsonobject.JsonObject):
 
 class ElasticacheClusterConfig(jsonobject.JsonObject):
     _allow_dynamic_properties = False
-    node_groups = jsonobject.IntegerProperty(default=1)
-    replicas_per_node = jsonobject.IntegerProperty(default=1)
+    create = jsonobject.BooleanProperty(default=True)
     cache_node_type = jsonobject.StringProperty(default="cache.t3.micro")
     cache_engine = jsonobject.StringProperty(default="redis")
     cache_engine_version = jsonobject.StringProperty(default="4.0.10")
-    cache_prameter_group = jsonobject.StringProperty(default="default.redis4.0.cluster.on")
+    cache_prameter_group = jsonobject.StringProperty(default="default.redis4.0")
     automatic_failover = jsonobject.BooleanProperty(default=True)
     transit_encryption = jsonobject.BooleanProperty(default=False)
     at_rest_encryption = jsonobject.BooleanProperty(default=True)
     auto_minor_version = jsonobject.BooleanProperty(default=False)
+    cluster_size = jsonobject.IntegerProperty(default=1)
     maintenance_window = jsonobject.StringProperty(default="sun:03:30-sun:04:30")
     snapshot_retention = jsonobject.IntegerProperty(default=5)
     snapshot_window = jsonobject.StringProperty(default="07:30-08:30")
 
 class RoutePrivateZoneConfig(jsonobject.JsonObject):
     _allow_dynamic_properties = False
+    create = jsonobject.BooleanProperty(default=True)
     domain_name = jsonobject.StringProperty()
     route_names = jsonobject.StringProperty()

--- a/src/commcare_cloud/terraform/modules/elasticache-cluster/CHANGELOG.md
+++ b/src/commcare_cloud/terraform/modules/elasticache-cluster/CHANGELOG.md
@@ -1,3 +1,5 @@
+# elasticache-cluster-v0.1.3
+[rameshganne] - Updated module to support Elasticache clsuter-enabled & clsuter-disabled.
 # elasticache-cluster-v0.1.2
 [rameshganne] - Updated module by removing snapshot_arn. It(snapshot_arn) can import db from s3 based rdb file but not working as we expecting ref: https://github.com/hashicorp/terraform-provider-aws/issues/5510.
 # elasticache-cluster-v0.1.1

--- a/src/commcare_cloud/terraform/modules/elasticache-cluster/main.tf
+++ b/src/commcare_cloud/terraform/modules/elasticache-cluster/main.tf
@@ -1,14 +1,17 @@
 resource "aws_elasticache_subnet_group" "redis-dev-subnet-group-0" {
   name       = "${var.namespace}-cache-subnet"
+  count      = "${var.create == "true" ? 1 : 0}"
   subnet_ids = ["${var.subnet_ids_cache}"]
 }
 
 resource "aws_elasticache_replication_group" "redis-dev-cluster-0" {
+  count                         = "${var.create == "true" ? 1 : 0}"
   engine                        = "${var.cache_engine}"
   engine_version                = "${var.cache_engine_version}"
   node_type                     = "${var.cache_node_type}"
   replication_group_description = "${var.replication_group_des}"
   replication_group_id          = "${var.cluster_id}"
+  number_cache_clusters         = "${var.cluster_size}"
   parameter_group_name          = "${var.cache_prameter_group}"
   port                          = "${var.port_number}"
   automatic_failover_enabled    = "${var.automatic_failover}"
@@ -23,10 +26,5 @@ resource "aws_elasticache_replication_group" "redis-dev-cluster-0" {
 
   tags = {
     Name = "${var.namespace}-cache"
-  }
-
-  cluster_mode {
-    replicas_per_node_group = "${var.replicas_per_node}"
-    num_node_groups         = "${var.node_groups}"
   }
 }

--- a/src/commcare_cloud/terraform/modules/elasticache-cluster/output.tf
+++ b/src/commcare_cloud/terraform/modules/elasticache-cluster/output.tf
@@ -1,3 +1,3 @@
-output "configuration_endpoint_address" {
-  value = "${aws_elasticache_replication_group.redis-dev-cluster-0.configuration_endpoint_address}"
+output "primary_configuration_endpoint_address" {
+  value = "${aws_elasticache_replication_group.redis-dev-cluster-0.*.primary_endpoint_address}"
 }

--- a/src/commcare_cloud/terraform/modules/elasticache-cluster/variables.tf
+++ b/src/commcare_cloud/terraform/modules/elasticache-cluster/variables.tf
@@ -6,8 +6,8 @@ variable "cluster_id" {
   description = "Id to assign the new cluster"
 }
 
-variable "node_groups" {
-  description = "The number of Nodes in the cluster"
+variable "cluster_size" {
+  description = "The size of Elasticache cluster-disabled mode. Default:single-mode"
   default     = 1
 }
 
@@ -65,9 +65,9 @@ variable "snapshot_window" {
   description = "The daily time range during which automated backups are initiated if automated backups are enabled."
 }
 
-variable "replicas_per_node" {
-  description = "The number of Shards in a Redis Cluster"
-  default     = 1
+variable "create" {
+  description = "Flag to enable/disable creation of a native Elasticache cluster-disabled."
+  default     = "true"
 }
 
 variable "port_number" {

--- a/src/commcare_cloud/terraform/modules/r53-private-zone-create-update/main.tf
+++ b/src/commcare_cloud/terraform/modules/r53-private-zone-create-update/main.tf
@@ -1,5 +1,6 @@
 resource "aws_route53_zone" "create-private-r53-zone" {
-  name = "${var.domain_name}"
+  count  = "${var.create == "true" ? 1 : 0}"
+  name   = "${var.domain_name}"
 
   vpc {
     vpc_id = "${var.zone_vpc_id}"
@@ -7,6 +8,7 @@ resource "aws_route53_zone" "create-private-r53-zone" {
 }
 
 resource "aws_route53_record" "create-record-r53-pri-zone" {
+  count   = "${var.create == "true" ? 1 : 0}"
   zone_id = "${aws_route53_zone.create-private-r53-zone.zone_id}"
   name    = "${var.route_names}"
   type    = "${var.type}"

--- a/src/commcare_cloud/terraform/modules/r53-private-zone-create-update/main.tf
+++ b/src/commcare_cloud/terraform/modules/r53-private-zone-create-update/main.tf
@@ -8,7 +8,7 @@ resource "aws_route53_zone" "create-private-r53-zone" {
 }
 
 resource "aws_route53_record" "create-record-r53-pri-zone" {
-  count   = "${var.create == "true" ? 1 : 0}"
+  count   = "${var.create_record == "true" ? 1 : 0}"
   zone_id = "${aws_route53_zone.create-private-r53-zone.zone_id}"
   name    = "${var.route_names}"
   type    = "${var.type}"

--- a/src/commcare_cloud/terraform/modules/r53-private-zone-create-update/variables.tf
+++ b/src/commcare_cloud/terraform/modules/r53-private-zone-create-update/variables.tf
@@ -30,3 +30,8 @@ variable "create" {
   description = "Flag to enable/disable r53-private-zone-create-update"
   default     = "true"
 }
+
+variable "create_record" {
+  description = "Flag to enable/disable r53-private-zone-create record"
+  default     = "true"
+}

--- a/src/commcare_cloud/terraform/modules/r53-private-zone-create-update/variables.tf
+++ b/src/commcare_cloud/terraform/modules/r53-private-zone-create-update/variables.tf
@@ -25,3 +25,8 @@ variable "records" {
   description = "List of records"
   type        = "list"
 }
+
+variable "create" {
+  description = "Flag to enable/disable r53-private-zone-create-update"
+  default     = "true"
+}


### PR DESCRIPTION
The latest Elasticache-cluster terraform module & other files can create AWS Elasticache-cluster disable mode in Staging environment. Present, it can supports for cluster-disabled mode only.

Here, we added "create option" in terraform [environments/staging/terraform.yml] environments files and creates infra based on create key value i.e. yes|no.
Updated files other than terraform module:

environments/staging/terraform.yml
environments/india/terraform.yml
environments/production/terraform.yml
file - src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2 : updated file to create commcarehq.tf with latest attributes
file - src/commcare_cloud/environment/schemas/terraform.py: updated file to get the latest values from environments-terraform files.[ example: environments/staging/terraform.yml ]

Similar to PR: https://github.com/dimagi/commcare-cloud/pull/4415  https://github.com/dimagi/commcare-cloud/pull/4417