### PR TITLE
internal domain: updating resolv.conf symbolic link for OS-distribution Ubuntu

### DIFF
--- a/src/commcare_cloud/ansible/deploy_common.yml
+++ b/src/commcare_cloud/ansible/deploy_common.yml
@@ -83,17 +83,6 @@
   hosts: all_commcarehq
   tasks:
 
-  - name: set running configuration
-    become: yes
-    lineinfile:
-      dest: /etc/resolv.conf
-      line: 'nameserver {{ item }}'
-    with_items: "{{ nameservers }}"
-    when: nameservers is defined
-    tags:
-      - dns
-      - after-reboot
-  
   - name: Checks existing resolv.conf
     stat:
       path: /run/systemd/resolve/resolv.conf
@@ -119,6 +108,17 @@
       dest: /etc/resolvconf/resolv.conf.d/base
       line: 'nameserver {{ item }}'
       create: yes
+    with_items: "{{ nameservers }}"
+    when: nameservers is defined
+    tags:
+      - dns
+      - after-reboot
+  
+  - name: set running configuration
+    become: yes
+    lineinfile:
+      dest: /etc/resolv.conf
+      line: 'nameserver {{ item }}'
     with_items: "{{ nameservers }}"
     when: nameservers is defined
     tags:

--- a/src/commcare_cloud/ansible/deploy_common.yml
+++ b/src/commcare_cloud/ansible/deploy_common.yml
@@ -93,7 +93,26 @@
     tags:
       - dns
       - after-reboot
+  
+  - name: Checks existing resolv.conf
+    stat:
+      path: /run/systemd/resolve/resolv.conf
+    register: resolvconf
+    tags:
+      - dns
+      - after-reboot
 
+  - name: Updating resolv.conf symbolic link 
+    when: ansible_distribution == "Ubuntu" and resolvconf.stat.exists
+    become: yes
+    file:
+      src: /run/systemd/resolve/resolv.conf
+      dest: /etc/resolv.conf
+      state: link
+    tags:
+      - dns
+      - after-reboot
+  
   - name: set resolvconf base configuration
     become: yes
     lineinfile:

--- a/src/commcare_cloud/ansible/deploy_common.yml
+++ b/src/commcare_cloud/ansible/deploy_common.yml
@@ -102,23 +102,23 @@
       - dns
       - after-reboot
   
+  - name: set running configuration
+    become: yes
+    lineinfile:
+      dest: /etc/resolv.conf
+      line: 'nameserver {{ item }}'
+    with_items: "{{ nameservers }}"
+    when: nameservers is defined
+    tags:
+      - dns
+      - after-reboot
+
   - name: set resolvconf base configuration
     become: yes
     lineinfile:
       dest: /etc/resolvconf/resolv.conf.d/base
       line: 'nameserver {{ item }}'
       create: yes
-    with_items: "{{ nameservers }}"
-    when: nameservers is defined
-    tags:
-      - dns
-      - after-reboot
-  
-  - name: set running configuration
-    become: yes
-    lineinfile:
-      dest: /etc/resolv.conf
-      line: 'nameserver {{ item }}'
     with_items: "{{ nameservers }}"
     when: nameservers is defined
     tags:


### PR DESCRIPTION
Here, I am updating the deploy_common playbook to update the symbolic link of /etc/resolv.conf file. 

Updated file: deploy_common.yml

**/run/systemd/resolve/resolv.conf** - this file contains the nameserver & domain search details. This update does not impact the public-domain resolutions. It can also resolve Route-53 private hosted-zones.

These changes can update the symbolic link for all environments { **Staging, Prod & India** }