### PR TITLE
updated max RDS limit to 10010

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -348,7 +348,7 @@ rds_instances:
   - identifier: "pgmain0-production"
     instance_type: "db.m5.8xlarge"
     storage: 500
-    max_storage: 5000
+    max_storage: 10010
     multi_az: true
     engine_version: 9.6.15
     params:


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
RDS instance rds_pgmain disk size has been changed to 10000GB
So max limit need to be set to 10010 GB


##### ENVIRONMENTS AFFECTED
Production
