### PR TITLE
Disable storage autoscaling on pgmain0-production

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -347,8 +347,7 @@ proxy_servers:
 rds_instances:
   - identifier: "pgmain0-production"
     instance_type: "db.m5.8xlarge"
-    storage: 500
-    max_storage: 5000
+    storage: 10000
     multi_az: true
     engine_version: 9.6.15
     params:


### PR DESCRIPTION
This is to reflect the current live state. We found in our recent P1 that autoscaling storage
has a very dangerous side effect of, if it does not add enough during autoscaling,
preventing you from making any further changes for about 12 hours.
(That time probably depends on a lot of factors including how much data you have on disk.)

In addition to this, we will lower the monitor alert threshold for disk usage to 75%. Regardless of whether or not we have autoscaling storage enabled, getting close to the allocated storage is (as we found yesterday) extremely dangerous.https://app.datadoghq.com/monitors/20795740

##### ENVIRONMENTS AFFECTED
production