### PR TITLE
Subprocess stdout and stderr return bytes-like objects

### DIFF
--- a/src/commcare_cloud/ansible/roles/pg_repack/files/pg_repack.py
+++ b/src/commcare_cloud/ansible/roles/pg_repack/files/pg_repack.py
@@ -179,18 +179,20 @@ def main():
         repack_command += ['--elevel=DEBUG']
 
     logger.info('Running pg_repack:\n\t%s', ' '.join(repack_command))
-    process = subprocess.Popen(repack_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    process = subprocess.Popen(repack_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding='utf-8')
     output, error_output = process.communicate()
     returncode = process.poll()
 
-    logger.info('\nSTDOUT:\n%s\nSTDERR:\n%s', output.decode(), error_output.decode())
+    logger.info(f'\nSTDOUT:\n{output}\nSTDERR:\n{error_output}')
     post_tables = [
-        table for table in get_table_info(dbname=args.database, host=args.host, port=args.port, username=args.username, password=args.password)
+        table for table in get_table_info(dbname=args.database, host=args.host, port=args.port,
+                                          username=args.username, password=args.password)
         if table.table_name in table_names
     ]
 
     log_state(tables, post_tables)
     return returncode
+
 
 if __name__ == '__main__':
     exit(main())

--- a/src/commcare_cloud/commands/ansible/ops_tool.py
+++ b/src/commcare_cloud/commands/ansible/ops_tool.py
@@ -350,7 +350,8 @@ class UpdateLocalKnownHosts(CommandBase):
                 hostname=hostname,
                 port=port
             )
-            procs[hostname] = subprocess.Popen([cmd], shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            procs[hostname] = subprocess.Popen([cmd], shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                               encoding='utf-8')
 
         lines = []
         error_hosts = set()
@@ -418,7 +419,8 @@ def _get_host_key_map(known_host_lines):
 
 def _get_lines(proc):
     """Read lines from process stdout
-    :returns tuple(error_message, lines)
+    :returns tuple(error_message: AnyStr, lines: [AnyStr])
+    To return a str, specify an encoding when creating the subprocess, otherwise bytes-like objects are returned
     """
     out = proc.stdout.read()
     if proc.returncode != 0:


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
```
Traceback (most recent call last):
  File "/Users/grahamherceg/.pyenv/versions/cloud/bin/cchq", line 11, in <module>
    load_entry_point('commcare-cloud', 'console_scripts', 'cchq')()
  File "/Users/grahamherceg/code/commcare-cloud/src/commcare_cloud/commcare_cloud.py", line 213, in main
    exit_code = call_commcare_cloud()
  File "/Users/grahamherceg/code/commcare-cloud/src/commcare_cloud/commcare_cloud.py", line 204, in call_commcare_cloud
    exit_code = commands[args.command].run(args, unknown_args)
  File "/Users/grahamherceg/code/commcare-cloud/src/commcare_cloud/commands/ansible/ops_tool.py", line 367, in run
    updated_keys_by_host = _get_host_key_map(lines)
  File "/Users/grahamherceg/code/commcare-cloud/src/commcare_cloud/commands/ansible/ops_tool.py", line 411, in _get_host_key_map
    csv_hosts, key_type, key = line.split(' ')
TypeError: a bytes-like object is required, not 'str'
```
This was caused by the subprocess package which by default, returns a bytes-like object from stdout and stderr of the subprocess. See [here](https://docs.python.org/3/library/subprocess.html) for more information.

Based on how the process object is used after creation, it seemed safe to add an `encoding` parameter at the creation of the subprocess which will instead return all stdout and stderr as a `str`. In addition to the instance that generated this error, I added the `encoding` parameter to the other spot where we create a subprocess, and updated how its stdout and stderr are used accordingly. 
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None