### PR TITLE
Default to cchq (python 3 venv) in init script

### DIFF
--- a/control/init.sh
+++ b/control/init.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-CCHQ_VIRTUALENV=${CCHQ_VIRTUALENV:-ansible}
+CCHQ_VIRTUALENV=${CCHQ_VIRTUALENV:-cchq}
 CCHQ_PYTHON=$([ "$CCHQ_VIRTUALENV" == ansible ] && echo 2 || echo 3)
 VENV=~/.virtualenvs/$CCHQ_VIRTUALENV
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
When users ssh into a machine, the init script still defaults to python 2. This will use the `cchq` venv running python 3, and install it if it does not exist.
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None