### PR TITLE
Lowered default pillow batch size on staging

### DIFF
--- a/environments/staging/app-processes.yml
+++ b/environments/staging/app-processes.yml
@@ -57,6 +57,7 @@ pillows:
       num_processes: 1
     case-pillow:
       num_processes: 2
+      processor_chunk_size: 1
     xform-pillow:
       num_processes: 2
     group-pillow:


### PR DESCRIPTION
Staging's usage is low enough that this threshold gets in the way of the QA team.

##### ENVIRONMENTS AFFECTED
staging
