### PR TITLE
add config for second pgbouncer

### DIFF
--- a/src/commcare_cloud/ansible/roles/pgbouncer/defaults/main.yml
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/defaults/main.yml
@@ -2,7 +2,9 @@ pgbouncer_port: 6432
 pgbouncer_pid_file: "/var/run/postgresql/pgbouncer.pid"
 pgbouncer_config_home: /etc/pgbouncer
 pgbouncer_ini: "{{ pgbouncer_config_home }}/pgbouncer.ini"
+pgbouncer2_ini: "{{ pgbouncer_config_home }}/pgbouncer2.ini"
 pgbouncer_users: "{{ pgbouncer_config_home }}/userlist.txt"
+pgbouncer2_socket_dir: "/var/run/postgresql2"
 
 pgbouncer_max_connections: 100
 pgbouncer_default_pool: 15

--- a/src/commcare_cloud/ansible/roles/pgbouncer/handlers/main.yml
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/handlers/main.yml
@@ -17,7 +17,7 @@
 
 - name: Restart pgbouncer2
   become: yes
-  action: service name=pgbouncer state=restarted
+  action: service name=pgbouncer2 state=restarted
 
 - name: Reload pgbouncer2
   become: yes

--- a/src/commcare_cloud/ansible/roles/pgbouncer/handlers/main.yml
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/handlers/main.yml
@@ -10,3 +10,15 @@
 - name: Reload pgbouncer
   become: yes
   action: service name=pgbouncer state=reloaded
+
+- name: Start pgbouncer2
+  become: yes
+  action: service name=pgbouncer2 state=started
+
+- name: Restart pgbouncer2
+  become: yes
+  action: service name=pgbouncer state=restarted
+
+- name: Reload pgbouncer2
+  become: yes
+  action: service name=pgbouncer2 state=reloaded

--- a/src/commcare_cloud/ansible/roles/pgbouncer/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/tasks/main.yml
@@ -13,12 +13,40 @@
     - pgbouncer
     - configure
 
+- name: Start pgbouncer
+  become: yes
+  action: service name=pgbouncer state=started
+
+- name: Restart pgbouncer
+  become: yes
+  action: service name=pgbouncer state=restarted
+
+- name: Reload pgbouncer
+  become: yes
+  action: service name=pgbouncer state=reloaded
+
+
 - name: pgbouncer users
   template: src=pgbouncer.users.j2 dest="{{ pgbouncer_users }}"
   notify: Reload pgbouncer
   tags:
     - pgbouncer
     - configure
+
+- name: pgbouncer2 configuration
+  template: src=pgbouncer2.ini.j2 dest="{{ pgbouncer2_ini }}"
+  notify: Reload pgbouncer2
+  tags:
+    - pgbouncer
+    - configure
+
+- name: pgbouncer2 socket dir
+  file:
+    become: yes
+    path: "{{ pgbouncer2_socket_dir }}"
+    state: directory
+    owner: postgres
+    group: postgres
 
 - name: pgbouncer defaults
   template: src=pgbouncer.defaults.j2 dest=/etc/default/pgbouncer
@@ -47,6 +75,12 @@
 - name: pgbouncer init script
   template: src=pgbouncer.init.j2 dest=/etc/init.d/pgbouncer
   notify: Restart pgbouncer
+  tags:
+    - pgbouncer
+
+- name: pgbouncer init script
+  template: src=pgbouncer2.init.j2 dest=/etc/init.d/pgbouncer2
+  notify: Restart pgbouncer2
   tags:
     - pgbouncer
 

--- a/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer2.ini.j2
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer2.ini.j2
@@ -20,8 +20,8 @@
 ;;; Administrative settings
 ;;;
 
-logfile = /var/log/postgresql/pgbouncer.log
-pidfile = {{ pgbouncer_pid_file }}
+logfile = /var/log/postgresql/pgbouncer2.log
+pidfile = /var/run/postgresql/pgbuncer2.pid
 
 ;;;
 ;;; Where to wait for clients
@@ -36,7 +36,7 @@ listen_port = {{ pgbouncer_port }}
 ;unix_socket_dir = /tmp
 ;unix_socket_mode = 0777
 ;unix_socket_group =
-unix_socket_dir = /var/run/postgresql
+unix_socket_dir = {{ pgbouncer2_socket_dir }}
 
 so_reuseport = 1
 

--- a/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer2.init.j2
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer2.init.j2
@@ -1,0 +1,100 @@
+#!/bin/sh
+
+### BEGIN INIT INFO
+# Provides:          pgbouncer
+# Required-Start:    $local_fs $remote_fs $network $syslog $named
+# Required-Stop:     $local_fs $remote_fs $network $syslog $named
+# Should-Start:      postgresql
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: start pgbouncer
+# Description: pgbouncer is a connection pool server and replication
+#              proxy for PostgreSQL.
+### END INIT INFO
+
+PATH=/sbin:/bin:/usr/sbin:/usr/bin
+NAME=pgbouncer2
+BIN=pgbouncer
+DAEMON=/usr/sbin/$BIN
+PIDDIR=/var/run/postgresql
+PIDFILE=$PIDDIR/$NAME.pid
+OPTS="-d /etc/pgbouncer/$NAME.ini"
+RUNASUSER="postgres"
+
+# Include pgbouncer defaults if available
+if [ -f /etc/default/pgbouncer ] ; then
+	. /etc/default/pgbouncer
+fi
+
+# Exit if we were uninstalled with the config still there
+test -x $DAEMON || exit 0
+
+# Check if configuration exists
+test -f $CONF || exit 0
+
+. /lib/lsb/init-functions
+
+if [ -n "$ULIMIT" ]; then
+  # Set ulimit if it is set in /etc/default/pgbouncer
+  ulimit $ULIMIT
+fi
+
+SSD="start-stop-daemon --pidfile $PIDFILE --exec $DAEMON --quiet"
+
+case "$1" in
+  start)
+    # Check if we are still disabled in /etc/default/pgbouncer
+    [ "${START:-}" = "0" ] && exit 0
+    log_daemon_msg "Starting PgBouncer" $NAME
+    test -d $PIDDIR || install -d -o postgres -g postgres -m 2775 $PIDDIR
+    $SSD --start --chuid $RUNASUSER --oknodo -- $OPTS 2> /dev/null
+    log_end_msg $?
+    ;;
+
+  stop)
+    log_daemon_msg "Stopping PgBouncer" $NAME
+    $SSD --stop --retry 30 --oknodo
+    log_end_msg $?
+    ;;
+
+  reload | force-reload)
+    log_daemon_msg "Reloading PgBouncer configuration" $NAME
+    $SSD --stop --signal HUP --oknodo
+    log_end_msg $?
+    ;;
+
+  restart)
+    # we would use "$SSD --status" here if it were available in squeeze
+    $SSD --stop --signal 0
+    if [ $? -eq 0 ] ; then
+	OLDPID=$(cat $PIDFILE)
+	log_daemon_msg "Invoking PgBouncer restart" $NAME
+	su -c "$DAEMON -R $OPTS 2> /dev/null" - ${RUNASUSER%:*}
+	if [ $? -ne 0 ]; then
+            log_end_msg 1
+            log_warning_msg "could not contact running instance"
+            log_warning_msg "(If you changed the port number, run \"stop\" and \"start\" separately.)"
+            exit 1
+        fi
+	# sleep until the process has changed PID
+	for t in 0.1 0.2 0.2 0.5 1.0 1.0 2.0; do # 5s in total
+	    NEWPID=$(cat $PIDFILE 2>/dev/null)
+	    [ "$NEWPID" ] && [ "$NEWPID" != "$OLDPID" ] && break
+	    sleep $t
+	done
+	$SSD --stop --signal 0
+	log_end_msg $?
+    else
+	$0 start
+    fi
+    ;;
+
+  status)
+    status_of_proc -p $PIDFILE $DAEMON $NAME && exit 0 || exit $?
+    ;;
+
+  *)
+    echo "Usage: /etc/init.d/$NAME {start|stop|reload|force-reload|restart|status}"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
This is obviously not the ideal way to accomplish the change, but this is POC for how the config files would need to look. Ideally it would be configured in some sort of loop where we specify a number of processes per machine, but in an effort to have this ready in case we need to roll it out in an emergency I have not done so.

We should not merge this as is, but can use it for a deploy tonight to a single machine if necessary. If we decide this is a route we want to go down, we can clean up the code before merge.

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
N/A
