### PR TITLE
updating REDIS_HOST and WS4REDIS_CONNECTION_HOST with Elasticache end-point: Staging env.

### DIFF
--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -145,13 +145,13 @@ localsettings:
   SES_CONFIGURATION_SET: staging-email-events
   SNS_EMAIL_EVENT_SECRET: "{{ SNS_EMAIL_EVENT_SECRET }}"
   REDIS_DB: '0'
-  REDIS_HOST: "{{ groups.redis.0 }}"
+  REDIS_HOST: "redis.staging.commcare.local"
   REDIS_PORT: '6379'
   REMINDERS_QUEUE_ENABLED: False
   SMS_GATEWAY_URL: 'http://gw1.promessaging.com/sms.php'
   SMS_QUEUE_ENABLED: True
   USE_KAFKA_SHORTEST_BACKLOG_PARTITIONER: True
-  WS4REDIS_CONNECTION_HOST: "{{ groups.redis.0 }}"
+  WS4REDIS_CONNECTION_HOST: "redis.staging.commcare.local"
   ENABLE_NEW_TRIAL_EXPERIENCE: True
   STATIC_ROOT:
   STATIC_CDN: 'https://d2f60qxn5rwjxl.cloudfront.net'


### PR DESCRIPTION
Information about changes:

This change [environments/staging/public.yml] can update the redis_host URL in services configuration.

Here, I am adding the cluster end-point (internal hosted-zone record) in place of redis URL.

These changes are related to the STAGING environment only.