### PR TITLE
Fix parsing of aws-cli expiration timestamp

### DIFF
--- a/src/commcare_cloud/commands/terraform/aws.py
+++ b/src/commcare_cloud/commands/terraform/aws.py
@@ -8,6 +8,7 @@ import subprocess
 import textwrap
 from datetime import datetime
 from dateutil import parser
+import pytz
 from io import open
 
 import boto3
@@ -585,7 +586,7 @@ def _has_valid_session_credentials_for_sso():
 
         if 'startUrl' in contents and 'expiresAt' in contents:
             expiration = parser.isoparse(contents['expiresAt'])
-            return expiration
+            return pytz.utc.localize(datetime.utcnow()) < expiration
     return False
 
 
@@ -603,7 +604,7 @@ def _has_valid_v1_session_credentials(aws_profile):
     except configparser.NoOptionError:
         return False
 
-    return expiration
+    return pytz.utc.localize(datetime.utcnow()) < expiration
 
 
 def _iter_files_in_dir(directory):

--- a/src/commcare_cloud/commands/terraform/aws.py
+++ b/src/commcare_cloud/commands/terraform/aws.py
@@ -6,8 +6,9 @@ import json
 import os
 import subprocess
 import textwrap
-from datetime import datetime, timezone
+from datetime import datetime
 from dateutil import parser
+import pytz
 from io import open
 
 import boto3
@@ -585,7 +586,7 @@ def _has_valid_session_credentials_for_sso():
 
         if 'startUrl' in contents and 'expiresAt' in contents:
             expiration = parser.parse(contents['expiresAt'])
-            return datetime.utcnow().replace(tzinfo=timezone.utc) < expiration
+            return pytz.utc.localize(datetime.utcnow()) < expiration
     return False
 
 
@@ -603,7 +604,7 @@ def _has_valid_v1_session_credentials(aws_profile):
     except configparser.NoOptionError:
         return False
 
-    return datetime.utcnow().replace(tzinfo=timezone.utc) < expiration
+    return pytz.utc.localize(datetime.utcnow()) < expiration
 
 
 def _iter_files_in_dir(directory):

--- a/src/commcare_cloud/commands/terraform/aws.py
+++ b/src/commcare_cloud/commands/terraform/aws.py
@@ -6,9 +6,8 @@ import json
 import os
 import subprocess
 import textwrap
-from datetime import datetime
+from datetime import datetime, timezone
 from dateutil import parser
-import pytz
 from io import open
 
 import boto3
@@ -439,7 +438,7 @@ def _sync_sso_to_v1_credentials(aws_session_profile):
         aws_access_key_id=credentials['AccessKeyId'],
         aws_secret_access_key=credentials['SecretAccessKey'],
         aws_session_token=credentials['SessionToken'],
-        expiration = parser.isoparse(credentials['Expiration']),
+        expiration=parser.isoparse(credentials['Expiration']),
     )
 
 
@@ -586,7 +585,7 @@ def _has_valid_session_credentials_for_sso():
 
         if 'startUrl' in contents and 'expiresAt' in contents:
             expiration = parser.isoparse(contents['expiresAt'])
-            return pytz.utc.localize(datetime.utcnow()) < expiration
+            return datetime.utcnow().replace(tzinfo=timezone.utc) < expiration
     return False
 
 
@@ -604,7 +603,7 @@ def _has_valid_v1_session_credentials(aws_profile):
     except configparser.NoOptionError:
         return False
 
-    return pytz.utc.localize(datetime.utcnow()) < expiration
+    return datetime.utcnow().replace(tzinfo=timezone.utc) < expiration
 
 
 def _iter_files_in_dir(directory):

--- a/src/commcare_cloud/commands/terraform/aws.py
+++ b/src/commcare_cloud/commands/terraform/aws.py
@@ -7,6 +7,7 @@ import os
 import subprocess
 import textwrap
 from datetime import datetime
+from dateutil import parser
 from io import open
 
 import boto3
@@ -437,7 +438,7 @@ def _sync_sso_to_v1_credentials(aws_session_profile):
         aws_access_key_id=credentials['AccessKeyId'],
         aws_secret_access_key=credentials['SecretAccessKey'],
         aws_session_token=credentials['SessionToken'],
-        expiration=datetime.strptime(credentials['Expiration'], "%Y-%m-%dT%H:%M:%SUTC"),
+        expiration = parser.isoparse(credentials['Expiration']),
     )
 
 
@@ -583,8 +584,8 @@ def _has_valid_session_credentials_for_sso():
             continue
 
         if 'startUrl' in contents and 'expiresAt' in contents:
-            expiration = datetime.strptime(contents['expiresAt'], "%Y-%m-%dT%H:%M:%SUTC")
-            return datetime.utcnow() < expiration
+            expiration = parser.isoparse(contents['expiresAt'])
+            return expiration
     return False
 
 
@@ -598,11 +599,11 @@ def _has_valid_v1_session_credentials(aws_profile):
     if aws_profile not in config.sections():
         return False
     try:
-        expiration = datetime.strptime(config.get(aws_profile, 'expiration'), "%Y-%m-%dT%H:%M:%SZ")
+        expiration = parser.isoparse(config.get(aws_profile, 'expiration'))
     except configparser.NoOptionError:
         return False
 
-    return datetime.utcnow() < expiration
+    return expiration
 
 
 def _iter_files_in_dir(directory):

--- a/src/commcare_cloud/commands/terraform/aws.py
+++ b/src/commcare_cloud/commands/terraform/aws.py
@@ -438,7 +438,7 @@ def _sync_sso_to_v1_credentials(aws_session_profile):
         aws_access_key_id=credentials['AccessKeyId'],
         aws_secret_access_key=credentials['SecretAccessKey'],
         aws_session_token=credentials['SessionToken'],
-        expiration=parser.isoparse(credentials['Expiration']),
+        expiration=parser.parse(credentials['Expiration']),
     )
 
 
@@ -584,7 +584,7 @@ def _has_valid_session_credentials_for_sso():
             continue
 
         if 'startUrl' in contents and 'expiresAt' in contents:
-            expiration = parser.isoparse(contents['expiresAt'])
+            expiration = parser.parse(contents['expiresAt'])
             return datetime.utcnow().replace(tzinfo=timezone.utc) < expiration
     return False
 
@@ -599,7 +599,7 @@ def _has_valid_v1_session_credentials(aws_profile):
     if aws_profile not in config.sections():
         return False
     try:
-        expiration = parser.isoparse(config.get(aws_profile, 'expiration'))
+        expiration = parser.parse(config.get(aws_profile, 'expiration'))
     except configparser.NoOptionError:
         return False
 


### PR DESCRIPTION
aws-cli seems to return the timestamp in ISO-8601 format, let's use
dateutil.parser to convert it in a datetime.datetime object.

##### ENVIRONMENTS AFFECTED
None
