### PR TITLE
Fix terraform error when route53 disabled

### DIFF
--- a/environments/india/terraform.yml
+++ b/environments/india/terraform.yml
@@ -262,6 +262,4 @@ rds_instances:
 elasticache_cluster:
   create: no
 
-r53_private_zone:
-  create: no
-  create_record: no
+r53_private_zone: null

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -423,6 +423,4 @@ elasticache:
 elasticache_cluster:
   create: no
 
-r53_private_zone:
-  create: no
-  create_record: no
+r53_private_zone: null


### PR DESCRIPTION
Currently on master running
```
cchq production terraform init
```
results in
```
There are some problems with the configuration, described below.

The Terraform configuration must be valid before initialization so that
Terraform can determine which modules and providers need to be installed.

Error: Error parsing /Users/danielroberts/dimagi/commcare-cloud/environments/production/.generated-terraform/commcarehq.tf: At 4293:17: Unknown token: 4293:17 IDENT null
```

Same with `cchq india terraform init`.

@rameshganne

##### ENVIRONMENTS AFFECTED
production