### PR TITLE
Fix Clean Releases

### DIFF
--- a/src/commcare_cloud/fab/operations/release.py
+++ b/src/commcare_cloud/fab/operations/release.py
@@ -415,7 +415,7 @@ def clean_releases(keep=3):
         for index, release in enumerate(reversed(releases)):
             if release == current_release or release == os.path.basename(env.code_root):
                 valid_releases += 1
-            elif files.contains(RELEASE_RECORD, release, use_sudo=True):
+            elif files.contains(RELEASE_RECORD, release):
                 valid_releases += 1
                 if valid_releases > keep:
                     to_remove.append(release)

--- a/src/commcare_cloud/fab/operations/release.py
+++ b/src/commcare_cloud/fab/operations/release.py
@@ -415,7 +415,7 @@ def clean_releases(keep=3):
         for index, release in enumerate(reversed(releases)):
             if release == current_release or release == os.path.basename(env.code_root):
                 valid_releases += 1
-            elif files.contains(RELEASE_RECORD, release):
+            elif files.contains(RELEASE_RECORD, release, use_sudo=True, shell=True):
                 valid_releases += 1
                 if valid_releases > keep:
                     to_remove.append(release)

--- a/src/commcare_cloud/fab/operations/release.py
+++ b/src/commcare_cloud/fab/operations/release.py
@@ -440,6 +440,11 @@ def clean_releases(keep=3):
         print(red('Aborting clean_releases, about to remove current release'))
         return
 
+    if valid_releases < keep:
+        print(red('\n\nAborting clean_releases, {}/{} valid '
+                  'releases were found\n\n'.format(valid_releases, keep)))
+        return
+
     for release in to_remove:
         sudo('rm -rf {}/{}'.format(env.releases, release))
 


### PR DESCRIPTION
We had a P1 triggered on the date this PR was created which resulted in all but the current release folder being deleted. As a result, when a rollback was attempted there was no other release to roll back to

Two key points:
- added a safeguard check to make sure that if less than three valid releases are found, we do not delete previous releases ever
- when `use_sudo=True` on `files.contains`, we should always use `shell=True`

##### ENVIRONMENTS AFFECTED
all
