### PR TITLE
cache state after clean releases

### DIFF
--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -497,8 +497,9 @@ def deploy_checkpoint(command_index, command_name, fn, *args, **kwargs):
     if env.resume and command_index < env.checkpoint_index:
         print(blue("Skipping command: '{}'".format(command_name)))
         return
-    cache_deploy_state(command_index)
     fn(*args, **kwargs)
+    cache_deploy_state(command_index + 1)
+
 
 
 def announce_deploy_start():


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
We currently never checkpoint the completion of clean releases so `resume` will always run it again even if it has finished. That caused issues today, and is generally unnecessary, so this should properly checkpoint it, by caching state on completion rather than before attempting tasks.

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
