### PR TITLE
Fix command printing

### DIFF
--- a/src/commcare_cloud/alias.py
+++ b/src/commcare_cloud/alias.py
@@ -2,10 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 
 def _generate_args(*args, **kwargs):
-    argv = []
-
-    for arg in args:
-        argv.append(arg)
+    argv = [str(arg) for arg in args]
     for key, value in kwargs.items():
         if value is False or value is None:
             continue

--- a/src/commcare_cloud/alias.py
+++ b/src/commcare_cloud/alias.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, unicode_literals
+import six
 
 
 def _generate_args(*args, **kwargs):
@@ -8,8 +9,13 @@ def _generate_args(*args, **kwargs):
             continue
         elif value is True:
             argv.append('--{}'.format(key))
+        elif isinstance(value, six.string_types + six.integer_types):
+            argv.extend(['--{}'.format(key), str(value)])
         else:
-            argv.extend(['--{}'.format(key), value])
+            raise TypeError(
+                "Do not know how to interpret {} as a command-line argument: {}"
+                .format(type(value), value)
+            )
     return argv
 
 


### PR DESCRIPTION
Resolve error in Django checks phase of `cchq ... update-config`. Given the location of the issue, I'm assuming could have affected other commands as well.
```
  File "src/commcare_cloud/cli_utils.py", line 96, in <genexpr>
    command = ' '.join(shlex_quote(arg) for arg in command)
  File "/usr/lib/python3.6/shlex.py", line 314, in quote
    if _find_unsafe(s) is None:
TypeError: expected string or bytes-like object
```

In this case the `arg` was a `ansible.inventory.host.Host` object, which must be converted to a string before it is passed to `shlex_quote`.

##### ENVIRONMENTS AFFECTED
all / none specifically
