### PR TITLE
use separate DS for flyway which bypasses pgbounce

### DIFF
--- a/src/commcare_cloud/ansible/roles/formplayer/templates/application.properties.j2
+++ b/src/commcare_cloud/ansible/roles/formplayer/templates/application.properties.j2
@@ -23,6 +23,12 @@ spring.datasource.url=jdbc:postgresql://{{ postgresql_dbs.formplayer.pgbouncer_e
 spring.datasource.username={{ postgres_users.commcare.username }}
 spring.datasource.password={{ postgres_users.commcare.password }}
 
+# separate DS for flyway which bypasses pgbouncer to avoid session locking issues
+spring.flyway.driver-class-name=org.postgresql.Driver
+spring.flyway.url=jdbc:postgresql://{{ postgresql_dbs.formplayer.host }}:5432/{{ formplayer_db_name }}?prepareThreshold=0
+spring.flyway.username={{ postgres_users.commcare.username }}
+spring.flyway.password={{ postgres_users.commcare.password }}
+
 spring.jpa.hibernate.ddl-auto
 
 smtp.host={{ localsettings.EMAIL_SMTP_HOST }}


### PR DESCRIPTION
Using this DS for flyway should resolve the session locking issue we've been experiencing: https://dimagi-dev.atlassian.net/browse/SAAS-11716

We have pgbouncer  configured in transaction pooling model which means that multiple connections from different Formplayer machines could end up using the same PG connection (session). It also means that successive transactions from Flyway could end up using different connections which can result in locks left hanging:

1: *connection A*: SELECT pg_try_advisory_lock(lockNum);
2. *connection X*: Perform some other queries
3. *connection B*: SELECT pg_advisory_unlock(lockNum);

If step 1 and 3 do not get assigned the same DB connection from pgbouncer then the lock will be left in the lock state until either  pgbouncer closes the connection or perhaps some other edge case where another Formplayer machines reuses the connection with the lock and is able to unlock it (I can't think how this would happen though).

I tested this locally and if you try to unlock a lock from a different connection, PG issues a warning notice and returns `f` but it does not error. The Flyway code does not check for a successful unlocking, only that there was not error (https://github.com/flyway/flyway/blob/f77ed0ebbf1ac22178e27cdff7c439d696817651/flyway-core/src/main/java/org/flywaydb/core/internal/database/postgresql/PostgreSQLAdvisoryLockTemplate.java#L85)

```
commcarehq=# select pg_advisory_unlock(1);
WARNING:  you don't own a lock of type ExclusiveLock
 pg_advisory_unlock 
--------------------
 f
(1 row)
```

##### ENVIRONMENTS AFFECTED
ALL