### PR TITLE
setting dedicated_migration_process to False

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -76,7 +76,7 @@ pillows:
   pillow_a000:
     case-pillow:
       num_processes: 16
-      dedicated_migration_process: True
+      dedicated_migration_process: False
     user-pillow:
       num_processes: 1
     group-pillow:
@@ -110,4 +110,4 @@ pillows:
   pillow_a001:
     xform-pillow:
       num_processes: 32
-      dedicated_migration_process: True
+      dedicated_migration_process: False


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->

Setting dedicated_migration_process to False as we have observed that for process_nums (case-SQL-15 and form-SQL-15, 31)  the `changes to process by Kafka Partition` is consistently growing after deploying these change. 

We will investigate more on this. thanks. 

![image](https://user-images.githubusercontent.com/11612356/104906812-309f7100-59aa-11eb-93c1-a58aa0fa537e.png)
