### PR TITLE
Changes that help when reconfiguring pgbouncer

### DIFF
--- a/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer.ini.j2
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer.ini.j2
@@ -10,7 +10,7 @@
 {% set current_host = inventory_hostname %}
 {% if is_monolith %}{% set current_host = DEFAULT_POSTGRESQL_HOST %}{% endif %}
 {% for db in postgresql_dbs.by_pgbouncer_host.get(current_host, []) %}
-{{ db.name }} = host={{ "localhost" if [db.host] == db.pgbouncer_hosts else db.host }} port={{ postgresql_port }}
+{{ db.name }} = host={{ "localhost" if db.host == inventory_hostname else db.host }} port={{ postgresql_port }}
 {% endfor %}
 
 ;; Configuration section

--- a/src/commcare_cloud/ansible/roles/postgresql_base/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/postgresql_base/tasks/main.yml
@@ -121,7 +121,9 @@
 
 - name: PostgreSQL access configuration
   template: src=pg_hba.conf.j2 dest="{{ postgresql_config_home }}/pg_hba.conf" owner="postgres"
-  tags: configure
+  tags:
+    - configure
+    - pg_hba
   notify: Reload postgres
 
 - meta: flush_handlers


### PR DESCRIPTION
These are just generic things that help when configuring pgbouncer especially the ones related to pl/proxy. The logic fix generalizes better to other situations, and the tag just makes it easier to update the pg_hba when needed to accommodate a new pgbouncer machine if necessary.

##### ENVIRONMENTS AFFECTED
None
