### PR TITLE
Add ability to specify io1 iops on RDS

### DIFF
--- a/src/commcare_cloud/commands/terraform/templates/postgresql.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/postgresql.tf.j2
@@ -9,6 +9,7 @@ module "postgresql__{{ rds_instance.identifier }}" {
     multi_az = "{{ "true" if rds_instance.multi_az else "false" }}"
     storage = {{ rds_instance.storage|tojson }}
     max_storage = {{ rds_instance.max_storage|tojson }}
+    iops = {{ rds_instance.iops|tojson }}
     create = {{ rds_instance.create|tojson }}
     username = {{ rds_instance.username|tojson }}
     backup_window = {{ rds_instance.backup_window|tojson }}

--- a/src/commcare_cloud/environment/schemas/terraform.py
+++ b/src/commcare_cloud/environment/schemas/terraform.py
@@ -128,6 +128,7 @@ class RdsInstanceConfig(jsonobject.JsonObject):
     multi_az = jsonobject.BooleanProperty(default=False)
     storage = jsonobject.IntegerProperty(required=True)
     max_storage = jsonobject.IntegerProperty(default=0)
+    iops = jsonobject.IntegerProperty(default=0)  # zero implies gp2, non-zero implies io1
     create = jsonobject.BooleanProperty(default=True)
     username = "root"
     backup_window = "06:27-06:57"

--- a/src/commcare_cloud/terraform/modules/postgresql/main.tf
+++ b/src/commcare_cloud/terraform/modules/postgresql/main.tf
@@ -16,6 +16,7 @@ module "postgresql" {
   instance_class    = "${var.rds_instance["instance_type"]}"
   allocated_storage = "${var.rds_instance["storage"]}"
   max_allocated_storage = "${var.rds_instance["max_storage"]}"
+  iops = "${var.rds_instance["iops"]}"
 
   apply_immediately     = "${var.apply_immediately}"
   auto_minor_version_upgrade = false


### PR DESCRIPTION
Setting the iops param implies io1; not setting or setting to 0 implies gp2. We'll need this to change an RDS instance's storage type from gp2 to io1.

I've tested that this PR doesn't change the output of terraform plan on existing environments. I haven't tested that setting iops = 9000 (or whatever) matches up to manually changing the storage type to io1 with 9000 iops because we don't have any such machines, but it makes sense that it would and if it doesn't then this PR is at least a step towards there and it should be pretty clear how to do the rest to get terraform output back in sync once that's done.

##### ENVIRONMENTS AFFECTED
None