### PR TITLE
PgBouncer multiprocess use reload

### DIFF
--- a/src/commcare_cloud/ansible/roles/pgbouncer/defaults/main.yml
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/defaults/main.yml
@@ -20,4 +20,5 @@ pgbouncer_client_tls_cert_file: ~
 postgresql_port: 5432
 
 pgbouncer_processes: 1
+pgbouncer_current_processes: [0]
 pgbouncer_min_version: "1.12"

--- a/src/commcare_cloud/ansible/roles/pgbouncer/handlers/main.yml
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/handlers/main.yml
@@ -21,21 +21,26 @@
   systemd:
     daemon_reload: yes
 
-- name: Restart pgbouncer
-  become: yes
-  systemd:
-    name: "pgbouncer-multiprocess@{{ item }}"
-    state: restarted
-    enabled: yes
-    masked: no
-  with_sequence: count={{ pgbouncer_processes | default(1) }}
-
-- name: Start pgbouncer
+- name: Start and enable pgbouncer
   become: yes
   systemd:
     name: "pgbouncer-multiprocess@{{ item }}"
     state: started
     enabled: yes
     masked: no
+  with_sequence: count={{ pgbouncer_processes | default(1) }}
+
+- name: Restart pgbouncer
+  become: yes
+  systemd:
+    name: "pgbouncer-multiprocess@{{ item }}"
+    state: restarted
+  with_sequence: count={{ pgbouncer_processes | default(1) }}
+
+- name: Reload pgbouncer
+  become: yes
+  systemd:
+    name: "pgbouncer-multiprocess@{{ item }}"
+    state: reloaded
   with_sequence: count={{ pgbouncer_processes | default(1) }}
 

--- a/src/commcare_cloud/ansible/roles/pgbouncer/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/tasks/main.yml
@@ -64,7 +64,7 @@
 
 - name: pgbouncer enumerate current processes
   set_fact:
-    pgbouncer_current_processes: "{{ pgbouncer_current_processes | default([]) | union([item.value.name | regex_search('pgbouncer-multiprocess\\@(\\d+)\\.service', '\\1') | first | int]) }}"
+    pgbouncer_current_processes: "{{ pgbouncer_current_processes | union([item.value.name | regex_search('pgbouncer-multiprocess\\@(\\d+)\\.service', '\\1') | first | int]) }}"
   loop: "{{ lookup('dict', ansible_facts.services) }}"
   when: item.key | regex_search('pgbouncer-multiprocess@(\d+)\.service')
   no_log: true
@@ -113,7 +113,8 @@
 - name: pgbouncer configuration
   template: src=pgbouncer.ini.j2 dest="{{ pgbouncer_ini }}"
   notify:
-    - Restart pgbouncer
+    - Start and enable pgbouncer
+    - Reload pgbouncer
   with_sequence: count="{{ pgbouncer_processes }}"
   tags:
     - pgbouncer
@@ -122,7 +123,8 @@
 - name: pgbouncer users
   template: src=pgbouncer.users.j2 dest="{{ pgbouncer_users }}"
   notify:
-    - Restart pgbouncer
+    - Start and enable pgbouncer
+    - Reload pgbouncer
   tags:
     - pgbouncer
     - configure
@@ -155,7 +157,7 @@
   changed_when: true
   notify:
     - Stop and disable pgbouncer (classic)
-    - Start pgbouncer
+    - Start and enable pgbouncer
   tags:
     - pgbouncer
     - configure


### PR DESCRIPTION
Use reload instead of restart for already running processes when
scaling up or down, to avoid downtime.

##### ENVIRONMENTS AFFECTED
All
