### PR TITLE
Change production couchdb compaction settings

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -83,7 +83,7 @@ couchdb2:
   password: "{{ COUCH_PASSWORD }}"
 
 couchdb_compaction_settings:
-  _default: '[{db_fragmentation, "20%"}, {view_fragmentation, "20%"}, {parallel_view_compaction, true}]'
+  _default: '[{db_fragmentation, "40%"}, {view_fragmentation, "40%"}, {from, "22:00"}, {to, "03:00"}]'
 
 
 couchdb2_client_max_body_size: 100M


### PR DESCRIPTION
- restrict to low traffic time window
- raise the threshold to compact
- disable parallel_view_compaction

From https://docs.couchdb.org/en/2.3.1/config/compaction.html
> parallel_view_compaction: If set to true, the database and its views are compacted in parallel. This is only useful on certain setups, like for example when the database and view index directories point to different disks. It defaults to false.



##### ENVIRONMENTS AFFECTED
production