### PR TITLE
Fix for couchdb_password_hash() in couchdb-cluster

### DIFF
--- a/src/commcare_cloud/ansible/requirements.yml
+++ b/src/commcare_cloud/ansible/requirements.yml
@@ -3,7 +3,7 @@ roles:
   - version: v2.1.5
     name: andrewrothstein.couchdb
   - src: git+https://github.com/dimagi/ansible-couchdb-cluster.git
-    version: ad1b24dc5ba52e4bd103c24d7fa914e7866dd885
+    version: faa4e49c1ac44aa327cd82c8dc56d74bb4c1ddf1
     name: andrewrothstein.couchdb-cluster
   - src: git+https://github.com/ANXS/tmpreaper.git
     version: 46f8e0b8b8f5732eecc68b08b5e0c392c418e3f3


### PR DESCRIPTION
Update andrewrothstein.couchdb-cluster to include https://github.com/dimagi/ansible-couchdb-cluster/commit/0a43d64e4336a49c5d7eabb13f3b3e3820be43ec, which was also submitted upstream in https://github.com/andrewrothstein/ansible-couchdb-cluster/pull/13

Tested on Python 2 and 3

##### ENVIRONMENTS AFFECTED
n/a
