### PR TITLE
Fix iteration over dict values

### DIFF
--- a/src/commcare_cloud/ansible/roles/postgresql_base/tasks/set_up_dbs.yml
+++ b/src/commcare_cloud/ansible/roles/postgresql_base/tasks/set_up_dbs.yml
@@ -49,7 +49,7 @@
     db: 'postgres'
     encrypted: True
   when: not is_pg_standby
-  with_items: "{{ postgres_users.values() }}"
+  with_items: "{{ postgres_users.values() | list }}"
   tags:
     - postgres_users
   register: result
@@ -75,7 +75,7 @@
     login_password: "{{ db_is_remote and postgres_users.root.password or omit }}"
   when: not is_pg_standby
   with_subelements:
-    - "{{ postgres_users.values() }}"
+    - "{{ postgres_users.values() | list }}"
     - privs
     - flags:
       skip_missing: True


### PR DESCRIPTION
On Python 3 the item (ansible_loop_var) was the dict_values object unless explicitly converted to a list. Apparently Ansible wraps non-list objects in a list.

Before:
```
item=dict_values([{'a': 1}, {'b': 2}])
```

After:
```
item={'a': 1}
item={'b': 2}
```

On Python 2 the conversion is implicit, but explicit conversion works too. Before and after:
```
item={'a': 1}
item={'b': 2}
```

The bug was verified and fix tested locally against Python 2 and 3.