### PR TITLE
nginx health check endpoint

### DIFF
--- a/src/commcare_cloud/ansible/roles/nginx/templates/default.j2
+++ b/src/commcare_cloud/ansible/roles/nginx/templates/default.j2
@@ -10,12 +10,3 @@ server {
       deny all;
   }
 }
-
-server {
-  listen {{ ansible_default_ipv4.address }}:80;
-
-  location /nginx-health {
-     access_log off;
-     return 200 "healthy\n";
-  }
-}

--- a/src/commcare_cloud/ansible/roles/nginx/templates/default.j2
+++ b/src/commcare_cloud/ansible/roles/nginx/templates/default.j2
@@ -10,3 +10,12 @@ server {
       deny all;
   }
 }
+
+server {
+  listen {{ ansible_default_ipv4.address }}:80;
+
+  location /nginx-health {
+     access_log off;
+     return 200 "healthy\n";
+  }
+}

--- a/src/commcare_cloud/ansible/roles/nginx/templates/site.j2
+++ b/src/commcare_cloud/ansible/roles/nginx/templates/site.j2
@@ -135,6 +135,13 @@ server {
   }
 {% endfor %}
 
+# For health check
+  location /healthz {
+     access_log off;
+     default_type text/html;
+     return 200 'Healthy';
+     }
+
 # For Letsencrypt
   location ^~ /.well-known/acme-challenge/ {
             root         /var/www/letsencrypt;


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-11731

deploy this PR 
Change the Target group end point to /healthz
change success . code from . 302 to 200
and then set  the interval . to 29s
Observe the status of health . check . 
set the interval back to 30s

##### ENVIRONMENTS AFFECTED
Staging [ It first need to be tested here]
India 
Production
