### PR TITLE
PgBouncer multiprocess tmpfiles configuration

### DIFF
--- a/src/commcare_cloud/ansible/roles/pgbouncer/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/tasks/main.yml
@@ -110,6 +110,12 @@
     - pgbouncer
     - configure
 
+- name: pgbouncer tmpfiles configuration
+  template: src=tmpfiles.postgresql-pgbouncer.conf.j2 dest=/etc/tmpfiles.d/postgresql-pgbouncer.conf
+  tags:
+    - pgbouncer
+    - configure
+
 - name: pgbouncer configuration
   template: src=pgbouncer.ini.j2 dest="{{ pgbouncer_ini }}"
   notify:

--- a/src/commcare_cloud/ansible/roles/pgbouncer/templates/tmpfiles.postgresql-pgbouncer.conf.j2
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/templates/tmpfiles.postgresql-pgbouncer.conf.j2
@@ -1,0 +1,4 @@
+{% for i in range(1, (pgbouncer_processes + 1)) %}
+# Directory for pgbouncer-multiprocess@{{ i }} socket
+d /run/postgresql/pgbouncer-{{ i }} 0775 postgres postgres - -
+{% endfor %}


### PR DESCRIPTION
Add tmpfiles configuration for pgbouncer-multiprocess socket directories,
which are otherwise deleted by systemd-tmpfiles.

##### ENVIRONMENTS AFFECTED
All
