### PR TITLE
Py2 compat: universal_newlines instead of encoding

### DIFF
--- a/src/commcare_cloud/commands/ansible/ops_tool.py
+++ b/src/commcare_cloud/commands/ansible/ops_tool.py
@@ -351,7 +351,7 @@ class UpdateLocalKnownHosts(CommandBase):
                 port=port
             )
             procs[hostname] = subprocess.Popen([cmd], shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                                               encoding='utf-8')
+                                               universal_newlines=True)
 
         lines = []
         error_hosts = set()


### PR DESCRIPTION
The encoding parameter was introduced in 3.6.