### PR TITLE
[formplayer] set -Xms to the same value as -Xmx and specify -XX:-UseCompressedOops

### DIFF
--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_formplayer_spring.conf.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_formplayer_spring.conf.j2
@@ -1,7 +1,7 @@
 [program:{{ project }}-{{ deploy_env }}-formsplayer-spring]
 environment={% for name, value in item.env_vars.items() %}{% if value %}{{ name }}="{{ value }}",{% endif %}{% endfor %}
 
-command=java {{ app_processes_config.formplayer_command_args }} {% if use_formplayer_debug_options %} -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9998 {% endif %} -Xmx{{ app_processes_config.formplayer_memory }} {{ extra_formplayer_args }} -XX:MaxMetaspaceSize=128m -XX:-OmitStackTraceInFastThrow -Xss1024k {% if use_formplayer_debug_options %} -XX:NativeMemoryTracking=summary -XX:+UnlockDiagnosticVMOptions {% endif %} -jar {{ www_home }}/formplayer_build/current/formplayer.jar
+command=java {{ app_processes_config.formplayer_command_args }} {% if use_formplayer_debug_options %} -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9998 {% endif %} -Xmx{{ app_processes_config.formplayer_memory }} -Xms{{ app_processes_config.formplayer_memory }} {{ extra_formplayer_args }} -XX:MaxMetaspaceSize=128m -XX:-OmitStackTraceInFastThrow -Xss1024k -XX:-UseCompressedOops {% if use_formplayer_debug_options %} -XX:NativeMemoryTracking=summary -XX:+UnlockDiagnosticVMOptions {% endif %} -jar {{ www_home }}/formplayer_build/current/formplayer.jar
 user={{ cchq_user }}
 autostart=true
 autorestart=true


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-11801

There are two ideas for alleviating the stress on formplayer machines:
1) increase number of machines by 10% (not this ticket)
2) tweak the jvm settings to be a little more robust. setting `-Xms` to the same value as `-Xmx` means that the gc process will be less stressed out and disabling `UseCompressedOops` would in theory allow us to bump the memory to more than 32GB. 

##### ENVIRONMENTS AFFECTED
all environments
