### PR TITLE
Remove redundant geerlingguy.filebeat role

### DIFF
--- a/src/commcare_cloud/ansible/deploy_logstash.yml
+++ b/src/commcare_cloud/ansible/deploy_logstash.yml
@@ -32,8 +32,6 @@
     sansible_java_apt_keyserver: 'http://keys.gnupg.net'
     filebeat_version: 7.x
   tasks:
-    - include_role:
-        name: geerlingguy.filebeat
     - import_role:
         name: dimagi.commcare_logstash.filebeat
   tags: filebeat

--- a/src/commcare_cloud/ansible/requirements.yml
+++ b/src/commcare_cloud/ansible/requirements.yml
@@ -15,8 +15,6 @@ roles:
     version: 1.2.7
   - src: sansible.logstash
     version: v2.4.0-latest
-  - src: geerlingguy.filebeat
-    version: 3.0.2 
   - src: cloudalchemy.prometheus
     version: 2.15.5
   - src: cloudalchemy.alertmanager


### PR DESCRIPTION
_filebeat.yml.j2_ installed by the [_geerlingguy.filebeat_](https://github.com/geerlingguy/ansible-role-filebeat) role uses a variable called `filebeat_inputs` to populate the config file. [`filebeat_inputs`](https://github.com/dimagi/commcare-cloud/blob/690e8a96fcc6b52a481282987b0f2f76763e21fe/environments/staging/public.yml#L31-L35) is set in our environments' _public.yml_, but it's the wrong format for geerlingguy's role, which means the config file is initially configured incorrectly. The first time filebeat tries to start it fails due to bad config:
```
Exiting: Failed to start crawler: starting input failed: Error while initializing input: No paths were defined for input accessing 'filebeat.inputs.0' (source:'/etc/filebeat/filebeat.yml')
```

The [_dimagi.commcare_logstash.filebeat_](https://github.com/dimagi/commcare-logstash/tree/master/roles/filebeat) role also has a _filebeat.yml.j2_, and it uses the same `filebeat_inputs` variable to configure the service, which results in a valid config and subsequent filebeat restart. Sometimes this second restart fails because `Start request repeated too quickly.` when running commcare-cloud with Python 3. This has been reproduced multiple times, and also compared to Python 2 where the problem does not occur.

It looks like the _dimagi.commcare_logstash.filebeat_ duplicates all functionality we need from _geerlingguy.filebeat_, and therefore _geerlingguy.filebeat_ is redundant.

<!--- Provide a link to the ticket or document which prompted this change -->

<!-- ##### ENVIRONMENTS AFFECTED -->
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
