### PR TITLE
Recommend python 3.6 for Manual Installation

### DIFF
--- a/changelog/0041-python3-support.yml
+++ b/changelog/0041-python3-support.yml
@@ -20,12 +20,8 @@ details: |
   encountered while using Python 3.
 
 update_steps: |
-  Setup Python 3
-  - Create a new Python-3.6-based virtualenv
-  - Run `pip install -r requirements3.txt`
-  - Run `pip install -e .`
-  - Run `rm src/commcare_cloud.egg-info/requires.txt`
-  - Run `manage-commcare-cloud install`
+  To setup Python 3.6, see
+  https://dimagi.github.io/commcare-cloud/setup/installation.html
 
   If you encounter a problem using Python 3, you can temporarily revert back to
   Python 2 by activating a Python 2 virtualenv and appending this option to your

--- a/control/check_install.sh
+++ b/control/check_install.sh
@@ -39,51 +39,9 @@ else
     printf "${RED} origin is not recognized: ${ORIGIN}\n"
 fi
 
-if [ ! -d ~/.commcare-cloud ]
-then
-    mkdir ~/.commcare-cloud
-    printf "${YELLOW}→ Created ~/.commcare-cloud\n"
-else
-    printf "${GREEN}✓ ~/.commcare-cloud exists\n"
-fi
-
-if [ ! -d ~/.commcare-cloud/repo ]
-then
-    ln -sf "${COMMCARE_CLOUD_REPO}" ~/.commcare-cloud/repo
-    printf "${YELLOW}→ Linked this repo to ~/.commcare-cloud/repo\n"
-else
-    printf "${GREEN}✓ ~/.commcare-cloud/repo exists\n"
-fi
-
-if [ ! -d ~/.commcare-cloud/bin ]
-then
-    mkdir ~/.commcare-cloud/bin
-    printf "${YELLOW}→ Created ~/.commcare-cloud/bin\n"
-else
-    printf "${GREEN}✓ ~/.commcare-cloud/bin exists\n"
-fi
-
-for executable in commcare-cloud cchq
-do
-    if [ ! -f ~/.commcare-cloud/bin/${executable} ]
-    then
-        if [ -h ~/.commcare-cloud/bin/${executable} ]
-        then
-            # if '! -f' (file does not exist) but '-h' (is symbolic link)
-            # then that means it's a broken link
-            rm ~/.commcare-cloud/bin/${executable}
-        fi
-        if [ -z "$(which ${executable})" ]
-        then
-            printf "${RED}✗ No executable found for ${executable}. Skipping\n"
-        else
-            ln -sf $(which ${executable}) ~/.commcare-cloud/bin/
-            printf "${YELLOW}→ Created ~/.commcare-cloud/bin/${executable}\n"
-        fi
-    else
-        printf "${GREEN}✓ ~/.commcare-cloud/bin/${executable} exists\n"
-    fi
-done
+# clean up obsolete ~/.commcare-cloud stuff
+[ -d ~/.commcare-cloud/bin ] && { rm ~/.commcare-cloud/bin/*; rmdir ~/.commcare-cloud/bin }
+[ -h ~/.commcare-cloud/repo ] && rm ~/.commcare-cloud/repo
 
 if [ ! -f "${FAB_CONFIG}" ]
 then

--- a/control/init.sh
+++ b/control/init.sh
@@ -47,10 +47,6 @@ then
         echo "    https://github.com/dimagi/commcare-cloud/blob/master/README.md"
         return 1
     fi
-elif [ -d ~/.commcare-cloud/repo ]
-then
-    # commcare-cloud is already installed; use the one specified
-    COMMCARE_CLOUD_REPO=~/.commcare-cloud/repo
 else
     # commcare-cloud is not yet installed; use the default location
     COMMCARE_CLOUD_REPO=${HOME}/commcare-cloud
@@ -83,7 +79,6 @@ fi
 if [ -d ~/commcarehq-ansible ]; then
     echo "Moving repo to ~/commcare-cloud"
     mv ~/commcarehq-ansible ~/commcare-cloud
-    # delete broken link
 fi
 
 # remove broken links
@@ -157,8 +152,7 @@ cd ${COMMCARE_CLOUD_REPO} && ./control/check_install.sh && cd -
 alias update-code='${COMMCARE_CLOUD_REPO}/control/update_code.sh && . ~/init-ansible'
 alias update_code='${COMMCARE_CLOUD_REPO}/control/update_code.sh && . ~/init-ansible'
 
-export PATH=$PATH:~/.commcare-cloud/bin
-source ~/.commcare-cloud/repo/src/commcare_cloud/.bash_completion
+source ${COMMCARE_CLOUD_REPO}/src/commcare_cloud/.bash_completion
 
 YELLOW='\033[0;33m'
 BLUE='\033[0;34m'

--- a/control/init.sh
+++ b/control/init.sh
@@ -48,8 +48,8 @@ then
         return 1
     fi
 else
-    # commcare-cloud is not yet installed; use the default location
-    COMMCARE_CLOUD_REPO=${HOME}/commcare-cloud
+    # use pre-assigned location if set; fallback to the default location
+    COMMCARE_CLOUD_REPO=${COMMCARE_CLOUD_REPO:-${HOME}/commcare-cloud}
 fi
 
 if [ -z "$TRAVIS_TEST" -a "$CCHQ_PYTHON" == 2 ]; then

--- a/docs/changelog/0041-python3-support.md
+++ b/docs/changelog/0041-python3-support.md
@@ -27,12 +27,8 @@ soon as possible. Python 2 should only serve as a backup if any issues are
 encountered while using Python 3.
 
 ## Steps to update
-Setup Python 3
-- Create a new Python-3.6-based virtualenv
-- Run `pip install -r requirements3.txt`
-- Run `pip install -e .`
-- Run `rm src/commcare_cloud.egg-info/requires.txt`
-- Run `manage-commcare-cloud install`
+To setup Python 3.6, see
+https://dimagi.github.io/commcare-cloud/setup/installation.html
 
 If you encounter a problem using Python 3, you can temporarily revert back to
 Python 2 by activating a Python 2 virtualenv and appending this option to your

--- a/docs/commcare-cloud/commands/index.md
+++ b/docs/commcare-cloud/commands/index.md
@@ -717,7 +717,7 @@ commcare-cloud <env> ansible-playbook deploy_proxy.yml --limit=proxy
 The ansible playbook .yml file to run.
 Options are the `*.yml` files located under `commcare_cloud/ansible`
 which is under `src` for an egg install and under
-`<virtualenv>/lib/python2.7/site-packages` for a wheel install.
+`<virtualenv>/lib/python3.6/site-packages` for a wheel install.
 
 ##### Optional Arguments
 

--- a/docs/setup/installation.md
+++ b/docs/setup/installation.md
@@ -55,6 +55,21 @@ then the `git clone` command did not run correctly.
 Make sure you have git installed and run it again
 with `--verbose` to give more logging output.
 
+If you see
+
+```bash
+fatal: destination path 'commcare-cloud' already exists and is not an empty directory.
+```
+
+Run the following commands to update the existing commcare-cloud repository
+
+```bash
+admin@control.example.com:~$ cd commcare-cloud
+admin@control.example.com:~$ git checkout master
+admin@control.example.com:~$ git pull
+admin@control.example.com:~$ cd ..
+```
+
 ### Step 3.
 
 Run the install script.

--- a/docs/setup/manual_installation.md
+++ b/docs/setup/manual_installation.md
@@ -18,11 +18,12 @@ source <(curl -s https://raw.githubusercontent.com/dimagi/commcare-cloud/master/
 
 You may now use `commcare-cloud` or its shorter alias `cchq` whenever you're in the virtualenv.
 
-We also recommend that you put the following in your `~/.profile` which gives you access to the tool
-from anywhere:
-```
-export PATH=$PATH:~/.commcare-cloud/bin
-source ~/.commcare-cloud/repo/src/commcare_cloud/.bash_completion
+`~/init-ansible` may be used in future sessions to activate the virtualenv and
+update requirements. If you want that to happen automatically when you create a
+new interactive shell, add the following to your `~/.profile`:
+
+```sh
+[ -t 1 ] && source ~/init-ansible
 ```
 
 ## Manual setup

--- a/docs/setup/manual_installation.md
+++ b/docs/setup/manual_installation.md
@@ -1,7 +1,7 @@
 # Manual Installation
 
 ## Install and setup
-You will need python 2.7.12+ and `virtualenvwrapper` installed to follow these instructions:
+You will need python 3.6 and `virtualenvwrapper` installed to follow these instructions:
 
 ```
 sudo apt-get install git python-dev python-pip

--- a/docs/setup/manual_installation.md
+++ b/docs/setup/manual_installation.md
@@ -1,11 +1,11 @@
 # Manual Installation
 
 ## Install and setup
-You will need python 3.6 and `virtualenvwrapper` installed to follow these instructions:
+You will need python 3.6 installed to follow these instructions (for
+Ubuntu 18.04; other operating systems may differ):
 
 ```
-sudo apt-get install git python-dev python-pip
-sudo pip install virtualenv virtualenvwrapper --ignore-installed six
+sudo apt-get install git python3-dev python3-pip
 ```
 
 ## Setup
@@ -28,20 +28,39 @@ new interactive shell, add the following to your `~/.profile`:
 
 ## Manual setup
 
-If you'd rather use your own virtualenv name, or the script above didn't work for you
-the set up is pretty simple. Just run:
+If you'd rather use your own virtualenv name or a different commcare-cloud repo
+location, or if the script above did not work.
 
-```
-$ mkvirtualenv ansible
-(ansible)$ git clone https://github.com/dimagi/commcare-cloud.git
-(ansible)$ pip install pip-tools
-(ansible)$ pip-sync commcare-cloud/requirements.txt
-(ansible)$ pip install -e commcare-cloud/
-(ansible)$ manage-commcare-cloud install
-(ansible)$ manage-commcare-cloud configure  # and copy the line from here into your ~/.bash_profile
+```sh
+## Create/activate Python 3.6 virtualenv (name and location may be customized)
+$ python3.6 -m pip install --user --upgrade virtualenv
+$ python3.6 -m virtualenv ~/.virtualenvs/cchq
+$ source ~/.virtualenvs/cchq/bin/activate
+
+## Install commcare-cloud
+(cchq)$ git clone https://github.com/dimagi/commcare-cloud.git
+(cchq)$ pip install --upgrade pip-tools
+(cchq)$ pip-sync commcare-cloud/requirements3.txt
+(cchq)$ pip install -e commcare-cloud
+(cchq)$ manage-commcare-cloud install
+
+## Optional: to setup local environments and use commcare-cloud (cchq) without
+## first activating virtualenv. Follow interactive prompts and instructions.
+(cchq)$ manage-commcare-cloud configure
 ```
 
-You will then be able to use cchq from anywhere.
+If you opted out of the final `manage-commcare-cloud configure` step and you
+have a local environments directory or cloned the repo somewhere other than
+`~/commcare-cloud` you should set one or both of the following in your bash
+profile (`~/.profile`) as needed:
+
+```sh
+# for non-standard commcare-cloud repo location
+export COMMCARE_CLOUD_REPO=/path/to/your/commcare-cloud
+
+# for local environments (other than $COMMCARE_CLOUD_REPO/environments)
+export COMMCARE_CLOUD_ENVIRONMENTS=/path/to/your/environments
+```
 
 ## git-hook setup
 
@@ -49,8 +68,7 @@ If you have done the manual setup, Before making any commits, make sure you inst
 the set up is pretty simple. Just run:
 
 ```
-(ansible)$ cd ~/commcare-cloud
-(ansible)$ ./git-hooks/install.sh
+(cchq)$ ~/commcare-cloud/git-hooks/install.sh
 ```
 
 This will make sure you never commit an unencrypted vault.yml file.

--- a/docs/setup/new_environment.md
+++ b/docs/setup/new_environment.md
@@ -96,6 +96,7 @@ This document will walk you through the process of setting up a new monolith ser
 Install commcare-cloud onto the monolith:
 
 ```bash
+$ cd ~
 $ git clone https://github.com/dimagi/commcare-cloud.git
 $ source commcare-cloud/control/init.sh
 ```

--- a/provisioning/control.sh
+++ b/provisioning/control.sh
@@ -1,5 +1,5 @@
 sudo apt-get update
-sudo apt-get install -y python-dev python-pip libffi-dev libssl-dev git
+sudo apt-get install -y python3-dev python3-pip libffi-dev libssl-dev git
 
 ssh-keyscan 192.168.33.15 >> /home/vagrant/.ssh/known_hosts
 ssh-keyscan 192.168.33.16 >> /home/vagrant/.ssh/known_hosts

--- a/src/commcare_cloud/ansible/roles/python/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/python/tasks/main.yml
@@ -2,6 +2,6 @@
   become: yes
   apt:
     name:
-      - python-pip
-      - python-dev
-      - python-setuptools
+      - python3-pip
+      - python3-dev
+      - python3-setuptools

--- a/src/commcare_cloud/commands/ansible/ansible_playbook.py
+++ b/src/commcare_cloud/commands/ansible/ansible_playbook.py
@@ -49,7 +49,7 @@ class AnsiblePlaybook(CommandBase):
             The ansible playbook .yml file to run.
             Options are the `*.yml` files located under `commcare_cloud/ansible`
             which is under `src` for an egg install and under
-            `<virtualenv>/lib/python2.7/site-packages` for a wheel install.
+            `<virtualenv>/lib/python3.6/site-packages` for a wheel install.
         """)
     )
 

--- a/src/commcare_cloud/commcare_cloud.py
+++ b/src/commcare_cloud/commcare_cloud.py
@@ -180,12 +180,8 @@ def call_commcare_cloud(input_argv=sys.argv):
                 to you can use Python 2 with this option {}
                 Python 2 support will end on 2021-03-04
 
-                Setup Python 3.6
-                - Create a new Python-3.6-based virtualenv
-                - pip install -r requirements3.txt
-                - pip install -e .
-                - rm src/commcare_cloud.egg-info/requires.txt
-                - manage-commcare-cloud install
+                To setup Python 3.6, see
+                https://dimagi.github.io/commcare-cloud/setup/installation.html
                 """.format(force_python_2)))
     elif sys.version_info[0] != 2 and force_python_2 in input_argv:
         exit(dedent("""


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Since we plan to no longer support Python 2 in the very near future this should recommend to use Python 3 (specifically 3.6). Feel free to improve wording.
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None