### PR TITLE
removing custom nameservers & updating REDIS_HOST and WS4REDIS_CONNECTION_HOST with Elasticache end-point: India env.

### DIFF
--- a/environments/india/public.yml
+++ b/environments/india/public.yml
@@ -29,10 +29,6 @@ nofile_limit: 65536
 
 KSPLICE_ACTIVE: yes
 
-nameservers:
-  - 8.8.8.8
-  - 8.8.4.4
-
 filebeat_inputs:
   - path: "{{ log_home }}/{{ deploy_env }}_commcare-nginx_error.log"
     tags:  nginx-error
@@ -140,7 +136,7 @@ localsettings:
   SES_CONFIGURATION_SET: india-email-events
   SNS_EMAIL_EVENT_SECRET: "{{ SNS_EMAIL_EVENT_SECRET }}"
   REDIS_DB: '0'
-  REDIS_HOST: "{{ groups.redis.0 }}"
+  REDIS_HOST: "redis.india.commcare.local"
   REDIS_PORT: '6379'
   REMINDERS_QUEUE_ENABLED: True
   SAVED_EXPORT_ACCESS_CUTOFF: 180
@@ -149,7 +145,7 @@ localsettings:
   SUMOLOGIC_URL: "{{ SUMOLOGIC_URL }}"
   SYNC_CASE_FOR_MESSAGING_ON_SAVE: False
 #  STATIC_ROOT:
-  WS4REDIS_CONNECTION_HOST: "{{ groups.redis.0 }}"
+  WS4REDIS_CONNECTION_HOST: "redis.india.commcare.local"
   OBFUSCATE_PASSWORD_FOR_NIC_COMPLIANCE: True
   USER_REPORTING_METADATA_BATCH_ENABLED: True
   UCR_COMPARISONS:


### PR DESCRIPTION
This change [environments/india/public.yml] can update the redis_host URL in the services configuration.

Here, I am adding the cluster end-point (an internal hosted-zone record) in place of the Redis URL. I am also removing custom nameservers IPs from the "resolv.conf" file.

These changes are related to the STAGING environment only.
Ref: SAAS-11824
