### PR TITLE
Updating elasticache cluster node type - India env only

### DIFF
--- a/environments/india/terraform.yml
+++ b/environments/india/terraform.yml
@@ -276,7 +276,7 @@ pgbouncer_nlbs:
 
 elasticache_cluster:
   create: yes
-  cache_node_type: "cache.r5.large"
+  cache_node_type: "cache.m5.large"
   cache_engine_version: "4.0.10"
   cache_prameter_group: "default.redis4.0"
   automatic_failover: true


### PR DESCRIPTION
 As per datadog historical data [ last 13 months] related to India env Redis instance, The maximum used memory is 5.72 GiB out of usable memory 13.52 GiB. In this case, we can use cache.m5.large which is having 2 vCPU & 6.38 GiB memory. Presently, we are using an r5.large [ 2 vCPU & 16 GiB memory ] instance for Redis service.

We can scale up the Elasticache cluster node type based on service metrics like Memory usage, Evictions, Swap Usage & Memory fragmentation ratio.
