### PR TITLE
cloudwatch_logs remove config file check

### DIFF
--- a/src/commcare_cloud/ansible/roles/cloudwatch_logs/handlers/main.yml
+++ b/src/commcare_cloud/ansible/roles/cloudwatch_logs/handlers/main.yml
@@ -5,3 +5,6 @@
     -c file:/opt/aws/amazon-cloudwatch-agent/etc/cloudwatch_logs.json
   become: yes
 
+- name: Start cloudwatch agent
+  shell: /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a start
+  become: yes

--- a/src/commcare_cloud/ansible/roles/cloudwatch_logs/handlers/main.yml
+++ b/src/commcare_cloud/ansible/roles/cloudwatch_logs/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Reload cloudwatch agent
+  shell: /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s
+    -c file:/opt/aws/amazon-cloudwatch-agent/etc/cloudwatch_logs.json
+  become: yes
+

--- a/src/commcare_cloud/ansible/roles/cloudwatch_logs/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/cloudwatch_logs/tasks/main.yml
@@ -22,13 +22,11 @@
       owner: cwagent
       mode: 0644
     become: yes
-    register: cloudwatch_logs_conf
 
-  - name: Reload cloudwatch agent if changed
+  - name: Reload cloudwatch agent
     shell: /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s
       -c file:/opt/aws/amazon-cloudwatch-agent/etc/cloudwatch_logs.json
     become: yes
-    when: cloudwatch_logs_conf.changed
 
   - name: Ensure cloudwatch agent enabled
     shell: /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a start

--- a/src/commcare_cloud/ansible/roles/cloudwatch_logs/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/cloudwatch_logs/tasks/main.yml
@@ -25,8 +25,9 @@
     notify: Reload cloudwatch agent
 
   - name: Ensure cloudwatch agent enabled
-    shell: /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a start
-    become: yes
+    shell: /bin/true
+    notify: Start cloudwatch agent
+    when: '"\"status\": \"running\"" not in ctl_status.stdout'
 
   when: enable_cloudwatch_logs and log_files_collect_list | length
   tags: cloudwatch-logs

--- a/src/commcare_cloud/ansible/roles/cloudwatch_logs/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/cloudwatch_logs/tasks/main.yml
@@ -22,14 +22,11 @@
       owner: cwagent
       mode: 0644
     become: yes
-
-  - name: Reload cloudwatch agent
-    shell: /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s
-      -c file:/opt/aws/amazon-cloudwatch-agent/etc/cloudwatch_logs.json
-    become: yes
+    notify: Reload cloudwatch agent
 
   - name: Ensure cloudwatch agent enabled
     shell: /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a start
     become: yes
+
   when: enable_cloudwatch_logs and log_files_collect_list | length
   tags: cloudwatch-logs


### PR DESCRIPTION
On a fresh run the config file would be created and its status is not changed, so the reload will not happen. I couldn't find a way to run if it changed or was created, but removing it should also work and we always reload.  
I think the better thing to do is to use handlers and notify a reload, but that would be a bigger refactor.