### PR TITLE
Adding Elasticache cluster node type & other attributes - Prod env only

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -458,6 +458,21 @@ elasticache:
   create: no
 
 elasticache_cluster:
-  create: no
+  create: yes
+  cache_node_type: "cache.r5.2xlarge"
+  cache_engine_version: "4.0.10"
+  cache_prameter_group: "default.redis4.0"
+  automatic_failover: true
+  transit_encryption: false
+  at_rest_encryption: true
+  auto_minor_version: false
+  cluster_size: 3
+  maintenance_window: "sun:08:30-sun:09:30"
+  snapshot_retention: 7
+  snapshot_window: "06:30-07:30"
 
-r53_private_zone: null
+r53_private_zone:
+  create: yes
+  domain_name:  "production.commcare.local"
+  create_record: yes
+  route_names:  "redis"


### PR DESCRIPTION
As per datadog historical data [ last 13 months] related to Production env Redis instance, The maximum used memory is 53.44 GiB out of usable memory 128 GiB and average used memory 14.75 GiB & 20.75 GiB per 6 months. 

In this case, we can use cache.r5.2xlarge which is having 8 vCPU & 52.82 GiB memory. Presently, we are using an r5.4xlarge [ 16 vCPU & 128 GiB memory ] instance for Redis service.

We are going to use three Elasticache nodes for high availability & launching these in different availability zones within the region.

We can scale up the Elasticache cluster node type based on service metrics like Memory usage, Evictions, Swap Usage & Memory fragmentation ratio.

ref: SAAS-11834
