### PR TITLE
Ce/user import queue

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -56,7 +56,7 @@ celery_processes:
     ucr_queue:
       concurrency: 9
     user_import_queue:
-      concurrency: 4
+      concurrency: 5
   celery_a006:
     # not really queues
     flower: {}

--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -55,6 +55,8 @@ celery_processes:
       concurrency: 1
     ucr_queue:
       concurrency: 9
+    user_import_queue:
+      concurrency: 4
   celery_a006:
     # not really queues
     flower: {}

--- a/environments/staging/app-processes.yml
+++ b/environments/staging/app-processes.yml
@@ -30,7 +30,7 @@ celery_processes:
       pooling: gevent
       concurrency: 4
     user_import_queue:
-      concurrency: 2
+      concurrency: 3
     flower: {}
     beat: {}
 pillows:

--- a/environments/staging/app-processes.yml
+++ b/environments/staging/app-processes.yml
@@ -29,6 +29,8 @@ celery_processes:
     reminder_queue:
       pooling: gevent
       concurrency: 4
+    user_import_queue:
+      concurrency: 2
     flower: {}
     beat: {}
 pillows:

--- a/src/commcare_cloud/environment/schemas/app_processes.py
+++ b/src/commcare_cloud/environment/schemas/app_processes.py
@@ -129,6 +129,7 @@ CELERY_PROCESSES = [
     CeleryProcess("submission_reprocessing_queue", required=False, blockage_threshold=60 * 60),
     CeleryProcess("ucr_indicator_queue", required=False, blockage_threshold=60 * 60),
     CeleryProcess("ucr_queue", required=False, blockage_threshold=60 * 60),
+    CeleryProcess("user_import_queue", required=False, blockage_threshold=60 * 60)
 ]
 
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
There is a followup HQ pr that will use this, but we wanted a dedicated queue to run user imports (that will be behind a flag) so that large USH user imports can run in parallel without blocking the main queue. Testing on staging now, but hope to roll this out in production tonight.

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Staging
Production