### PR TITLE
celery queue for ush background tasks

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -57,6 +57,8 @@ celery_processes:
       concurrency: 9
     user_import_queue:
       concurrency: 5
+    ush_background_tasks:
+      concurrency: 8
   celery_a006:
     # not really queues
     flower: {}
@@ -73,6 +75,8 @@ celery_processes:
     sumologic_logs_queue:
       pooling: gevent
       concurrency: 50
+    ush_background_tasks:
+      concurrency: 8
 
 pillows:
   pillow_a000:

--- a/src/commcare_cloud/environment/schemas/app_processes.py
+++ b/src/commcare_cloud/environment/schemas/app_processes.py
@@ -129,7 +129,8 @@ CELERY_PROCESSES = [
     CeleryProcess("submission_reprocessing_queue", required=False, blockage_threshold=60 * 60),
     CeleryProcess("ucr_indicator_queue", required=False, blockage_threshold=60 * 60),
     CeleryProcess("ucr_queue", required=False, blockage_threshold=60 * 60),
-    CeleryProcess("user_import_queue", required=False, blockage_threshold=60 * 60)
+    CeleryProcess("user_import_queue", required=False, blockage_threshold=60 * 60),
+    CeleryProcess("ush_background_tasks", required=False, blockage_threshold=3 * 60 * 60)
 ]
 
 


### PR DESCRIPTION
Dedicated queue for running USH background tasks to avoid blocking the existing queues. Currently the only task that would use this is the USH formplayer restore priming.

@calellowitz can I have moved the user import tasks to use this queue as well: https://github.com/dimagi/commcare-hq/pull/29181
I think this is safe to do since the user import tasks shouldn't be running in parallel with the formplayer priming tasks.

I've left the `user_import_queue` config in place for now to make the changes easier to roll out / roll back.

##### ENVIRONMENTS AFFECTED
production