### PR TITLE
Add another read replica to production case_search elasticsearch index

### DIFF
--- a/environments/production/elasticsearch.yml
+++ b/environments/production/elasticsearch.yml
@@ -1,0 +1,3 @@
+settings:
+  case_search:
+    number_of_replicas: 2  # store in triplicate for an extra read replica


### PR DESCRIPTION
the default is 1 replica, this sets it to 2. Including the primary that means there will be three copies total instead of two copies total of each shard on case_search.

This is an untested example for someone to get started off of if we have to do this. If we decide it's worth doing, we should first do this on staging to redefine the process and make sure it works smoothly. The code to support it should all be there already, it's just a matter of piecing it together and doing a test run to make sure it all still works, since we haven't done it in a long time.

##### ENVIRONMENTS AFFECTED
production
