### PR TITLE
Prem/prod enabling dedicated migration process

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -81,7 +81,7 @@ celery_processes:
 pillows:
   pillow_a000:
     case-pillow:
-      num_processes: 16
+      num_processes: 17
       dedicated_migration_process: True
     user-pillow:
       num_processes: 1
@@ -115,5 +115,5 @@ pillows:
       num_processes: 1
   pillow_a001:
     xform-pillow:
-      num_processes: 32
+      num_processes: 33
       dedicated_migration_process: True

--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -82,7 +82,7 @@ pillows:
   pillow_a000:
     case-pillow:
       num_processes: 16
-      dedicated_migration_process: False
+      dedicated_migration_process: True
     user-pillow:
       num_processes: 1
     group-pillow:
@@ -116,4 +116,4 @@ pillows:
   pillow_a001:
     xform-pillow:
       num_processes: 32
-      dedicated_migration_process: False
+      dedicated_migration_process: True


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production

Enabled dedicated_migration_process for the case and xform pillows. Also increased # of processes for the case and xform pillows (total_processes + 1(dedicated_migration_process)) 
case: 16+1
xform: 32+1