### PR TITLE
Prem/prod fp database migration

### DIFF
--- a/environments/production/aws-resources.yml
+++ b/environments/production/aws-resources.yml
@@ -293,6 +293,7 @@ pgbouncer8-production: 10.202.40.236
 pgbouncer8-production.instance_id: i-08e49cdf329ab51ab
 pgbouncer9-production: 10.202.40.241
 pgbouncer9-production.instance_id: i-00f2c8e5755593a07
+pgformplayer0-production: pgformplayer0-production.cl9dmuo3ok4h.us-east-1.rds.amazonaws.com
 pgformplayer_nlb-production: pgformplayer-nlb-production-ec7390b942368541.elb.us-east-1.amazonaws.com
 pgmain0-production: pgmain0-production.cl9dmuo3ok4h.us-east-1.rds.amazonaws.com
 pgmain1-production: pgmain1-production.cl9dmuo3ok4h.us-east-1.rds.amazonaws.com

--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -124,6 +124,9 @@ mobile_webworkers
 [rds_pgmain0]
 pgmain0-production.cl9dmuo3ok4h.us-east-1.rds.amazonaws.com
 
+[rds_pgformplayer0]
+pgformplayer0-production.cl9dmuo3ok4h.us-east-1.rds.amazonaws.com
+
 [rds_pgucr0]
 pgucr0-production.cl9dmuo3ok4h.us-east-1.rds.amazonaws.com
 
@@ -150,6 +153,7 @@ pgformplayer-nlb-production-ec7390b942368541.elb.us-east-1.amazonaws.com
 
 [remote_postgresql:children]
 rds_pgmain0
+rds_pgformplayer0
 rds_pgucr0
 rds_pgshard1
 rds_pgshard2

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -35,6 +35,8 @@ mobile_webworkers
 
 {{ __rds_pgmain0__ }}
 
+{{ __rds_pgformplayer0__ }}
+
 {{ __rds_pgucr0__ }}
 
 {{ __rds_pgshard1__ }}
@@ -53,6 +55,7 @@ mobile_webworkers
 
 [remote_postgresql:children]
 rds_pgmain0
+rds_pgformplayer0
 rds_pgucr0
 rds_pgshard1
 rds_pgshard2

--- a/environments/production/postgresql.yml
+++ b/environments/production/postgresql.yml
@@ -42,7 +42,7 @@ dbs:
     host: rds_pgmain0
     pgbouncer_host: pgbouncer7
   formplayer:
-    host: rds_pgmain0
+    host: rds_pgformplayer0
     pgbouncer_endpoint: pgformplayer_nlb
     pgbouncer_hosts:
       - pgbouncer5

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -372,6 +372,18 @@ rds_instances:
       effective_cache_size: 11520MB
       maintenance_work_mem: 960MB
 
+  - identifier: "pgformplayer0-production"
+    instance_type: "db.m5.8xlarge"
+    storage: 10000
+    multi_az: true
+    engine_version: 9.6.15
+    params:
+      shared_preload_libraries: pg_stat_statements
+      log_min_duration_statement: 1000
+      # This is for autovacuuming the huge TOAST table for formplayer.formplayer_sessions table.
+      # When 'commcarehq' and 'formplayer' dbs are split, this should move to formplayer db instance
+      maintenance_work_mem: 4172000kB
+
 pgbouncer_nlbs:
   - name: pgformplayer_nlb-production
     targets:


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production Formplayer service

Moved Formplayer DB into new RDS instance. Update-config ran successfully. 

Unable to enable enhanced monitoring for pgformplayer0-production. Seems like I don't have enough privileges. 
Could you please help me here @shyamkumarlchauhan @dannyroberts. I have to run `terraform apply` with target as new db and push changes.

![image](https://user-images.githubusercontent.com/11612356/108594202-85198000-739e-11eb-84cc-a6aabca6c110.png)
