### PR TITLE
Updating redis_host & ws4redis_connection_host endpoint with Elasticache-Production env

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -165,7 +165,7 @@ localsettings:
   SES_CONFIGURATION_SET: production-email-events
   SNS_EMAIL_EVENT_SECRET: "{{ SNS_EMAIL_EVENT_SECRET }}"
   REDIS_DB: '0'
-  REDIS_HOST: "{{ groups.redis.0 }}"
+  REDIS_HOST: "redis.production.commcare.local"
   REDIS_PORT: '6379'
   REMINDERS_QUEUE_ENABLED: True
   REQUIRE_TWO_FACTOR_FOR_SUPERUSERS: True
@@ -186,7 +186,7 @@ localsettings:
         - 'ils-gateway-train'
 #  USE_KAFKA_SHORTEST_BACKLOG_PARTITIONER: True
   USER_REPORTING_METADATA_BATCH_ENABLED: True
-  WS4REDIS_CONNECTION_HOST: "{{ groups.redis.0 }}"
+  WS4REDIS_CONNECTION_HOST: "redis.production.commcare.local"
 
 # comment these two lines out to make a new rackspace machine
 commcare_cloud_root_user: ubuntu


### PR DESCRIPTION
This change [environments/production/public.yml] can update the redis_host URL in the services configuration.

Here, I am adding the cluster end-point (an internal hosted-zone record) in place of the Redis URL.

These changes are related to the Production environment only.
Ref: SAAS-11511