### PR TITLE
update config and logging for formplayer sentry upgrade

### DIFF
--- a/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
@@ -120,7 +120,6 @@
     mode: 0644
   with_items:
     - filename: application.properties
-    - filename: sentry.properties
     - filename: logback-spring.xml
   tags:
     - formplayer_deploy

--- a/src/commcare_cloud/ansible/roles/formplayer/templates/application.properties.j2
+++ b/src/commcare_cloud/ansible/roles/formplayer/templates/application.properties.j2
@@ -1,4 +1,4 @@
-{% set host='https://' ALTERNATE_FORMPLAYER_HQ_HOST | default(SITE_HOST) %}
+{% set host='https://' ~ ALTERNATE_FORMPLAYER_HQ_HOST | default(SITE_HOST) %}
 commcarehq.host={{ host }}
 commcarehq.formplayerAuthKey={{ FORMPLAYER_INTERNAL_AUTH_KEY }}
 server.port={{ formplayer_port }}

--- a/src/commcare_cloud/ansible/roles/formplayer/templates/application.properties.j2
+++ b/src/commcare_cloud/ansible/roles/formplayer/templates/application.properties.j2
@@ -1,14 +1,11 @@
-{% if ALTERNATE_FORMPLAYER_HQ_HOST is defined %}
-commcarehq.host=https://{{ ALTERNATE_FORMPLAYER_HQ_HOST }}
-{% else %}
-commcarehq.host=https://{{ SITE_HOST }}
-{% endif %}
-commcarehq.environment={{ env_monitoring_id }}
+{% set host='https://' ALTERNATE_FORMPLAYER_HQ_HOST | default(SITE_HOST) %}
+commcarehq.host={{ host }}
 commcarehq.formplayerAuthKey={{ FORMPLAYER_INTERNAL_AUTH_KEY }}
 server.port={{ formplayer_port }}
 user.suffix=commcarehq.org
 logging.config=logback-spring.xml
 sqlite.dataDir={{ formplayer_data_dir }}/
+
 // Takes the format of https://<key>@sentry.io/<project>
 // More info on the DSN can be found here: https://docs.sentry.io/quickstart/#configure-the-dsn
 {% if http_proxy_address is defined %}
@@ -16,6 +13,8 @@ sentry.dsn={{ formplayer_sentry_dsn }}?http.proxy.host={{ http_proxy_address }}&
 {% else %}
 sentry.dsn={{ formplayer_sentry_dsn }}
 {% endif %}
+sentry.environment={{ env_monitoring_id }}
+sentry.tags.HQHost={{ host }}
 
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.datasource.url=jdbc:postgresql://{{ postgresql_dbs.formplayer.pgbouncer_endpoint }}:{{ postgresql_dbs.formplayer.port

--- a/src/commcare_cloud/ansible/roles/formplayer/templates/logback-spring.xml.j2
+++ b/src/commcare_cloud/ansible/roles/formplayer/templates/logback-spring.xml.j2
@@ -1,10 +1,13 @@
 <configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d{yyyy-MM-dd HH:mm:ss.SS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
+
+    <appender name="SENTRY" class="io.sentry.logback.SentryAppender" />
 
     {% if formplayer_sensitive_data_logging -%}
     <appender name="requests" class="ch.qos.logback.core.rolling.RollingFileAppender">
@@ -27,6 +30,7 @@
 
     <root level="INFO">
         <appender-ref ref="STDOUT" />
+        <appender-ref ref="SENTRY" />
     </root>
 
     <logger name="org.springframework.web.filter.CommonsRequestLoggingFilter">

--- a/src/commcare_cloud/ansible/roles/formplayer/templates/sentry.properties.j2
+++ b/src/commcare_cloud/ansible/roles/formplayer/templates/sentry.properties.j2
@@ -1,2 +1,0 @@
-// Silences a very verbose sentry warning
-stacktrace.app.packages=


### PR DESCRIPTION
Changes to formplayer config for sentry upgrade.

This needs to be rolled out in conjunction with the formplayer changes: https://github.com/dimagi/formplayer/pull/886
The logging config changes particularly will error if the old version of formplayer is running.

Is it worth trying to split this up into two:
1. Deploy config changes
2. Deploy formpalyer
3. Deploy logging changes (with restart)


##### ENVIRONMENTS AFFECTED
all
