### PR TITLE
Add detailed tagging domains to production

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -65,6 +65,8 @@ formplayer_purge_time_spec: '10d'
 formplayer_sensitive_data_logging: true
 formplayer_forward_ip_proxy: true
 formplayer_enable_cache: true
+formplayer_detailed_tagging_domains: "{{ detailed_tagging_domains }}"
+formplayer_detailed_tags:
 
 KSPLICE_ACTIVE: yes
 

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -66,7 +66,7 @@ formplayer_sensitive_data_logging: true
 formplayer_forward_ip_proxy: true
 formplayer_enable_cache: true
 formplayer_detailed_tagging_domains: "{{ detailed_tagging_domains }}"
-formplayer_detailed_tags:
+formplayer_detailed_tags: []
 
 KSPLICE_ACTIVE: yes
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Initially tested on [this PR](https://github.com/dimagi/commcare-cloud/pull/4536) on staging, but also just tested a branch with an empty `detailed_tag_names` list on staging to ensure it behaves as expected which it does. 

Rolling this out empty so that we can first add domains, then update which tags are considered "detailed" after. This will allow for a smooth transition from a reporting metrics side since `form_name` is already deployed. 
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production