### PR TITLE
removing redis0-production instance from inventory & terraform resource list. ref: SAAS-11906

### DIFF
--- a/environments/production/aws-resources.yml
+++ b/environments/production/aws-resources.yml
@@ -273,8 +273,6 @@ rabbit2-production: 10.202.42.100
 rabbit2-production.instance_id: i-0afd113aa270a774d
 rabbit3-production: 10.202.42.102
 rabbit3-production.instance_id: i-08f06ed3dea9f37e6
-redis0-production: 10.202.40.233
-redis0-production.instance_id: i-055334f56a475b851
 shareddir1-production: 10.202.40.218
 shareddir1-production.instance_id: i-0d1e0f3874426383e
 vpn-production: 10.202.20.194

--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -493,12 +493,6 @@ use_monit_for_formplayer=true
 formplayer_c014
 formplayer_c023
 
-[redis0]
-10.202.40.233 hostname=redis0-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-055334f56a475b851 swap_size=1G
-
-[redis:children]
-redis0
-
 [shareddir1]
 10.202.40.218 hostname=shareddir1-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-0d1e0f3874426383e
 

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -141,11 +141,6 @@ use_monit_for_formplayer=true
 formplayer_c014
 formplayer_c023
 
-{{ __redis0__ }} swap_size=1G
-
-[redis:children]
-redis0
-
 {{ __shareddir1__ }}
 
 [shared_dir_host:children]

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -196,15 +196,6 @@ servers:
     os: ubuntu_pro_bionic
     count: 74
 
-  - server_name: "redis0-production"
-    server_instance_type: r5.4xlarge
-    network_tier: "db-private"
-    az: "a"
-    volume_size: 600
-    volume_encrypted: no
-    group: "redis"
-    os: bionic
-
   - server_name: "shareddir1-production"
     server_instance_type: t3.micro
     network_tier: "db-private"


### PR DESCRIPTION
I am doing a instance termination process for **_redis0-production_** (i-055334f56a475b851). We had completed migration process (redis - elasticache ) in prod env. 

We are not using redis0-production [**_i-055334f56a475b851_**] host for redis db service.
ref: SAAS-11906