### PR TITLE
Updated required files to create EFS,Access-point & mount-targets - all environments

### DIFF
--- a/environments/india/terraform.yml
+++ b/environments/india/terraform.yml
@@ -284,3 +284,5 @@ r53_private_zone:
   domain_name:  "india.commcare.local"
   create_record: yes
   route_names:  "redis"
+
+efs_file_systems: null

--- a/environments/india/terraform.yml
+++ b/environments/india/terraform.yml
@@ -285,4 +285,12 @@ r53_private_zone:
   create_record: yes
   route_names:  "redis"
 
-efs_file_systems: null
+efs_file_systems:
+  - efs_name: "efs_india"
+    create: yes
+    transition_to_ia:  "AFTER_14_DAYS"
+    create_access: no
+    create_mount: yes
+    create_record: yes
+    domain_name: "india.commcare.local"
+    route_names: "shared-efs"

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -424,3 +424,5 @@ r53_private_zone:
   domain_name:  "production.commcare.local"
   create_record: yes
   route_names:  "redis"
+
+efs_file_systems: null

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -425,4 +425,12 @@ r53_private_zone:
   create_record: yes
   route_names:  "redis"
 
-efs_file_systems: null
+efs_file_systems: 
+  - efs_name: "efs_production"
+    create: yes
+    transition_to_ia:  "AFTER_14_DAYS"
+    create_access: no
+    create_mount: yes
+    create_record: yes
+    domain_name: "production.commcare.local"
+    route_names: "shared-efs"

--- a/environments/staging/terraform.yml
+++ b/environments/staging/terraform.yml
@@ -360,3 +360,13 @@ r53_private_zone:
   domain_name:  "staging.commcare.local"
   create_record: yes
   route_names:  "redis"
+
+efs_file_systems:
+  - efs_name: "efs_staging"
+    create: yes
+    transition_to_ia:  "AFTER_14_DAYS"
+    create_access: no
+    create_mount: yes
+    create_record: yes
+    domain_name: "staging.commcare.local"
+    route_names: "shared-efs"

--- a/src/commcare_cloud/ansible/requirements.yml
+++ b/src/commcare_cloud/ansible/requirements.yml
@@ -21,7 +21,7 @@ roles:
     version: 0.19.0
   - src: cloudalchemy.grafana
     version: 0.17.0
-  - src: cloudalchemy.node-exporter
+  - src: cloudalchemy.node_exporter
     version: 0.21.5
   - src: bdellegrazie.postgres_exporter
     version: v4.1.0

--- a/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
@@ -281,3 +281,39 @@ module "pgbouncer_nlb__{{ pgbouncer_nlb.name }}" {
 }
 
 {% endfor %}
+
+{% if efs_file_systems %}
+{% for efs_file_system in efs_file_systems %}
+module "efs_file_system__{{ efs_file_system.efs_name }}" {
+  source = "./modules/efs_file_system"
+  create      = "{{ efs_file_system.create|tojson }}"
+  efs_name    = {{ efs_file_system.efs_name|tojson }}
+  transition_to_ia = {{ efs_file_system.transition_to_ia|tojson }}
+  namespace        = "${var.environment}"
+  create_access    = "{{ efs_file_system.create_access|tojson }}"
+}
+{% endfor %}
+
+{%- for az in az_codes %}
+{%- for efs_file_system_mount in efs_file_systems %}{% if not loop.first %}, {% endif %} 
+module "efs_mount__{{ efs_file_system_mount.efs_name }}__{{ az }}" {
+  source = "./modules/efs_file_system/mount-point"
+  create_mount   = "{{ efs_file_system_mount.create_mount|tojson }}"
+  file_system_id = "${module.efs_file_system__{{ efs_file_system_mount.efs_name }}.efs_id}"
+  subnet_ids_efs = "${lookup(module.network.subnets-app-private, "{{ az }}", "")}"
+  securitygroup_id = ["${module.network.app-private-sg}"]
+}
+{% endfor %}
+{% endfor %}
+
+{%- for efs_file_system_route53 in efs_file_systems %}{% if not loop.first %}, {% endif %}
+    module "efs_route53__{{ efs_file_system_route53.efs_name }}" {
+        source = "./modules/r53-record-create-update"
+        create_record   = "{{ efs_file_system_route53.create_record|tojson }}"
+        domain_name = {{ efs_file_system_route53.domain_name|tojson }}
+        route_names = {{ efs_file_system_route53.route_names|tojson }}
+        records = [ "${module.efs_file_system__{{ efs_file_system_route53.efs_name }}.efs_endpoint_address}" ]
+      }
+{% endfor %}
+
+{% endif %}

--- a/src/commcare_cloud/environment/schemas/terraform.py
+++ b/src/commcare_cloud/environment/schemas/terraform.py
@@ -32,6 +32,7 @@ class TerraformConfig(jsonobject.JsonObject):
     elasticache = jsonobject.ObjectProperty(lambda: ElasticacheConfig, default=None)
     elasticache_cluster = jsonobject.ObjectProperty(lambda: ElasticacheClusterConfig, default=None)
     r53_private_zone = jsonobject.ObjectProperty(lambda: RoutePrivateZoneConfig, default=None)
+    efs_file_systems = jsonobject.ListProperty(lambda: EfsFileSystem, default=None)
 
     @classmethod
     def wrap(cls, data):
@@ -200,3 +201,15 @@ class RoutePrivateZoneConfig(jsonobject.JsonObject):
     domain_name = jsonobject.StringProperty()
     create_record = jsonobject.BooleanProperty(default=True)
     route_names = jsonobject.StringProperty()
+
+class EfsFileSystem(jsonobject.JsonObject):
+    _allow_dynamic_properties = False
+    create = jsonobject.BooleanProperty(default=True)
+    transition_to_ia = jsonobject.StringProperty(required=True)
+    efs_name = jsonobject.StringProperty(required=True)
+    create_access = jsonobject.BooleanProperty(default=True)
+    create_mount = jsonobject.BooleanProperty(default=True)
+    create_record = jsonobject.BooleanProperty(default=True)
+    domain_name = jsonobject.StringProperty(required=True)
+    record_type = jsonobject.StringProperty(default="CNAME")
+    route_names = jsonobject.StringProperty(required=True)

--- a/src/commcare_cloud/terraform/modules/efs_file_system/CHANGELOG.md
+++ b/src/commcare_cloud/terraform/modules/efs_file_system/CHANGELOG.md
@@ -1,0 +1,2 @@
+# efs_file_system-v0.1.0
+[rameshganne] - Initial commit to creating the AWS EFS file-system & mount target.

--- a/src/commcare_cloud/terraform/modules/efs_file_system/README.md
+++ b/src/commcare_cloud/terraform/modules/efs_file_system/README.md
@@ -1,0 +1,8 @@
+# efs_file_system Module Usage #
+
+To call efs_file_system module add source as defined below:
+```
+module "efs_file_system" {
+  source      = "../modules/efs_file_system"
+}
+```

--- a/src/commcare_cloud/terraform/modules/efs_file_system/main.tf
+++ b/src/commcare_cloud/terraform/modules/efs_file_system/main.tf
@@ -1,0 +1,15 @@
+resource "aws_efs_file_system" "elastic_file_system" {
+  count  = "${var.create == "true" ? 1 : 0}"
+  encrypted = true
+  lifecycle_policy {
+    transition_to_ia = "${var.transition_to_ia}"
+  }
+  tags = {
+    Name = "${var.efs_name}-${var.namespace}"
+  }
+}
+
+resource "aws_efs_access_point" "efs_access_point" {
+  count  = "${var.create_access == "true" ? 1 : 0}"
+  file_system_id = "${aws_efs_file_system.elastic_file_system.id}"
+}

--- a/src/commcare_cloud/terraform/modules/efs_file_system/main.tf
+++ b/src/commcare_cloud/terraform/modules/efs_file_system/main.tf
@@ -5,7 +5,8 @@ resource "aws_efs_file_system" "elastic_file_system" {
     transition_to_ia = "${var.transition_to_ia}"
   }
   tags = {
-    Name = "${var.efs_name}-${var.namespace}"
+    Name = "${var.efs_name}"
+    Environment = "${var.namespace}"
   }
 }
 

--- a/src/commcare_cloud/terraform/modules/efs_file_system/mount-point/README.md
+++ b/src/commcare_cloud/terraform/modules/efs_file_system/mount-point/README.md
@@ -1,0 +1,8 @@
+# aws_efs_mount_target Module Usage #
+
+To call aws_efs_mount_target module add source as defined below:
+```
+module "aws_efs_mount_target" {
+  source      = "../modules/efs_file_system/mount-point"
+}
+```

--- a/src/commcare_cloud/terraform/modules/efs_file_system/mount-point/main.tf
+++ b/src/commcare_cloud/terraform/modules/efs_file_system/mount-point/main.tf
@@ -1,0 +1,6 @@
+resource "aws_efs_mount_target" "efs_mount_target" {
+  count  = "${var.create_mount == "true" ? 1 : 0}"
+  file_system_id = "${var.file_system_id}"
+  subnet_id      = "${var.subnet_ids_efs}"
+  security_groups = ["${var.securitygroup_id}"]
+}

--- a/src/commcare_cloud/terraform/modules/efs_file_system/mount-point/output.tf
+++ b/src/commcare_cloud/terraform/modules/efs_file_system/mount-point/output.tf
@@ -1,0 +1,9 @@
+output "mount_target_ids" {
+  value       = "${join(",",aws_efs_mount_target.efs_mount_target.*.id)}"
+  description = "List of EFS mount target IDs (one per Availability Zone)"
+}
+
+output "mount_dns_name" {
+  value       = "${join(",",aws_efs_mount_target.efs_mount_target.*.dns_name)}"
+  description = "The DNS name for the EFS file system"
+}

--- a/src/commcare_cloud/terraform/modules/efs_file_system/mount-point/variables.tf
+++ b/src/commcare_cloud/terraform/modules/efs_file_system/mount-point/variables.tf
@@ -1,0 +1,16 @@
+variable "subnet_ids_efs" {
+  description = "The Subnet Group of the EFS"
+}
+
+variable "securitygroup_id" {
+  type        = "list"
+  description = "If the nodes are not in VPC, these are the names of the Security Groups. If the nodes are in a VPC, these are the IDs of the VPC security groups"
+}
+
+variable "file_system_id" {
+  description = "Flag to EFS ID"
+}
+
+variable "create_mount" {
+  description = "Flag to enable/disable EFS aws_efs_mount_target"
+}

--- a/src/commcare_cloud/terraform/modules/efs_file_system/output.tf
+++ b/src/commcare_cloud/terraform/modules/efs_file_system/output.tf
@@ -1,0 +1,7 @@
+output "efs_endpoint_address" {
+  value = "${aws_efs_file_system.elastic_file_system.*.dns_name}"
+}
+
+output "efs_id" {
+  value = "${join(",",aws_efs_file_system.elastic_file_system.*.id)}"
+}

--- a/src/commcare_cloud/terraform/modules/efs_file_system/variables.tf
+++ b/src/commcare_cloud/terraform/modules/efs_file_system/variables.tf
@@ -1,0 +1,20 @@
+variable "namespace" {
+  description = "namespace - indicate environment name"
+}
+
+variable "create" {
+  description = "Flag to enable/disable EFS file-system"
+  default     = "true"
+}
+
+variable "create_access" {
+  description = "Flag to enable/disable EFS Access-point file-system"
+}
+
+variable "transition_to_ia" {
+  description = "Indicates how long it takes to transition files to the IA storage class. Valid values: AFTER_7_DAYS, AFTER_14_DAYS, AFTER_30_DAYS, AFTER_60_DAYS, or AFTER_90_DAYS"
+}
+
+variable "efs_name" {
+  description = "indicate EFS name - Human readable"
+}

--- a/src/commcare_cloud/terraform/modules/r53-record-create-update/main.tf
+++ b/src/commcare_cloud/terraform/modules/r53-record-create-update/main.tf
@@ -6,7 +6,7 @@ data "aws_route53_zone" "existing-zone-name" {
 resource "aws_route53_record" "zone-record-create" {
   zone_id = "${data.aws_route53_zone.existing-zone-name.zone_id}"
   name    = "${var.route_names}"
-  type    = "${var.type}"
+  type    = "${var.record_type}"
   ttl     = "${var.ttl}"
   records = ["${var.records}"]
 }

--- a/src/commcare_cloud/terraform/modules/r53-record-create-update/variables.tf
+++ b/src/commcare_cloud/terraform/modules/r53-record-create-update/variables.tf
@@ -11,7 +11,7 @@ variable "private_zone" {
   default     = "true"
 }
 
-variable "type" {
+variable "record_type" {
   description = "Type of record in route53"
   type        = "string"
   default     = "CNAME"
@@ -25,4 +25,9 @@ variable "ttl" {
 variable "records" {
   description = "List of records"
   type        = "list"
+}
+
+variable "create_record" {
+  description = "Flag to enable/disable r53-private-zone-create record"
+  default     = "true"
 }


### PR DESCRIPTION
I am adding the "**_efs_file_system_**" terraform module to create an AWS EFS file system with access-point & mount targets. 
In the process of EFS creation in environments, I am also updating template, schema & resource files. 

Here, Based on provided availability-zones in the resource file(terraform.yml), we are creating EFS mount targets. 

About the EFS file system, access-point, mount-target & internal DNS map, we are providing options-based flags to create.

Example:     
    create: yes
    create_access: no
    create_mount: yes
    create_record: yes

Verified & Created EFS resource in Staging, India & Production environments.

updating file : commcare-cloud/src/commcare_cloud/ansible/requirements.yml 

reference: https://galaxy.ansible.com/cloudalchemy/node_exporter

ref: Due to limitations of galaxy.ansible.com we had to move role to https://galaxy.ansible.com/cloudalchemy/node_exporter and use _ instead of - in role name.