### PR TITLE
Enable django security middleware on swiss and india

### DIFF
--- a/environments/india/public.yml
+++ b/environments/india/public.yml
@@ -132,6 +132,11 @@ localsettings:
   INVOICE_PREFIX: India-
   INVOICE_STARTING_NUMBER: 5000
   J2ME_ADDRESS: "{{ J2ME_SITE_HOST }}"
+  LOCAL_MIDDLEWARE:
+    - 'django.middleware.security.SecurityMiddleware'
+  SECURE_HSTS_SECONDS: 300
+  SILENCED_SYSTEM_CHECKS:
+    - 'security.W008' # the ALB and nginx already redirect HTTP to HTTPS so safe to silence this warning
   PILLOWTOP_MACHINE_ID: indiacloud
   RATE_LIMIT_SUBMISSIONS: yes
   SES_CONFIGURATION_SET: india-email-events

--- a/environments/swiss/public.yml
+++ b/environments/swiss/public.yml
@@ -121,6 +121,11 @@ localsettings:
   J2ME_ADDRESS: ''
 #  KAFKA_HOST:
   #  PILLOWTOP_MACHINE_ID:
+  LOCAL_MIDDLEWARE:
+    - 'django.middleware.security.SecurityMiddleware'
+  SECURE_HSTS_SECONDS: 300
+  SILENCED_SYSTEM_CHECKS:
+    - 'security.W008' # the ALB and nginx already redirect HTTP to HTTPS so safe to silence this warning
   REDIS_DB: '0'
   REDIS_HOST: "localhost"
   REDIS_PORT: '6379'


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
These changes have [been on staging](https://github.com/dimagi/commcare-cloud/pull/4279) for awhile now and should be safe to roll out. Will start with India and Swiss and then rollout to Production.
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
India, Swiss