### PR TITLE
prepend PR with '- ' to make it more readable when copied

### DIFF
--- a/src/commcare_cloud/fab/utils.py
+++ b/src/commcare_cloud/fab/utils.py
@@ -347,7 +347,7 @@ class DeployDiff:
     def _print_prs_formatted(self, pr_list):
         for pr in pr_list:
             print(
-                cyan(pr['title']),
+                "- ", cyan(pr['title']),
                 yellow(pr['url']),
                 ", ".join(label for label in pr['labels']),
             )


### PR DESCRIPTION
This should make the changes more readable when they are copied into an email / slack / text doc