### PR TITLE
downsizing prod pg0-formplayer RDS instance 

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -361,7 +361,7 @@ rds_instances:
       maintenance_work_mem: 960MB
 
   - identifier: "pgformplayer0-production"
-    instance_type: "db.m5.8xlarge"
+    instance_type: "db.m5.4xlarge"
     storage: 10000
     multi_az: true
     engine_version: 9.6.15


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
production.

Downsizing pg0-formplayer RDS instance from m5.8xlarge to m5.4xlarge. 
We have separated formplayer db from pg0-main RDS instance and also routed formplayer requests to new instance.  