### PR TITLE
Stop running tests on Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 ---
 language: python
 python:
-  - "2.7"
   - "3.6"
 os: linux
 dist: bionic


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Python 2 is no longer supported on commcare-cloud.

I've checked for specific python 2 tests by searching for `six.PY[23]`, `sys.version_info` and `platform.python_version()`. 

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None