### PR TITLE
Enable detailed tagging on india and swiss

### DIFF
--- a/environments/india/public.yml
+++ b/environments/india/public.yml
@@ -25,6 +25,10 @@ aws_region: 'ap-south-1'
 
 formplayer_sensitive_data_logging: true
 formplayer_enable_cache: true
+formplayer_detailed_tagging_domains: "{{ detailed_tagging_domains }}"
+formplayer_detailed_tags:
+    - form_name
+    - module_name
 
 nofile_limit: 65536
 

--- a/environments/swiss/public.yml
+++ b/environments/swiss/public.yml
@@ -33,6 +33,11 @@ couchdb_snapshot_bucket: commcare-almanach-backup
 
 aws_versioning_enabled: false
 
+formplayer_detailed_tagging_domains: "{{ detailed_tagging_domains }}"
+formplayer_detailed_tags:
+    - form_name
+    - module_name
+
 KSPLICE_ACTIVE: yes
 
 nameservers:


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
I should have done this sooner, but this will limit the values for `form_name` and `module_name` to be "_other" except for domains specified, which right now is none. Since this feature is specifically for USH I don't expect it to be used on these environments, but it is there if needed and will reduce Datadog billing in the meantime. 
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Swiss, India