### PR TITLE
moving main, ucr and synclogs routing via NLB

### DIFF
--- a/environments/staging/aws-resources.yml
+++ b/environments/staging/aws-resources.yml
@@ -42,8 +42,11 @@ pgbouncer0-staging: 10.201.40.72
 pgbouncer0-staging.instance_id: i-0315ba6f2f8ba45f5
 pgformplayer0-staging: pgformplayer0-staging.czkracjslrn2.us-east-1.rds.amazonaws.com
 pgformplayer_nlb-staging: pgformplayer-nlb-staging-98b68467f6f5717b.elb.us-east-1.amazonaws.com
+pgmain_nlb-staging: pgmain-nlb-staging-fe77ab2d143eedbb.elb.us-east-1.amazonaws.com
 pgproxy2-staging: 10.201.40.16
 pgproxy2-staging.instance_id: i-0638ff6218ed9f753
+pgsynclogs_nlb-staging: pgsynclogs-nlb-staging-1102365451f68242.elb.us-east-1.amazonaws.com
+pgucr_nlb-staging: pgucr-nlb-staging-b32586fcc9999b2d.elb.us-east-1.amazonaws.com
 pillow3-staging: 10.201.10.68
 pillow3-staging.instance_id: i-0ef555fec7fe64804
 proxy2-staging: 10.201.10.72

--- a/environments/staging/inventory.ini
+++ b/environments/staging/inventory.ini
@@ -203,6 +203,9 @@ control1
 rds_pg0
 rds_pgformplayer0
 pgformplayer_nlb
+pgmain_nlb
+pgucr_nlb
+pgsynclogs_nlb
 
 
 [django_manage:children]

--- a/environments/staging/inventory.ini
+++ b/environments/staging/inventory.ini
@@ -53,11 +53,20 @@ rds_pgformplayer0
 
 [pgformplayer_nlb]
 pgformplayer-nlb-staging-98b68467f6f5717b.elb.us-east-1.amazonaws.com
+[pgmain_nlb]
+pgmain-nlb-staging-fe77ab2d143eedbb.elb.us-east-1.amazonaws.com
+[pgucr_nlb]
+pgucr-nlb-staging-b32586fcc9999b2d.elb.us-east-1.amazonaws.com
+[pgsynclogs_nlb]
+pgsynclogs-nlb-staging-1102365451f68242.elb.us-east-1.amazonaws.com
 
 [postgresql:children]
 pgproxy2
 remote_postgresql
 pgformplayer_nlb
+pgmain_nlb
+pgucr_nlb
+pgsynclogs_nlb
 
 [pgbouncer:children]
 pgbouncer0
@@ -88,12 +97,6 @@ pgbouncer0
 
 [couch17]
 10.201.42.185 hostname=couch17-staging ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-0baac7bd48f3c963d datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws
-
-[couch10]
-10.201.40.248 hostname=couch10-staging ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-0fa01675d113d6c6c datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws
-
-[couch11]
-10.201.40.133 hostname=couch11-staging ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-0867dcf5a63d0a6b7 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws
 
 [couchdb2:children]
 couch6

--- a/environments/staging/inventory.ini.j2
+++ b/environments/staging/inventory.ini.j2
@@ -41,11 +41,17 @@ rds_pg0
 rds_pgformplayer0
 
 {{ __pgformplayer_nlb__ }}
+{{ __pgmain_nlb__ }}
+{{ __pgucr_nlb__ }}
+{{ __pgsynclogs_nlb__ }}
 
 [postgresql:children]
 pgproxy2
 remote_postgresql
 pgformplayer_nlb
+pgmain_nlb
+pgucr_nlb
+pgsynclogs_nlb
 
 [pgbouncer:children]
 pgbouncer0

--- a/environments/staging/inventory.ini.j2
+++ b/environments/staging/inventory.ini.j2
@@ -169,6 +169,9 @@ control1
 rds_pg0
 rds_pgformplayer0
 pgformplayer_nlb
+pgmain_nlb
+pgucr_nlb
+pgsynclogs_nlb
 
 
 [django_manage:children]

--- a/environments/staging/postgresql.yml
+++ b/environments/staging/postgresql.yml
@@ -24,13 +24,19 @@ pg_repack:
 
 dbs:
   main:
-    pgbouncer_host: pgproxy2
+    pgbouncer_endpoint: pgmain_nlb
+    pgbouncer_hosts:
+      - pgproxy2
     query_stats: True
   ucr:
-    pgbouncer_host: pgproxy2
+    pgbouncer_endpoint: pgucr_nlb
+    pgbouncer_hosts:
+      - pgproxy2
     query_stats: True
   synclogs:
-    pgbouncer_host: pgproxy2
+    pgbouncer_endpoint: pgsynclogs_nlb
+    pgbouncer_hosts:
+      - pgproxy2
   formplayer:
     host: rds_pgformplayer0
     pgbouncer_endpoint: pgformplayer_nlb

--- a/environments/staging/terraform.yml
+++ b/environments/staging/terraform.yml
@@ -219,30 +219,6 @@ servers:
     group: "couchdb2"
     os: ubuntu_pro_bionic
 
-  - server_name: "couch10-staging"
-    server_instance_type: "t3.large"
-    network_tier: "db-private"
-    az: "a"
-    volume_size: 30
-    volume_encrypted: yes
-    block_device:
-      volume_size: 80
-      encrypted: true
-    group: "couchdb2"
-    os: ubuntu_pro_bionic
-
-  - server_name: "couch11-staging"
-    server_instance_type: "t3.large"
-    network_tier: "db-private"
-    az: "a"
-    volume_size: 30
-    volume_encrypted: yes
-    block_device:
-      volume_size: 80
-      encrypted: true
-    group: "couchdb2"
-    os: ubuntu_pro_bionic
-
   - server_name: "rabbit2-staging"
     server_instance_type: "t3.large"
     network_tier: "app-private"
@@ -330,7 +306,6 @@ servers:
     group: "redis"
     os: ubuntu_pro_bionic
 
-
 proxy_servers:
   - server_name: "proxy2-staging"
     server_instance_type: "t3.medium"
@@ -397,6 +372,15 @@ pgbouncer_nlbs:
   - name: "pgformplayer_nlb-staging"
     targets:
       - pgbouncer0-staging
+      - pgproxy2-staging
+  - name: "pgmain_nlb-staging"
+    targets:
+      - pgproxy2-staging
+  - name: "pgucr_nlb-staging"
+    targets:
+      - pgproxy2-staging
+  - name: "pgsynclogs_nlb-staging"
+    targets:
       - pgproxy2-staging
 
 elasticache:


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-11923

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Staging. 

updated pgbouncer URL to routed Via a new Network Load Balancer. This helps in handling high availability and routing requests to multiple servers. 