### PR TITLE
Auditcare db and routing setting for staging

### DIFF
--- a/environments/staging/postgresql.yml
+++ b/environments/staging/postgresql.yml
@@ -37,6 +37,8 @@ dbs:
     pgbouncer_hosts:
       - pgproxy2
       - pgbouncer0
+  auditcare:
+    pgbouncer_host: pgproxy2
   form_processing:
     proxy:
       host: pgproxy2

--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -141,6 +141,7 @@ localsettings:
   J2ME_ADDRESS: "{{ J2ME_SITE_HOST }}"
   LOCAL_APPS:
     - {name: 'ddtrace.contrib.django', host: webworkers}
+  LOCAL_CUSTOM_DB_ROUTING: "{'auditcare': 'auditcare'}"
   LOCAL_MIDDLEWARE:
     - 'django.middleware.security.SecurityMiddleware'
   SECURE_HSTS_SECONDS: 300

--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -141,7 +141,8 @@ localsettings:
   J2ME_ADDRESS: "{{ J2ME_SITE_HOST }}"
   LOCAL_APPS:
     - {name: 'ddtrace.contrib.django', host: webworkers}
-  LOCAL_CUSTOM_DB_ROUTING: "{'auditcare': 'auditcare'}"
+  LOCAL_CUSTOM_DB_ROUTING:
+    auditcare: auditcare
   LOCAL_MIDDLEWARE:
     - 'django.middleware.security.SecurityMiddleware'
   SECURE_HSTS_SECONDS: 300

--- a/src/commcare_cloud/environment/constants.py
+++ b/src/commcare_cloud/environment/constants.py
@@ -8,6 +8,7 @@ class _Constants(jsonobject.JsonObject):
     formplayer_db_name = jsonobject.StringProperty(default='formplayer')
     ucr_db_name = jsonobject.StringProperty(default='commcarehq_ucr')
     synclogs_db_name = jsonobject.StringProperty(default='commcarehq_synclogs')
+    auditcare_db_name = jsonobject.StringProperty(default='commcarehq_auditcare')
     form_processing_proxy_db_name = jsonobject.StringProperty(default='commcarehq_proxy')
     form_processing_proxy_standby_db_name = jsonobject.StringProperty(default='commcarehq_proxy_standby')
 

--- a/src/commcare_cloud/environment/schemas/postgresql.py
+++ b/src/commcare_cloud/environment/schemas/postgresql.py
@@ -232,7 +232,11 @@ class PostgresqlConfig(jsonobject.JsonObject):
             self.dbs.main, self.dbs.synclogs,
         ] + (
             self.dbs.form_processing.get_db_list() if self.dbs.form_processing else []
-        ) + [self.dbs.ucr, self.dbs.formplayer] + self.dbs.custom + self.dbs.standby if _f]
+        ) + [
+            self.dbs.ucr,
+            self.dbs.formplayer,
+            self.dbs.auditcare,
+        ] + self.dbs.custom + self.dbs.standby if _f]
 
     def _check_reporting_databases(self):
         referenced_django_aliases = set()
@@ -294,6 +298,7 @@ class SmartDBConfig(jsonobject.JsonObject):
     ucr = jsonobject.ObjectProperty(lambda: UcrDBOptions, required=True)
     synclogs = jsonobject.ObjectProperty(lambda: SynclogsDBOptions, required=False)
     form_processing = jsonobject.ObjectProperty(lambda: FormProcessingConfig, required=False)
+    auditcare = jsonobject.ObjectProperty(lambda: AuditcareDBOptions, required=False, default=None)
 
     custom = jsonobject.ListProperty(lambda: CustomDBOptions)
     standby = jsonobject.ListProperty(lambda: StandbyDBOptions)
@@ -355,6 +360,11 @@ class UcrDBOptions(DBOptions):
 class SynclogsDBOptions(DBOptions):
     name = constants.synclogs_db_name
     django_alias = 'synclogs'
+
+
+class AuditcareDBOptions(DBOptions):
+    name = constants.auditcare_db_name
+    django_alias = 'auditcare'
 
 
 class FormProcessingConfig(jsonobject.JsonObject):

--- a/tests/test_envs/2018-04-04-development-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-development-snapshot/.generated.yml
@@ -45,6 +45,7 @@ postgresql_dbs:
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
+  auditcare: null
   by_pgbouncer_host:
     192.168.33.16:
     - *id001

--- a/tests/test_envs/2018-04-04-development-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-development-snapshot/.generated.yml
@@ -11,7 +11,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 192.168.33.16
     pgbouncer_hosts:
-      - 192.168.33.16
+    - 192.168.33.16
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -26,7 +26,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 192.168.33.16
     pgbouncer_hosts:
-      - 192.168.33.16
+    - 192.168.33.16
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -41,7 +41,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 192.168.33.16
     pgbouncer_hosts:
-      - 192.168.33.16
+    - 192.168.33.16
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -63,7 +63,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 192.168.33.16
     pgbouncer_hosts:
-      - 192.168.33.16
+    - 192.168.33.16
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -78,7 +78,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 192.168.33.16
     pgbouncer_hosts:
-      - 192.168.33.16
+    - 192.168.33.16
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -95,7 +95,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 192.168.33.16
     pgbouncer_hosts:
-      - 192.168.33.16
+    - 192.168.33.16
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'

--- a/tests/test_envs/2018-04-04-enikshay-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-enikshay-snapshot/.generated.yml
@@ -255,6 +255,7 @@ postgresql_dbs:
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
+  auditcare: null
   by_pgbouncer_host:
     172.25.3.5:
     - *id001

--- a/tests/test_envs/2018-04-04-enikshay-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-enikshay-snapshot/.generated.yml
@@ -11,7 +11,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
-      - 172.25.3.5
+    - 172.25.3.5
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -26,7 +26,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
-      - 172.25.3.5
+    - 172.25.3.5
     port: 6432
     query_stats: false
     shards:
@@ -44,7 +44,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
-      - 172.25.3.5
+    - 172.25.3.5
     port: 6432
     query_stats: false
     shards:
@@ -62,7 +62,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
-      - 172.25.3.5
+    - 172.25.3.5
     port: 6432
     query_stats: false
     shards:
@@ -80,7 +80,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
-      - 172.25.3.5
+    - 172.25.3.5
     port: 6432
     query_stats: false
     shards:
@@ -98,7 +98,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
-      - 172.25.3.5
+    - 172.25.3.5
     port: 6432
     query_stats: false
     shards:
@@ -116,7 +116,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
-      - 172.25.3.5
+    - 172.25.3.5
     port: 6432
     query_stats: false
     shards:
@@ -134,7 +134,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
-      - 172.25.3.5
+    - 172.25.3.5
     port: 6432
     query_stats: false
     shards:
@@ -152,7 +152,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
-      - 172.25.3.5
+    - 172.25.3.5
     port: 6432
     query_stats: false
     shards:
@@ -170,7 +170,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
-      - 172.25.3.5
+    - 172.25.3.5
     port: 6432
     query_stats: false
     shards:
@@ -188,7 +188,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
-      - 172.25.3.5
+    - 172.25.3.5
     port: 6432
     query_stats: false
     shards:
@@ -206,7 +206,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
-      - 172.25.3.5
+    - 172.25.3.5
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -221,7 +221,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
-      - 172.25.3.5
+    - 172.25.3.5
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -236,7 +236,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
-      - 172.25.3.5
+    - 172.25.3.5
     port: 6432
     query_stats: true
     user: '{{ postgres_users.commcare.username }}'
@@ -251,7 +251,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
-      - 172.25.3.5
+    - 172.25.3.5
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -286,7 +286,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: 172.25.3.5
         pgbouncer_hosts:
-          - 172.25.3.5
+        - 172.25.3.5
         port: 6432
         query_stats: false
         shards:
@@ -304,7 +304,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: 172.25.3.5
         pgbouncer_hosts:
-          - 172.25.3.5
+        - 172.25.3.5
         port: 6432
         query_stats: false
         shards:
@@ -322,7 +322,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: 172.25.3.5
         pgbouncer_hosts:
-          - 172.25.3.5
+        - 172.25.3.5
         port: 6432
         query_stats: false
         shards:
@@ -340,7 +340,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: 172.25.3.5
         pgbouncer_hosts:
-          - 172.25.3.5
+        - 172.25.3.5
         port: 6432
         query_stats: false
         shards:
@@ -358,7 +358,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: 172.25.3.5
         pgbouncer_hosts:
-          - 172.25.3.5
+        - 172.25.3.5
         port: 6432
         query_stats: false
         shards:
@@ -376,7 +376,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: 172.25.3.5
         pgbouncer_hosts:
-          - 172.25.3.5
+        - 172.25.3.5
         port: 6432
         query_stats: false
         shards:
@@ -394,7 +394,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: 172.25.3.5
         pgbouncer_hosts:
-          - 172.25.3.5
+        - 172.25.3.5
         port: 6432
         query_stats: false
         shards:
@@ -412,7 +412,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: 172.25.3.5
         pgbouncer_hosts:
-          - 172.25.3.5
+        - 172.25.3.5
         port: 6432
         query_stats: false
         shards:
@@ -430,7 +430,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: 172.25.3.5
         pgbouncer_hosts:
-          - 172.25.3.5
+        - 172.25.3.5
         port: 6432
         query_stats: false
         shards:
@@ -448,7 +448,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: 172.25.3.5
         pgbouncer_hosts:
-          - 172.25.3.5
+        - 172.25.3.5
         port: 6432
         query_stats: false
         shards:
@@ -466,7 +466,7 @@ postgresql_dbs:
       pg_config: []
       pgbouncer_endpoint: 172.25.3.5
       pgbouncer_hosts:
-        - 172.25.3.5
+      - 172.25.3.5
       port: 6432
       query_stats: false
       user: '{{ postgres_users.commcare.username }}'
@@ -495,7 +495,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
-      - 172.25.3.5
+    - 172.25.3.5
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -510,7 +510,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
-      - 172.25.3.5
+    - 172.25.3.5
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -526,7 +526,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
-      - 172.25.3.5
+    - 172.25.3.5
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -541,7 +541,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
-      - 172.25.3.5
+    - 172.25.3.5
     port: 6432
     query_stats: true
     user: '{{ postgres_users.commcare.username }}'

--- a/tests/test_envs/2018-04-04-icds-new-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-icds-new-snapshot/.generated.yml
@@ -286,6 +286,7 @@ postgresql_dbs:
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
+  auditcare: null
   by_pgbouncer_host:
     10.247.164.20: &id007
     - *id001

--- a/tests/test_envs/2018-04-04-icds-new-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-icds-new-snapshot/.generated.yml
@@ -11,7 +11,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.247.164.26
     pgbouncer_hosts:
-      - 10.247.164.26
+    - 10.247.164.26
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -26,15 +26,15 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.247.164.25
     pgbouncer_hosts:
-      - 10.247.164.25
+    - 10.247.164.25
     port: 6432
     query_stats: true
     user: '{{ postgres_users.commcare.username }}'
-  - create: false
+  - acceptable_replication_delay: 30
+    create: false
     django_alias: icds-ucr-standby1
     django_migrate: false
     host: 10.247.164.24
-    acceptable_replication_delay: 30
     master: icds-ucr
     name: commcarehq_icds_aggregatedata
     options: {}
@@ -42,7 +42,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.247.164.24
     pgbouncer_hosts:
-      - 10.247.164.24
+    - 10.247.164.24
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -57,7 +57,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.247.164.66
     pgbouncer_hosts:
-      - 10.247.164.66
+    - 10.247.164.66
     port: 6432
     query_stats: false
     shards:
@@ -75,7 +75,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.247.164.64
     pgbouncer_hosts:
-      - 10.247.164.64
+    - 10.247.164.64
     port: 6432
     query_stats: false
     shards:
@@ -93,7 +93,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.247.164.66
     pgbouncer_hosts:
-      - 10.247.164.66
+    - 10.247.164.66
     port: 6432
     query_stats: false
     shards:
@@ -111,7 +111,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.247.164.21
     pgbouncer_hosts:
-      - 10.247.164.21
+    - 10.247.164.21
     port: 6432
     query_stats: false
     shards:
@@ -129,7 +129,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.247.164.21
     pgbouncer_hosts:
-      - 10.247.164.21
+    - 10.247.164.21
     port: 6432
     query_stats: false
     shards:
@@ -147,7 +147,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.247.164.21
     pgbouncer_hosts:
-      - 10.247.164.21
+    - 10.247.164.21
     port: 6432
     query_stats: false
     shards:
@@ -165,7 +165,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.247.164.20
     pgbouncer_hosts:
-      - 10.247.164.20
+    - 10.247.164.20
     port: 6432
     query_stats: false
     shards:
@@ -183,7 +183,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.247.164.20
     pgbouncer_hosts:
-      - 10.247.164.20
+    - 10.247.164.20
     port: 6432
     query_stats: false
     shards:
@@ -201,7 +201,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.247.164.20
     pgbouncer_hosts:
-      - 10.247.164.20
+    - 10.247.164.20
     port: 6432
     query_stats: false
     shards:
@@ -219,7 +219,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.247.164.64
     pgbouncer_hosts:
-      - 10.247.164.64
+    - 10.247.164.64
     port: 6432
     query_stats: false
     shards:
@@ -237,7 +237,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.247.164.56
     pgbouncer_hosts:
-      - 10.247.164.56
+    - 10.247.164.56
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -252,7 +252,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.247.164.70
     pgbouncer_hosts:
-      - 10.247.164.70
+    - 10.247.164.70
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -267,7 +267,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.247.164.25
     pgbouncer_hosts:
-      - 10.247.164.25
+    - 10.247.164.25
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -282,7 +282,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.247.164.25
     pgbouncer_hosts:
-      - 10.247.164.25
+    - 10.247.164.25
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -331,7 +331,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.247.164.25
     pgbouncer_hosts:
-      - 10.247.164.25
+    - 10.247.164.25
     port: 6432
     query_stats: true
     user: '{{ postgres_users.commcare.username }}'
@@ -348,7 +348,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: 10.247.164.66
         pgbouncer_hosts:
-          - 10.247.164.66
+        - 10.247.164.66
         port: 6432
         query_stats: false
         shards:
@@ -366,7 +366,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: 10.247.164.64
         pgbouncer_hosts:
-          - 10.247.164.64
+        - 10.247.164.64
         port: 6432
         query_stats: false
         shards:
@@ -384,7 +384,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: 10.247.164.66
         pgbouncer_hosts:
-          - 10.247.164.66
+        - 10.247.164.66
         port: 6432
         query_stats: false
         shards:
@@ -402,7 +402,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: 10.247.164.21
         pgbouncer_hosts:
-          - 10.247.164.21
+        - 10.247.164.21
         port: 6432
         query_stats: false
         shards:
@@ -420,7 +420,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: 10.247.164.21
         pgbouncer_hosts:
-          - 10.247.164.21
+        - 10.247.164.21
         port: 6432
         query_stats: false
         shards:
@@ -438,7 +438,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: 10.247.164.21
         pgbouncer_hosts:
-          - 10.247.164.21
+        - 10.247.164.21
         port: 6432
         query_stats: false
         shards:
@@ -456,7 +456,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: 10.247.164.20
         pgbouncer_hosts:
-          - 10.247.164.20
+        - 10.247.164.20
         port: 6432
         query_stats: false
         shards:
@@ -474,7 +474,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: 10.247.164.20
         pgbouncer_hosts:
-          - 10.247.164.20
+        - 10.247.164.20
         port: 6432
         query_stats: false
         shards:
@@ -492,7 +492,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: 10.247.164.20
         pgbouncer_hosts:
-          - 10.247.164.20
+        - 10.247.164.20
         port: 6432
         query_stats: false
         shards:
@@ -510,7 +510,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: 10.247.164.64
         pgbouncer_hosts:
-          - 10.247.164.64
+        - 10.247.164.64
         port: 6432
         query_stats: false
         shards:
@@ -528,7 +528,7 @@ postgresql_dbs:
       pg_config: []
       pgbouncer_endpoint: 10.247.164.56
       pgbouncer_hosts:
-        - 10.247.164.56
+      - 10.247.164.56
       port: 6432
       query_stats: false
       user: '{{ postgres_users.commcare.username }}'
@@ -557,7 +557,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.247.164.25
     pgbouncer_hosts:
-      - 10.247.164.25
+    - 10.247.164.25
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -572,16 +572,16 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.247.164.26
     pgbouncer_hosts:
-      - 10.247.164.26
+    - 10.247.164.26
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
   standby:
-  - create: false
+  - acceptable_replication_delay: 30
+    create: false
     django_alias: icds-ucr-standby1
     django_migrate: false
     host: 10.247.164.24
-    acceptable_replication_delay: 30
     master: icds-ucr
     name: commcarehq_icds_aggregatedata
     options: {}
@@ -589,7 +589,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.247.164.24
     pgbouncer_hosts:
-      - 10.247.164.24
+    - 10.247.164.24
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -604,7 +604,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.247.164.70
     pgbouncer_hosts:
-      - 10.247.164.70
+    - 10.247.164.70
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -619,7 +619,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.247.164.25
     pgbouncer_hosts:
-      - 10.247.164.25
+    - 10.247.164.25
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'

--- a/tests/test_envs/2018-04-04-pna-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-pna-snapshot/.generated.yml
@@ -11,7 +11,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
-      - 196.207.230.171
+    - 196.207.230.171
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -26,7 +26,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
-      - 196.207.230.171
+    - 196.207.230.171
     port: 6432
     query_stats: false
     shards:
@@ -44,7 +44,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
-      - 196.207.230.171
+    - 196.207.230.171
     port: 6432
     query_stats: false
     shards:
@@ -62,7 +62,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
-      - 196.207.230.171
+    - 196.207.230.171
     port: 6432
     query_stats: false
     shards:
@@ -80,7 +80,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
-      - 196.207.230.171
+    - 196.207.230.171
     port: 6432
     query_stats: false
     shards:
@@ -98,7 +98,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
-      - 196.207.230.171
+    - 196.207.230.171
     port: 6432
     query_stats: false
     shards:
@@ -116,7 +116,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
-      - 196.207.230.171
+    - 196.207.230.171
     port: 6432
     query_stats: false
     shards:
@@ -134,7 +134,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
-      - 196.207.230.171
+    - 196.207.230.171
     port: 6432
     query_stats: false
     shards:
@@ -152,7 +152,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
-      - 196.207.230.171
+    - 196.207.230.171
     port: 6432
     query_stats: false
     shards:
@@ -170,7 +170,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
-      - 196.207.230.171
+    - 196.207.230.171
     port: 6432
     query_stats: false
     shards:
@@ -188,7 +188,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
-      - 196.207.230.171
+    - 196.207.230.171
     port: 6432
     query_stats: false
     shards:
@@ -206,7 +206,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
-      - 196.207.230.171
+    - 196.207.230.171
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -221,7 +221,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
-      - 196.207.230.171
+    - 196.207.230.171
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -236,7 +236,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
-      - 196.207.230.171
+    - 196.207.230.171
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -251,7 +251,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
-      - 196.207.230.171
+    - 196.207.230.171
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -286,7 +286,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: 196.207.230.171
         pgbouncer_hosts:
-          - 196.207.230.171
+        - 196.207.230.171
         port: 6432
         query_stats: false
         shards:
@@ -304,7 +304,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: 196.207.230.171
         pgbouncer_hosts:
-          - 196.207.230.171
+        - 196.207.230.171
         port: 6432
         query_stats: false
         shards:
@@ -322,7 +322,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: 196.207.230.171
         pgbouncer_hosts:
-          - 196.207.230.171
+        - 196.207.230.171
         port: 6432
         query_stats: false
         shards:
@@ -340,7 +340,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: 196.207.230.171
         pgbouncer_hosts:
-          - 196.207.230.171
+        - 196.207.230.171
         port: 6432
         query_stats: false
         shards:
@@ -358,7 +358,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: 196.207.230.171
         pgbouncer_hosts:
-          - 196.207.230.171
+        - 196.207.230.171
         port: 6432
         query_stats: false
         shards:
@@ -376,7 +376,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: 196.207.230.171
         pgbouncer_hosts:
-          - 196.207.230.171
+        - 196.207.230.171
         port: 6432
         query_stats: false
         shards:
@@ -394,7 +394,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: 196.207.230.171
         pgbouncer_hosts:
-          - 196.207.230.171
+        - 196.207.230.171
         port: 6432
         query_stats: false
         shards:
@@ -412,7 +412,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: 196.207.230.171
         pgbouncer_hosts:
-          - 196.207.230.171
+        - 196.207.230.171
         port: 6432
         query_stats: false
         shards:
@@ -430,7 +430,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: 196.207.230.171
         pgbouncer_hosts:
-          - 196.207.230.171
+        - 196.207.230.171
         port: 6432
         query_stats: false
         shards:
@@ -448,7 +448,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: 196.207.230.171
         pgbouncer_hosts:
-          - 196.207.230.171
+        - 196.207.230.171
         port: 6432
         query_stats: false
         shards:
@@ -466,7 +466,7 @@ postgresql_dbs:
       pg_config: []
       pgbouncer_endpoint: 196.207.230.171
       pgbouncer_hosts:
-        - 196.207.230.171
+      - 196.207.230.171
       port: 6432
       query_stats: false
       user: '{{ postgres_users.commcare.username }}'
@@ -495,7 +495,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
-      - 196.207.230.171
+    - 196.207.230.171
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -510,7 +510,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
-      - 196.207.230.171
+    - 196.207.230.171
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -526,7 +526,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
-      - 196.207.230.171
+    - 196.207.230.171
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -541,7 +541,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
-      - 196.207.230.171
+    - 196.207.230.171
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'

--- a/tests/test_envs/2018-04-04-pna-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-pna-snapshot/.generated.yml
@@ -255,6 +255,7 @@ postgresql_dbs:
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
+  auditcare: null
   by_pgbouncer_host:
     196.207.230.171:
     - *id001

--- a/tests/test_envs/2018-04-04-production-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-production-snapshot/.generated.yml
@@ -11,7 +11,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: hqdb0.internal-va.commcarehq.org
     pgbouncer_hosts:
-      - hqdb0.internal-va.commcarehq.org
+    - hqdb0.internal-va.commcarehq.org
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -26,7 +26,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: hqdb1.internal-va.commcarehq.org
     pgbouncer_hosts:
-      - hqdb1.internal-va.commcarehq.org
+    - hqdb1.internal-va.commcarehq.org
     port: 6432
     query_stats: false
     shards:
@@ -44,7 +44,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: hqdb1.internal-va.commcarehq.org
     pgbouncer_hosts:
-      - hqdb1.internal-va.commcarehq.org
+    - hqdb1.internal-va.commcarehq.org
     port: 6432
     query_stats: false
     shards:
@@ -62,7 +62,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: hqdb2.internal-va.commcarehq.org
     pgbouncer_hosts:
-      - hqdb2.internal-va.commcarehq.org
+    - hqdb2.internal-va.commcarehq.org
     port: 6432
     query_stats: false
     shards:
@@ -80,7 +80,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: hqdb2.internal-va.commcarehq.org
     pgbouncer_hosts:
-      - hqdb2.internal-va.commcarehq.org
+    - hqdb2.internal-va.commcarehq.org
     port: 6432
     query_stats: false
     shards:
@@ -98,7 +98,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: hqdb2.internal-va.commcarehq.org
     pgbouncer_hosts:
-      - hqdb2.internal-va.commcarehq.org
+    - hqdb2.internal-va.commcarehq.org
     port: 6432
     query_stats: false
     shards:
@@ -116,7 +116,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: hqdb1.internal-va.commcarehq.org
     pgbouncer_hosts:
-      - hqdb1.internal-va.commcarehq.org
+    - hqdb1.internal-va.commcarehq.org
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -131,7 +131,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: pgsynclog.internal-va.commcarehq.org
     pgbouncer_hosts:
-      - pgsynclog.internal-va.commcarehq.org
+    - pgsynclog.internal-va.commcarehq.org
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -146,7 +146,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: hqdb0.internal-va.commcarehq.org
     pgbouncer_hosts:
-      - hqdb0.internal-va.commcarehq.org
+    - hqdb0.internal-va.commcarehq.org
     port: 6432
     query_stats: true
     user: '{{ postgres_users.commcare.username }}'
@@ -161,7 +161,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: hqdb0.internal-va.commcarehq.org
     pgbouncer_hosts:
-      - hqdb0.internal-va.commcarehq.org
+    - hqdb0.internal-va.commcarehq.org
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -194,7 +194,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: hqdb1.internal-va.commcarehq.org
         pgbouncer_hosts:
-          - hqdb1.internal-va.commcarehq.org
+        - hqdb1.internal-va.commcarehq.org
         port: 6432
         query_stats: false
         shards:
@@ -212,7 +212,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: hqdb1.internal-va.commcarehq.org
         pgbouncer_hosts:
-          - hqdb1.internal-va.commcarehq.org
+        - hqdb1.internal-va.commcarehq.org
         port: 6432
         query_stats: false
         shards:
@@ -230,7 +230,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: hqdb2.internal-va.commcarehq.org
         pgbouncer_hosts:
-          - hqdb2.internal-va.commcarehq.org
+        - hqdb2.internal-va.commcarehq.org
         port: 6432
         query_stats: false
         shards:
@@ -248,7 +248,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: hqdb2.internal-va.commcarehq.org
         pgbouncer_hosts:
-          - hqdb2.internal-va.commcarehq.org
+        - hqdb2.internal-va.commcarehq.org
         port: 6432
         query_stats: false
         shards:
@@ -266,7 +266,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: hqdb2.internal-va.commcarehq.org
         pgbouncer_hosts:
-          - hqdb2.internal-va.commcarehq.org
+        - hqdb2.internal-va.commcarehq.org
         port: 6432
         query_stats: false
         shards:
@@ -284,7 +284,7 @@ postgresql_dbs:
       pg_config: []
       pgbouncer_endpoint: hqdb1.internal-va.commcarehq.org
       pgbouncer_hosts:
-        - hqdb1.internal-va.commcarehq.org
+      - hqdb1.internal-va.commcarehq.org
       port: 6432
       query_stats: false
       user: '{{ postgres_users.commcare.username }}'
@@ -313,7 +313,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: hqdb0.internal-va.commcarehq.org
     pgbouncer_hosts:
-      - hqdb0.internal-va.commcarehq.org
+    - hqdb0.internal-va.commcarehq.org
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -328,7 +328,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: hqdb0.internal-va.commcarehq.org
     pgbouncer_hosts:
-      - hqdb0.internal-va.commcarehq.org
+    - hqdb0.internal-va.commcarehq.org
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -344,7 +344,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: pgsynclog.internal-va.commcarehq.org
     pgbouncer_hosts:
-      - pgsynclog.internal-va.commcarehq.org
+    - pgsynclog.internal-va.commcarehq.org
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -359,7 +359,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: hqdb0.internal-va.commcarehq.org
     pgbouncer_hosts:
-      - hqdb0.internal-va.commcarehq.org
+    - hqdb0.internal-va.commcarehq.org
     port: 6432
     query_stats: true
     user: '{{ postgres_users.commcare.username }}'

--- a/tests/test_envs/2018-04-04-production-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-production-snapshot/.generated.yml
@@ -15,7 +15,22 @@ postgresql_dbs:
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
-  - &id004
+  - &id002
+    create: true
+    django_alias: auditcare
+    django_migrate: true
+    host: hqdb0.internal-va.commcarehq.org
+    name: commcarehq_auditcare
+    options: {}
+    password: '{{ postgres_users.commcare.password }}'
+    pg_config: []
+    pgbouncer_endpoint: hqdb0.internal-va.commcarehq.org
+    pgbouncer_hosts:
+    - hqdb0.internal-va.commcarehq.org
+    port: 6432
+    query_stats: false
+    user: '{{ postgres_users.commcare.username }}'
+  - &id005
     create: true
     django_alias: p1
     django_migrate: true
@@ -33,7 +48,7 @@ postgresql_dbs:
     - 0
     - 204
     user: '{{ postgres_users.commcare.username }}'
-  - &id005
+  - &id006
     create: true
     django_alias: p2
     django_migrate: true
@@ -51,7 +66,7 @@ postgresql_dbs:
     - 205
     - 409
     user: '{{ postgres_users.commcare.username }}'
-  - &id007
+  - &id008
     create: true
     django_alias: p3
     django_migrate: true
@@ -69,7 +84,7 @@ postgresql_dbs:
     - 410
     - 614
     user: '{{ postgres_users.commcare.username }}'
-  - &id008
+  - &id009
     create: true
     django_alias: p4
     django_migrate: true
@@ -87,7 +102,7 @@ postgresql_dbs:
     - 615
     - 819
     user: '{{ postgres_users.commcare.username }}'
-  - &id009
+  - &id010
     create: true
     django_alias: p5
     django_migrate: true
@@ -105,7 +120,7 @@ postgresql_dbs:
     - 820
     - 1023
     user: '{{ postgres_users.commcare.username }}'
-  - &id006
+  - &id007
     create: true
     django_alias: proxy
     django_migrate: true
@@ -120,7 +135,7 @@ postgresql_dbs:
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
-  - &id010
+  - &id011
     create: true
     django_alias: synclogs
     django_migrate: true
@@ -135,7 +150,7 @@ postgresql_dbs:
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
-  - &id002
+  - &id003
     create: true
     django_alias: ucr
     django_migrate: false
@@ -150,7 +165,7 @@ postgresql_dbs:
     port: 6432
     query_stats: true
     user: '{{ postgres_users.commcare.username }}'
-  - &id003
+  - &id004
     create: true
     django_alias: null
     django_migrate: true
@@ -165,21 +180,37 @@ postgresql_dbs:
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
+  auditcare:
+    create: true
+    django_alias: auditcare
+    django_migrate: true
+    host: hqdb0.internal-va.commcarehq.org
+    name: commcarehq_auditcare
+    options: {}
+    password: '{{ postgres_users.commcare.password }}'
+    pg_config: []
+    pgbouncer_endpoint: hqdb0.internal-va.commcarehq.org
+    pgbouncer_hosts:
+    - hqdb0.internal-va.commcarehq.org
+    port: 6432
+    query_stats: false
+    user: '{{ postgres_users.commcare.username }}'
   by_pgbouncer_host:
     hqdb0.internal-va.commcarehq.org:
     - *id001
     - *id002
     - *id003
-    hqdb1.internal-va.commcarehq.org:
     - *id004
+    hqdb1.internal-va.commcarehq.org:
     - *id005
     - *id006
-    hqdb2.internal-va.commcarehq.org:
     - *id007
+    hqdb2.internal-va.commcarehq.org:
     - *id008
     - *id009
-    pgsynclog.internal-va.commcarehq.org:
     - *id010
+    pgsynclog.internal-va.commcarehq.org:
+    - *id011
   custom: []
   form_processing:
     partitions:

--- a/tests/test_envs/2018-04-04-production-snapshot/postgresql.yml
+++ b/tests/test_envs/2018-04-04-production-snapshot/postgresql.yml
@@ -10,6 +10,8 @@ dbs:
       query_stats: True
   synclogs:
     host: pgsynclog
+  auditcare:
+    host: hqdb0
   form_processing:
     proxy:
       host: hqdb1

--- a/tests/test_envs/2018-04-04-softlayer-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-softlayer-snapshot/.generated.yml
@@ -11,7 +11,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
-      - 10.162.36.205
+    - 10.162.36.205
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -26,7 +26,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
-      - 10.162.36.205
+    - 10.162.36.205
     port: 6432
     query_stats: false
     shards:
@@ -44,7 +44,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
-      - 10.162.36.205
+    - 10.162.36.205
     port: 6432
     query_stats: false
     shards:
@@ -62,7 +62,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
-      - 10.162.36.205
+    - 10.162.36.205
     port: 6432
     query_stats: false
     shards:
@@ -80,7 +80,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
-      - 10.162.36.205
+    - 10.162.36.205
     port: 6432
     query_stats: false
     shards:
@@ -98,7 +98,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
-      - 10.162.36.205
+    - 10.162.36.205
     port: 6432
     query_stats: false
     shards:
@@ -116,7 +116,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
-      - 10.162.36.205
+    - 10.162.36.205
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -131,7 +131,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
-      - 10.162.36.205
+    - 10.162.36.205
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -146,7 +146,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
-      - 10.162.36.205
+    - 10.162.36.205
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -161,7 +161,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
-      - 10.162.36.205
+    - 10.162.36.205
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -176,7 +176,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
-      - 10.162.36.205
+    - 10.162.36.205
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -204,7 +204,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
-      - 10.162.36.205
+    - 10.162.36.205
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -221,7 +221,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: 10.162.36.205
         pgbouncer_hosts:
-          - 10.162.36.205
+        - 10.162.36.205
         port: 6432
         query_stats: false
         shards:
@@ -239,7 +239,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: 10.162.36.205
         pgbouncer_hosts:
-          - 10.162.36.205
+        - 10.162.36.205
         port: 6432
         query_stats: false
         shards:
@@ -257,7 +257,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: 10.162.36.205
         pgbouncer_hosts:
-          - 10.162.36.205
+        - 10.162.36.205
         port: 6432
         query_stats: false
         shards:
@@ -275,7 +275,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: 10.162.36.205
         pgbouncer_hosts:
-          - 10.162.36.205
+        - 10.162.36.205
         port: 6432
         query_stats: false
         shards:
@@ -293,7 +293,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: 10.162.36.205
         pgbouncer_hosts:
-          - 10.162.36.205
+        - 10.162.36.205
         port: 6432
         query_stats: false
         shards:
@@ -311,7 +311,7 @@ postgresql_dbs:
       pg_config: []
       pgbouncer_endpoint: 10.162.36.205
       pgbouncer_hosts:
-        - 10.162.36.205
+      - 10.162.36.205
       port: 6432
       query_stats: false
       user: '{{ postgres_users.commcare.username }}'
@@ -340,7 +340,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
-      - 10.162.36.205
+    - 10.162.36.205
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -355,7 +355,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
-      - 10.162.36.205
+    - 10.162.36.205
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -371,7 +371,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
-      - 10.162.36.205
+    - 10.162.36.205
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -386,7 +386,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
-      - 10.162.36.205
+    - 10.162.36.205
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'

--- a/tests/test_envs/2018-04-04-softlayer-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-softlayer-snapshot/.generated.yml
@@ -180,6 +180,7 @@ postgresql_dbs:
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
+  auditcare: null
   by_pgbouncer_host:
     10.162.36.205:
     - *id001

--- a/tests/test_envs/2018-04-04-staging-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-staging-snapshot/.generated.yml
@@ -165,6 +165,7 @@ postgresql_dbs:
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
+  auditcare: null
   by_pgbouncer_host:
     hqdb1-staging.internal-va.commcarehq.org:
     - *id001

--- a/tests/test_envs/2018-04-04-staging-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-staging-snapshot/.generated.yml
@@ -11,7 +11,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
-      - hqdb1-staging.internal-va.commcarehq.org
+    - hqdb1-staging.internal-va.commcarehq.org
     port: 6432
     query_stats: true
     user: '{{ postgres_users.commcare.username }}'
@@ -26,7 +26,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
-      - hqdb1-staging.internal-va.commcarehq.org
+    - hqdb1-staging.internal-va.commcarehq.org
     port: 6432
     query_stats: true
     shards:
@@ -44,7 +44,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
-      - hqdb1-staging.internal-va.commcarehq.org
+    - hqdb1-staging.internal-va.commcarehq.org
     port: 6432
     query_stats: true
     shards:
@@ -62,7 +62,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
-      - hqdb1-staging.internal-va.commcarehq.org
+    - hqdb1-staging.internal-va.commcarehq.org
     port: 6432
     query_stats: true
     shards:
@@ -80,7 +80,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
-      - hqdb1-staging.internal-va.commcarehq.org
+    - hqdb1-staging.internal-va.commcarehq.org
     port: 6432
     query_stats: true
     shards:
@@ -98,7 +98,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
-      - hqdb1-staging.internal-va.commcarehq.org
+    - hqdb1-staging.internal-va.commcarehq.org
     port: 6432
     query_stats: true
     shards:
@@ -116,7 +116,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
-      - hqdb1-staging.internal-va.commcarehq.org
+    - hqdb1-staging.internal-va.commcarehq.org
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -131,7 +131,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
-      - hqdb1-staging.internal-va.commcarehq.org
+    - hqdb1-staging.internal-va.commcarehq.org
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -146,7 +146,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
-      - hqdb1-staging.internal-va.commcarehq.org
+    - hqdb1-staging.internal-va.commcarehq.org
     port: 6432
     query_stats: true
     user: '{{ postgres_users.commcare.username }}'
@@ -161,7 +161,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
-      - hqdb1-staging.internal-va.commcarehq.org
+    - hqdb1-staging.internal-va.commcarehq.org
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -191,7 +191,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
         pgbouncer_hosts:
-          - hqdb1-staging.internal-va.commcarehq.org
+        - hqdb1-staging.internal-va.commcarehq.org
         port: 6432
         query_stats: true
         shards:
@@ -209,7 +209,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
         pgbouncer_hosts:
-          - hqdb1-staging.internal-va.commcarehq.org
+        - hqdb1-staging.internal-va.commcarehq.org
         port: 6432
         query_stats: true
         shards:
@@ -227,7 +227,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
         pgbouncer_hosts:
-          - hqdb1-staging.internal-va.commcarehq.org
+        - hqdb1-staging.internal-va.commcarehq.org
         port: 6432
         query_stats: true
         shards:
@@ -245,7 +245,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
         pgbouncer_hosts:
-          - hqdb1-staging.internal-va.commcarehq.org
+        - hqdb1-staging.internal-va.commcarehq.org
         port: 6432
         query_stats: true
         shards:
@@ -263,7 +263,7 @@ postgresql_dbs:
         pg_config: []
         pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
         pgbouncer_hosts:
-          - hqdb1-staging.internal-va.commcarehq.org
+        - hqdb1-staging.internal-va.commcarehq.org
         port: 6432
         query_stats: true
         shards:
@@ -281,7 +281,7 @@ postgresql_dbs:
       pg_config: []
       pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
       pgbouncer_hosts:
-        - hqdb1-staging.internal-va.commcarehq.org
+      - hqdb1-staging.internal-va.commcarehq.org
       port: 6432
       query_stats: false
       user: '{{ postgres_users.commcare.username }}'
@@ -310,7 +310,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
-      - hqdb1-staging.internal-va.commcarehq.org
+    - hqdb1-staging.internal-va.commcarehq.org
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -325,7 +325,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
-      - hqdb1-staging.internal-va.commcarehq.org
+    - hqdb1-staging.internal-va.commcarehq.org
     port: 6432
     query_stats: true
     user: '{{ postgres_users.commcare.username }}'
@@ -341,7 +341,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
-      - hqdb1-staging.internal-va.commcarehq.org
+    - hqdb1-staging.internal-va.commcarehq.org
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -356,7 +356,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
-      - hqdb1-staging.internal-va.commcarehq.org
+    - hqdb1-staging.internal-va.commcarehq.org
     port: 6432
     query_stats: true
     user: '{{ postgres_users.commcare.username }}'

--- a/tests/test_envs/2018-04-04-swiss-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-swiss-snapshot/.generated.yml
@@ -11,7 +11,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 127.0.0.1
     pgbouncer_hosts:
-      - 127.0.0.1
+    - 127.0.0.1
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -26,7 +26,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 127.0.0.1
     pgbouncer_hosts:
-      - 127.0.0.1
+    - 127.0.0.1
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -41,7 +41,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 127.0.0.1
     pgbouncer_hosts:
-      - 127.0.0.1
+    - 127.0.0.1
     port: 6432
     query_stats: true
     user: '{{ postgres_users.commcare.username }}'
@@ -56,7 +56,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 127.0.0.1
     pgbouncer_hosts:
-      - 127.0.0.1
+    - 127.0.0.1
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -79,7 +79,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 127.0.0.1
     pgbouncer_hosts:
-      - 127.0.0.1
+    - 127.0.0.1
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -94,7 +94,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 127.0.0.1
     pgbouncer_hosts:
-      - 127.0.0.1
+    - 127.0.0.1
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -110,7 +110,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 127.0.0.1
     pgbouncer_hosts:
-      - 127.0.0.1
+    - 127.0.0.1
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -125,7 +125,7 @@ postgresql_dbs:
     pg_config: []
     pgbouncer_endpoint: 127.0.0.1
     pgbouncer_hosts:
-      - 127.0.0.1
+    - 127.0.0.1
     port: 6432
     query_stats: true
     user: '{{ postgres_users.commcare.username }}'

--- a/tests/test_envs/2018-04-04-swiss-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-swiss-snapshot/.generated.yml
@@ -60,6 +60,7 @@ postgresql_dbs:
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
+  auditcare: null
   by_pgbouncer_host:
     127.0.0.1:
     - *id001

--- a/tests/test_postgresql_config.py
+++ b/tests/test_postgresql_config.py
@@ -19,6 +19,9 @@ TEST_ENVIRONMENTS = os.listdir(TEST_ENVIRONMENTS_DIR)
 
 @parameterized(TEST_ENVIRONMENTS)
 def test_postgresql_config(env_name):
+    # To update test configs when they get outdated:
+    # python tests/test_postgresql_config.py
+
     env = Environment(DefaultPaths(env_name, environments_dir=TEST_ENVIRONMENTS_DIR))
 
     if not os.path.exists(env.paths.generated_yml):
@@ -42,3 +45,24 @@ def test_postgresql_config(env_name):
             lineterm=''
         ))
     ))
+
+
+def update_configs():
+    for env_name in TEST_ENVIRONMENTS:
+        env = Environment(DefaultPaths(env_name, environments_dir=TEST_ENVIRONMENTS_DIR))
+        if os.path.exists(env.paths.generated_yml):
+            print("updating config:", env_name)
+            update_config(env)
+
+
+def update_config(env):
+    json_data = env.postgresql_config.to_generated_variables(env)['postgresql_dbs']
+    with open(env.paths.generated_yml, "w", encoding="utf-8") as fh:
+        fh.write(yaml.dump(
+            {"postgresql_dbs": json_data},
+            Dumper=PreserveUnsafeDumper,
+        ))
+
+
+if __name__ == "__main__":
+    update_configs()


### PR DESCRIPTION
Prepare to write auditcare data to PostgreSQL instead of CouchDB. This mirrors configuration that will be used on prod: separate DB, custom routing. Unlike prod, it uses the same pg host as other dbs (prod will use a separate RDS instance).

https://dimagi-dev.atlassian.net/browse/SAAS-11381

##### ENVIRONMENTS AFFECTED
staging
