### PR TITLE
Fix bad permissions modes

### DIFF
--- a/src/commcare_cloud/ansible/roles/kafka/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/kafka/tasks/main.yml
@@ -59,7 +59,7 @@
     dest: /opt/kafka/config/log4j.properties
     owner: root
     group: root
-    mode: 644
+    mode: 0644
   when: kafka_version is version('2.0', '>')
   tags: log4j
 
@@ -69,7 +69,7 @@
     dest: /opt/kafka/config/log4j.properties
     owner: root
     group: root
-    mode: 644
+    mode: 0644
   when: kafka_version == "0.8.2.2"
   tags: log4j
 
@@ -98,4 +98,4 @@
   tags: after-reboot
 
 - name: Add Kafka binaries to PATH
-  copy: src=kafka.sh dest=/etc/profile.d/ owner=root group=root mode=644
+  copy: src=kafka.sh dest=/etc/profile.d/ owner=root group=root mode=0644

--- a/src/commcare_cloud/ansible/roles/postgresql_base/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/postgresql_base/tasks/main.yml
@@ -58,7 +58,7 @@
     dest: "{{ postgresql_systemd_config_dir }}/limits.conf"
     owner: root
     group: root
-    mode: 644
+    mode: 0644
   notify:
     - Restart postgres
     - reload systemd


### PR DESCRIPTION
You must either add a leading zero so that Ansible's YAML parser knows it is an octal number (like 0644 or 01777) or quote it (like '644' or '1777') so Ansible receives a string and can do its own conversion from string into number.

Previously seen in ansible output
```diff
TASK [postgresql_base : Configure service limits] ******************************************************************
--- before
+++ after
@@ -1,4 +1,4 @@
 {
-    "mode": "0644",
+    "mode": "01204",
     "path": "/etc/systemd/system/postgresql@.service.d/limits.conf"
 }
```

Might be related to the Python 3 upgrade?