### PR TITLE
Do not run service check on remote database

### DIFF
--- a/src/commcare_cloud/ansible/roles/postgresql_base/tasks/set_up_dbs.yml
+++ b/src/commcare_cloud/ansible/roles/postgresql_base/tasks/set_up_dbs.yml
@@ -31,6 +31,7 @@
   service:
     name: "postgresql@{{ postgresql_version }}-main"
     state: started
+  when: not db_is_remote
 
 - name: Create PostgreSQL users
   become: yes


### PR DESCRIPTION
set_up_dbs.yml on remote db may have been broken by https://github.com/dimagi/commcare-cloud/commit/7b5a7f456ea16fde7c95428bc1aedd7fe2127cf9
