### PR TITLE
terminating redis2-staging(shared_dir_host) & removing from resources list.

### DIFF
--- a/environments/staging/aws-resources.yml
+++ b/environments/staging/aws-resources.yml
@@ -64,8 +64,6 @@ rabbit2-staging: 10.201.10.239
 rabbit2-staging.instance_id: i-01bfeae5f4febaddf
 rabbit3-staging: 10.201.10.175
 rabbit3-staging.instance_id: i-0b9337eaa43eb4d77
-redis2-staging: 10.201.40.121
-redis2-staging.instance_id: i-0ba9234c3f9c17993
 vpn-staging: 10.201.20.112
 vpn-staging.instance_id: i-0e43738c0151d44b7
 vpn-staging.public_ip: 54.227.170.89

--- a/environments/staging/inventory.ini
+++ b/environments/staging/inventory.ini
@@ -169,11 +169,6 @@ formplayer_efs_dns=fs-ba70cd39.efs.us-east-1.amazonaws.com:/
 cchq_uid=1026
 cchq_gid=1027
 
-
-
-[redis:children]
-redis2
-
 [es6]
 10.201.40.126 hostname=es6-staging ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-0161d2187f667e405 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws elasticsearch_node_name=es6-staging elasticsearch_node_zone=aws elasticsearch_master=true
 

--- a/environments/staging/inventory.ini
+++ b/environments/staging/inventory.ini
@@ -169,8 +169,7 @@ formplayer_efs_dns=fs-ba70cd39.efs.us-east-1.amazonaws.com:/
 cchq_uid=1026
 cchq_gid=1027
 
-[redis2]
-10.201.40.121 hostname=redis2-staging ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-0ba9234c3f9c17993 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws
+
 
 [redis:children]
 redis2
@@ -190,16 +189,12 @@ es6
 es7
 es8
 
-[shared_dir_host:children]
-redis2
-
 [shared_efs_client_host:children]
 celery
 django_manage
 proxy
 pillowtop
 webworkers
-shared_dir_host
 
 [control1]
 10.201.10.170 hostname=control1-staging ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-04ed8ae39462cca8f root_encryption_mode=aws

--- a/environments/staging/inventory.ini.j2
+++ b/environments/staging/inventory.ini.j2
@@ -136,11 +136,6 @@ formplayer_efs_dns={{ aws_resources['formplayer-efs'] }}:/
 cchq_uid=1026
 cchq_gid=1027
 
-{{ __redis2__ }}
-
-[redis:children]
-redis2
-
 {{ __es6__ }} elasticsearch_node_name=es6-staging elasticsearch_node_zone=aws elasticsearch_master=true
 
 {{ __es7__ }} elasticsearch_node_name=es7-staging elasticsearch_node_zone=aws elasticsearch_master=true

--- a/environments/staging/inventory.ini.j2
+++ b/environments/staging/inventory.ini.j2
@@ -153,16 +153,12 @@ es6
 es7
 es8
 
-[shared_dir_host:children]
-redis2
-
 [shared_efs_client_host:children]
 celery
 django_manage
 proxy
 pillowtop
 webworkers
-shared_dir_host
 
 {{ __control1__ }}
 

--- a/environments/staging/terraform.yml
+++ b/environments/staging/terraform.yml
@@ -294,17 +294,6 @@ servers:
     group: postgresql
     os: ubuntu_pro_bionic
 
-  - server_name: "redis2-staging"
-    server_instance_type: t3.medium
-    network_tier: "db-private"
-    az: "a"
-    volume_size: 30
-    volume_encrypted: yes
-    block_device:
-      volume_size: 60
-      encrypted: true
-    group: "redis"
-    os: ubuntu_pro_bionic
 
 proxy_servers:
   - server_name: "proxy2-staging"


### PR DESCRIPTION
I am doing a instance termination process for redis2-staging ( i-0ba9234c3f9c17993). We had completed migration process (redis - elasticache ) & NFS to EFS in Staging env.

We are not using redis2-staging ( i-0ba9234c3f9c17993) host for redis db & NFS service.
ref: SAAS-11830