### PR TITLE
Fix typos in the docs for tmux command

### DIFF
--- a/docs/commcare-cloud/commands/index.md
+++ b/docs/commcare-cloud/commands/index.md
@@ -576,8 +576,8 @@ Use '-' for default (django_manage[0])
 ###### `remote_command`
 
 Command to run in the tmux.
-If a command specified, then it will always run in a new window.
-If a command is *not* specified, then a it will rejoin the most
+If a command is specified, then it will always run in a new window.
+If a command is *not* specified, then it will rejoin the most
 recently visited tmux window; only if there are no currently open
 tmux windows will a new one be opened.
 

--- a/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -125,8 +125,8 @@ class Tmux(_Ssh):
     arguments = _Ssh.arguments + (
         Argument('remote_command', nargs='?', help="""
             Command to run in the tmux.
-            If a command specified, then it will always run in a new window.
-            If a command is *not* specified, then a it will rejoin the most
+            If a command is specified, then it will always run in a new window.
+            If a command is *not* specified, then it will rejoin the most
             recently visited tmux window; only if there are no currently open
             tmux windows will a new one be opened.
         """),


### PR DESCRIPTION
Just something I found while looking at https://dimagi.github.io/commcare-cloud/commcare-cloud/commands/#tmux

##### ENVIRONMENTS AFFECTED
None