### PR TITLE
Production - routing pgbouncer traffic via NLB for main, ucr and synclogs dbs 

### DIFF
--- a/environments/production/aws-resources.yml
+++ b/environments/production/aws-resources.yml
@@ -213,13 +213,16 @@ pgformplayer0-production: pgformplayer0-production.cl9dmuo3ok4h.us-east-1.rds.am
 pgformplayer_nlb-production: pgformplayer-nlb-production-ec7390b942368541.elb.us-east-1.amazonaws.com
 pgmain0-production: pgmain0-production.cl9dmuo3ok4h.us-east-1.rds.amazonaws.com
 pgmain1-production: pgmain1-production.cl9dmuo3ok4h.us-east-1.rds.amazonaws.com
+pgmain_nlb-production: pgmain-nlb-production-5816580de5d475ff.elb.us-east-1.amazonaws.com
 pgshard1-production: pgshard1-production.cl9dmuo3ok4h.us-east-1.rds.amazonaws.com
 pgshard2-production: pgshard2-production.cl9dmuo3ok4h.us-east-1.rds.amazonaws.com
 pgshard3-production: pgshard3-production.cl9dmuo3ok4h.us-east-1.rds.amazonaws.com
 pgshard4-production: pgshard4-production.cl9dmuo3ok4h.us-east-1.rds.amazonaws.com
 pgshard5-production: pgshard5-production.cl9dmuo3ok4h.us-east-1.rds.amazonaws.com
 pgsynclog0-production: pgsynclog0-production.cl9dmuo3ok4h.us-east-1.rds.amazonaws.com
+pgsynclogs_nlb-production: pgsynclogs-nlb-production-a0590d45cd55994b.elb.us-east-1.amazonaws.com
 pgucr0-production: pgucr0-production.cl9dmuo3ok4h.us-east-1.rds.amazonaws.com
+pgucr_nlb-production: pgucr-nlb-production-3790c322477cf782.elb.us-east-1.amazonaws.com
 pillow_a000-production: 10.202.12.40
 pillow_a000-production.instance_id: i-0602e9c17c2720084
 pillow_a001-production: 10.202.12.224

--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -151,6 +151,15 @@ pgsynclog0-production.cl9dmuo3ok4h.us-east-1.rds.amazonaws.com
 [pgformplayer_nlb]
 pgformplayer-nlb-production-ec7390b942368541.elb.us-east-1.amazonaws.com
 
+[pgmain_nlb]
+pgmain-nlb-production-5816580de5d475ff.elb.us-east-1.amazonaws.com
+
+[pgucr_nlb]
+pgucr-nlb-production-3790c322477cf782.elb.us-east-1.amazonaws.com
+
+[pgsynclogs_nlb]
+pgsynclogs-nlb-production-a0590d45cd55994b.elb.us-east-1.amazonaws.com
+
 [remote_postgresql:children]
 rds_pgmain0
 rds_pgformplayer0
@@ -174,10 +183,16 @@ pgbouncer7
 pgbouncer8
 pgbouncer9
 pgformplayer_nlb
+pgmain_nlb
+pgucr_nlb
+pgsynclogs_nlb
 
 [ansible_skip:children]
 remote_postgresql
 pgformplayer_nlb
+pgmain_nlb
+pgucr_nlb
+pgsynclogs_nlb
 
 [rabbit2]
 10.202.42.100 hostname=rabbit2-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-0afd113aa270a774d root_encryption_mode=aws

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -53,6 +53,12 @@ mobile_webworkers
 
 {{ __pgformplayer_nlb__ }}
 
+{{ __pgmain_nlb__ }}
+
+{{ __pgucr_nlb__ }}
+
+{{ __pgsynclogs_nlb__ }}
+
 [remote_postgresql:children]
 rds_pgmain0
 rds_pgformplayer0
@@ -76,10 +82,16 @@ pgbouncer7
 pgbouncer8
 pgbouncer9
 pgformplayer_nlb
+pgmain_nlb
+pgucr_nlb
+pgsynclogs_nlb
 
 [ansible_skip:children]
 remote_postgresql
 pgformplayer_nlb
+pgmain_nlb
+pgucr_nlb
+pgsynclogs_nlb
 
 {{ __rabbit2__ }}
 {{ __rabbit3__ }}

--- a/environments/production/postgresql.yml
+++ b/environments/production/postgresql.yml
@@ -40,7 +40,9 @@ pg_repack:
 dbs:
   main:
     host: rds_pgmain0
-    pgbouncer_host: pgbouncer7
+    pgbouncer_endpoint: pgmain_nlb
+    pgbouncer_hosts:
+      - pgbouncer7
   formplayer:
     host: rds_pgformplayer0
     pgbouncer_endpoint: pgformplayer_nlb
@@ -49,11 +51,15 @@ dbs:
       - pgbouncer8
   ucr:
     host: rds_pgucr0
-    pgbouncer_host: pgbouncer7
+    pgbouncer_endpoint: pgucr_nlb
+    pgbouncer_hosts:
+      - pgbouncer7
     query_stats: True
   synclogs:
     host: rds_pgsynclog0
-    pgbouncer_host: pgbouncer6
+    pgbouncer_endpoint: pgsynclogs_nlb
+    pgbouncer_hosts:
+      - pgbouncer6
   form_processing:
     proxy:
       host: pgbouncer3

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -377,6 +377,15 @@ pgbouncer_nlbs:
     targets:
       - pgbouncer5-production
       - pgbouncer8-production
+  - name: pgmain_nlb-production
+    targets:
+      - pgbouncer7-production
+  - name: pgucr_nlb-production
+    targets:
+      - pgbouncer7-production
+  - name: pgsynclogs_nlb-production
+    targets:
+      - pgbouncer6-production
 
 elasticache:
   create: no


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-11923
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production.

updated pgbouncer URL to routed Via a new Network Load Balancer. This helps in handling high availability and routing requests to multiple servers. 