### PR TITLE
Change pgbouncer tcp_keepidle to be less than AWS NLBs hard timeout

### DIFF
--- a/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer.ini.j2
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer.ini.j2
@@ -206,11 +206,11 @@ tcp_keepalive = 1
 ;; they also require tcp_keepalive=1
 
 ;; count of keepaliva packets
-tcp_keepcnt = 9
+tcp_keepcnt = 27
 
 ;; how long the connection can be idle,
 ;; before sending keepalive packets
-tcp_keepidle = 900
+tcp_keepidle = 300
 
 ;; The time between individual keepalive probes.
 tcp_keepintvl = 30


### PR DESCRIPTION
and increase tcp_keepcnt by the same factor.
The logic for lowering tcp_keepidle is that we need to send keepalive packets
to keep the NLB from timing out. The logic for raising tcp_keepcnt is to keep
the total length of time during which we are willing to send a keepalive the same.

I believe this to be the cause of the increased (but low) rate of postgres errors since we switched a number of pgbouncer connections to go through an AWS NLB: https://app.datadoghq.com/dashboard/g9s-pw6-tpg/hq-vitals?from_ts=1616094587232&fullscreen_end_ts=1616268783670&fullscreen_paused=true&fullscreen_section=overview&fullscreen_start_ts=1616095983670&fullscreen_widget=200684876&live=true&to_ts=1616267387232. I got the idea from a web search of the error I found in https://sentry.io/organizations/dimagi/issues/2286137371/?environment=production&project=136860&query=is%3Aunresolved+connection+already+closed&statsPeriod=14d ("nlb connection already closed" and then "tcp keepalives nlb pgbouncer") leading to https://blog.cskr.dev/posts/pgbouncer-nlb-connection-leak/, which matches our situation closely (app -> NLB -> pgbouncer -> RDS) and suggests this fix.

##### ENVIRONMENTS AFFECTED
All, but shouldn't matter except for staging, india, production which are using NLBs.