### PR TITLE
Update password text to token for Github

### DIFF
--- a/src/commcare_cloud/environment/schemas/meta.py
+++ b/src/commcare_cloud/environment/schemas/meta.py
@@ -17,7 +17,7 @@ def get_github(repo):
     token = None
     if repo.is_private:
         message = "This environment references a private repository: {}".format(repo.url)
-        token = get_github_token(message, force=True)
+        token = get_github_token(message, required=True)
         if not token:
             raise EnvironmentException("Github credentials required")
     return Github(login_or_token=token, password=None)

--- a/src/commcare_cloud/environment/schemas/meta.py
+++ b/src/commcare_cloud/environment/schemas/meta.py
@@ -8,20 +8,19 @@ from memoized import memoized_property, memoized
 
 from commcare_cloud.environment.exceptions import EnvironmentException
 from commcare_cloud.environment.secrets.backends import all_secrets_backends_by_name
-from commcare_cloud.environment.secrets.backends.abstract_backend import AbstractSecretsBackend
-from commcare_cloud.fab.utils import get_github_credentials
+from commcare_cloud.fab.utils import get_github_token
 import six
 
 
 @memoized
 def get_github(repo):
-    login_or_token, password = None, None
+    token = None
     if repo.is_private:
         message = "This environment references a private repository: {}".format(repo.url)
-        login_or_token, password = get_github_credentials(message, force=True)
-        if not login_or_token and not password:
+        token = get_github_token(message, force=True)
+        if not token:
             raise EnvironmentException("Github credentials required")
-    return Github(login_or_token=login_or_token, password=password)
+    return Github(login_or_token=token, password=None)
 
 
 class GitRepository(jsonobject.JsonObject):

--- a/src/commcare_cloud/fab/utils.py
+++ b/src/commcare_cloud/fab/utils.py
@@ -172,7 +172,7 @@ def _get_github_token(message, force=False):
             "    $ cp {project_root}/config.example.py {project_root}/config.py\n"
             "Then edit {project_root}/config.py"
         ).format(project_root=PROJECT_ROOT))
-        GITHUB_TOKEN = getpass('Github token: ')
+        GITHUB_TOKEN = getpass('Github Token: ')
     else:
         GITHUB_TOKEN = GITHUB_APIKEY
     return GITHUB_TOKEN

--- a/src/commcare_cloud/fab/utils.py
+++ b/src/commcare_cloud/fab/utils.py
@@ -173,9 +173,9 @@ def _get_github_credentials(message, force=False):
             "    $ cp {project_root}/config.example.py {project_root}/config.py\n"
             "Then edit {project_root}/config.py"
         ).format(project_root=PROJECT_ROOT))
-        username = input('Github username or token (leave blank to skip): ') or None
-        password = getpass('Github password: ') if username else None
-        GITHUB_CREDENTIALS = (username, password)
+        username = input('Github username (leave blank to skip): ') or None
+        token = getpass('Github token: ') if username else None
+        GITHUB_CREDENTIALS = (username, token)
     else:
         GITHUB_CREDENTIALS = (GITHUB_APIKEY, None)
     return GITHUB_CREDENTIALS

--- a/src/commcare_cloud/fab/utils.py
+++ b/src/commcare_cloud/fab/utils.py
@@ -156,10 +156,10 @@ class DeployMetadata(object):
 GITHUB_TOKEN = None
 
 
-def _get_github_token(message, force=False):
+def _get_github_token(message, required=False):
     global GITHUB_TOKEN
 
-    if GITHUB_TOKEN is not None and not force:
+    if GITHUB_TOKEN or not required:
         return GITHUB_TOKEN
 
     try:
@@ -178,7 +178,7 @@ def _get_github_token(message, force=False):
     return GITHUB_TOKEN
 
 
-def get_github_token(message=None, force=False):
+def get_github_token(message=None, required=False):
     if not message:
         message = "This deploy script uses the Github API to display a summary of changes to be deployed."
         if env.tag_deploy_commits:
@@ -186,7 +186,7 @@ def get_github_token(message=None, force=False):
                 "\nYou're deploying an environment which uses release tags. "
                 "Provide Github auth details to enable release tags."
             )
-    return _get_github_token(message, force)
+    return _get_github_token(message, required)
 
 
 @memoized
@@ -197,7 +197,7 @@ def _get_github():
 
 @memoized
 def _github_auth_provided():
-    return bool(get_github_token()[0])
+    return bool(get_github_token())
 
 
 def _get_checkpoint_filename():


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
The use of a password in this context has been deprecated and we need to use our token to login when deploying, not a password.

From what I've experienced, following the current text and putting a token in for the first field ("Github username or token") does not work.

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None