### PR TITLE
Add additional certificate to certifi for celery

### DIFF
--- a/src/commcare_cloud/ansible/deploy_commcarehq.yml
+++ b/src/commcare_cloud/ansible/deploy_commcarehq.yml
@@ -33,7 +33,9 @@
   tags: services
 
 - name: Celery Supervisor Config
-  hosts: celery
+  hosts:
+    - celery
+  become: true
   tasks:
     - include_tasks: roles/commcarehq/tasks/celery.yml
   tags: services

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/celery.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/celery.yml
@@ -16,7 +16,6 @@
       - "{{supervisor_celery_workers}}"
 
 - name: Add celery_bash_runner files
-  become: yes
   template:
     src: "../templates/celery_bash_runner.sh.j2"
     dest: "{{ item.file_name }}"
@@ -29,7 +28,6 @@
       python_options: "-O"
 
 - name: define special celery services
-  become: yes
   template:
     src: "{{ item.template }}"
     dest: "{{ item.file_name }}"
@@ -46,7 +44,6 @@
       should_apply: "{{ app_processes_config.celery_processes.get(inventory_hostname).beat is defined }}"
 
 - name: define celery workers
-  become: yes
   template:
     src: "../templates/supervisor_celery_workers.conf.j2"
     dest: "{{ supervisor_celery_workers }}"
@@ -61,3 +58,38 @@
         no_proxy: "{% if http_proxy_address is defined %}{{ groups['all'] | join(',') }},{{ app_processes_config.additional_no_proxy_hosts }}{% endif %}"
         PROMETHEUS_PUSHGATEWAY_HOST: "{% if prometheus_celery_pushgateway is defined %}{{ prometheus_celery_pushgateway }}{% endif %}"
         TMPDIR: '{{ encrypted_tmp }}'
+
+- name: add "DigiCert SHA2 Secure Server CA" certificate to certifi
+  blockinfile:
+    path: "{{ py3_virtualenv_home }}/lib/python3.6/site-packages/certifi/cacert.pem"
+    block: |
+      -----BEGIN CERTIFICATE-----
+      MIIE6DCCA9CgAwIBAgIQAnQuqhfKjiHHF7sf/P0MoDANBgkqhkiG9w0BAQsFADBh
+      MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3
+      d3cuZGlnaWNlcnQuY29tMSAwHgYDVQQDExdEaWdpQ2VydCBHbG9iYWwgUm9vdCBD
+      QTAeFw0yMDA5MjMwMDAwMDBaFw0zMDA5MjIyMzU5NTlaME0xCzAJBgNVBAYTAlVT
+      MRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxJzAlBgNVBAMTHkRpZ2lDZXJ0IFNIQTIg
+      U2VjdXJlIFNlcnZlciBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+      ANyuWJBNwcQwFZA1W248ghX1LFy949v/cUP6ZCWA1O4Yok3wZtAKc24RmDYXZK83
+      nf36QYSvx6+M/hpzTc8zl5CilodTgyu5pnVILR1WN3vaMTIa16yrBvSqXUu3R0bd
+      KpPDkC55gIDvEwRqFDu1m5K+wgdlTvza/P96rtxcflUxDOg5B6TXvi/TC2rSsd9f
+      /ld0Uzs1gN2ujkSYs58O09rg1/RrKatEp0tYhG2SS4HD2nOLEpdIkARFdRrdNzGX
+      kujNVA075ME/OV4uuPNcfhCOhkEAjUVmR7ChZc6gqikJTvOX6+guqw9ypzAO+sf0
+      /RR3w6RbKFfCs/mC/bdFWJsCAwEAAaOCAa4wggGqMB0GA1UdDgQWBBQPgGEcgjFh
+      1S8o541GOLQs4cbZ4jAfBgNVHSMEGDAWgBQD3lA1VtFMu2bwo+IbG8OXsj3RVTAO
+      BgNVHQ8BAf8EBAMCAYYwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBIG
+      A1UdEwEB/wQIMAYBAf8CAQAwdgYIKwYBBQUHAQEEajBoMCQGCCsGAQUFBzABhhho
+      dHRwOi8vb2NzcC5kaWdpY2VydC5jb20wQAYIKwYBBQUHMAKGNGh0dHA6Ly9jYWNl
+      cnRzLmRpZ2ljZXJ0LmNvbS9EaWdpQ2VydEdsb2JhbFJvb3RDQS5jcnQwewYDVR0f
+      BHQwcjA3oDWgM4YxaHR0cDovL2NybDMuZGlnaWNlcnQuY29tL0RpZ2lDZXJ0R2xv
+      YmFsUm9vdENBLmNybDA3oDWgM4YxaHR0cDovL2NybDQuZGlnaWNlcnQuY29tL0Rp
+      Z2lDZXJ0R2xvYmFsUm9vdENBLmNybDAwBgNVHSAEKTAnMAcGBWeBDAEBMAgGBmeB
+      DAECATAIBgZngQwBAgIwCAYGZ4EMAQIDMA0GCSqGSIb3DQEBCwUAA4IBAQB3MR8I
+      l9cSm2PSEWUIpvZlubj6kgPLoX7hyA2MPrQbkb4CCF6fWXF7Ef3gwOOPWdegUqHQ
+      S1TSSJZI73fpKQbLQxCgLzwWji3+HlU87MOY7hgNI+gH9bMtxKtXc1r2G1O6+x/6
+      vYzTUVEgR17vf5irF0LKhVyfIjc0RXbyQ14AniKDrN+v0ebHExfppGlkTIBn6rak
+      f4994VH6npdn6mkus5CkHBXIrMtPKex6XF2firjUDLuU7tC8y7WlHgjPxEEDDb0G
+      w6D0yDdVSvG/5XlCNatBmO/8EznDu1vr72N8gJzISUZwa6CCUD7QBLbKJcXBBVVf
+      8nwvV9GvlW+sbXlr
+      -----END CERTIFICATE-----
+


### PR DESCRIPTION
Add the needed "DigiCert SHA2 Secure Server CA" intermediate
certificate to certifi, in order to fix the validation error
with smspro.mtn.ci until they can fix their configuration to
serve the complete certificate chain.

https://dimagi-dev.atlassian.net/browse/SAAS-11999

##### ENVIRONMENTS AFFECTED
All
