### PR TITLE
Display help message with no args

### DIFF
--- a/src/commcare_cloud/commands/deploy.py
+++ b/src/commcare_cloud/commands/deploy.py
@@ -46,6 +46,10 @@ class Deploy(CommandBase):
     )
 
     def modify_parser(self):
+        if len(sys.argv) <= 1:
+            # No environment specified, so no need to add environment-specific repositories
+            return
+
         env_name = sys.argv[1]
         if env_name not in get_available_envs():
             return

--- a/src/commcare_cloud/commcare_cloud.py
+++ b/src/commcare_cloud/commcare_cloud.py
@@ -182,7 +182,13 @@ def call_commcare_cloud(input_argv=sys.argv):
 
     put_virtualenv_bin_on_the_path()
     parser, subparsers, commands = make_command_parser(available_envs=get_available_envs())
-    args, unknown_args = parser.parse_known_args(input_argv[1:])
+
+    raw_args = input_argv[1:]
+    if not raw_args:
+        parser.print_help()
+        return
+
+    args, unknown_args = parser.parse_known_args(raw_args)
 
     if args.control:
         run_on_control_instead(args, input_argv)


### PR DESCRIPTION
This should fix trying to execute commcare-cloud with no arguments. Previously, it would error out as the deploy command's documentation expected at least 1 argument.  Additionally, changed the behavior so it will display the help documentation with no arguments, rather than simply claiming 'not enough arguments'
