### PR TITLE
Only ask for github token (not username)

### DIFF
--- a/src/commcare_cloud/environment/schemas/meta.py
+++ b/src/commcare_cloud/environment/schemas/meta.py
@@ -17,10 +17,10 @@ def get_github(repo):
     token = None
     if repo.is_private:
         message = "This environment references a private repository: {}".format(repo.url)
-        token = get_github_token(message, required=True)
+        token = get_github_token(message, force=False)
         if not token:
             raise EnvironmentException("Github credentials required")
-    return Github(login_or_token=token, password=None)
+    return Github(login_or_token=token)
 
 
 class GitRepository(jsonobject.JsonObject):

--- a/src/commcare_cloud/environment/schemas/meta.py
+++ b/src/commcare_cloud/environment/schemas/meta.py
@@ -8,20 +8,19 @@ from memoized import memoized_property, memoized
 
 from commcare_cloud.environment.exceptions import EnvironmentException
 from commcare_cloud.environment.secrets.backends import all_secrets_backends_by_name
-from commcare_cloud.environment.secrets.backends.abstract_backend import AbstractSecretsBackend
-from commcare_cloud.fab.utils import get_github_credentials
+from commcare_cloud.fab.utils import get_github_token
 import six
 
 
 @memoized
 def get_github(repo):
-    login_or_token, password = None, None
+    token = None
     if repo.is_private:
         message = "This environment references a private repository: {}".format(repo.url)
-        login_or_token, password = get_github_credentials(message, force=True)
-        if not login_or_token and not password:
+        token = get_github_token(message, required=True)
+        if not token:
             raise EnvironmentException("Github credentials required")
-    return Github(login_or_token=login_or_token, password=password)
+    return Github(login_or_token=token, password=None)
 
 
 class GitRepository(jsonobject.JsonObject):

--- a/src/commcare_cloud/environment/schemas/meta.py
+++ b/src/commcare_cloud/environment/schemas/meta.py
@@ -17,7 +17,7 @@ def get_github(repo):
     token = None
     if repo.is_private:
         message = "This environment references a private repository: {}".format(repo.url)
-        token = get_github_token(message, force=False)
+        token = get_github_token(message, required=True)
         if not token:
             raise EnvironmentException("Github credentials required")
     return Github(login_or_token=token)

--- a/src/commcare_cloud/fab/utils.py
+++ b/src/commcare_cloud/fab/utils.py
@@ -187,7 +187,7 @@ def get_github_token(message=None, required=False):
                 "\nYou're deploying an environment which uses release tags. "
                 "Provide Github auth details to enable release tags."
             )
-    return _get_github_token(message, allow_empty)
+    return _get_github_token(message, required)
 
 
 @memoized

--- a/src/commcare_cloud/fab/utils.py
+++ b/src/commcare_cloud/fab/utils.py
@@ -153,15 +153,14 @@ class DeployMetadata(object):
         return DeployDiff(self.repo, self.last_commit_sha, self.deploy_ref)
 
 
-GITHUB_CREDENTIALS = None
+GITHUB_TOKEN = None
 
 
-def _get_github_credentials(message, force=False):
-    global GITHUB_CREDENTIALS
+def _get_github_token(message, required=False):
+    global GITHUB_TOKEN
 
-    if GITHUB_CREDENTIALS is not None:
-        if not force or GITHUB_CREDENTIALS[0]:
-            return GITHUB_CREDENTIALS
+    if GITHUB_TOKEN or not required:
+        return GITHUB_TOKEN
 
     try:
         from .config import GITHUB_APIKEY
@@ -173,15 +172,13 @@ def _get_github_credentials(message, force=False):
             "    $ cp {project_root}/config.example.py {project_root}/config.py\n"
             "Then edit {project_root}/config.py"
         ).format(project_root=PROJECT_ROOT))
-        username = input('Github username or token (leave blank to skip): ') or None
-        password = getpass('Github password: ') if username else None
-        GITHUB_CREDENTIALS = (username, password)
+        GITHUB_TOKEN = getpass('Github Token: ')
     else:
-        GITHUB_CREDENTIALS = (GITHUB_APIKEY, None)
-    return GITHUB_CREDENTIALS
+        GITHUB_TOKEN = GITHUB_APIKEY
+    return GITHUB_TOKEN
 
 
-def get_github_credentials(message=None, force=False):
+def get_github_token(message=None, required=False):
     if not message:
         message = "This deploy script uses the Github API to display a summary of changes to be deployed."
         if env.tag_deploy_commits:
@@ -189,18 +186,18 @@ def get_github_credentials(message=None, force=False):
                 "\nYou're deploying an environment which uses release tags. "
                 "Provide Github auth details to enable release tags."
             )
-    return _get_github_credentials(message, force)
+    return _get_github_token(message, required)
 
 
 @memoized
 def _get_github():
-    login_or_token, password = get_github_credentials()
-    return Github(login_or_token=login_or_token, password=password)
+    token = get_github_token()
+    return Github(login_or_token=token, password=None)
 
 
 @memoized
 def _github_auth_provided():
-    return bool(get_github_credentials()[0])
+    return bool(get_github_token())
 
 
 def _get_checkpoint_filename():

--- a/src/commcare_cloud/fab/utils.py
+++ b/src/commcare_cloud/fab/utils.py
@@ -156,12 +156,12 @@ class DeployMetadata(object):
 GITHUB_TOKEN = None
 
 
-def _get_github_token(message, force=False):
+def _get_github_token(message, required=False):
     global GITHUB_TOKEN
 
-    # return existing token if it exists and caller has not requested a fresh token fetch
-    if GITHUB_TOKEN and not force:
-        return GITHUB_TOKEN
+    if GITHUB_TOKEN is not None:
+        if GITHUB_TOKEN or not required:
+            return GITHUB_TOKEN
 
     try:
         from .config import GITHUB_APIKEY
@@ -179,7 +179,7 @@ def _get_github_token(message, force=False):
     return GITHUB_TOKEN
 
 
-def get_github_token(message=None, force=False):
+def get_github_token(message=None, required=False):
     if not message:
         message = "This deploy script uses the Github API to display a summary of changes to be deployed."
         if env.tag_deploy_commits:
@@ -187,7 +187,7 @@ def get_github_token(message=None, force=False):
                 "\nYou're deploying an environment which uses release tags. "
                 "Provide Github auth details to enable release tags."
             )
-    return _get_github_token(message, force)
+    return _get_github_token(message, allow_empty)
 
 
 @memoized

--- a/src/commcare_cloud/fab/utils.py
+++ b/src/commcare_cloud/fab/utils.py
@@ -156,10 +156,11 @@ class DeployMetadata(object):
 GITHUB_TOKEN = None
 
 
-def _get_github_token(message, required=False):
+def _get_github_token(message, force=False):
     global GITHUB_TOKEN
 
-    if GITHUB_TOKEN or not required:
+    # return existing token if it exists and caller has not requested a fresh token fetch
+    if GITHUB_TOKEN and not force:
         return GITHUB_TOKEN
 
     try:
@@ -178,7 +179,7 @@ def _get_github_token(message, required=False):
     return GITHUB_TOKEN
 
 
-def get_github_token(message=None, required=False):
+def get_github_token(message=None, force=False):
     if not message:
         message = "This deploy script uses the Github API to display a summary of changes to be deployed."
         if env.tag_deploy_commits:
@@ -186,13 +187,13 @@ def get_github_token(message=None, required=False):
                 "\nYou're deploying an environment which uses release tags. "
                 "Provide Github auth details to enable release tags."
             )
-    return _get_github_token(message, required)
+    return _get_github_token(message, force)
 
 
 @memoized
 def _get_github():
     token = get_github_token()
-    return Github(login_or_token=token, password=None)
+    return Github(login_or_token=token)
 
 
 @memoized


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Take 2. A premature merge of [this PR](https://github.com/dimagi/commcare-cloud/pull/4601) resulted in an issue and needed to be reverted. I've pulled in the commits from that PR into the first commit here, and the second commit fixes the issue originally seen (which was the credentials not being asked for).

@snopoke I know the logic for forcing a token was in question during the last PR, and I've changed it back to an `and` statement because I believe that is what we want. You mentioned "The intention is to allow blank tokens unless 'force=true' in which case a token is required" so if force is true, regardless of the value of `GITHUB_TOKEN`, we want to fetch the token from the config file or ask the user again. 
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
