### PR TITLE
New settings for formplayer java process

### DIFF
--- a/environments/india/app-processes.yml
+++ b/environments/india/app-processes.yml
@@ -1,4 +1,5 @@
 formplayer_memory: "15g"
+formplayer_g1heapregionsize: "8m"
 management_commands:
   celery1:
     run_submission_reprocessing_queue:

--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -3,7 +3,8 @@ django_command_prefix: ''
 celery_command_prefix: ''
 gunicorn_workers_static_factor: 0
 gunicorn_workers_factor: 2
-formplayer_memory: "30g"
+formplayer_memory: "31g"
+formplayer_g1heapregionsize: "16m"
 management_commands:
   celery_a006:
     run_submission_reprocessing_queue:

--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -424,7 +424,6 @@ formplayer_c050
 formplayer_c
 
 [formplayer:vars]
-extra_formplayer_args='-XX:+UseG1GC -XX:+UseStringDeduplication'
 formplayer_efs_dns=fs-150b0596.efs.us-east-1.amazonaws.com:/
 cchq_uid=1025
 cchq_gid=1026

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -137,7 +137,6 @@ pillow_a
 formplayer_c
 
 [formplayer:vars]
-extra_formplayer_args='-XX:+UseG1GC -XX:+UseStringDeduplication'
 formplayer_efs_dns={{ aws_resources['formplayer-efs'] }}:/
 cchq_uid=1025
 cchq_gid=1026

--- a/environments/swiss/app-processes.yml
+++ b/environments/swiss/app-processes.yml
@@ -1,4 +1,5 @@
 formplayer_memory: "1024m"
+formplayer_g1heapregionsize: "1m"
 
 management_commands:
   swiss0:

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_formplayer_spring.conf.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_formplayer_spring.conf.j2
@@ -1,7 +1,7 @@
 [program:{{ project }}-{{ deploy_env }}-formsplayer-spring]
 environment={% for name, value in item.env_vars.items() %}{% if value %}{{ name }}="{{ value }}",{% endif %}{% endfor %}
 
-command=java {{ app_processes_config.formplayer_command_args }} {% if use_formplayer_debug_options %} -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9998 {% endif %} -Xms{{ app_processes_config.formplayer_memory }} -Xmx{{ app_processes_config.formplayer_memory }} {{ extra_formplayer_args }} -XX:MaxMetaspaceSize=128m -XX:-OmitStackTraceInFastThrow -Xss1024k {% if use_formplayer_debug_options %} -XX:NativeMemoryTracking=summary -XX:+UnlockDiagnosticVMOptions {% endif %} -jar {{ www_home }}/formplayer_build/current/formplayer.jar
+command=java {{ app_processes_config.formplayer_command_args }} {% if use_formplayer_debug_options %} -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9998 {% endif %} -Xms{{ app_processes_config.formplayer_memory }} -Xmx{{ app_processes_config.formplayer_memory }} {{ extra_formplayer_args }} -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+ParallelRefProcEnabled -XX:G1HeapRegionSize={{ app_processes_config.formplayer_g1heapregionsize }} -XX:MaxMetaspaceSize={{ app_processes_config.formplayer_maxmetaspacesize }} -XX:-OmitStackTraceInFastThrow -Xss1024k {% if use_formplayer_debug_options %} -XX:NativeMemoryTracking=summary -XX:+UnlockDiagnosticVMOptions {% endif %} -jar {{ www_home }}/formplayer_build/current/formplayer.jar
 user={{ cchq_user }}
 autostart=true
 autorestart=true

--- a/src/commcare_cloud/environment/schemas/app_processes.py
+++ b/src/commcare_cloud/environment/schemas/app_processes.py
@@ -43,6 +43,8 @@ class AppProcessesConfig(jsonobject.JsonObject):
     gunicorn_workers_factor = jsonobject.IntegerProperty()
     gunicorn_workers_static_factor = jsonobject.IntegerProperty()
     formplayer_memory = MemorySpecProperty()
+    formplayer_maxmetaspacesize = MemorySpecProperty()
+    formplayer_g1heapregionsize = MemorySpecProperty()
     http_proxy = IpAddressAndPortProperty()
     django_command_prefix = jsonobject.StringProperty()
     celery_command_prefix = jsonobject.StringProperty()

--- a/src/commcare_cloud/environmental-defaults/app-processes.yml
+++ b/src/commcare_cloud/environmental-defaults/app-processes.yml
@@ -26,6 +26,8 @@ flower_port: 5555
 gunicorn_workers_factor: 1
 gunicorn_workers_static_factor: 0
 formplayer_memory: "3584m"
+formplayer_maxmetaspacesize: "512m"
+formplayer_g1heapregionsize: "2m"
 http_proxy: null
 django_command_prefix: ''
 celery_command_prefix: ''


### PR DESCRIPTION
include -XX:+UseG1GC and -XX:+UseStringDeduplication in defaults
increase heap size in production (31g from 30g)
add -XX:+ParallelRefProcEnabled
add -XX:G1HeapRegionSize (set based on the heap size - default: 2m, production: 16m, india: 8m, swiss: 1m)
change -XX:MaxMetaspaceSize (512m from 128m)

https://dimagi-dev.atlassian.net/browse/SAAS-11943

##### ENVIRONMENTS AFFECTED
All