### PR TITLE
Reference proxy hsts value for django setting

### DIFF
--- a/environments/staging/proxy.yml
+++ b/environments/staging/proxy.yml
@@ -2,6 +2,7 @@ fake_ssl_cert: yes
 SITE_HOST: 'staging.commcarehq.org'
 J2ME_SITE_HOST: 'j2mestaging.commcarehq.org'
 primary_ssl_env: "staging"
+nginx_hsts_max_age: 300 # 5 minutes
 
 trusted_proxies:
   - 10.201.0.0/16

--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -145,7 +145,7 @@ localsettings:
     auditcare: auditcare
   LOCAL_MIDDLEWARE:
     - 'django.middleware.security.SecurityMiddleware'
-  SECURE_HSTS_SECONDS: 300
+  SECURE_HSTS_SECONDS: "{{ nginx_hsts_max_age }}"
   SILENCED_SYSTEM_CHECKS:
     - 'security.W008' # the ALB and nginx already redirect HTTP to HTTPS so safe to silence this warning
   PILLOWTOP_MACHINE_ID: staging-hqdb0-ubuntu


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
[Classic Ticket](https://dimagi-dev.atlassian.net/browse/SAAS-11207)

Overcomplicated this with [this PR](https://github.com/dimagi/commcare-cloud/pull/4537) but this is a much more promising and simple solution. We want the nginx value and django value to match, and this is the easiest way to maintain that moving forward. I'll roll out to other environments when we are sure this is error free (should be pretty safe).

I tested locally by running `cchq staging update-config --branch=gh/set-value-in-proxy` after updating the value to 500 and saw that the django setting `SECURE_HSTS_SECONDS` was updated as well.
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Staging