### PR TITLE
Reference proxy hsts max age value for django settings

### DIFF
--- a/environments/india/proxy.yml
+++ b/environments/india/proxy.yml
@@ -5,5 +5,6 @@ J2ME_SITE_HOST: 'j2me-india.commcarehq.org'
 tableau_server: 'tableau2.internal.commcarehq.org'
 TABLEAU_HOST: 'icds.commcarehq.org'
 primary_ssl_env: "india"
+nginx_hsts_max_age: 300 # 5 minutes
 trusted_proxies:
   - 10.203.0.0/16

--- a/environments/india/public.yml
+++ b/environments/india/public.yml
@@ -136,7 +136,7 @@ localsettings:
     auditcare: auditcare
   LOCAL_MIDDLEWARE:
     - 'django.middleware.security.SecurityMiddleware'
-  SECURE_HSTS_SECONDS: 300
+  SECURE_HSTS_SECONDS: "{{ nginx_hsts_max_age }}"
   SILENCED_SYSTEM_CHECKS:
     - 'security.W008' # the ALB and nginx already redirect HTTP to HTTPS so safe to silence this warning
   PILLOWTOP_MACHINE_ID: indiacloud

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -165,7 +165,7 @@ localsettings:
     auditcare: auditcare
   LOCAL_MIDDLEWARE:
     - 'django.middleware.security.SecurityMiddleware'
-  SECURE_HSTS_SECONDS: 300
+  SECURE_HSTS_SECONDS: "{{ nginx_hsts_max_age }}"
   SILENCED_SYSTEM_CHECKS:
     - 'security.W008' # the ALB and nginx already redirect HTTP to HTTPS so safe to silence this warning
   PILLOWTOP_MACHINE_ID: hqdb0

--- a/environments/swiss/proxy.yml
+++ b/environments/swiss/proxy.yml
@@ -1,3 +1,4 @@
 SITE_HOST: 'swiss.commcarehq.org'
 letsencrypt_cchq_ssl: True
 primary_ssl_env: 'swiss'
+nginx_hsts_max_age: 300 # 5 minutes

--- a/environments/swiss/public.yml
+++ b/environments/swiss/public.yml
@@ -123,7 +123,7 @@ localsettings:
   #  PILLOWTOP_MACHINE_ID:
   LOCAL_MIDDLEWARE:
     - 'django.middleware.security.SecurityMiddleware'
-  SECURE_HSTS_SECONDS: 300
+  SECURE_HSTS_SECONDS: "{{ nginx_hsts_max_age }}"
   SILENCED_SYSTEM_CHECKS:
     - 'security.W008' # the ALB and nginx already redirect HTTP to HTTPS so safe to silence this warning
   REDIS_DB: '0'


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Followup to [this PR](https://github.com/dimagi/commcare-cloud/pull/4621), updates these envs to reference the proxy value for hsts_max_age. Worth noting all of these environments have already had this value set to 300 in django, so adding it to the proxy _should_ not change anything. 
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production, India, Swiss