### PR TITLE
adding pgbouncer6, pgbouncer7 as targets for pgmain, pgucr and pgsynclog NLB

### DIFF
--- a/environments/production/postgresql.yml
+++ b/environments/production/postgresql.yml
@@ -68,6 +68,7 @@ dbs:
     pgbouncer_endpoint: pgmain_nlb
     pgbouncer_hosts:
       - pgbouncer7
+      - pgbouncer6
   form_processing:
     proxy:
       host: pgbouncer3

--- a/environments/production/postgresql.yml
+++ b/environments/production/postgresql.yml
@@ -43,6 +43,7 @@ dbs:
     pgbouncer_endpoint: pgmain_nlb
     pgbouncer_hosts:
       - pgbouncer7
+      - pgbouncer6
   formplayer:
     host: rds_pgformplayer0
     pgbouncer_endpoint: pgformplayer_nlb
@@ -54,12 +55,14 @@ dbs:
     pgbouncer_endpoint: pgucr_nlb
     pgbouncer_hosts:
       - pgbouncer7
+      - pgbouncer6
     query_stats: True
   synclogs:
     host: rds_pgsynclog0
     pgbouncer_endpoint: pgsynclogs_nlb
     pgbouncer_hosts:
       - pgbouncer6
+      - pgbouncer7
   auditcare:
     host: rds_pgauditcare0
     pgbouncer_endpoint: pgmain_nlb

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -388,12 +388,15 @@ pgbouncer_nlbs:
   - name: pgmain_nlb-production
     targets:
       - pgbouncer7-production
+      - pgbouncer6-production
   - name: pgucr_nlb-production
     targets:
       - pgbouncer7-production
+      - pgbouncer6-production
   - name: pgsynclogs_nlb-production
     targets:
       - pgbouncer6-production
+      - pgbouncer7-production
 
 elasticache:
   create: no


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-11923
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production

Adding two instances as target machines for pgmain, pgsynclogs and pgucr NLB's. 
This way there is redundancy and we can swap in and out pgbouncer nodes without downtime for those dbs. 

We will be running cchq <env> terraform apply command for specific targets. 
@dannyroberts Please let me know if I have to run update-config as well. 

Thanks.