### PR TITLE
Increase reminder_case_update_queue concurrency by 88% on production

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -36,8 +36,8 @@ celery_processes:
       concurrency: 5
     reminder_case_update_queue:
       pooling: gevent
-      concurrency: 32
-      num_workers: 2
+      concurrency: 24
+      num_workers: 5
     reminder_queue:
       pooling: gevent
       concurrency: 20


### PR DESCRIPTION
Fewer gevent threads, more workers.
We have a hypothesis that too many gevent threads each running long tasks
causes the BrokenPipeError that halted some of the workers

https://docs.google.com/document/d/1-zJLGSgWTNYbqVdmjDCjCJgJYd1ZC_gptGDIgJTsWIw/edit

##### ENVIRONMENTS AFFECTED
production