### PR TITLE
Run QA tests on formplayer deploy

### DIFF
--- a/src/commcare_cloud/events.py
+++ b/src/commcare_cloud/events.py
@@ -1,0 +1,30 @@
+import json
+
+import requests
+from fabric.colors import red
+
+
+def publish_deploy_event(name, component, environment):
+    url = environment.fab_settings_config.deploy_event_url
+    if not url:
+        return
+    token = environment.get_secret("deploy_event_token")
+    if not token:
+        print(red(f"skipping {name} event: deploy_event_token secret not set"))
+        return
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github.v3+json",
+    }
+    data = json.dumps({
+        "event_type": name,
+        "client_payload": {
+            "component": component,
+            "environment": environment.meta_config.deploy_env,
+        },
+    })
+    response = requests.post(url, data=data, headers=headers)
+    if 200 <= response.status_code < 300:
+        print(f"triggered {name} event")
+    else:
+        print(red(f"{name} event status: {response.status_code}"))

--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -41,6 +41,7 @@ from github import GithubException
 
 from commcare_cloud.environment.main import get_environment
 from commcare_cloud.environment.paths import get_available_envs
+from commcare_cloud.events import publish_deploy_event
 from fabric import utils
 from fabric.api import env, execute, parallel, roles, sudo, task
 from fabric.colors import blue, magenta, red
@@ -548,7 +549,7 @@ def _deploy_without_asking(skip_record):
         if skip_record == 'no':
             execute_with_timing(release.record_successful_release)
             execute_with_timing(release.record_successful_deploy)
-            release.publish_deploy_event("deploy_success")
+            publish_deploy_event("deploy_success", "commcare", env.ccc_environment)
         clear_cached_deploy()
 
 

--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -146,7 +146,8 @@ def load_env():
     # except a short blacklist that we expect app-processes.yml vars to overwrite
     overlap = set(vars_not_to_overwrite) & set(vars)
     for key in overlap:
-        print('NOTE: ignoring app-processes.yml var {}={!r}. Using value {!r} instead.'.format(key, vars[key], vars_not_to_overwrite[key]))
+        print(f'NOTE: ignoring app-processes.yml var {key}={vars[key]!r}. '
+              f'Using value {vars_not_to_overwrite[key]!r} instead.')
     vars.update(vars_not_to_overwrite)
     env.update(vars)
     env.deploy_env = env.ccc_environment.meta_config.deploy_env
@@ -316,8 +317,9 @@ def _confirm_translated():
     if datetime.datetime.now().isoweekday() != 3 or env.deploy_env != 'production':
         return True
     return console.confirm(
-        "It's the weekly Wednesday deploy, did you update the translations from transifex? "
-        "Try running this handy script from the root of your commcare-hq directory:\n./scripts/update-translations.sh\n"
+        "It's the weekly Wednesday deploy, did you update the translations "
+        "from transifex? Try running this handy script from the root of your "
+        "commcare-hq directory:\n./scripts/update-translations.sh\n"
     )
 
 
@@ -501,7 +503,6 @@ def deploy_checkpoint(command_index, command_name, fn, *args, **kwargs):
     cache_deploy_state(command_index + 1)
 
 
-
 def announce_deploy_start():
     if env.email_enabled:
         execute_with_timing(
@@ -663,10 +664,7 @@ def deploy_commcare(confirm="yes", resume='no', offline='no', skip_record='no'):
     fab <env> deploy_commcare:skip_record=yes  # skip record_successful_release
     """
     _require_target()
-    if strtobool(confirm) and (
-        not _confirm_translated() or
-        not _confirm_changes()
-    ):
+    if strtobool(confirm) and not (_confirm_translated() and _confirm_changes()):
         utils.abort('Deployment aborted.')
 
     env.full_deploy = True
@@ -691,7 +689,7 @@ def deploy_commcare(confirm="yes", resume='no', offline='no', skip_record='no'):
             'Ensure that you have run `fab prepare_offline_deploy`.'
         ))
         offline_ops.check_ready()
-        if not console.confirm('Are you sure you want to do an offline deploy?'.format(default=False)):
+        if not console.confirm('Are you sure you want to do an offline deploy?'):
             utils.abort('Task aborted')
 
         # Force ansible user and prompt for password

--- a/src/commcare_cloud/fab/operations/release.py
+++ b/src/commcare_cloud/fab/operations/release.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 import functools
-import json
 import os
 from collections import namedtuple
 from datetime import datetime, timedelta
@@ -15,10 +14,8 @@ from fabric.contrib.project import rsync_project
 from fabric.operations import put
 
 import posixpath
-import requests
 
 from commcare_cloud.environment.exceptions import EnvironmentException
-from commcare_cloud.environment.main import get_environment
 
 from ..const import (
     DATE_FMT,
@@ -370,31 +367,6 @@ def record_successful_deploy():
             'minutes': str(int(delta.total_seconds() // 60)),
             'commit': env.deploy_metadata.deploy_ref
         })
-
-
-@roles(ROLES_DEPLOY)
-def publish_deploy_event(name):
-    environment = get_environment(env.deploy_env)
-    url = environment.fab_settings_config.deploy_event_url
-    if not url:
-        return
-    token = environment.get_secret("deploy_event_token")
-    if not token:
-        print(red(f"skipping {name} event: deploy_event_token secret not set"))
-        return
-    headers = {
-        "Authorization": f"token {token}",
-        "Accept": "application/vnd.github.v3+json",
-    }
-    data = json.dumps({
-        "event_type": name,
-        "client_payload": {"environment": env.deploy_env},
-    })
-    response = requests.post(url, data=data, headers=headers)
-    if 200 <= response.status_code < 300:
-        print(f"triggered {name} event")
-    else:
-        print(red(f"{name} event status: {response.status_code}"))
 
 
 @roles(ROLES_ALL_SRC)


### PR DESCRIPTION
Move `publish_deploy_event` to a common place and call it on successful formplayer release.

The first commit is minor lint cleanup.

##### ENVIRONMENTS AFFECTED
Deploy events are currently only enabled on staging
