### PR TITLE
Updating efs_file_system terraform module to support Terraform version 12 & higher

### DIFF
--- a/src/commcare_cloud/terraform/modules/efs_file_system/CHANGELOG.md
+++ b/src/commcare_cloud/terraform/modules/efs_file_system/CHANGELOG.md
@@ -1,2 +1,4 @@
+# efs_file_system-v0.2.0
+[rameshganne] - Updating module to support Terraform v12 or higher.
 # efs_file_system-v0.1.0
 [rameshganne] - Initial commit to creating the AWS EFS file-system & mount target.

--- a/src/commcare_cloud/terraform/modules/efs_file_system/main.tf
+++ b/src/commcare_cloud/terraform/modules/efs_file_system/main.tf
@@ -1,16 +1,16 @@
 resource "aws_efs_file_system" "elastic_file_system" {
-  count  = "${var.create == "true" ? 1 : 0}"
+  count  = var.create == true ? 1 : 0
   encrypted = true
   lifecycle_policy {
-    transition_to_ia = "${var.transition_to_ia}"
+    transition_to_ia = var.transition_to_ia
   }
   tags = {
-    Name = "${var.efs_name}"
-    Environment = "${var.namespace}"
+    Name = var.efs_name
+    Environment = var.namespace
   }
 }
 
 resource "aws_efs_access_point" "efs_access_point" {
-  count  = "${var.create_access == "true" ? 1 : 0}"
-  file_system_id = "${aws_efs_file_system.elastic_file_system.id}"
+  count  = var.create_access == true ? 1 : 0
+  file_system_id = aws_efs_file_system.elastic_file_system[count.index].id
 }

--- a/src/commcare_cloud/terraform/modules/efs_file_system/mount-point/main.tf
+++ b/src/commcare_cloud/terraform/modules/efs_file_system/mount-point/main.tf
@@ -1,6 +1,6 @@
 resource "aws_efs_mount_target" "efs_mount_target" {
-  count  = "${var.create_mount == "true" ? 1 : 0}"
-  file_system_id = "${var.file_system_id}"
-  subnet_id      = "${var.subnet_ids_efs}"
-  security_groups = ["${var.securitygroup_id}"]
+  count  = var.create_mount == true ? 1 : 0
+  file_system_id = var.file_system_id
+  subnet_id      = var.subnet_ids_efs
+  security_groups = var.securitygroup_id
 }

--- a/src/commcare_cloud/terraform/modules/efs_file_system/mount-point/variables.tf
+++ b/src/commcare_cloud/terraform/modules/efs_file_system/mount-point/variables.tf
@@ -3,7 +3,7 @@ variable "subnet_ids_efs" {
 }
 
 variable "securitygroup_id" {
-  type        = "list"
+  type        = list
   description = "If the nodes are not in VPC, these are the names of the Security Groups. If the nodes are in a VPC, these are the IDs of the VPC security groups"
 }
 
@@ -13,4 +13,6 @@ variable "file_system_id" {
 
 variable "create_mount" {
   description = "Flag to enable/disable EFS aws_efs_mount_target"
+  default     = true
+  type        = bool
 }

--- a/src/commcare_cloud/terraform/modules/efs_file_system/variables.tf
+++ b/src/commcare_cloud/terraform/modules/efs_file_system/variables.tf
@@ -4,11 +4,14 @@ variable "namespace" {
 
 variable "create" {
   description = "Flag to enable/disable EFS file-system"
-  default     = "true"
+  default     = true
+  type        = bool
 }
 
 variable "create_access" {
   description = "Flag to enable/disable EFS Access-point file-system"
+  default     = true
+  type        = bool
 }
 
 variable "transition_to_ia" {


### PR DESCRIPTION
Updating efs_file_system terraform module to support Terraform version 12 & higher

- Verified on Terraform version 12.30
- First-class expressions: Updating expressions from string interpolation to directly as argument values
- Using "splat" operator `file_system_id = aws_efs_file_system.elastic_file_system[count.index].id`
- Updating variable type ex: `type        = bool`