### PR TITLE
Add localsettings.AUDIT_TRACE_ID_HEADER

### DIFF
--- a/environments/india/public.yml
+++ b/environments/india/public.yml
@@ -102,6 +102,7 @@ localsettings:
     - "{{ J2ME_SITE_HOST }}"
   ASYNC_INDICATORS_TO_QUEUE: 30000
   AUDIT_ALL_VIEWS: True
+  AUDIT_TRACE_ID_HEADER: "X-Amzn-Trace-Id"
   BANK_ADDRESS: { 'first_line': "1 Citizens Drive", 'city': "Riverside", 'region': "RI", 'postal_code': "02915" }
   BANK_NAME: "RBS Citizens N.A."
   BANK_SWIFT_CODE: 'CTZIUS33'

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -125,6 +125,7 @@ localsettings:
   ANALYTICS_DEBUG: False
   ANALYTICS_LOG_LEVEL: "warning"
   AUDIT_ALL_VIEWS: True
+  AUDIT_TRACE_ID_HEADER: "X-Amzn-Trace-Id"
   AVAILABLE_CUSTOM_RULE_CRITERIA:
     COVID_US_ASSOCIATED_USER_CASES: custom.covid.rules.custom_criteria.associated_user_case_closed
   AVAILABLE_CUSTOM_RULE_ACTIONS:

--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -105,6 +105,7 @@ localsettings:
   ANALYTICS_DEBUG: True
   ANALYTICS_LOG_LEVEL: "debug"
   AUDIT_ALL_VIEWS: True
+  AUDIT_TRACE_ID_HEADER: "X-Amzn-Trace-Id"
   AVAILABLE_CUSTOM_RULE_CRITERIA:
     COVID_US_ASSOCIATED_USER_CASES: custom.covid.rules.custom_criteria.associated_user_case_closed
   AVAILABLE_CUSTOM_RULE_ACTIONS:

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -357,8 +357,6 @@ ANALYTICS_CONFIG = {
 
 EULA_COMPLIANCE = {{ localsettings.EULA_COMPLIANCE|default(False) }}
 
-AXES_LOCK_OUT_AT_FAILURE = False
-
 NEW_DOMAIN_RECIPIENTS = ['{{ new_domain_email }}']
 
 CUSTOM_REPORT_MAP = {

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -923,6 +923,10 @@ AUDIT_VIEWS= [
 AUDIT_ALL_VIEWS = {{ localsettings.AUDIT_ALL_VIEWS }}
 {% endif %}
 
+{% if localsettings.AUDIT_TRACE_ID_HEADER is defined %}
+AUDIT_TRACE_ID_HEADER = '{{ localsettings.AUDIT_TRACE_ID_HEADER }}'
+{% endif %}
+
 {% if localsettings.get('STATIC_TOGGLE_STATES') is not none %}
 STATIC_TOGGLE_STATES = {{ localsettings.STATIC_TOGGLE_STATES }}
 {% endif %}


### PR DESCRIPTION
This setting was added as part of the SQL auditcare work. It is useful for tracing requests across the system.

Also remove an obsolete setting.

##### ENVIRONMENTS AFFECTED
staging, india, production
