### PR TITLE
Drastically lower concurrency for repeat_record_queue in production

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -46,7 +46,7 @@ celery_processes:
       concurrency: 1
     repeat_record_queue:
       pooling: gevent
-      concurrency: 100
+      concurrency: 3
     saved_exports_queue:
       concurrency: 4
     sms_queue:


### PR DESCRIPTION
During the course of https://dimagi-dev.atlassian.net/browse/SAAS-12077, we discovered that a concurrency of 3 per process (for a total concurrency of 3 x 6 = 12) was enough to get through most of a workday's worth of backlogged process_repeat_record tasks in less than an hour. That should be more than enough to keep up with the steady state while creating a little bit of elasticity during very high submission periods.

##### ENVIRONMENTS AFFECTED
production