### PR TITLE
updating server & logshipping module to support terraform v12 ref: SAAS-12058

### DIFF
--- a/src/commcare_cloud/terraform/modules/logshipping/firehose_stream/main.tf
+++ b/src/commcare_cloud/terraform/modules/logshipping/firehose_stream/main.tf
@@ -1,7 +1,7 @@
 data "aws_region" "current" {}
 
 resource "aws_kinesis_firehose_delivery_stream" "firehose_stream" {
-  name = "${var.firehose_stream_name}"
+  name = var.firehose_stream_name
   destination = "extended_s3"
   server_side_encryption {
     enabled = true
@@ -11,11 +11,11 @@ resource "aws_kinesis_firehose_delivery_stream" "firehose_stream" {
     prefix = "${var.log_bucket_prefix}/"
     error_output_prefix = "${var.log_bucket_error_prefix}/"
     kms_key_arn = "arn:aws:kms:${data.aws_region.current.name}:${var.account_id}:alias/aws/s3"
-    bucket_arn = "${var.log_bucket_arn}"
-    role_arn = "${aws_iam_role.firehose_role.arn}"
+    bucket_arn = var.log_bucket_arn
+    role_arn = aws_iam_role.firehose_role.arn
   }
-  tags {
-    Environment = "${var.environment}"
+  tags = {
+    Environment = var.environment
   }
 }
 
@@ -29,8 +29,8 @@ EOF
 
 resource "aws_iam_role_policy" "firehose_role" {
   name = "${var.firehose_stream_name}-role-policy"
-  role = "${aws_iam_role.firehose_role.id}"
-  policy = <<EOF
+  role = aws_iam_role.firehose_role.id
+  policy = <<POLICY
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -131,5 +131,6 @@ resource "aws_iam_role_policy" "firehose_role" {
       }
     }
   ]
-}EOF
+}
+POLICY
 }

--- a/src/commcare_cloud/terraform/modules/logshipping/main.tf
+++ b/src/commcare_cloud/terraform/modules/logshipping/main.tf
@@ -5,7 +5,7 @@ locals {
 }
 
 resource "aws_s3_bucket" "log_bucket" {
-  bucket = "${local.log_bucket_name}"
+  bucket = local.log_bucket_name
   acl = "private"
 
   server_side_encryption_configuration {
@@ -19,11 +19,11 @@ resource "aws_s3_bucket" "log_bucket" {
 
 module "formplayer_request_response_logs_firehose_stream" {
   source = "./firehose_stream"
-  environment = "${var.environment}"
-  account_id = "${var.account_id}"
-  log_bucket_name = "${local.log_bucket_name}"
-  log_bucket_arn = "${aws_s3_bucket.log_bucket.arn}"
-  log_bucket_prefix = "${local.formplayer_request_response_log_bucket_prefix}"
-  log_bucket_error_prefix = "${local.formplayer_request_response_log_bucket_error_prefix}"
-  firehose_stream_name = "${local.formplayer_request_response_log_bucket_prefix}"
+  environment = var.environment
+  account_id = var.account_id
+  log_bucket_name = local.log_bucket_name
+  log_bucket_arn = aws_s3_bucket.log_bucket.arn
+  log_bucket_prefix = local.formplayer_request_response_log_bucket_prefix
+  log_bucket_error_prefix = local.formplayer_request_response_log_bucket_error_prefix
+  firehose_stream_name = local.formplayer_request_response_log_bucket_prefix
 }

--- a/src/commcare_cloud/terraform/modules/server/iam/main.tf
+++ b/src/commcare_cloud/terraform/modules/server/iam/main.tf
@@ -19,20 +19,20 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "server_role_attach_cloudwatch_policy" {
-  role       = "${aws_iam_role.commcare_server_role.name}"
+  role       = aws_iam_role.commcare_server_role.name
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
 }
 
 resource "aws_iam_role_policy_attachment" "server_role_attach_awsmanagedinstance_policy" {
-  role       = "${aws_iam_role.commcare_server_role.name}"
+  role       = aws_iam_role.commcare_server_role.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
 resource "aws_iam_role_policy" "request_response_stream_put_policy" {
   name = "RequestResponseStreamPutPolicy"
-  role = "${aws_iam_role.commcare_server_role.id}"
+  role = aws_iam_role.commcare_server_role.id
 
-  policy = <<-EOF
+  policy = <<POLICY
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -48,14 +48,14 @@ resource "aws_iam_role_policy" "request_response_stream_put_policy" {
     }
   ]
 }
-  EOF
+  POLICY
 }
 
 resource "aws_iam_role_policy" "commcare_secrets_access_policy" {
   name = "CommCareSecretsAccess"
-  role = "${aws_iam_role.commcare_server_role.id}"
+  role = aws_iam_role.commcare_server_role.id
 
-  policy = <<-EOF
+  policy = <<POLICY
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -76,10 +76,10 @@ resource "aws_iam_role_policy" "commcare_secrets_access_policy" {
         }
     ]
 }
-  EOF
+  POLICY
 }
 
 resource "aws_iam_instance_profile" "commcare_server_instance_profile" {
   name = "CommCareServerRole"
-  role = "${aws_iam_role.commcare_server_role.name}"
+  role = aws_iam_role.commcare_server_role.name
 }

--- a/src/commcare_cloud/terraform/modules/server/main.tf
+++ b/src/commcare_cloud/terraform/modules/server/main.tf
@@ -1,59 +1,65 @@
 resource aws_instance "server" {
-  ami                     = "${var.server_image}"
-  instance_type           = "${var.server_instance_type}"
-  subnet_id               = "${var.subnet_options[
+  ami                     = var.server_image
+  instance_type           = var.server_instance_type
+  subnet_id               = var.subnet_options[
     format("%s-%s", var.network_tier, var.az)
-  ]}"
-  key_name                = "${var.key_name}"
-  vpc_security_group_ids  = ["${var.security_group_options[var.network_tier]}"]
+  ]
+  key_name                = var.key_name
+  vpc_security_group_ids  = var.security_group_options[var.network_tier]
   source_dest_check       = false
-  iam_instance_profile    = "${var.iam_instance_profile}"
+  iam_instance_profile    = var.iam_instance_profile
 
   disable_api_termination = true
   ebs_optimized = true
   root_block_device {
-    volume_size           = "${var.volume_size}"
-    encrypted             = "${var.volume_encrypted}"
-    volume_type           = "gp2"
+    volume_size           = var.volume_size
+    encrypted             = var.volume_encrypted
+    volume_type           = var.volume_type
     delete_on_termination = true
   }
   lifecycle {
-    ignore_changes = ["user_data", "key_name", "root_block_device.0.delete_on_termination",
-      "ebs_optimized", "ami", "volume_tags", "iam_instance_profile"]
+    ignore_changes = [user_data, key_name, root_block_device.0.delete_on_termination,
+      ebs_optimized, ami, volume_tags, iam_instance_profile]
   }
-  tags {
-    Name        = "${var.server_name}"
-    Environment = "${var.environment}"
-    Group = "${var.group_tag}"
+  tags = {
+    Name        = var.server_name
+    Environment = var.environment
+    Group = var.group_tag
   }
-  volume_tags {
+  volume_tags = {
     Name = "vol-${var.server_name}"
-    ServerName = "${var.server_name}"
-    Environment = "${var.environment}"
-    Group = "${var.group_tag}"
+    ServerName = var.server_name
+    Environment = var.environment
+    Group = var.group_tag
   }
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_put_response_hop_limit = 1
+    http_tokens                 = var.metadata_tokens
+  }
+
 }
 
 resource "aws_ebs_volume" "ebs_volume" {
-  count = "${var.secondary_volume_size > 0 ? 1 : 0}"
-  availability_zone = "${aws_instance.server.availability_zone}"
-  size = "${var.secondary_volume_size}"
-  type = "${var.secondary_volume_type}"
-  encrypted = "${var.secondary_volume_encrypted}"
+  count = var.secondary_volume_size > 0 ? 1 : 0
+  availability_zone = aws_instance.server.availability_zone
+  size = var.secondary_volume_size
+  type = var.secondary_volume_type
+  encrypted = var.secondary_volume_encrypted
 
-  tags {
+  tags = {
     Name = "data-vol-${var.server_name}"
-    ServerName = "${var.server_name}"
-    Environment = "${var.environment}"
-    Group = "${var.group_tag}"
+    ServerName = var.server_name
+    Environment = var.environment
+    Group = var.group_tag
     VolumeType = "data"
     GroupDetail = "${var.group_tag}:data"
   }
 }
 
 resource "aws_volume_attachment" "ebs_att" {
-  count = "${var.secondary_volume_size > 0 ? 1 : 0}"
+  count = var.secondary_volume_size > 0 ? 1 : 0
   device_name = "/dev/sdf"
-  volume_id   = "${aws_ebs_volume.ebs_volume.id}"
-  instance_id = "${aws_instance.server.id}"
+  volume_id   = aws_ebs_volume.ebs_volume[count.index].id
+  instance_id = aws_instance.server.id
 }

--- a/src/commcare_cloud/terraform/modules/server/variables.tf
+++ b/src/commcare_cloud/terraform/modules/server/variables.tf
@@ -1,11 +1,11 @@
 variable "key_name" {}
 
 variable "security_group_options" {
-  type = "map"
+  type = map
 }
 
 variable "subnet_options" {
-  type = "map"
+  type = map
 }
 
 variable "server_image" {}
@@ -16,10 +16,23 @@ variable "iam_instance_profile" {}
 variable "server_name" {}
 variable "server_instance_type" {}
 variable "network_tier" {}
-variable "volume_size" {}
-variable "volume_encrypted" {}
-variable "secondary_volume_size" {}
+variable "volume_size" {
+  type = number
+}
+variable "volume_type" {}
+variable "volume_encrypted" {
+  type        = bool
+}
+variable "secondary_volume_size" {
+  type = number
+}
 variable "secondary_volume_type" {}
-variable "secondary_volume_encrypted" {}
+variable "secondary_volume_encrypted" {
+  type        = bool
+}
 variable "az" {}
 variable "group_tag" {}
+variable "metadata_tokens" {
+  description = "Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2). Valid values include optional or required. Defaults to optional"
+  default     = "optional"
+}


### PR DESCRIPTION
Updating server & logshipping terraform modules to support v12.
Ref: SAAS-12058

**Server module:** added metadata_options & volume-type. It can support for EBS gp3 volume type. 
metadata_options - Customize the metadata options of the instance. It can refer to as Instance Metadata Service Version 2 (IMDSv2) &  IMDSv1.