### PR TITLE
Revert "Lower concurrency for repeat_record_queue in production to 1 x 6"

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -48,7 +48,7 @@ celery_processes:
       concurrency: 1
     repeat_record_queue:
       pooling: gevent
-      concurrency: 1
+      concurrency: 3
     saved_exports_queue:
       concurrency: 4
     sms_queue:


### PR DESCRIPTION
Reverts dimagi/commcare-cloud#4658

This was applied Apr 15 during https://dimagi-dev.atlassian.net/browse/SAAS-12077.