### PR TITLE
Increase production couch os_process_timeout to 20s

### DIFF
--- a/src/commcare_cloud/ansible/roles/couchdb2/templates/extras.ini.j2
+++ b/src/commcare_cloud/ansible/roles/couchdb2/templates/extras.ini.j2
@@ -6,3 +6,6 @@ os_process_limit = {{ couchdb_os_process_limit }}
 
 [rexi]
 server_per_node = true
+
+[couchdb]
+os_process_timeout = 20000


### PR DESCRIPTION
Applied during https://dimagi-dev.atlassian.net/browse/SAAS-12077

##### ENVIRONMENTS AFFECTED
production