### PR TITLE
Add way to exclude couch host from couch proxy

### DIFF
--- a/src/commcare_cloud/ansible/roles/nginx/templates/site.j2
+++ b/src/commcare_cloud/ansible/roles/nginx/templates/site.j2
@@ -13,7 +13,9 @@ upstream {{ balancer.name }} {
   {% endif %}
 
 {% for host in groups[balancer.hosts] | default(balancer.hosts) %}
+{% if not balancer.excluded_hosts or host not in groups[balancer.excluded_hosts] | default([]) %}
   server {{ host }}:{{ balancer.port }}{% for key, value in (balancer.params | default({})).items() %} {{ key }}={{ value }}{% endfor %};
+{% endif %}
 {% endfor %}
 }
 {% endfor %}

--- a/src/commcare_cloud/ansible/roles/nginx/vars/couchdb2.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/couchdb2.yml
@@ -4,6 +4,7 @@ nginx_sites:
    balancers:
     - name: "{{ deploy_env }}_couchdb_{{ couchdb2_proxy_port }}"
       hosts: couchdb2
+      excluded_hosts: "{{ couch_excluded_hosts | default(None) }}"
       port: "{{ couchdb2_port }}"
       params:
         # http://nginx.org/en/docs/http/ngx_http_upstream_module.html#server


### PR DESCRIPTION
e.g.

```
cchq <env> ap deploy_couchdb2.yml --limit couchdb2_proxy --tags=proxy -e couch_excluded_hosts=<couch_host>
```

Tooling created to make restarting couch nodes one at a time without downtime simpler during https://dimagi-dev.atlassian.net/browse/SAAS-12077.

##### ENVIRONMENTS AFFECTED
production
