### PR TITLE
add commit data to sentry releases

### DIFF
--- a/src/commcare_cloud/commands/deploy/formplayer.py
+++ b/src/commcare_cloud/commands/deploy/formplayer.py
@@ -85,7 +85,7 @@ def record_deploy_success(environment, repo, diff, start):
     end = datetime.utcnow()
     create_release_tag(environment, repo, diff)
     record_deploy_in_datadog(environment, diff, end - start)
-    update_sentry_post_deploy(environment, "formplayer", "dimagi/formplayer", diff, start, end)
+    update_sentry_post_deploy(environment, "formplayer", repo, diff, start, end)
     announce_deploy_success(environment, diff.get_email_diff())
     publish_deploy_event("deploy_success", "formplayer", environment)
 

--- a/src/commcare_cloud/commands/deploy/sentry.py
+++ b/src/commcare_cloud/commands/deploy/sentry.py
@@ -16,7 +16,7 @@ def update_sentry_post_deploy(environment, sentry_project, github_repo, diff, de
     localsettings = environment.public_vars["localsettings"]
     client = SentryClient(
         environment.get_secret('SENTRY_API_KEY'),
-        localsettings.get('SENTRY_ORGANIZATION_SLUG'),
+        localsettings.get('SENTRY_ORGANIZATION_SLUG', 'dimagi'),
         sentry_project
     )
     if client.is_valid():

--- a/src/commcare_cloud/commands/deploy/sentry.py
+++ b/src/commcare_cloud/commands/deploy/sentry.py
@@ -1,37 +1,43 @@
 import requests
 from jsonobject.base import namedtuple
 
+ISO_DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 
-def update_sentry_post_deploy(environment, sentry_project, sentry_repo, diff, deploy_start, deploy_end):
+FILE_STATUS = {
+    "added": "A",
+    "modified": "M",
+    "renamed": "M",
+    "deleted": "D",
+    "removed": "D"
+}
+
+
+def update_sentry_post_deploy(environment, sentry_project, github_repo, diff, deploy_start, deploy_end):
     localsettings = environment.public_vars["localsettings"]
     client = SentryClient(
         environment.get_secret('SENTRY_API_KEY'),
-        sentry_repo,
         localsettings.get('SENTRY_ORGANIZATION_SLUG'),
         sentry_project
     )
     if client.is_valid():
         release_name = environment.new_release_name()
-        client.create_release(release_name, diff.deploy_commit)
+        commits = get_release_commits(github_repo, diff.current_commit, diff.deploy_commit)
+        client.create_release(release_name, commits)
         client.create_deploy(
             release_name, environment.meta_config.env_monitoring_id,
             deploy_start, deploy_end
         )
 
 
-class SentryClient(namedtuple("SentryClient", "api_key, repo_name, org_slug, project_slug")):
+class SentryClient(namedtuple("SentryClient", "api_key, org_slug, project_slug")):
     def is_valid(self):
         return all(self)
 
-    def create_release(self, release_name, git_commit):
-        # TODO: include more commit detail: https://docs.sentry.io/product/releases/setup/manual-setup-releases/
+    def create_release(self, release_name, commit_data):
         payload = {
             'version': release_name,
-            'refs': [{
-                'repository': self.repo_name,
-                'commit': git_commit
-            }],
-            'projects': [self.project_slug]
+            'projects': [self.project_slug],
+            'commits': commit_data
         }
 
         headers = {'Authorization': 'Bearer {}'.format(self.api_key), }
@@ -52,3 +58,24 @@ class SentryClient(namedtuple("SentryClient", "api_key, repo_name, org_slug, pro
         headers = {'Authorization': 'Bearer {}'.format(self.api_key), }
         releases_url = f'https://sentry.io/api/0/organizations/{self.org_slug}/releases/{release_name}/deploys/'
         requests.post(releases_url, headers=headers, json=payload)
+
+
+def get_release_commits(git_repo, base, head):
+    # https://docs.sentry.io/product/releases/setup/manual-setup-releases/
+    comparison = git_repo.compare(base, head)
+    commits = []
+    for commit in comparison.commits:
+        author = commit.commit.author
+        commits.append({
+            "repository": git_repo.full_name,
+            "author_name": author.name,
+            "author_email": author.email,
+            "timestamp": author.date.strftime(ISO_DATETIME_FORMAT),
+            "message": commit.commit.message,
+            "id": commit.sha,
+            "patch_set": [
+                {"path": file.filename, "type": FILE_STATUS.get(file.status, "M")}
+                for file in commit.files
+            ],
+        })
+    return commits


### PR DESCRIPTION
[USH-935](https://dimagi-dev.atlassian.net/browse/USH-935)

Include full commit data in sentry releases. This should allow Sentry to give more accurate 'suspect commits': https://docs.sentry.io/product/releases/setup/manual-setup-releases/#using-the-api