### PR TITLE
Add option to deploy both commcare and formplayer

### DIFF
--- a/docs/commcare-cloud/commands/index.md
+++ b/docs/commcare-cloud/commands/index.md
@@ -1061,15 +1061,15 @@ Deploy CommCare
 
 ```
 commcare-cloud <env> deploy [--resume] [--skip-record] [--commcare-rev COMMCARE_REV] [--set FAB_SETTINGS]
-                            [{commcare,formplayer,both}]
+                            [{commcare,formplayer} [{commcare,formplayer} ...]]
 ```
 
 ##### Positional Arguments
 
-###### `{commcare,formplayer,both}`
+###### `{commcare,formplayer}`
 
-The component to deploy. If not specified, will deploy CommCare, or
-both, if always_deploy_formplayer is set in meta.yml
+Component(s) to deploy. Default is 'commcare', or if
+always_deploy_formplayer is set in meta.yml, 'commcare formplayer'
 
 ##### Optional Arguments
 

--- a/docs/commcare-cloud/commands/index.md
+++ b/docs/commcare-cloud/commands/index.md
@@ -1061,12 +1061,12 @@ Deploy CommCare
 
 ```
 commcare-cloud <env> deploy [--resume] [--skip-record] [--commcare-rev COMMCARE_REV] [--set FAB_SETTINGS]
-                            [{commcare,formplayer}]
+                            [{commcare,formplayer,both}]
 ```
 
 ##### Positional Arguments
 
-###### `{commcare,formplayer}`
+###### `{commcare,formplayer,both}`
 
 The component to deploy. If not specified, will deploy CommCare, or
 both, if always_deploy_formplayer is set in meta.yml

--- a/src/commcare_cloud/commands/deploy/command.py
+++ b/src/commcare_cloud/commands/deploy/command.py
@@ -27,7 +27,7 @@ class Deploy(CommandBase):
     )
 
     arguments = (
-        Argument('component', nargs='?', choices=['commcare', 'formplayer'], help="""
+        Argument('component', nargs='?', choices=['commcare', 'formplayer', 'both'], help="""
             The component to deploy. If not specified, will deploy CommCare, or
             both, if always_deploy_formplayer is set in meta.yml
         """),

--- a/src/commcare_cloud/commands/deploy/command.py
+++ b/src/commcare_cloud/commands/deploy/command.py
@@ -20,6 +20,13 @@ from commcare_cloud.environment.main import get_environment
 from commcare_cloud.environment.paths import get_available_envs
 
 
+class ZeroOrMore(list):
+    # HACK work around `nargs='*', choices=[...]` produces
+    # "error: invalid choice: [] (choose from ...)" when no value is provided
+    def __contains__(self, item):
+        return item == [] or super().__contains__(item)
+
+
 class Deploy(CommandBase):
     command = 'deploy'
     help = (
@@ -27,9 +34,9 @@ class Deploy(CommandBase):
     )
 
     arguments = (
-        Argument('component', nargs='?', choices=['commcare', 'formplayer', 'both'], help="""
-            The component to deploy. If not specified, will deploy CommCare, or
-            both, if always_deploy_formplayer is set in meta.yml
+        Argument('component', nargs='*', choices=ZeroOrMore(['commcare', 'formplayer']), help="""
+            Component(s) to deploy. Default is 'commcare', or if
+            always_deploy_formplayer is set in meta.yml, 'commcare formplayer'
         """),
         Argument('--resume', action='store_true', help="""
             Rather than starting a new deploy, start where you left off the last one.
@@ -69,15 +76,17 @@ class Deploy(CommandBase):
         environment = get_environment(args.env_name)
 
         deploy_component = args.component
-        if deploy_component is None:
-            deploy_component = 'both' if environment.meta_config.always_deploy_formplayer else 'commcare'
+        if not deploy_component:
+            deploy_component = ['commcare']
+            if environment.meta_config.always_deploy_formplayer:
+                deploy_component.append('formplayer')
 
-        if deploy_component in ['commcare', 'both']:
-            if deploy_component != 'both':
+        if 'commcare' in deploy_component:
+            if 'formplayer' not in deploy_component:
                 _warn_no_formplayer()
             return deploy_commcare(environment, args, unknown_args)
-        if deploy_component in ['formplayer', 'both']:
-            if deploy_component != 'both':
+        if 'formplayer' in deploy_component:
+            if 'commcare' not in deploy_component:
                 if args.commcare_rev:
                     print(color_warning('--commcare-rev does not apply to a formplayer deploy and will be ignored'))
                 if args.fab_settings:


### PR DESCRIPTION
I thought this had previously been possible. Is this a good idea or will it not work? I think it's supposed to be the default behavior if no component is specified and the environment metadata has `always_deploy_formplayer: true`, but it doesn't look like that option is used by any of our environments.

Motivation: the deploy process now specifies that both HQ and formplayer should be deployed by on-call SaaS developer. Would be nice to be able to kick that off with a single command.

##### ENVIRONMENTS AFFECTED
n/a
