### PR TITLE
disable deploy diffs for staging

### DIFF
--- a/environments/staging/fab-settings.yml
+++ b/environments/staging/fab-settings.yml
@@ -4,3 +4,4 @@ tag_deploy_commits: True
 use_shared_dir_for_staticfiles: True
 shared_dir_for_staticfiles: /mnt/shared_staging/temp
 deploy_event_url: https://api.github.com/repos/dimagi/dimagi-qa/dispatches
+generate_deploy_diffs: False

--- a/environments/staging/fab-settings.yml
+++ b/environments/staging/fab-settings.yml
@@ -5,3 +5,5 @@ use_shared_dir_for_staticfiles: True
 shared_dir_for_staticfiles: /mnt/shared_staging/temp
 deploy_event_url: https://api.github.com/repos/dimagi/dimagi-qa/dispatches
 generate_deploy_diffs: False
+custom_deploy_details:
+  View staging branches here: https://github.com/dimagi/commcare-hq/blob/autostaging/scripts/staging.yaml

--- a/src/commcare_cloud/commands/deploy/commcare.py
+++ b/src/commcare_cloud/commands/deploy/commcare.py
@@ -82,7 +82,11 @@ def _get_diff(environment, deploy_revs):
     deployed_version = _get_deployed_version(environment)
     latest_version = repo.get_commit(deploy_revs['commcare']).sha if repo else None
 
-    DEPLOY_DIFF = DeployDiff(repo, deployed_version, latest_version, new_version_details=deploy_revs)
+    DEPLOY_DIFF = DeployDiff(
+        repo, deployed_version, latest_version,
+        new_version_details=deploy_revs,
+        generate_diff=environment.fab_settings_config.generate_deploy_diffs
+    )
     return DEPLOY_DIFF
 
 

--- a/src/commcare_cloud/commands/deploy/commcare.py
+++ b/src/commcare_cloud/commands/deploy/commcare.py
@@ -82,9 +82,14 @@ def _get_diff(environment, deploy_revs):
     deployed_version = _get_deployed_version(environment)
     latest_version = repo.get_commit(deploy_revs['commcare']).sha if repo else None
 
+    new_version_details = {
+        'Branch deployed': ', '.join([f'{repo}: {ref}' for repo, ref in deploy_revs.items()])
+    }
+    if environment.fab_settings_config.custom_deploy_details:
+        new_version_details.update(environment.fab_settings_config.custom_deploy_details)
     DEPLOY_DIFF = DeployDiff(
         repo, deployed_version, latest_version,
-        new_version_details=deploy_revs,
+        new_version_details=new_version_details,
         generate_diff=environment.fab_settings_config.generate_deploy_diffs
     )
     return DEPLOY_DIFF

--- a/src/commcare_cloud/commands/deploy/formplayer.py
+++ b/src/commcare_cloud/commands/deploy/formplayer.py
@@ -109,7 +109,8 @@ def get_deploy_diff(environment, repo):
         new_version_details["Build time"] = f"{latest_version.build_time_ago} ({latest_version.build_time})"
     diff = DeployDiff(
         repo, current_commit, latest_version.commit,
-        new_version_details=new_version_details
+        new_version_details=new_version_details,
+        generate_diff=environment.fab_settings_config.generate_deploy_diffs
     )
     return diff
 

--- a/src/commcare_cloud/environment/schemas/fab_settings.py
+++ b/src/commcare_cloud/environment/schemas/fab_settings.py
@@ -25,6 +25,7 @@ class FabSettingsConfig(jsonobject.JsonObject):
     use_shared_dir_for_staticfiles = jsonobject.BooleanProperty(default=False)
     shared_dir_for_staticfiles = jsonobject.StringProperty(default=None)
     deploy_event_url = jsonobject.StringProperty(default=None)
+    generate_deploy_diffs = jsonobject.BooleanProperty(default=True)
 
     @classmethod
     def wrap(cls, data):

--- a/src/commcare_cloud/environment/schemas/fab_settings.py
+++ b/src/commcare_cloud/environment/schemas/fab_settings.py
@@ -26,6 +26,7 @@ class FabSettingsConfig(jsonobject.JsonObject):
     shared_dir_for_staticfiles = jsonobject.StringProperty(default=None)
     deploy_event_url = jsonobject.StringProperty(default=None)
     generate_deploy_diffs = jsonobject.BooleanProperty(default=True)
+    custom_deploy_details = jsonobject.DictProperty()
 
     @classmethod
     def wrap(cls, data):

--- a/src/commcare_cloud/fab/deploy_diff.py
+++ b/src/commcare_cloud/fab/deploy_diff.py
@@ -22,17 +22,19 @@ LABELS_TO_EXPAND = [
 
 
 class DeployDiff:
-    def __init__(self, repo, current_commit, deploy_commit, new_version_details=None):
+    def __init__(self, repo, current_commit, deploy_commit, new_version_details=None, generate_diff=True):
         """
         :param repo: github.Repository.Repository object
         :param current_commit: Commit SHA of the currently deployed code
         :param deploy_commit: Commit SHA of the code being deployed
         :param new_version_details: dict of additional metadata to display in diff output.
+        :param generate_diff: True if deploy diffs should be produced
         """
         self.repo = repo
         self.current_commit = current_commit
         self.deploy_commit = deploy_commit
         self.new_version_details = new_version_details
+        self.generate_diff = generate_diff
         self.j2 = jinja2.Environment(loader=jinja2.FileSystemLoader(TEMPLATE_DIR))
         register_console_filters(self.j2)
 
@@ -67,6 +69,12 @@ class DeployDiff:
             return context
 
         context["compare_url"] = self.url
+
+        if not self.generate_diff:
+            disabled_msg = "Deploy diffs disabled for this environment."
+            print(color_warning(disabled_msg))
+            context["warnings"].append(disabled_msg)
+            return
 
         if not self.repo.permissions:
             # using unauthenticated API calls, skip diff creation to avoid hitting rate limits


### PR DESCRIPTION
See https://github.com/dimagi/commcare-cloud/pull/4693#issuecomment-831722189

Since the staging branch is rebuilt and force pushed frequently the concept of a diff is misleading since the branch history is not linear. This disabled the generation of the deploy diff for staging.