### PR TITLE
checking resolv.conf status - Path exists and is a symlink

### DIFF
--- a/src/commcare_cloud/ansible/deploy_common.yml
+++ b/src/commcare_cloud/ansible/deploy_common.yml
@@ -90,9 +90,17 @@
     tags:
       - dns
       - after-reboot
+  
+  - name: Checks resolv.conf stat
+    stat:
+      path: /etc/resolv.conf
+    register: etc_resolv_conf
+    tags:
+      - dns
+      - after-reboot
 
   - name: Updating resolv.conf symbolic link 
-    when: ansible_distribution == "Ubuntu" and resolvconf.stat.exists
+    when: ansible_distribution == "Ubuntu" and resolvconf.stat.exists and etc_resolv_conf.stat.islnk is defined and etc_resolv_conf.stat.islnk
     become: yes
     file:
       src: /run/systemd/resolve/resolv.conf


### PR DESCRIPTION
To resolve the below listed issue, updating it to check /etc/resolv.conf status: Path exists and is a symlink
verified in staging env.

ref: https://forum.dimagi.com/t/update-config-failing/8171/9