### PR TITLE
adding token based instance metadata URL- supports IMDS-v2

### DIFF
--- a/src/commcare_cloud/commands/terraform/aws.py
+++ b/src/commcare_cloud/commands/terraform/aws.py
@@ -354,10 +354,20 @@ def aws_sign_in(environment, duration_minutes=DEFAULT_SIGN_IN_DURATION_MINUTES, 
 
 def is_ec2_instance_in_account(account_id):
     try:
-        aws_instance_identity_doc = requests.get(
-            'http://169.254.169.254/latest/dynamic/instance-identity/document',
-            timeout=.100
+        token_api_headers = {
+            'X-aws-ec2-metadata-token-ttl-seconds': '21600',
+        }
+        token_api_response = requests.put('http://169.254.169.254/latest/api/token', headers=token_api_headers)
+        if token_api_response.status_code==200:
+            TOKEN = token_api_response.text
+            headers = {	'X-aws-ec2-metadata-token': TOKEN,	}
+            aws_instance_identity_doc = requests.get('http://169.254.169.254/latest/dynamic/instance-identity/document',
+            timeout=.100,
+            headers=headers
         ).json()
+        else:
+            return False
+
     except (requests.exceptions.ConnectTimeout, requests.exceptions.ConnectionError):
         return False
 

--- a/src/commcare_cloud/commands/terraform/aws.py
+++ b/src/commcare_cloud/commands/terraform/aws.py
@@ -364,7 +364,7 @@ def is_ec2_instance_in_account(account_id):
                 'http://169.254.169.254/latest/dynamic/instance-identity/document',
                 timeout=.100,
                 headers={'X-aws-ec2-metadata-token': token_api_response.text},
-        ).json()
+            ).json()
         else:
             return False
 

--- a/src/commcare_cloud/commands/terraform/aws.py
+++ b/src/commcare_cloud/commands/terraform/aws.py
@@ -354,16 +354,16 @@ def aws_sign_in(environment, duration_minutes=DEFAULT_SIGN_IN_DURATION_MINUTES, 
 
 def is_ec2_instance_in_account(account_id):
     try:
-        token_api_headers = {
+        # AWS Metadata v2 requires multiple requests in this format as per
+        # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
+        token_api_response = requests.put('http://169.254.169.254/latest/api/token', headers={
             'X-aws-ec2-metadata-token-ttl-seconds': '21600',
-        }
-        token_api_response = requests.put('http://169.254.169.254/latest/api/token', headers=token_api_headers)
-        if token_api_response.status_code==200:
-            TOKEN = token_api_response.text
-            headers = {	'X-aws-ec2-metadata-token': TOKEN,	}
-            aws_instance_identity_doc = requests.get('http://169.254.169.254/latest/dynamic/instance-identity/document',
-            timeout=.100,
-            headers=headers
+        })
+        if token_api_response.status_code == 200:
+            aws_instance_identity_doc = requests.get(
+                'http://169.254.169.254/latest/dynamic/instance-identity/document',
+                timeout=.100,
+                headers={'X-aws-ec2-metadata-token': token_api_response.text},
         ).json()
         else:
             return False


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-12187

Updating "commcare-cloud/src/commcare_cloud/commands/terraform/aws.py" to request instance metadata through the token.

These are the draft changes related to IMDS-v2.