### PR TITLE
White listed URL

### DIFF
--- a/src/commcare_cloud/commands/terraform/constants.py
+++ b/src/commcare_cloud/commands/terraform/constants.py
@@ -10,6 +10,7 @@ COMMCAREHQ_XML_POST_URLS_REGEX = r"""
 ^/a/([\w\.:-]+)/apps/([\w-]+)/multimedia/uploaded/image/$
 ^/a/([\w\.:-]+)/apps/edit_form_attr/([\w-]+)/([\w-]+)/([\w-]+)/$
 ^/a/([\w\.:-]+)/apps/edit_form_attr_api/([\w-]+)/([\w-]+)/([\w-]+)/$
+^/a/([\w\.:-]+)/apps/edit_module_detail_screens/([\w-]+)/([\w-]+)/$
 ^/a/([\w\.:-]+)/apps/patch_xform/([\w-]+)/([\w-]+)/$
 ^/a/([\w\.:-]+)/apps/view/([\w-]+)/languages/bulk_app_translations/upload/$
 ^/a/([\w\.:-]+)/cloudcare/api/readable_questions/$


### PR DESCRIPTION
Ticket: https://dimagi-dev.atlassian.net/browse/INDIV-8
WAF was blocking some of the requests from this endpoint. As this endpoint allows XML kind of script to be taken from the user so it needs to be whitelisted.
relevant PR:  https://github.com/dimagi/commcare-hq/pull/29674