### PR TITLE
Update announce deploy

### DIFF
--- a/src/commcare_cloud/commands/deploy/commcare.py
+++ b/src/commcare_cloud/commands/deploy/commcare.py
@@ -27,7 +27,7 @@ def deploy_commcare(environment, args, unknown_args):
         var = 'code_branch' if name == 'commcare' else '{}_code_branch'.format(name)
         fab_settings.append('{}={}'.format(var, rev))
 
-    announce_deploy_start(environment, "CommCare HQ")
+    announce_deploy_start(environment, "CommCare HQ", args.commcare_rev)
     start = datetime.utcnow()
     rc = commcare_cloud(
         environment.name, 'fab', 'deploy_commcare{}'.format(fab_func_args),

--- a/src/commcare_cloud/commands/deploy/commcare.py
+++ b/src/commcare_cloud/commands/deploy/commcare.py
@@ -6,7 +6,7 @@ from commcare_cloud.alias import commcare_cloud
 from commcare_cloud.cli_utils import ask
 from commcare_cloud.colors import color_notice
 from commcare_cloud.commands.deploy.sentry import update_sentry_post_deploy
-from commcare_cloud.commands.deploy.utils import announce_deploy_start, announce_deploy_success, create_release_tag
+from commcare_cloud.commands.deploy.utils import announce_deploy_start, announce_deploy_success, create_release_tag, within_maintenance_window
 from commcare_cloud.commands.terraform.aws import get_default_username
 from commcare_cloud.commands.utils import run_fab_task
 from commcare_cloud.events import publish_deploy_event
@@ -107,14 +107,10 @@ def _confirm_translated(environment, quiet=False):
 
 
 def _confirm_environment_time(environment, quiet=False):
-    window = environment.fab_settings_config.acceptable_maintenance_window
-    if window:
-        d = datetime.now(pytz.timezone(window['timezone']))
-        if window['hour_start'] <= d.hour < window['hour_end']:
-            return True
-    else:
+    if within_maintenance_window(environment):
         return True
-
+    window = environment.fab_settings_config.acceptable_maintenance_window
+    d = datetime.now(pytz.timezone(window['timezone']))
     message = (
         "Whoa there bud! You're deploying '%s' outside the configured maintenance window. "
         "The current local time is %s.\n"

--- a/src/commcare_cloud/commands/deploy/formplayer.py
+++ b/src/commcare_cloud/commands/deploy/formplayer.py
@@ -62,7 +62,7 @@ def deploy_formplayer(environment, args):
         return 1
 
     start = datetime.utcnow()
-    announce_deploy_start(environment, FORMPLAYER)
+    announce_deploy_start(environment, FORMPLAYER, args.commcare_rev)
 
     rc = run_ansible_playbook_command(environment, args)
     if rc != 0:

--- a/src/commcare_cloud/commands/deploy/utils.py
+++ b/src/commcare_cloud/commands/deploy/utils.py
@@ -25,18 +25,19 @@ def announce_deploy_start(environment, service_name, commcare_rev=None):
     is_nonstandard_deploy_time = not within_maintenance_window(environment)
     is_non_default_branch = (
         commcare_rev != environment.fab_settings_config.default_branch and
-        commcare_rev != None
+        commcare_rev is not None
     )
     env_name = environment.meta_config.deploy_env
     subject = ""
-    if is_non_default_branch and is_nonstandard_deploy_time:
-        subject = f"ATTENTION: {user} has initiated {service_name} deploy outside maintenance window with branch {commcare_rev} to {env_name}"
-    elif is_nonstandard_deploy_time:
-        subject = f"ATTENTION: {user} has initiated {service_name} deploy outside maintenance window to {env_name}"
-    elif is_non_default_branch:
-        subject = f"ATTENTION: {user} has initiated {service_name} deploy with branch {commcare_rev} to {env_name}"
-    else:
-        subject = f"{user} has initiated a {service_name} deploy to {env_name}"
+    subject = f"{user} has initiated a {service_name} deploy to {env_name}"
+    prefix = ""
+    if is_nonstandard_deploy_time:
+        subject += " outside maintenance window"
+        prefix = "ATTENTION: "
+    if is_non_default_branch:
+        subject += f" with non-default branch '{commcare_rev}'"
+        prefix = "ATTENTION: "
+    subject = f"{prefix}{subject}"
 
     send_email(
         environment,

--- a/src/commcare_cloud/commands/deploy/utils.py
+++ b/src/commcare_cloud/commands/deploy/utils.py
@@ -22,10 +22,22 @@ def create_release_tag(environment, repo, diff):
 
 def announce_deploy_start(environment, service_name, commcare_rev=None):
     user = get_default_username()
+    is_nonstandard_deploy_time = not within_maintenance_window(environment)
+    is_non_default_branch = (
+        commcare_rev != environment.fab_settings_config.default_branch and
+        commcare_rev != None
+    )
     env_name = environment.meta_config.deploy_env
-    subject = f"{user} has initiated a {service_name} deploy to {env_name}"
-    if commcare_rev:
+    subject = ""
+    if is_non_default_branch and is_nonstandard_deploy_time:
+        subject = f"ATTENTION: {user} has initiated {service_name} deploy outside maintenance window with branch {commcare_rev} to {env_name}"
+    elif is_nonstandard_deploy_time:
+        subject = f"ATTENTION: {user} has initiated {service_name} deploy outside maintenance window to {env_name}"
+    elif is_non_default_branch:
         subject = f"ATTENTION: {user} has initiated {service_name} deploy with branch {commcare_rev} to {env_name}"
+    else:
+        subject = f"{user} has initiated a {service_name} deploy to {env_name}"
+
     send_email(
         environment,
         subject=subject,

--- a/src/commcare_cloud/commands/deploy/utils.py
+++ b/src/commcare_cloud/commands/deploy/utils.py
@@ -28,7 +28,6 @@ def announce_deploy_start(environment, service_name, commcare_rev=None):
         commcare_rev is not None
     )
     env_name = environment.meta_config.deploy_env
-    subject = ""
     subject = f"{user} has initiated a {service_name} deploy to {env_name}"
     prefix = ""
     if is_nonstandard_deploy_time:

--- a/src/commcare_cloud/commands/deploy/utils.py
+++ b/src/commcare_cloud/commands/deploy/utils.py
@@ -1,4 +1,6 @@
+from datetime import datetime
 from github.GithubException import GithubException
+import pytz
 
 from commcare_cloud.alias import commcare_cloud
 from commcare_cloud.colors import color_summary, color_error
@@ -78,3 +80,10 @@ def send_email(environment, subject, message='', to_admins=True, recipients=None
             *args,
             show_command=False
         )
+
+def within_maintenance_window(environment):
+    window = environment.fab_settings_config.acceptable_maintenance_window
+    if window:
+        d = datetime.now(pytz.timezone(window['timezone']))
+        return window['hour_start'] <= d.hour < window['hour_end']
+    return True

--- a/src/commcare_cloud/commands/deploy/utils.py
+++ b/src/commcare_cloud/commands/deploy/utils.py
@@ -18,14 +18,15 @@ def create_release_tag(environment, repo, diff):
             print(color_error(f"Error creating release tag: {e}"))
 
 
-def announce_deploy_start(environment, service_name):
+def announce_deploy_start(environment, service_name, commcare_rev=None):
+    user = get_default_username()
+    env_name = environment.meta_config.deploy_env
+    subject = f"{user} has initiated a {service_name} deploy to {env_name}"
+    if commcare_rev:
+        subject = f"ATTENTION: {user} has initiated {service_name} deploy with branch {commcare_rev} to {env_name}"
     send_email(
         environment,
-        subject="{user} has initiated a {system_name} deploy to {environment}".format(
-            user=get_default_username(),
-            system_name=service_name,
-            environment=environment.meta_config.deploy_env,
-        ),
+        subject=subject,
     )
 
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-12177

We want to be notified when something is deployed outside of the normal deploy processes eg -  hotfix deploys. 
The change updates `announce_deploy_start`. Now if a branch is deployed with `--comcare-rev` the deploy start email subject will be updated. 
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
This will affect all environments