### PR TITLE
adding terraform archive provider version -1.3.0 ref: SAAS-12204

### DIFF
--- a/src/commcare_cloud/commands/terraform/templates/terraform.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/terraform.tf.j2
@@ -13,6 +13,11 @@ provider "aws" {
   region  = {{ region|tojson }}
 }
 
+provider "archive" {
+  source  = "hashicorp/archive"
+  version = "1.3.0"
+}
+
 // for global accelerator which can only be configured in us-west-2
 provider "aws" {
   alias = "us-west-2"


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-12204

We are getting the errors like `Error installing provider "archive": openpgp: signature made by unknown entity. & No available provider "archive" plugins are compatible with this Terraform version.`  at the time executing terraform init command in Staging, India & Prod environments. 
To resolve it, We are including archive provider version in terraform.tf.j2 file. The provided version(1.3.0) can support for terraform v11. 

The latest versions of [archive providers](https://github.com/hashicorp/terraform-provider-archive/blob/main/CHANGELOG.md) does not support for terraform v11. 