### PR TITLE
adding pgshard_nlb for form_processing partitions

### DIFF
--- a/environments/staging/aws-resources.yml
+++ b/environments/staging/aws-resources.yml
@@ -50,6 +50,7 @@ pgformplayer_nlb-staging: pgformplayer-nlb-staging-98b68467f6f5717b.elb.us-east-
 pgmain_nlb-staging: pgmain-nlb-staging-fe77ab2d143eedbb.elb.us-east-1.amazonaws.com
 pgproxy2-staging: 10.201.40.16
 pgproxy2-staging.instance_id: i-0638ff6218ed9f753
+pgshard_nlb-staging: pgshard-nlb-staging-e8ef6b4c55f3618d.elb.us-east-1.amazonaws.com
 pgsynclogs_nlb-staging: pgsynclogs-nlb-staging-1102365451f68242.elb.us-east-1.amazonaws.com
 pgucr_nlb-staging: pgucr-nlb-staging-b32586fcc9999b2d.elb.us-east-1.amazonaws.com
 pillow3-staging: 10.201.10.68

--- a/environments/staging/inventory.ini
+++ b/environments/staging/inventory.ini
@@ -59,6 +59,8 @@ pgmain-nlb-staging-fe77ab2d143eedbb.elb.us-east-1.amazonaws.com
 pgucr-nlb-staging-b32586fcc9999b2d.elb.us-east-1.amazonaws.com
 [pgsynclogs_nlb]
 pgsynclogs-nlb-staging-1102365451f68242.elb.us-east-1.amazonaws.com
+[pgshard_nlb]
+pgshard-nlb-staging-e8ef6b4c55f3618d.elb.us-east-1.amazonaws.com
 
 [postgresql:children]
 pgproxy2
@@ -67,6 +69,7 @@ pgformplayer_nlb
 pgmain_nlb
 pgucr_nlb
 pgsynclogs_nlb
+pgshard_nlb
 
 [pgbouncer:children]
 pgbouncer0
@@ -222,6 +225,7 @@ pgformplayer_nlb
 pgmain_nlb
 pgucr_nlb
 pgsynclogs_nlb
+pgshard_nlb
 
 
 [django_manage:children]

--- a/environments/staging/inventory.ini.j2
+++ b/environments/staging/inventory.ini.j2
@@ -44,6 +44,7 @@ rds_pgformplayer0
 {{ __pgmain_nlb__ }}
 {{ __pgucr_nlb__ }}
 {{ __pgsynclogs_nlb__ }}
+{{ __pgshard_nlb__ }}
 
 [postgresql:children]
 pgproxy2
@@ -52,6 +53,7 @@ pgformplayer_nlb
 pgmain_nlb
 pgucr_nlb
 pgsynclogs_nlb
+pgshard_nlb
 
 [pgbouncer:children]
 pgbouncer0
@@ -183,6 +185,7 @@ pgformplayer_nlb
 pgmain_nlb
 pgucr_nlb
 pgsynclogs_nlb
+pgshard_nlb
 
 
 [django_manage:children]

--- a/environments/staging/postgresql.yml
+++ b/environments/staging/postgresql.yml
@@ -50,22 +50,32 @@ dbs:
       host: pgproxy2
     partitions:
       p1:
-        pgbouncer_host: pgproxy2
+        pgbouncer_endpoint: pgshard_nlb
+        pgbouncer_hosts:
+          - pgbouncer0
         shards: [0, 99]
         query_stats: True
       p2:
-        pgbouncer_host: pgproxy2
+        pgbouncer_endpoint: pgshard_nlb
+        pgbouncer_hosts:
+          - pgbouncer0
         shards: [100, 199]
         query_stats: True
       p3:
-        pgbouncer_host: pgproxy2
+        pgbouncer_endpoint: pgshard_nlb
+        pgbouncer_hosts:
+          - pgbouncer0
         shards: [200, 299]
         query_stats: True
       p4:
-        pgbouncer_host: pgproxy2
+        pgbouncer_endpoint: pgshard_nlb
+        pgbouncer_hosts:
+          - pgbouncer0
         shards: [300, 399]
         query_stats: True
       p5:
-        pgbouncer_host: pgproxy2
+        pgbouncer_endpoint: pgshard_nlb
+        pgbouncer_hosts:
+          - pgbouncer0
         shards: [400, 511]
         query_stats: True

--- a/environments/staging/terraform.yml
+++ b/environments/staging/terraform.yml
@@ -389,6 +389,9 @@ pgbouncer_nlbs:
   - name: "pgsynclogs_nlb-staging"
     targets:
       - pgproxy2-staging
+  - name: "pgshard_nlb-staging"
+    targets:
+      - pgbouncer0-staging
 
 elasticache:
   create: no


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-11923
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Staging

Configured form_processing partitions to route traffic via NLB with pgbouncer0 as the target node. 
Updated shards configuration to use NLB URL instead of pgproxy2 ip.
