### PR TITLE
modify control1-production instance role 

### DIFF
--- a/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
@@ -92,7 +92,6 @@ module "server_iam_role" {
 module "server__{{ server_name }}" {
   source = "./modules/server"
 
-
   server_name = {{ server_name|tojson }}
   server_instance_type = {{ server_spec.server_instance_type|tojson }}
   network_tier = {{ server_spec.network_tier|tojson }}

--- a/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
@@ -92,6 +92,7 @@ module "server_iam_role" {
 module "server__{{ server_name }}" {
   source = "./modules/server"
 
+
   server_name = {{ server_name|tojson }}
   server_instance_type = {{ server_spec.server_instance_type|tojson }}
   network_tier = {{ server_spec.network_tier|tojson }}
@@ -101,7 +102,12 @@ module "server__{{ server_name }}" {
   secondary_volume_size = {{ server_spec.block_device.volume_size|default(0)|tojson }}
   secondary_volume_type = {{ server_spec.block_device.volume_type|default("")|tojson }}
   secondary_volume_encrypted = {{ server_spec.block_device.encrypted|default(False)|tojson }}
+
+{% if server_name == "control1-production" %}
+  iam_instance_profile = "${module.server_iam_role.formplayerlogbucket_instance_profile}"
+{% else %}
   iam_instance_profile = "${module.server_iam_role.commcare_server_instance_profile}"
+{% endif %}
 
 {% if server_spec.os == 'ubuntu_pro_bionic' %}
   server_image = "${data.aws_ami.ubuntu_pro_bionic.id}"

--- a/src/commcare_cloud/terraform/modules/server/iam/main.tf
+++ b/src/commcare_cloud/terraform/modules/server/iam/main.tf
@@ -84,8 +84,8 @@ resource "aws_iam_instance_profile" "commcare_server_instance_profile" {
   role = "${aws_iam_role.commcare_server_role.name}"
 }
 
-resource "aws_iam_role" "formplayerlogbucket_role" {
-  name = "formplayerlogbucket_role"
+resource "aws_iam_role" "formplayer_log_role" {
+  name = "formplayerlogbucketrole"
 
   assume_role_policy = <<EOF
 {
@@ -96,16 +96,19 @@ resource "aws_iam_role" "formplayerlogbucket_role" {
       "Principal": {
           "Service": "ec2.amazonaws.com"
       },
-      "Action": "sts:AssumeRole"
+      "Action": "sts:AssumeRole",
+      "Sid": ""
     }
   ]
 }
 EOF
 }
 
-resource "aws_iam_policy" "formplayerlog_policy" {
+resource "aws_iam_role_policy" "formplayerlog_policy" {
   name = "formplayerlog_bucket_policy"
-  policy = <<EOF
+  role = "${aws_iam_role.formplayer_log_role.id}"
+
+  policy = <<-EOF
 {
 	"Version": "2012-10-17",
 	"Statement": [{
@@ -131,10 +134,16 @@ resource "aws_iam_policy" "formplayerlog_policy" {
 		}
 	]
 }
-EOF
+  EOF
 }
 
-resource "aws_iam_role_policy_attachment" "formplayerlogbucket_roleattachment" {
-  role       = "${aws_iam_role.formplayerlogbucket_role.name}"
-  policy_arn = "${aws_iam_policy.formplayerlog_policy.arn}"
+# resource "aws_iam_role_policy_attachment" "formplayerlogbucket_roleattachment" {
+#   role       = "${aws_iam_role.formplayerlogbucket_role.name}"
+#   policy_arn = "${aws_iam_policy.formplayerlog_policy.arn}"
+# }
+
+resource "aws_iam_instance_profile" "formplayerlogbucket_instance_profile" {
+  name = "FormplayerLogBucketRole"
+  role = "${aws_iam_role.formplayer_log_role.name}"
 }
+

--- a/src/commcare_cloud/terraform/modules/server/iam/main.tf
+++ b/src/commcare_cloud/terraform/modules/server/iam/main.tf
@@ -137,13 +137,7 @@ resource "aws_iam_role_policy" "formplayerlog_policy" {
   EOF
 }
 
-# resource "aws_iam_role_policy_attachment" "formplayerlogbucket_roleattachment" {
-#   role       = "${aws_iam_role.formplayerlogbucket_role.name}"
-#   policy_arn = "${aws_iam_policy.formplayerlog_policy.arn}"
-# }
-
 resource "aws_iam_instance_profile" "formplayerlogbucket_instance_profile" {
   name = "FormplayerLogBucketRole"
   role = "${aws_iam_role.formplayer_log_role.name}"
 }
-

--- a/src/commcare_cloud/terraform/modules/server/iam/outputs.tf
+++ b/src/commcare_cloud/terraform/modules/server/iam/outputs.tf
@@ -6,3 +6,10 @@ output "commcare_server_instance_profile" {
   value = "${aws_iam_instance_profile.commcare_server_instance_profile.name}"
 }
 
+output "formplayer_log_role_arn" {
+  value = "${aws_iam_role.formplayer_log_role.arn}"
+}
+
+output "formplayerlogbucket_instance_profile" {
+  value = "${aws_iam_instance_profile.formplayerlogbucket_instance_profile.name}"
+}


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production Control1 server. 

@dannyroberts made small modifications to the formplayerlogbucket role. 
- Learned that a separate resource section is not required to add a policy to the role so, I removed that section and used `aws_iam_role_policy` 
- retrieving new role values using output.tf. 
- renamed the role and policy name.

#### temporary change#1
```
{% if server_name == "control1-production" %}
  iam_instance_profile = "${module.server_iam_role.formplayerlogbucket_instance_profile}"
{% else %}
  iam_instance_profile = "${module.server_iam_role.commcare_server_instance_profile}"
{% endif %}
```

#### temporary change#2
remove/comment `"iam_instance_profile"` from the lifecycle and add back after a change has been applied. 
```
file:  src/commcare_cloud/terraform/modules/server/main.tf
lifecycle {
    ignore_changes = ["user_data", "key_name", "root_block_device.0.delete_on_termination",
      "ebs_optimized", "ami", "volume_tags", "iam_instance_profile"]
  }
  ```
test result on staging after making above changes. 
<img width="730" alt="image" src="https://user-images.githubusercontent.com/11612356/118362300-9f818500-b5ac-11eb-906b-07ef008417e1.png">
  
Please let me know your suggestions. thanks.
  
