### PR TITLE
check ssh user

### DIFF
--- a/src/commcare_cloud/cli_utils.py
+++ b/src/commcare_cloud/cli_utils.py
@@ -11,7 +11,6 @@ from six.moves import input, shlex_quote
 from commcare_cloud.colors import color_code, color_error
 
 from .environment.paths import ANSIBLE_DIR
-from .environment.main import get_environment
 
 
 def ask(message, strict=False, quiet=False):
@@ -34,31 +33,6 @@ def ask_option(message, options, acceptable_responses=None):
         r = input('Please enter one of {} :'.format(', '.join(options)))
     return r
 
-def get_dev_username(env_name):
-    from .commands.terraform.aws import (
-        print_help_message_about_the_commcare_cloud_default_username_env_var,
-    )
-    from .user_utils import get_default_username
-
-    environment = get_environment(env_name)
-    username = default_username = get_default_username()
-    while True:
-        if not username or default_username.is_guess:
-            username = input(f"Enter your SSH username ({default_username}): ")
-            if not username:
-                username = default_username
-        if username in environment.users_config.dev_users.present:
-            break
-        allowed_users = environment.users_config.dev_users.present
-        env_users = '\n  - '.join([''] + allowed_users)
-        puts(color_error(
-            f"Unauthorized user {username}.\n\n"
-            f"Please pass in one of the allowed ssh users:{env_users}"
-        ))
-        username = ""
-    if default_username.is_guess:
-        print_help_message_about_the_commcare_cloud_default_username_env_var(username)
-    return username
 
 def has_arg(unknown_args, short_form, long_form):
     """

--- a/src/commcare_cloud/cli_utils.py
+++ b/src/commcare_cloud/cli_utils.py
@@ -36,9 +36,9 @@ def ask_option(message, options, acceptable_responses=None):
 
 def get_dev_username(env_name):
     from .commands.terraform.aws import (
-        get_default_username,
         print_help_message_about_the_commcare_cloud_default_username_env_var,
     )
+    from .user_utils import get_default_username
 
     environment = get_environment(env_name)
     username = default_username = get_default_username()

--- a/src/commcare_cloud/commands/ansible/ansible_playbook.py
+++ b/src/commcare_cloud/commands/ansible/ansible_playbook.py
@@ -11,7 +11,8 @@ from clint.textui import puts
 from six.moves import shlex_quote
 
 from commcare_cloud.alias import commcare_cloud
-from commcare_cloud.cli_utils import ask, has_arg, check_branch, print_command, get_dev_username
+from commcare_cloud.cli_utils import ask, has_arg, check_branch, print_command
+from commcare_cloud.user_utils import get_dev_username
 from commcare_cloud.colors import color_error, color_notice
 from commcare_cloud.commands import shared_args
 from commcare_cloud.commands.ansible.helpers import (

--- a/src/commcare_cloud/commands/deploy/command.py
+++ b/src/commcare_cloud/commands/deploy/command.py
@@ -15,7 +15,7 @@ from commcare_cloud.commands.ansible.helpers import AnsibleContext
 from commcare_cloud.commands.command_base import Argument, CommandBase
 from commcare_cloud.commands.deploy.commcare import deploy_commcare
 from commcare_cloud.commands.deploy.formplayer import deploy_formplayer
-from commcare_cloud.commands.terraform.aws import get_default_username
+from commcare_cloud.user_utils import get_default_username
 from commcare_cloud.environment.main import get_environment
 from commcare_cloud.environment.paths import get_available_envs
 from commcare_cloud.fab.utils import retrieve_cached_deploy_env

--- a/src/commcare_cloud/commands/deploy/commcare.py
+++ b/src/commcare_cloud/commands/deploy/commcare.py
@@ -7,7 +7,7 @@ from commcare_cloud.cli_utils import ask
 from commcare_cloud.colors import color_notice
 from commcare_cloud.commands.deploy.sentry import update_sentry_post_deploy
 from commcare_cloud.commands.deploy.utils import announce_deploy_start, announce_deploy_success, create_release_tag, within_maintenance_window
-from commcare_cloud.commands.terraform.aws import get_default_username
+from commcare_cloud.user_utils import get_default_username
 from commcare_cloud.commands.utils import run_fab_task
 from commcare_cloud.events import publish_deploy_event
 from commcare_cloud.fab.deploy_diff import DeployDiff

--- a/src/commcare_cloud/commands/deploy/formplayer.py
+++ b/src/commcare_cloud/commands/deploy/formplayer.py
@@ -14,7 +14,7 @@ from commcare_cloud.commands.ansible.helpers import AnsibleContext
 from commcare_cloud.commands.deploy.sentry import update_sentry_post_deploy
 from commcare_cloud.commands.deploy.utils import announce_deploy_start, announce_deploy_failed, \
     announce_deploy_success, create_release_tag
-from commcare_cloud.commands.terraform.aws import get_default_username
+from commcare_cloud.user_utils import get_default_username
 from commcare_cloud.commands.utils import timeago
 from commcare_cloud.events import publish_deploy_event
 from commcare_cloud.fab.deploy_diff import DeployDiff

--- a/src/commcare_cloud/commands/deploy/utils.py
+++ b/src/commcare_cloud/commands/deploy/utils.py
@@ -4,7 +4,7 @@ import pytz
 
 from commcare_cloud.alias import commcare_cloud
 from commcare_cloud.colors import color_summary, color_error
-from commcare_cloud.commands.terraform.aws import get_default_username
+from commcare_cloud.user_utils import get_default_username
 
 
 def create_release_tag(environment, repo, diff):

--- a/src/commcare_cloud/commands/inventory_lookup/getinventory.py
+++ b/src/commcare_cloud/commands/inventory_lookup/getinventory.py
@@ -9,7 +9,7 @@ import re
 import attr
 from ansible.utils.display import Display
 
-from commcare_cloud.commands.terraform.aws import get_default_username
+from commcare_cloud.user_utils import get_default_username
 from commcare_cloud.environment.main import get_environment
 
 display = Display()

--- a/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -11,6 +11,7 @@ from six.moves import shlex_quote
 from commcare_cloud.cli_utils import print_command
 from commcare_cloud.commands.command_base import Argument, CommandBase
 from commcare_cloud.environment.main import get_environment
+from commcare_cloud.user_utils import get_ssh_username
 from ..ansible.helpers import get_default_ssh_options_as_cmd_parts
 
 from ...colors import color_error
@@ -67,6 +68,9 @@ class _Ssh(Lookup):
         if ':' in address:
             address, port = address.split(':')
             ssh_args = ['-p', port] + ssh_args
+        if '@' not in address:
+            username = get_ssh_username(address, args.env_name)
+            address = f"{username}@{address}"
         cmd_parts = [self.command, address, '-t'] + ssh_args
         cmd = ' '.join(shlex_quote(arg) for arg in cmd_parts)
         if not args.quiet:

--- a/src/commcare_cloud/commands/terraform/aws.py
+++ b/src/commcare_cloud/commands/terraform/aws.py
@@ -22,7 +22,8 @@ from six.moves import configparser, input, shlex_quote
 from commcare_cloud.cli_utils import print_command
 from commcare_cloud.colors import color_notice, color_success
 from commcare_cloud.commands.command_base import Argument, CommandBase
-from commcare_cloud.user_utils import get_default_username
+from commcare_cloud.user_utils import get_default_username, \
+    print_help_message_about_the_commcare_cloud_default_username_env_var
 from commcare_cloud.environment.main import get_environment
 
 
@@ -289,12 +290,6 @@ class AwsFillInventoryHelper(object):
 
 
 DEFAULT_SIGN_IN_DURATION_MINUTES = 30
-
-
-def print_help_message_about_the_commcare_cloud_default_username_env_var(username):
-    puts(color_notice("Did you know? You can put"))
-    puts(color_notice("    export COMMCARE_CLOUD_DEFAULT_USERNAME={}".format(username)))
-    puts(color_notice("in your profile to never have to type that in again! 🌈"))
 
 
 class AwsSignIn(CommandBase):

--- a/src/commcare_cloud/commands/terraform/aws.py
+++ b/src/commcare_cloud/commands/terraform/aws.py
@@ -1,7 +1,6 @@
 # coding=utf-8
 from __future__ import absolute_import, print_function, unicode_literals
 
-import getpass
 import json
 import os
 import subprocess
@@ -14,7 +13,6 @@ from io import open
 import boto3
 import jinja2
 import requests
-import six
 import yaml
 from clint.textui import puts
 from memoized import memoized
@@ -24,6 +22,7 @@ from six.moves import configparser, input, shlex_quote
 from commcare_cloud.cli_utils import print_command
 from commcare_cloud.colors import color_notice, color_success
 from commcare_cloud.commands.command_base import Argument, CommandBase
+from commcare_cloud.user_utils import get_default_username
 from commcare_cloud.environment.main import get_environment
 
 
@@ -290,29 +289,6 @@ class AwsFillInventoryHelper(object):
 
 
 DEFAULT_SIGN_IN_DURATION_MINUTES = 30
-
-
-class StringIsGuess(six.text_type):
-    def __new__(cls, *args, **kwargs):
-        is_guess = kwargs.pop('is_guess')
-        self = super(StringIsGuess, cls).__new__(cls, *args, **kwargs)
-        self.is_guess = is_guess
-        return self
-
-
-@memoized
-def get_default_username():
-    """
-    Returns a special string type that has field is_guess
-
-    If is_guess is True, the caller should assume the user wants this value
-    and should not give them a chance to change their choice of user interactively.
-    """
-    environ_username = os.environ.get('COMMCARE_CLOUD_DEFAULT_USERNAME')
-    if environ_username:
-        return StringIsGuess(environ_username, is_guess=False)
-    else:
-        return StringIsGuess(getpass.getuser(), is_guess=True)
 
 
 def print_help_message_about_the_commcare_cloud_default_username_env_var(username):

--- a/src/commcare_cloud/commands/terraform/terraform.py
+++ b/src/commcare_cloud/commands/terraform/terraform.py
@@ -14,9 +14,9 @@ from commcare_cloud.commands.command_base import Argument, CommandBase
 from commcare_cloud.commands.terraform import postgresql_units
 from commcare_cloud.commands.terraform.aws import (
     aws_sign_in,
-    get_default_username,
     print_help_message_about_the_commcare_cloud_default_username_env_var,
 )
+from commcare_cloud.user_utils import get_default_username
 from commcare_cloud.commands.terraform.constants import (
     COMMCAREHQ_XML_POST_URLS_REGEX,
     COMMCAREHQ_XML_QUERYSTRING_URLS_REGEX,

--- a/src/commcare_cloud/commands/terraform/terraform.py
+++ b/src/commcare_cloud/commands/terraform/terraform.py
@@ -14,9 +14,9 @@ from commcare_cloud.commands.command_base import Argument, CommandBase
 from commcare_cloud.commands.terraform import postgresql_units
 from commcare_cloud.commands.terraform.aws import (
     aws_sign_in,
-    print_help_message_about_the_commcare_cloud_default_username_env_var,
 )
-from commcare_cloud.user_utils import get_default_username
+from commcare_cloud.user_utils import get_default_username, \
+    print_help_message_about_the_commcare_cloud_default_username_env_var
 from commcare_cloud.commands.terraform.constants import (
     COMMCAREHQ_XML_POST_URLS_REGEX,
     COMMCAREHQ_XML_QUERYSTRING_URLS_REGEX,

--- a/src/commcare_cloud/fab/deploy_diff.py
+++ b/src/commcare_cloud/fab/deploy_diff.py
@@ -11,7 +11,7 @@ from commcare_cloud.colors import (
     color_warning, color_error, color_success,
     color_highlight, color_summary, color_code
 )
-from commcare_cloud.commands.terraform.aws import get_default_username
+from commcare_cloud.user_utils import get_default_username
 
 TEMPLATE_DIR = os.path.join(os.path.dirname(__file__), 'diff_templates')
 LABELS_TO_EXPAND = [

--- a/src/commcare_cloud/user_utils.py
+++ b/src/commcare_cloud/user_utils.py
@@ -1,0 +1,28 @@
+import getpass
+import os
+
+import six
+from memoized import memoized
+
+
+class StringIsGuess(six.text_type):
+    def __new__(cls, *args, **kwargs):
+        is_guess = kwargs.pop('is_guess')
+        self = super(StringIsGuess, cls).__new__(cls, *args, **kwargs)
+        self.is_guess = is_guess
+        return self
+
+
+@memoized
+def get_default_username():
+    """
+    Returns a special string type that has field is_guess
+
+    If is_guess is True, the caller should assume the user wants this value
+    and should not give them a chance to change their choice of user interactively.
+    """
+    environ_username = os.environ.get('COMMCARE_CLOUD_DEFAULT_USERNAME')
+    if environ_username:
+        return StringIsGuess(environ_username, is_guess=False)
+    else:
+        return StringIsGuess(getpass.getuser(), is_guess=True)

--- a/src/commcare_cloud/user_utils.py
+++ b/src/commcare_cloud/user_utils.py
@@ -34,44 +34,55 @@ def get_default_username():
 
 
 def get_dev_username(env_name):
-    environment = get_environment(env_name)
-    username = default_username = get_default_username()
-    while True:
-        if not username or default_username.is_guess:
-            username = input(f"Enter your SSH username ({default_username}): ")
-            if not username:
-                username = default_username
-        if username in environment.users_config.dev_users.present:
-            break
-        allowed_users = environment.users_config.dev_users.present
-        env_users = '\n  - '.join([''] + allowed_users)
-        puts(color_error(
-            f"Unauthorized user {username}.\n\n"
-            f"Please pass in one of the allowed ssh users:{env_users}"
-        ))
-        username = ""
-    if default_username.is_guess:
-        print_help_message_about_the_commcare_cloud_default_username_env_var(username)
-    return username
+    """Get the configured username (OS or via env var) and verify it against
+    the list of users configured in the environment."""
+    username = get_default_username()
+    return _check_username(env_name, username, COMMCARE_CLOUD_DEFAULT_USERNAME_ENV_VAR_MESSAGE)
+
+
+COMMCARE_CLOUD_DEFAULT_USERNAME_ENV_VAR_MESSAGE = """
+Did you know? You can put
+    export COMMCARE_CLOUD_DEFAULT_USERNAME={username}
+in your profile to never have to type that in again! 🌈
+"""
 
 
 def print_help_message_about_the_commcare_cloud_default_username_env_var(username):
-    puts(color_notice("Did you know? You can put"))
-    puts(color_notice("    export COMMCARE_CLOUD_DEFAULT_USERNAME={}".format(username)))
-    puts(color_notice("in your profile to never have to type that in again! 🌈"))
+    puts(color_notice(COMMCARE_CLOUD_DEFAULT_USERNAME_ENV_VAR_MESSAGE.format(username)))
 
 
 @memoized
 def get_default_ssh_username(host):
+    """
+    Returns a special string type that has field is_guess
+
+    If is_guess is False, the caller should assume the user wants this value
+    and should not give them a chance to change their choice of user interactively.
+    """
     for line in subprocess.check_output(['ssh', host, '-G']).decode('utf8').splitlines():
         if line.startswith("user "):
             return StringIsGuess(line.split()[1], is_guess=False)
     return StringIsGuess(getpass.getuser(), is_guess=False)
 
 
+DEFAULT_SSH_USERNAME_MESSAGE = """
+Did you know? You can add this to you '~/.ssh/config' to set your username:
+
+Host *
+    User {username}
+"""
+
+
 def get_ssh_username(host, env_name):
+    """Use `ssh -G <host>` to get the SSH username and verify it against
+    the list of users configured in the environment."""
+    username = get_default_ssh_username(host)
+    return _check_username(env_name, username, DEFAULT_SSH_USERNAME_MESSAGE)
+
+
+def _check_username(env_name, username, message):
+    default_username = username
     environment = get_environment(env_name)
-    username = default_username = get_default_ssh_username(host)
     while True:
         if not username or default_username.is_guess:
             username = input(f"Enter your SSH username ({default_username}): ")
@@ -87,12 +98,5 @@ def get_ssh_username(host, env_name):
         ))
         username = ""
     if default_username.is_guess:
-        print_help_message_about_default_ssh_username(username)
+        print(color_notice(message.format(username)))
     return username
-
-
-def print_help_message_about_default_ssh_username(username):
-    puts(color_notice("Did you know? You can use the '~/.ssh/config' file to set your SSH username."))
-    puts(color_notice(""))
-    puts(color_notice("Host *"))
-    puts(color_notice(f"    User {username}"))

--- a/src/commcare_cloud/user_utils.py
+++ b/src/commcare_cloud/user_utils.py
@@ -23,7 +23,7 @@ def get_default_username():
     """
     Returns a special string type that has field is_guess
 
-    If is_guess is True, the caller should assume the user wants this value
+    If is_guess is False, the caller should assume the user wants this value
     and should not give them a chance to change their choice of user interactively.
     """
     environ_username = os.environ.get('COMMCARE_CLOUD_DEFAULT_USERNAME')

--- a/src/commcare_cloud/user_utils.py
+++ b/src/commcare_cloud/user_utils.py
@@ -62,7 +62,7 @@ def get_default_ssh_username(host):
     for line in subprocess.check_output(['ssh', host, '-G']).decode('utf8').splitlines():
         if line.startswith("user "):
             return StringIsGuess(line.split()[1], is_guess=False)
-    return StringIsGuess(getpass.getuser(), is_guess=False)
+    return StringIsGuess(getpass.getuser(), is_guess=True)
 
 
 DEFAULT_SSH_USERNAME_MESSAGE = """

--- a/src/commcare_cloud/user_utils.py
+++ b/src/commcare_cloud/user_utils.py
@@ -2,7 +2,11 @@ import getpass
 import os
 
 import six
+from clint.textui import puts
 from memoized import memoized
+
+from commcare_cloud.colors import color_error, color_notice
+from commcare_cloud.environment.main import get_environment
 
 
 class StringIsGuess(six.text_type):
@@ -26,3 +30,31 @@ def get_default_username():
         return StringIsGuess(environ_username, is_guess=False)
     else:
         return StringIsGuess(getpass.getuser(), is_guess=True)
+
+
+def get_dev_username(env_name):
+    environment = get_environment(env_name)
+    username = default_username = get_default_username()
+    while True:
+        if not username or default_username.is_guess:
+            username = input(f"Enter your SSH username ({default_username}): ")
+            if not username:
+                username = default_username
+        if username in environment.users_config.dev_users.present:
+            break
+        allowed_users = environment.users_config.dev_users.present
+        env_users = '\n  - '.join([''] + allowed_users)
+        puts(color_error(
+            f"Unauthorized user {username}.\n\n"
+            f"Please pass in one of the allowed ssh users:{env_users}"
+        ))
+        username = ""
+    if default_username.is_guess:
+        print_help_message_about_the_commcare_cloud_default_username_env_var(username)
+    return username
+
+
+def print_help_message_about_the_commcare_cloud_default_username_env_var(username):
+    puts(color_notice("Did you know? You can put"))
+    puts(color_notice("    export COMMCARE_CLOUD_DEFAULT_USERNAME={}".format(username)))
+    puts(color_notice("in your profile to never have to type that in again! 🌈"))

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from mock import patch
 
-from commcare_cloud.commands.terraform.aws import StringIsGuess
+from commcare_cloud.user_utils import StringIsGuess
 
 
 def setup_package():


### PR DESCRIPTION
Redo of https://github.com/dimagi/commcare-cloud/pull/4715

This is useful for checking the SSH username and giving early warning / error messages when the local SSH username differs from what's required by commcare-cloud.

First few commits are moving similar code around into a new package.

Can review by commit.