### PR TITLE
Add WAF routes to terraform const.py

### DIFF
--- a/src/commcare_cloud/commands/terraform/constants.py
+++ b/src/commcare_cloud/commands/terraform/constants.py
@@ -6,6 +6,8 @@
 from __future__ import unicode_literals
 COMMCAREHQ_XML_POST_URLS_REGEX = r"""
 ^/a/([\w\.:-]+)/api/v([\d\.]+)/form/$
+^/a/([\w\.:-]+)/api/v0.6/case/$
+^/a/([\w\.:-]+)/api/v0.6/case/([\w-]+)/$
 ^/a/([\w\.:-]+)/apps/([\w-]+)/multimedia/uploaded/app_logo/([\w\-]+)/$
 ^/a/([\w\.:-]+)/apps/([\w-]+)/multimedia/uploaded/image/$
 ^/a/([\w\.:-]+)/apps/edit_form_attr/([\w-]+)/([\w-]+)/([\w-]+)/$
@@ -17,6 +19,7 @@ COMMCAREHQ_XML_POST_URLS_REGEX = r"""
 ^/a/([\w\.:-]+)/cloudcare/apps/report_formplayer_error
 ^/a/([\w\.:-]+)/data/export/custom/download_data_files/$
 ^/a/([\w\.:-]+)/data_dictionary/import$
+^/a/([\w\.:-]+)/dhis2/map/(\w+)/$
 ^/a/([\w\.:-]+)/fixtures/edit_lookup_tables/upload/$
 ^/a/([\w\.:-]+)/fixtures/fixapi/
 ^/a/([\w\.:-]+)/importer/excel/bulk_upload_api/$
@@ -28,6 +31,7 @@ COMMCAREHQ_XML_POST_URLS_REGEX = r"""
 ^/a/([\w\.:-]+)/receiver/submission/?$
 ^/a/([\w\.:-]+)/settings/users/commcare/fields/$
 ^/a/([\w\.:-]+)/settings/users/commcare/upload/$
+^/a/([\w\.:-]+)/settings/users/web/upload/$
 ^/formplayer/new-form$
 ^/formplayer/validate_form$
 ^/gvi/api/sms/$


### PR DESCRIPTION
See route annotation PR [here](https://github.com/dimagi/commcare-hq/pull/29753).

##### ENVIRONMENTS AFFECTED
All

This PR contains changes which I did not make but were on CCHQ master when I executed `./manage.py list_waf_allow_patterns` (I pulled master before executing). I added the relevant reviewers for the other changes.