### PR TITLE
removing source key from provider.archiver ref:SAAS-12204

### DIFF
--- a/src/commcare_cloud/commands/terraform/templates/terraform.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/terraform.tf.j2
@@ -14,7 +14,6 @@ provider "aws" {
 }
 
 provider "archive" {
-  source  = "hashicorp/archive"
   version = "1.3.0"
 }
 


### PR DESCRIPTION
I am removing source key from provider.archive block to resolve error `"provider.archive: : invalid or unknown key: source"`.

Reason: The provider argument name "source" is reserved for use by Terrform in a future version.