### PR TITLE
Set commits to None on github error

### DIFF
--- a/src/commcare_cloud/commands/deploy/sentry.py
+++ b/src/commcare_cloud/commands/deploy/sentry.py
@@ -33,6 +33,7 @@ def update_sentry_post_deploy(environment, sentry_project, github_repo, diff, de
             try:
                 commits = get_release_commits(diff)
             except GithubException as e:
+                commits = None
                 print(color_error(f"Error getting release commits: {e}"))
         else:
             commits = None


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
This was causing an issue on eCHIS on deploy as github was not accessible, and the default setting was set to `True`

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
