### PR TITLE
Fix terraform v0.11 error w/ archive provider

### DIFF
--- a/src/commcare_cloud/commands/terraform/templates/terraform.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/terraform.tf.j2
@@ -14,7 +14,6 @@ provider "aws" {
 }
 
 provider "archive" {
-  source  = "hashicorp/archive"
   version = "1.3.0"
 }
 


### PR DESCRIPTION
This was something @skodde and I noticed locally when running terraform. Removing just this one line fixes it. The error is

> Error: provider.archive: : invalid or unknown key: source