### PR TITLE
split at first occurrence & don't mutate username during address lookup 

### DIFF
--- a/src/commcare_cloud/commands/deploy/command.py
+++ b/src/commcare_cloud/commands/deploy/command.py
@@ -1,21 +1,16 @@
 from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
+
 import sys
 from textwrap import dedent
 
-from clint.textui import indent
-
-from commcare_cloud.alias import commcare_cloud
-from commcare_cloud.cli_utils import ask, check_branch
-from commcare_cloud.colors import color_notice, color_summary, color_warning, color_error
+from commcare_cloud.cli_utils import check_branch
+from commcare_cloud.colors import color_notice, color_warning, color_error
 from commcare_cloud.commands import shared_args
-from commcare_cloud.commands.ansible import ansible_playbook
-from commcare_cloud.commands.ansible.helpers import AnsibleContext
 from commcare_cloud.commands.command_base import Argument, CommandBase
 from commcare_cloud.commands.deploy.commcare import deploy_commcare
 from commcare_cloud.commands.deploy.formplayer import deploy_formplayer
-from commcare_cloud.user_utils import get_default_username
 from commcare_cloud.environment.main import get_environment
 from commcare_cloud.environment.paths import get_available_envs
 from commcare_cloud.fab.utils import retrieve_cached_deploy_env

--- a/src/commcare_cloud/commands/inventory_lookup/getinventory.py
+++ b/src/commcare_cloud/commands/inventory_lookup/getinventory.py
@@ -9,7 +9,6 @@ import re
 import attr
 from ansible.utils.display import Display
 
-from commcare_cloud.user_utils import get_default_username
 from commcare_cloud.environment.main import get_environment
 
 display = Display()

--- a/src/commcare_cloud/commands/inventory_lookup/getinventory.py
+++ b/src/commcare_cloud/commands/inventory_lookup/getinventory.py
@@ -64,11 +64,7 @@ def get_server_address(environment, group):
             raise HostMatchException("Non-numeric group index: {}".format(index))
 
     if not username:
-        default_username = get_default_username()
-        if default_username.is_guess:
-            username = ""
-        else:
-            username = "{}@".format(default_username)
+        username = ""
 
     if re.match(r'(\d+\.?){4}', group):
         # short circuit for IP addresses

--- a/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -69,7 +69,7 @@ class _Ssh(Lookup):
             address, port = address.split(':')
             ssh_args = ['-p', port] + ssh_args
         if '@' in address:
-            username, address = address.split('@')
+            username, address = address.split('@', 1)
             username = get_ssh_username(address, args.env_name, requested_username=username)
         elif '@' not in address:
             username = get_ssh_username(address, args.env_name)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -11,7 +11,7 @@ def setup_package():
         patch.dict("os.environ", COMMCARE_CLOUD_DEFAULT_USERNAME=""),
         # handle memoized decorator (in case get_default_username has already been called)
         patch(
-            "commcare_cloud.commands.inventory_lookup.getinventory.get_default_username",
+            "commcare_cloud.user_utils.get_default_username",
             lambda: StringIsGuess("", is_guess=True),
         ),
 

--- a/tests/test_ssh.py
+++ b/tests/test_ssh.py
@@ -17,7 +17,6 @@ TEST_ENVIRONMENTS_DIR = os.path.join(os.path.dirname(__file__), 'test_ssh_envs')
 @mock.patch.object(subprocess, 'call')
 @mock.patch('commcare_cloud.commands.inventory_lookup.inventory_lookup.print_command', lambda args: None)
 def _test_ssh_args(args, ssh_args, expected_cmd_parts, mock_call, get_ssh_username):
-    os.environ['COMMCARE_CLOUD_DEFAULT_USERNAME'] = ''
     Ssh(ArgumentParser()).run(args, ssh_args)
     mock_call.assert_called_with(expected_cmd_parts)
 


### PR DESCRIPTION
First commit from PR comment: https://github.com/dimagi/commcare-cloud/pull/4733#discussion_r636384125 I think it's extremely unlikely that there will be more than 1 `@` symbol here but in the interest of caution I've added the change.

I've also changed the `get_server_address` function to remove the `get_default_username` lookup. This may break someone's workflow if they were relying on the `COMMCARE_CLOUD_DEFAULT_USERNAME` to set their SSH username.

`COMMCARE_CLOUD_DEFAULT_USERNAME` is now only used by `get_default_username` and `get_dev_username`:
* Terraform calls `get_default_username` to specify the public key to place on new servers
* Deploy calls `get_default_username` to get the username of the user doing deploy (or announce workflows)
* `update-users` command calls `get_dev_username` and passes the value to ansible which validates it against the list of allowed users