### PR TITLE
Adding terraform version lock [ ~>12.0, <12.31 ]

### DIFF
--- a/src/commcare_cloud/commands/terraform/templates/terraform.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/terraform.tf.j2
@@ -5,7 +5,7 @@ terraform {
     region  = {{ state_bucket_region|tojson }}
     encrypt = true
   }
-  required_version = "~> 0.12.30"
+  required_version = "~> 0.12.0, < 0.12.31"
 }
 
 provider "aws" {
@@ -14,7 +14,7 @@ provider "aws" {
 }
 
 provider "archive" {
-  version = "1.3.0"
+  version = "2.1.0"
 }
 
 // for global accelerator which can only be configured in us-west-2

--- a/src/commcare_cloud/terraform/modules/server/iam/main.tf
+++ b/src/commcare_cloud/terraform/modules/server/iam/main.tf
@@ -86,8 +86,6 @@ resource "aws_iam_instance_profile" "commcare_server_instance_profile" {
 
 resource "aws_iam_role" "formplayer_log_role" {
   name = "formplayerlogbucketrole"
-  resource "aws_iam_role" "formplayerlogbucket_role" {
-  name = "formplayerlogbucket_role"
 
   assume_role_policy = <<POLICY
 {
@@ -136,15 +134,10 @@ resource "aws_iam_role_policy" "formplayerlog_policy" {
 		}
 	]
 }
-POLICY
+  POLICY
 }
 
 resource "aws_iam_instance_profile" "formplayerlogbucket_instance_profile" {
   name = "FormplayerLogBucketRole"
-  role = "${aws_iam_role.formplayer_log_role.name}"
-}
-
-resource "aws_iam_role_policy_attachment" "formplayerlogbucket_roleattachment" {
-  role       = aws_iam_role.formplayerlogbucket_role.name
-  policy_arn = aws_iam_policy.formplayerlog_policy.arn 
+  role = aws_iam_role.formplayer_log_role.name
 }


### PR DESCRIPTION
Here I am placing terraform version local. Allowing ~>12.0, <12.31 versions. Suggesting to use 12.30

resolving` Error: Argument or block definition required` related to `commcare-cloud/src/commcare_cloud/terraform/modules/server/iam/main.tf`
