### PR TITLE
Updating EBS volume-type (gp2 --> gp3) to proxy-servers & web-workers in staging env

### DIFF
--- a/environments/staging/terraform.yml
+++ b/environments/staging/terraform.yml
@@ -27,6 +27,7 @@ servers:
     network_tier: "app-private"
     az: "b"
     volume_size: 80
+    volume_type: "gp3"
     volume_encrypted: yes
     group: webworkers
     os: ubuntu_pro_bionic
@@ -35,6 +36,7 @@ servers:
     network_tier: "app-private"
     az: "b"
     volume_size: 80
+    volume_type: "gp3"
     volume_encrypted: yes
     group: webworkers
     os: ubuntu_pro_bionic
@@ -321,6 +323,7 @@ proxy_servers:
     network_tier: "app-private"
     az: "a"
     volume_size: 80
+    volume_type: "gp3"
     volume_encrypted: yes
     group: "proxy"
     os: ubuntu_pro_bionic
@@ -329,6 +332,7 @@ proxy_servers:
     network_tier: "app-private"
     az: "a"
     volume_size: 80
+    volume_type: "gp3"
     volume_encrypted: yes
     group: "proxy"
     os: ubuntu_pro_bionic
@@ -337,6 +341,7 @@ proxy_servers:
     network_tier: "app-private"
     az: "a"
     volume_size: 80
+    volume_type: "gp3"
     volume_encrypted: yes
     group: "proxy"
     os: ubuntu_pro_bionic
@@ -345,6 +350,7 @@ proxy_servers:
     network_tier: "app-private"
     az: "a"
     volume_size: 80
+    volume_type: "gp3"
     volume_encrypted: yes
     group: "proxy"
     os: ubuntu_pro_bionic
@@ -354,6 +360,7 @@ proxy_servers:
     network_tier: "app-private"
     az: "a"
     volume_size: 80
+    volume_type: "gp3"
     volume_encrypted: yes
     group: "proxy"
     os: ubuntu_pro_bionic

--- a/src/commcare_cloud/terraform/modules/server/iam/main.tf
+++ b/src/commcare_cloud/terraform/modules/server/iam/main.tf
@@ -86,8 +86,6 @@ resource "aws_iam_instance_profile" "commcare_server_instance_profile" {
 
 resource "aws_iam_role" "formplayer_log_role" {
   name = "formplayerlogbucketrole"
-  resource "aws_iam_role" "formplayerlogbucket_role" {
-  name = "formplayerlogbucket_role"
 
   assume_role_policy = <<POLICY
 {
@@ -108,7 +106,7 @@ POLICY
 
 resource "aws_iam_role_policy" "formplayerlog_policy" {
   name = "formplayerlog_bucket_policy"
-  role = "${aws_iam_role.formplayer_log_role.id}"
+  role = aws_iam_role.formplayer_log_role.id
 
   policy = <<POLICY
 {


### PR DESCRIPTION
In the process of gp2 to gp3 volume-type, Updating EBS volume-type (gp2 --> gp3) to proxy-servers & web-workers in staging env.