### PR TITLE
adding ingress rule for db-private-sg

### DIFF
--- a/src/commcare_cloud/terraform/modules/network/main.tf
+++ b/src/commcare_cloud/terraform/modules/network/main.tf
@@ -332,6 +332,13 @@ resource "aws_security_group" "db-private" {
   }
 
   ingress {
+    from_port   = 6432
+    to_port     = 6432
+    protocol    = "tcp"
+    cidr_blocks = aws_subnet.subnet-db-private.*.cidr_block
+  }
+
+  ingress {
     from_port   = 2049
     to_port     = 2049
     protocol    = "tcp"


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->

Staging 
Allowing 6432 port from DB-private-subnets. This is to fix the NLB connectivity issue from the pgproxy2 machine.
 