### PR TITLE
Remove references to detailed tagging domains

### DIFF
--- a/commcare-cloud-bootstrap/environment/private.yml.j2
+++ b/commcare-cloud-bootstrap/environment/private.yml.j2
@@ -48,4 +48,3 @@ localsettings_private:
   SECRET_KEY: '{{ generate_uuid() }}'
 
 ansible_sudo_pass: '{{ generate_uuid() }}'
-detailed_tagging_domains: []

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -66,7 +66,6 @@ formplayer_purge_time_spec: '10d'
 formplayer_sensitive_data_logging: true
 formplayer_forward_ip_proxy: true
 formplayer_enable_cache: true
-formplayer_detailed_tagging_domains: "{{ detailed_tagging_domains }}"
 formplayer_detailed_tags: []
 
 KSPLICE_ACTIVE: yes

--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -39,7 +39,6 @@ aws_region: 'us-east-1'
 formplayer_archive_time_spec: '10m'
 formplayer_sensitive_data_logging: true
 formplayer_enable_cache: false
-formplayer_detailed_tagging_domains: "{{ detailed_tagging_domains }}"
 formplayer_detailed_tags:
     - form_name
     - module_name

--- a/src/commcare_cloud/ansible/roles/formplayer/templates/application.properties.j2
+++ b/src/commcare_cloud/ansible/roles/formplayer/templates/application.properties.j2
@@ -65,7 +65,6 @@ server.forward-headers-strategy=NATIVE
 spring.cache.type=caffeine
 {% endif %}
 
-{% if formplayer_detailed_tagging_domains is defined %}
-detailed_tagging.domains={{ formplayer_detailed_tagging_domains|join(',') }}
+{% if formplayer_detailed_tags is defined %}
 detailed_tagging.tag_names={{ formplayer_detailed_tags|join(',') }}
 {% endif %}

--- a/src/commcare_cloud/environment/secrets/backends/ansible_vault/tests/expected-generated-variables.yml
+++ b/src/commcare_cloud/environment/secrets/backends/ansible_vault/tests/expected-generated-variables.yml
@@ -62,5 +62,4 @@ old_s3_blob_db_secret_key: "{{ secrets.OLD_S3_BLOB_DB_SECRET_KEY | default(None)
 postgres_users: "{{ secrets.POSTGRES_USERS | default(None) }}"
 s3_access_key: "{{ secrets.S3_ACCESS_KEY | default(None) }}"
 s3_secret_key: "{{ secrets.S3_SECRET_KEY | default(None) }}"
-detailed_tagging_domains: "{{ detailed_tagging_domains | default([]) }}"
 deploy_event_token: "{{ deploy_event_token | default(None) }}"

--- a/src/commcare_cloud/environment/secrets/backends/aws_secrets/tests/expected-generated-variables.yml
+++ b/src/commcare_cloud/environment/secrets/backends/aws_secrets/tests/expected-generated-variables.yml
@@ -63,5 +63,4 @@ postgres_users: "{{ lookup('cchq_aws_secret', 'commcare-staging/POSTGRES_USERS',
 s3_access_key: "{{ lookup('cchq_aws_secret', 'commcare-staging/S3_ACCESS_KEY', errors='ignore') | default(None) }}"
 s3_secret_key: "{{ lookup('cchq_aws_secret', 'commcare-staging/S3_SECRET_KEY', errors='ignore') | default(None) }}"
 ansible_sudo_pass: "{{ lookup('cchq_aws_secret', 'commcare-staging/ansible_sudo_pass', errors='ignore') }}"
-detailed_tagging_domains: "{{ lookup('cchq_aws_secret', 'commcare-staging/detailed_tagging_domains', errors='ignore') | default([]) }}"
 deploy_event_token: "{{ lookup('cchq_aws_secret', 'commcare-staging/deploy_event_token', errors='ignore') | default(None) }}"

--- a/src/commcare_cloud/environment/secrets/secrets.yml
+++ b/src/commcare_cloud/environment/secrets/secrets.yml
@@ -166,6 +166,4 @@
   legacy_namespace: localsettings_private
 - name: ansible_sudo_pass
   required: yes
-- name: detailed_tagging_domains
-  default: []
 - name: deploy_event_token


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-12284

Now that feature flags are available in formplayer, detailed tagging domains do not need to be stored in secrets. This PR removes all references to detailed tagging domains, but leaves the detailed tags themselves as those are still applied at this level.
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
