### PR TITLE
Add CaseSearch only pillow to prod

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -86,6 +86,8 @@ pillows:
     case-pillow:
       num_processes: 17
       dedicated_migration_process: True
+    CaseSearchToElasticsearchPillow:
+      num_processes: 34
     user-pillow:
       num_processes: 1
     group-pillow:


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-12291?focusedCommentId=146855

Adding this temporarily to reprocess Case Search pillows as the index was down. The case-search pillow [checkpoint](url) was reset to case-pillow's [Friday checkpoint](https://www.commcarehq.org/admin/hqadmin/historicalpillowcheckpoint/58597/change/?_changelist_filters=q%3Dcase-pillow-hqcases_2016-03-04-case_search_2018-05-29-messaging-sync).

@snopoke @calellowitz 