### PR TITLE
Revert "Revert "Add CaseSearch only pillow to prod""

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -86,6 +86,8 @@ pillows:
     case-pillow:
       num_processes: 17
       dedicated_migration_process: True
+    CaseSearchToElasticsearchPillow:
+      num_processes: 34
     user-pillow:
       num_processes: 1
     group-pillow:


### PR DESCRIPTION
Reverts dimagi/commcare-cloud#4767

@calellowitz FYI you can use this to roll out the pillow to do the extra backfilling:

```
cchq production update-supervisor-confs
```

Then to reset the checkpoint:

```

# Create JSON file with contents as follows:

{
  "CaseSearchToElasticsearchPillow": "sequence from the historical checkpoint"
}

# Run the following management command: 

python manage.py fix_checkpoints_from_file checkpoint.json
```
