### PR TITLE
Add formplayer_detailed_tags on prod

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -66,7 +66,9 @@ formplayer_purge_time_spec: '10d'
 formplayer_sensitive_data_logging: true
 formplayer_forward_ip_proxy: true
 formplayer_enable_cache: true
-formplayer_detailed_tags: []
+formplayer_detailed_tags:
+  - form_name
+  - module_name
 
 KSPLICE_ACTIVE: yes
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-12284

This would make it so that a domain needs to have the detailed tagging feature flag enabled in order to collect metrics related to these 2 tags.

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Prod