### PR TITLE
fixing reroute example command which was not ended correctly 

### DIFF
--- a/docs/firefighting/index.md
+++ b/docs/firefighting/index.md
@@ -827,7 +827,7 @@ Currently on ICDS (maybe on prod/india) shard allocation is disabled. In case a 
   - Shard assignment can be checked via Elasticsearch [shards API](https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-shards.html) or the shards graph on Elasticsearch datadog dashboard
 - If any primaries are not allocated. Use rereoute API ([official docs](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/cluster-reroute.html))
   - Reroute according to existing shard allocation
-  - The rerouting of unassigned primary shards will cause data loss (w.r.t es_2.4.6).
+  - The rerouting of unassigned primary shards will cause data loss (w.r.t es_2.4.6). <br>
   :warning: The <b>allow_primary</b> parameter will force a new empty primary shard to be allocated without any data. If a node which has a copy of the original shard (including data) rejoins the cluster later on, that data will be deleted: the old shard copy will be replaced by the new live shard copy.
 
   - Example reroute command to allocate replica shard

--- a/docs/firefighting/index.md
+++ b/docs/firefighting/index.md
@@ -827,7 +827,8 @@ Currently on ICDS (maybe on prod/india) shard allocation is disabled. In case a 
   - Shard assignment can be checked via Elasticsearch [shards API](https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-shards.html) or the shards graph on Elasticsearch datadog dashboard
 - If any primaries are not allocated. Use rereoute API ([official docs](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/cluster-reroute.html))
   - Reroute according to existing shard allocation
-  - Example reroute command to allocate primary shard
+  - Example reroute command to allocate primary shard <br>
+    :warning: The <b>allow_primary</b> parameter will force a new empty primary shard to be allocated without any data. If a node which has a copy of the original shard (including data) rejoins the cluster later on, that data will be deleted: the old shard copy will be replaced by the new live shard copy.
     ```
     curl -XPOST 'http://<es_url>/_cluster/reroute' -d ' {"commands" :[{"allocate": {"shard": 0, "node": "es34", "allow_primary": true, "index": "xforms_2020-02-20"}}]}'
     ```

--- a/docs/firefighting/index.md
+++ b/docs/firefighting/index.md
@@ -829,11 +829,23 @@ Currently on ICDS (maybe on prod/india) shard allocation is disabled. In case a 
   - Reroute according to existing shard allocation
   - Example reroute command to allocate primary shard
     ```
-    curl -XPOST 'http://<es_url>/_cluster/reroute' -d ' {"commands" :[{"allocate": {"shard": 0, "node": "es34", "allow_primary": true, "index": "xforms_2020-02-20"}}’
+    curl -XPOST 'http://<es_url>/_cluster/reroute' -d ' {"commands" :[{"allocate": {"shard": 0, "node": "es34", "allow_primary": true, "index": "xforms_2020-02-20"}}]}'
     ```
   - Example reroute command to allocate replica shard
     ```
-    curl -XPOST 'http://<es_url>/_cluster/reroute' -d ' {"commands" :[{"allocate": {"shard": 0, "node": "es34", "index": "xforms_2020-02-20"}}’
+    curl -XPOST 'http://<es_url>/_cluster/reroute' -d ' {"commands" :[{"allocate": {"shard": 0, "node": "es34", "index": "xforms_2020-02-20"}}]}'
+    ```
+
+    ```
+    curl -XPOST 'http://<es_url>:<port>/_cluster/reroute' -d '{
+    "commands" : [
+        {
+          "allocate" : {
+              "index" : "case_search_2018-05-29", "shard" : 0, "node" : "es-b013-production", "allow_primary": true
+             }
+          }
+        ]
+      }'
     ```
 - Replicas won’t get auto assigned. To assign replicas, auto shard allocation needs to be enabled
   - Make sure no primaries are unassigned

--- a/docs/firefighting/index.md
+++ b/docs/firefighting/index.md
@@ -831,10 +831,6 @@ Currently on ICDS (maybe on prod/india) shard allocation is disabled. In case a 
     ```
     curl -XPOST 'http://<es_url>/_cluster/reroute' -d ' {"commands" :[{"allocate": {"shard": 0, "node": "es34", "allow_primary": true, "index": "xforms_2020-02-20"}}]}'
     ```
-  - Example reroute command to allocate replica shard
-    ```
-    curl -XPOST 'http://<es_url>/_cluster/reroute' -d ' {"commands" :[{"allocate": {"shard": 0, "node": "es34", "index": "xforms_2020-02-20"}}]}'
-    ```
 
     ```
     curl -XPOST 'http://<es_url>:<port>/_cluster/reroute' -d '{
@@ -847,6 +843,12 @@ Currently on ICDS (maybe on prod/india) shard allocation is disabled. In case a 
         ]
       }'
     ```
+
+  - Example reroute command to allocate replica shard
+    ```
+    curl -XPOST 'http://<es_url>/_cluster/reroute' -d ' {"commands" :[{"allocate": {"shard": 0, "node": "es34", "index": "xforms_2020-02-20"}}]}'
+    ```
+
 - Replicas won’t get auto assigned. To assign replicas, auto shard allocation needs to be enabled
   - Make sure no primaries are unassigned
   - Turn on auto shard allocation using

--- a/docs/firefighting/index.md
+++ b/docs/firefighting/index.md
@@ -827,23 +827,8 @@ Currently on ICDS (maybe on prod/india) shard allocation is disabled. In case a 
   - Shard assignment can be checked via Elasticsearch [shards API](https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-shards.html) or the shards graph on Elasticsearch datadog dashboard
 - If any primaries are not allocated. Use rereoute API ([official docs](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/cluster-reroute.html))
   - Reroute according to existing shard allocation
-  - Example reroute command to allocate primary shard <br>
-    :warning: The <b>allow_primary</b> parameter will force a new empty primary shard to be allocated without any data. If a node which has a copy of the original shard (including data) rejoins the cluster later on, that data will be deleted: the old shard copy will be replaced by the new live shard copy.
-    ```
-    curl -XPOST 'http://<es_url>/_cluster/reroute' -d ' {"commands" :[{"allocate": {"shard": 0, "node": "es34", "allow_primary": true, "index": "xforms_2020-02-20"}}]}'
-    ```
-
-    ```
-    curl -XPOST 'http://<es_url>:<port>/_cluster/reroute' -d '{
-    "commands" : [
-        {
-          "allocate" : {
-              "index" : "case_search_2018-05-29", "shard" : 0, "node" : "es-b013-production", "allow_primary": true
-             }
-          }
-        ]
-      }'
-    ```
+  - The rerouting of unassigned primary shards will cause data loss (w.r.t es_2.4.6).
+  :warning: The <b>allow_primary</b> parameter will force a new empty primary shard to be allocated without any data. If a node which has a copy of the original shard (including data) rejoins the cluster later on, that data will be deleted: the old shard copy will be replaced by the new live shard copy.
 
   - Example reroute command to allocate replica shard
     ```


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-12298
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
The reroute example command was not correctly ended with brackets and quotes. Fixed them and added another example. 

@shyamkumarlchauhan @dannyroberts Thanks