### PR TITLE
rotating elasticsearch logs using logrotate

### DIFF
--- a/src/commcare_cloud/ansible/roles/elasticsearch/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/elasticsearch/tasks/main.yml
@@ -231,3 +231,24 @@
     mode: 0640
   notify: reload monit
   tags: monit
+
+- name: ElasticSearchlogs
+  include_role:
+    name: ansible-logrotate
+  vars:
+    logrotate_scripts:
+      - name: "elasticsearch"
+        path: "{{ elasticsearch_data_dir }}/logs/*.log"
+        options:
+          - hourly
+          - size 750M
+          - rotate 7
+          - missingok
+          - compress
+          - delaycompress
+          - copytruncate
+          - nocreate
+          - notifempty
+  tags:
+    - elasticsearch
+    - logging

--- a/src/commcare_cloud/ansible/roles/elasticsearch/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/elasticsearch/tasks/main.yml
@@ -238,10 +238,10 @@
   vars:
     logrotate_scripts:
       - name: "elasticsearch"
-        path: "{{ elasticsearch_data_dir }}/logs/*.log"
+        path: "{{ elasticsearch_data_dir }}/logs/*.log.????-??-??"
         options:
-          - hourly
-          - size 750M
+          - daily
+          - size 50M
           - rotate 7
           - missingok
           - compress


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->

Applied on the es6-staging server only for now. Please review and let me know your suggestions 
Size: 750M is this sufficient or shall we increase it to 1024M 

