### PR TITLE
Revert "Bump urllib3 from 1.25.10 to 1.26.5"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ s3transfer==0.3.3         # via boto3
 simplejson==3.17.2        # via commcare-cloud (setup.py)
 six==1.15.0               # via bcrypt, commcare-cloud (setup.py), cryptography, fabric3, jsonobject, pynacl, python-dateutil
 tabulate==0.8.7           # via commcare-cloud (setup.py)
-urllib3==1.26.5          # via botocore, requests
+urllib3==1.25.10          # via botocore, requests
 wrapt==1.12.1             # via deprecated
 zipp==3.2.0               # via importlib-metadata, importlib-resources
 zope.event==4.5.0         # via gevent


### PR DESCRIPTION
Reverts dimagi/commcare-cloud#4771

boto3 and requests also need to be upgraded for this to work, but the `datadog==0.2.0` pin in `setup.py` is preventing that. It's unclear if it is safe to upgrade `datadog` to a more recent version.