### PR TITLE
Fix CommCareSecretsAccess target prefix

### DIFF
--- a/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
@@ -85,6 +85,7 @@ module "server_iam_role" {
   account_id = {{ account_id|tojson }}
   region_name = "${var.region}"
   formplayer_request_response_logs_firehose_stream_arn = "${module.logshipping.formplayer_request_response_logs_firehose_stream_arn}"
+  account_alias =  "${var.account_alias}"
 }
 
 {% for server_spec in servers + proxy_servers %}

--- a/src/commcare_cloud/terraform/modules/server/iam/main.tf
+++ b/src/commcare_cloud/terraform/modules/server/iam/main.tf
@@ -72,7 +72,7 @@ resource "aws_iam_role_policy" "commcare_secrets_access_policy" {
             "Sid": "VisualEditor1",
             "Effect": "Allow",
             "Action": "secretsmanager:*",
-            "Resource": "arn:aws:secretsmanager:${var.region_name}:${var.account_id}:secret:commcare-${var.environment}/*"
+            "Resource": "arn:aws:secretsmanager:${var.region_name}:${var.account_id}:secret:${var.account_alias}/*"
         }
     ]
 }

--- a/src/commcare_cloud/terraform/modules/server/iam/variables.tf
+++ b/src/commcare_cloud/terraform/modules/server/iam/variables.tf
@@ -2,3 +2,4 @@ variable "formplayer_request_response_logs_firehose_stream_arn" {}
 variable "account_id" {}
 variable "environment" {}
 variable "region_name" {}
+variable "account_alias" {}


### PR DESCRIPTION
There may be discrepancies between the environment name we set in
terraform and the actual name of the environment, so let's use
account_alias instead as the prefix for the secrets.

##### ENVIRONMENTS AFFECTED
All
