### PR TITLE
rolling back to t3.small since the memory requirement has been completed

### DIFF
--- a/environments/india/terraform.yml
+++ b/environments/india/terraform.yml
@@ -29,7 +29,7 @@ servers:
     group: control
     os: bionic
   - server_name: "djangomanage0-india"
-    server_instance_type: "t3.xlarge"
+    server_instance_type: "t3.small"
     network_tier: "app-private"
     az: "a"
     volume_size: 80


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
India. 

We switched to a higher instance when we were running some migrations on India env. It's completed, so we are rolling back to the previous instance type. 