### PR TITLE
Upgrade datadog client library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ cryptography==3.3.2
     #   ansible
     #   commcare-cloud (setup.py)
     #   paramiko
-datadog==0.2.0
+datadog==0.41.0
     # via commcare-cloud (setup.py)
 decorator==4.4.2
     # via datadog

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_deps = [
     'clint',
     'couchdb-cluster-admin>=0.7.0',
     'cryptography>=3.2',
-    'datadog==0.2.0',
+    'datadog>=0.2.0',
     'dimagi-memoized>=1.1.0',
     'dnspython',
     'Fabric3>=1.10.2,<1.11',


### PR DESCRIPTION
Reviewed [change log](https://github.com/DataDog/datadogpy/blob/master/CHANGELOG.md) and verified that we are not using any APIs with backward-incompatible changes.

This was originally done as a precursor for another library upgrade, but then after I had verified the safety of this change I realized it was not strictly required for that other upgrade. Therefore I am spinning it off as a separate PR so that work doesn't go to waste.
