### PR TITLE
adding couchalb_proxy to route couch traffic via ALB - Production 

### DIFF
--- a/environments/production/aws-resources.yml
+++ b/environments/production/aws-resources.yml
@@ -24,6 +24,7 @@ couch13-production: 10.202.40.154
 couch13-production.instance_id: i-00a287226e9555670
 couch14-production: 10.202.40.216
 couch14-production.instance_id: i-0634cf1adc9ba838c
+couch_alb-production: internal-couch-alb-production-4251727.us-east-1.elb.amazonaws.com
 couchproxy3-production: 10.202.40.196
 couchproxy3-production.instance_id: i-0b1a2bc019f113be3
 djangomanage2-production: 10.202.10.167

--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -163,6 +163,9 @@ pgucr-nlb-production-3790c322477cf782.elb.us-east-1.amazonaws.com
 [pgsynclogs_nlb]
 pgsynclogs-nlb-production-a0590d45cd55994b.elb.us-east-1.amazonaws.com
 
+[couch_alb]
+internal-couch-alb-production-4251727.us-east-1.elb.amazonaws.com
+
 [remote_postgresql:children]
 rds_pgmain0
 rds_pgformplayer0
@@ -197,6 +200,7 @@ pgformplayer_nlb
 pgmain_nlb
 pgucr_nlb
 pgsynclogs_nlb
+couch_alb
 
 [rabbit2]
 10.202.42.100 hostname=rabbit2-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-0afd113aa270a774d root_encryption_mode=aws
@@ -551,6 +555,7 @@ es_data
 couch11
 couch12
 couch13
+couch_alb
 
 [couchdb2:vars]
 swap_size=8G
@@ -559,7 +564,10 @@ swap_size=8G
 10.202.40.196 hostname=couchproxy3-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-0b1a2bc019f113be3 root_encryption_mode=aws
 
 [couchdb2_proxy:children]
-couchproxy3
+couch_alb
+
+[couchdb2_alb:children]
+couch_alb
 
 [control1]
 10.202.10.158 hostname=control1-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-0cff282a9692b2f47

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -61,6 +61,8 @@ mobile_webworkers
 
 {{ __pgsynclogs_nlb__ }}
 
+{{ __couch_alb__ }}
+
 [remote_postgresql:children]
 rds_pgmain0
 rds_pgformplayer0
@@ -95,6 +97,7 @@ pgformplayer_nlb
 pgmain_nlb
 pgucr_nlb
 pgsynclogs_nlb
+couch_alb
 
 {{ __rabbit2__ }}
 {{ __rabbit5__ }}
@@ -204,6 +207,7 @@ es_data
 couch11
 couch12
 couch13
+couch_alb
 
 [couchdb2:vars]
 swap_size=8G
@@ -211,7 +215,10 @@ swap_size=8G
 {{ __couchproxy3__ }}
 
 [couchdb2_proxy:children]
-couchproxy3
+couch_alb
+
+[couchdb2_alb:children]
+couch_alb
 
 {{ __control1__ }}
 {{ __control2__ }}

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -75,7 +75,7 @@ run_websockets_wsgi: True
 
 couch_dbs:
   default:
-    host: "{{ groups.couchdb2_proxy.0 }}"
+    host: "{{ groups.couchdb2_alb[0] }}"
     port: "{{ couchdb2_proxy_port }}"
     name: commcarehq
     username: "{{ COUCH_USERNAME }}"

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -420,6 +420,15 @@ pgbouncer_nlbs:
       - pgbouncer6-production
       - pgbouncer7-production
 
+internal_albs:
+  - name: "couch_alb-production"
+    listener_port: 25984
+    target_port: 15984
+    targets:
+      - couch11-production
+      - couch12-production
+      - couch13-production
+
 elasticache:
   create: no
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-12150
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production. 

Routing Couch requests via ProxyALB.

