### PR TITLE
remove reference to allow_primary in docs

### DIFF
--- a/docs/firefighting/index.md
+++ b/docs/firefighting/index.md
@@ -829,7 +829,7 @@ Currently on ICDS (maybe on prod/india) shard allocation is disabled. In case a 
   - Reroute according to existing shard allocation
   - Example reroute command to allocate primary shard
     ```
-    curl -XPOST 'http://<es_url>/_cluster/reroute' -d ' {"commands" :[{"allocate": {"shard": 0, "node": "es34", "allow_primary": true, "index": "xforms_2020-02-20"}}’
+    curl -XPOST 'http://<es_url>/_cluster/reroute' -d ' {"commands" :[{"allocate": {"shard": 0, "node": "es34", "index": "xforms_2020-02-20"}}’
     ```
   - Example reroute command to allocate replica shard
     ```


### PR DESCRIPTION
`allow_primary` is a dangerous parameter to include:

> The allow_primary parameter will force a new empty primary shard to be allocated without any data. If a node which has a copy of the original shard (including data) rejoins the cluster later on, that data will be deleted: the old shard copy will be replaced by the new live shard copy.
