### PR TITLE
Extract celery queue

### DIFF
--- a/environments/staging/app-processes.yml
+++ b/environments/staging/app-processes.yml
@@ -8,7 +8,9 @@ management_commands:
     run_pillow_retry_queue:
 celery_processes:
   'celery3':
-    repeat_record_queue,reminder_case_update_queue,reminder_rule_queue,celery,export_download_queue,case_import_queue:
+    repeat_record_queue,reminder_case_update_queue,reminder_rule_queue,export_download_queue,case_import_queue:
+      concurrency: 4
+    celery:
       concurrency: 4
     background_queue,case_rule_queue,analytics_queue,linked_domain_queue:
       concurrency: 2


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
I believe due to multiple queues being handled by the same worker, it has been going down repeatedly, and the resolution has been to restart this worker.
This PR just extracts out the celery queue, out, which is the default queue and should be handling lots of tasks, and hence it would reduce the load on the worker.

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
`staging`
