### PR TITLE
Make after-reboot idempotent (no restarts!)

### DIFF
--- a/src/commcare_cloud/ansible/roles/kafka/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/kafka/tasks/main.yml
@@ -93,9 +93,21 @@
     daemon_reload: yes
   when: ansible_distribution_version == '18.04'
 
+# Allows to excecute task only when a tag is specified: https://serverfault.com/a/748864
+- shell: /bin/true
+  changed_when: false
+  register: no_tags
+
+- name: start Kafka service
+  service: name=kafka-server enabled=yes state=started
+  when: no_tags is not defined
+  register: kafka_service_started
+  tags: after-reboot
+
+#Restarting a service right after it's been started can cause an inconsistent state. adding condition.
 - name: Enable and start Kafka service
   service: name=kafka-server enabled=yes state=restarted
-  tags: after-reboot
+  when: kafka_service_started.changed == False
 
 - name: Add Kafka binaries to PATH
   copy: src=kafka.sh dest=/etc/profile.d/ owner=root group=root mode=0644

--- a/src/commcare_cloud/ansible/roles/kafka/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/kafka/tasks/main.yml
@@ -104,7 +104,7 @@
   register: kafka_service_started
   tags: after-reboot
 
-#Restarting a service right after it's been started can cause an inconsistent state. adding condition.
+# Restarting a service right after it's been started will cause an unnecessary/non-idempotent restart
 - name: Enable and start Kafka service
   service: name=kafka-server enabled=yes state=restarted
   when: kafka_service_started.changed == False


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-11220
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All

Avoid restarting the Kafka service when already started in case of after-reboot. 