### PR TITLE
resizing couchproxy3 machine to get metrics on datadog

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -103,7 +103,7 @@ servers:
     count: 16
 
   - server_name: "couchproxy3-production"
-    server_instance_type: c5.xlarge
+    server_instance_type: m3.medium
     network_tier: "db-private"
     az: "a"
     volume_size: 80


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-12426
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production.

After couchproxy3 machine has been stopped, couch metrics on datadog stopped reporting. Therefore, we resized the instance for now. 

cc: @shyamkumarlchauhan 