### PR TITLE
Disable swiss device logs

### DIFF
--- a/environments/swiss/public.yml
+++ b/environments/swiss/public.yml
@@ -98,6 +98,7 @@ localsettings:
   COUCH_PASSWORD: "{{ COUCH_PASSWORD }}"
   COUCH_USERNAME: "{{ COUCH_USERNAME }}"
   DEPLOY_MACHINE_NAME: "{{ ansible_hostname }}"
+  DEVICE_LOGS_ENABLED: no
   EMAIL_SMTP_HOST: email-smtp.us-east-1.amazonaws.com
   EMAIL_SMTP_PORT: 587
   EMAIL_USE_TLS: yes


### PR DESCRIPTION
Disable swiss device logs to stop daily spike of 5xx errors.

Jira: [SAAS-12451](https://dimagi-dev.atlassian.net/browse/SAAS-12451)

##### ENVIRONMENTS AFFECTED
- swiss
