### PR TITLE
Add ability to use aws ssm to connect through the control machine

### DIFF
--- a/control/init.sh
+++ b/control/init.sh
@@ -132,6 +132,10 @@ if ! grep -q init-ansible ~/.profile 2>/dev/null; then
             echo '[ -t 1 ] && source ~/init-ansible' >> ~/.profile
             printf "${YELLOW}→ Added init script to ~/.profile\n"
         ;;
+        [Nn]* )
+            echo '# [ -t 1 ] && source ~/init-ansible' >> ~/.profile
+            printf "${YELLOW}→ Okay, I won't ask you again. Added a line you can uncomment in ~/.profile if you want it later.\n"
+        ;;
         * )
             printf "\n${BLUE}You can always set it up later by running this command:\n"
             printf "${BLUE}echo '[ -t 1 ] && source ~/init-ansible' >> ~/.profile${NC}\n"

--- a/docs/commcare-cloud/commands/index.md
+++ b/docs/commcare-cloud/commands/index.md
@@ -11,7 +11,7 @@ All `commcare-cloud` commands take the following form:
 ```
 commcare-cloud [--control]
                <env>
-               {after-reboot,ansible-playbook,ap,aws-fill-inventory,aws-list,aws-sign-in,bootstrap-users,celery-resource-report,copy-files,couchdb-cluster-info,deploy,deploy-stack,aps,django-manage,downtime,export-sentry-events,fab,list-postgresql-dbs,lookup,migrate-couchdb,migrate_couchdb,migrate-secrets,mosh,openvpn-activate-user,openvpn-claim-user,pillow-resource-report,pillow-topic-assignments,ping,run-module,run-shell-command,secrets,send-datadog-event,service,ssh,terraform,terraform-migrate-state,tmux,update-config,update-local-known-hosts,update-supervisor-confs,update-user-key,update-users,validate-environment-settings}
+               {after-reboot,ansible-playbook,ap,aws-fill-inventory,aws-list,aws-sign-in,bootstrap-users,celery-resource-report,copy-files,couchdb-cluster-info,deploy,deploy-stack,aps,django-manage,downtime,export-sentry-events,fab,forward-port,list-postgresql-dbs,lookup,migrate-couchdb,migrate_couchdb,migrate-secrets,mosh,openvpn-activate-user,openvpn-claim-user,pillow-resource-report,pillow-topic-assignments,ping,run-module,run-shell-command,secrets,send-datadog-event,service,ssh,terraform,terraform-migrate-state,tmux,update-config,update-local-known-hosts,update-supervisor-confs,update-user-key,update-users,validate-environment-settings}
                ...
 ```
 
@@ -1543,5 +1543,21 @@ Must be one of the defined ssh users defined for the environment.
 ###### `--use-factory-auth`
 
 authenticate using the pem file (or prompt for root password if there is no pem file)
+
+---
+
+#### `forward-port`
+
+Port forward to access a remote admin console
+
+```
+commcare-cloud <env> forward-port {flower,couch,elasticsearch}
+```
+
+##### Positional Arguments
+
+###### `{flower,couch,elasticsearch}`
+
+The remote service to port forward. Must be one of couch,elasticsearch,flower.
 
 ---

--- a/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -299,9 +299,9 @@ class ForwardPort(CommandBase):
     Port forward to access a remote admin console
     """
     _SERVICES = {
-        'flower': ('celery[0]', 5555),
-        'couch': ('couchdb2_proxy[0]', 25984),
-        'elasticsearch': ('elasticsearch[0]', 9200),
+        'flower': ('celery[0]', 5555, '/'),
+        'couch': ('couchdb2_proxy[0]', 25984, '/_utils/'),
+        'elasticsearch': ('elasticsearch[0]', 9200, '/'),
     }
 
     arguments = (
@@ -313,7 +313,7 @@ class ForwardPort(CommandBase):
     def run(self, args, unknown_args):
         environment = get_environment(args.env_name)
         nice_name = environment.terraform_config.account_alias
-        remote_host_key, remote_port = self._SERVICES[args.service]
+        remote_host_key, remote_port, url_path = self._SERVICES[args.service]
         loopback_address = f'127.0.{environment.terraform_config.vpc_begin_range}'
         remote_host = lookup_server_address(args.env_name, remote_host_key)
         local_port = self.get_random_available_port()
@@ -333,7 +333,7 @@ class ForwardPort(CommandBase):
                 return -1
             puts()
 
-        puts(color_notice(f'You should now be able to reach {args.env_name} {args.service} at {color_link(f"http://{nice_name}:{local_port}/")}.'))
+        puts(color_notice(f'You should now be able to reach {args.env_name} {args.service} at {color_link(f"http://{nice_name}:{local_port}{url_path}")}.'))
         puts(f'Interrupt with ^C to stop port-forwarding and exit.')
         puts()
         try:

--- a/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -355,7 +355,7 @@ class ForwardPort(CommandBase):
     @staticmethod
     def is_etc_hosts_alias_set_up(loopback_address, nice_name):
 
-        grep_regex = rf"{loopback_address}\s+{nice_name}"
+        grep_regex = rf"^{loopback_address}\s+{nice_name}"
         try:
             subprocess.check_output(f'grep -E {shlex_quote(grep_regex)} /etc/hosts', shell=True)
         except subprocess.CalledProcessError:

--- a/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -17,7 +17,7 @@ from ..ansible.helpers import get_default_ssh_options_as_cmd_parts
 from ..terraform.aws import aws_sign_in, is_aws_env, is_ec2_instance_in_account
 from ...alias import commcare_cloud
 
-from ...colors import color_error, color_notice
+from ...colors import color_error, color_notice, color_link
 from .getinventory import (get_monolith_address, get_server_address,
                            split_host_group)
 
@@ -326,8 +326,8 @@ class ForwardPort(CommandBase):
                 return -1
             puts()
 
-        puts(color_notice(f'{args.env_name} {args.service} should now be available to you at {nice_name}:{remote_port}'))
-        puts(color_notice(f'^C to stop port-forwarding and exit'))
+        puts(color_notice(f'You should now be able to reach {args.env_name} {args.service} at {color_link(f"http://{nice_name}:{remote_port}/")}.'))
+        puts(f'Interrupt with ^C to stop port-forwarding and exit.')
         puts()
         try:
             return commcare_cloud(args.env_name, 'ssh', 'control', '-NL', f'{loopback_address}:{remote_port}:{remote_host}:{remote_port}')

--- a/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -350,8 +350,9 @@ class ForwardPort(CommandBase):
     @staticmethod
     def is_etc_hosts_alias_set_up(loopback_address, nice_name):
 
+        grep_regex = rf"{loopback_address}\s+{nice_name}"
         try:
-            subprocess.check_output(f'grep {shlex_quote(f"{loopback_address} {nice_name}")} /etc/hosts', shell=True)
+            subprocess.check_output(f'grep -E {shlex_quote(grep_regex)} /etc/hosts', shell=True)
         except subprocess.CalledProcessError:
             return False
         else:

--- a/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -309,4 +309,4 @@ class ForwardPort(CommandBase):
         remote_host_key, remote_port = self._SERVICES[args.service]
         loopback_address = f'127.0.{environment.terraform_config.vpc_begin_range}'
         remote_host = lookup_server_address(args.env_name, remote_host_key)
-        return commcare_cloud(args.env_name, 'ssh', 'control', '-gNL', f'{loopback_address}:{remote_port}:{remote_host}:{remote_port}')
+        return commcare_cloud(args.env_name, 'ssh', 'control', '-NL', f'{loopback_address}:{remote_port}:{remote_host}:{remote_port}')

--- a/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import os
+import socket
 import subprocess
 import sys
 
@@ -354,11 +355,10 @@ class ForwardPort(CommandBase):
 
     @staticmethod
     def is_etc_hosts_alias_set_up(loopback_address, nice_name):
-
-        grep_regex = rf"^{loopback_address}\s+{nice_name}"
         try:
-            subprocess.check_output(f'grep -E {shlex_quote(grep_regex)} /etc/hosts', shell=True)
-        except subprocess.CalledProcessError:
+            resolved = socket.gethostbyname(nice_name)
+        except socket.gaierror:
             return False
         else:
-            return True
+            return resolved == loopback_address
+

--- a/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -340,10 +340,13 @@ class ForwardPort(CommandBase):
     @staticmethod
     def is_loopback_address_set_up(loopback_address):
         try:
-            subprocess.check_output(f'ifconfig | grep {shlex_quote(loopback_address)}', shell=True)
+            # Use either ifconfig or ip, whichever is available
+            subprocess.check_output(f'{{ ifconfig || ip addr show dev lo; }} | grep {shlex_quote(loopback_address)}', shell=True)
         except subprocess.CalledProcessError:
+            print("NO")
             return False
         else:
+            print("YES")
             return True
 
     @staticmethod

--- a/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -346,7 +346,7 @@ class ForwardPort(CommandBase):
     def is_loopback_address_set_up(loopback_address):
         try:
             # Use either ifconfig or ip, whichever is available
-            subprocess.check_output(f'{{ ifconfig 2> /dev/null || ip addr show dev lo; }} | grep {shlex_quote(loopback_address)}', shell=True)
+            subprocess.check_output(f'ping -c 1 -W 1 {shlex_quote(loopback_address)}', shell=True)
         except subprocess.CalledProcessError:
             return False
         else:

--- a/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -85,7 +85,7 @@ class _Ssh(Lookup):
         cmd = ' '.join(shlex_quote(arg) for arg in cmd_parts)
         if not args.quiet:
             print_command(cmd)
-        return subprocess.call(cmd_parts, env=env_vars)
+        return subprocess.call(cmd_parts, **({'env': env_vars} if env_vars else {}))
 
 
 class Ssh(_Ssh):

--- a/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -341,12 +341,10 @@ class ForwardPort(CommandBase):
     def is_loopback_address_set_up(loopback_address):
         try:
             # Use either ifconfig or ip, whichever is available
-            subprocess.check_output(f'{{ ifconfig || ip addr show dev lo; }} | grep {shlex_quote(loopback_address)}', shell=True)
+            subprocess.check_output(f'{{ ifconfig 2> /dev/null || ip addr show dev lo; }} | grep {shlex_quote(loopback_address)}', shell=True)
         except subprocess.CalledProcessError:
-            print("NO")
             return False
         else:
-            print("YES")
             return True
 
     @staticmethod

--- a/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -107,7 +107,10 @@ class Ssh(_Ssh):
         if 'control' in split_host_group(args.server).group and '-A' not in ssh_args:
             # Always include ssh agent forwarding on control machine
             ssh_args = ['-A'] + ssh_args
-            if is_aws_env(environment) and not is_ec2_instance_in_account(environment.aws_config.sso_config.sso_account_id):
+
+            if os.environ.get('COMMCARE_CLOUD_USE_AWS_SSM') == '1' and \
+                    is_aws_env(environment) and \
+                    not is_ec2_instance_in_account(environment.aws_config.sso_config.sso_account_id):
                 use_aws_ssm_with_instance_id = environment.get_host_vars(environment.groups['control'][0])['ec2_instance_id']
                 env_vars = os.environ.copy()
                 env_vars.update({'AWS_PROFILE': aws_sign_in(environment)})

--- a/src/commcare_cloud/commands/terraform/aws.py
+++ b/src/commcare_cloud/commands/terraform/aws.py
@@ -337,6 +337,13 @@ AWS_SSO_CACHE_DIR = os.path.expanduser('~/.aws/sso/cache/')
 AWS_CLI_CACHE_DIR = os.path.expanduser('~/.aws/cli/cache/')
 
 
+def is_aws_env(environment):
+    if environment.terraform_config:
+        return True
+    else:
+        return False
+
+
 @memoized
 def aws_sign_in(environment, duration_minutes=DEFAULT_SIGN_IN_DURATION_MINUTES, force_new=False):
     if is_ec2_instance_in_account(environment.aws_config.sso_config.sso_account_id):

--- a/src/commcare_cloud/commands/terraform/aws.py
+++ b/src/commcare_cloud/commands/terraform/aws.py
@@ -338,10 +338,7 @@ AWS_CLI_CACHE_DIR = os.path.expanduser('~/.aws/cli/cache/')
 
 
 def is_aws_env(environment):
-    if environment.terraform_config:
-        return True
-    else:
-        return False
+    return bool(environment.terraform_config)
 
 
 @memoized

--- a/src/commcare_cloud/commands/terraform/aws.py
+++ b/src/commcare_cloud/commands/terraform/aws.py
@@ -371,6 +371,16 @@ def is_ec2_instance_in_account(account_id):
     return aws_instance_identity_doc.get('accountId') == account_id
 
 
+def is_session_manager_plugin_installed():
+    try:
+        # swallow output
+        subprocess.check_output('session-manager-plugin', shell=True)
+    except subprocess.CalledProcessError:
+        return False
+    else:
+        return True
+
+
 @memoized
 def _aws_sign_in_with_sso(environment):
     """

--- a/src/commcare_cloud/commcare_cloud.py
+++ b/src/commcare_cloud/commcare_cloud.py
@@ -34,7 +34,7 @@ from .commands.ansible.ansible_playbook import (
 from commcare_cloud.commands.ansible.service import Service
 from .commands.ansible.run_module import RunAnsibleModule, RunShellCommand, Ping, SendDatadogEvent
 from .commands.fab import Fab
-from .commands.inventory_lookup.inventory_lookup import Lookup, Ssh, Mosh, DjangoManage, Tmux
+from .commands.inventory_lookup.inventory_lookup import Lookup, Ssh, Mosh, DjangoManage, Tmux, ForwardPort
 from .commands.ansible.ops_tool import ListDatabases, CeleryResourceReport, PillowResourceReport, \
     CouchDBClusterInfo, UpdateLocalKnownHosts, PillowTopicAssignments
 from commcare_cloud.commands.command_base import CommandBase, Argument, CommandError
@@ -90,6 +90,7 @@ COMMAND_GROUPS = OrderedDict([
         AwsFillInventory,
         OpenvpnActivateUser,
         OpenvpnClaimUser,
+        ForwardPort,
     ])
 ])
 


### PR DESCRIPTION
Note: currently requires `export COMMCARE_CLOUD_USE_AWS_SSM=1` to work

## Using AWS SSM to log onto control machine

This is the "main" change. This adds an alternative to using the VPN: using SSM to log onto the control machine and running all further commands from the control machine. Eventually this will be the default, but in the short term to use this functionality you will need to add `export COMMCARE_CLOUD_USE_AWS_SSM=1` to your `~/.profile` or run it once per new terminal tab you open. After that, you can just use the `cchq` command normally: `cchq staging ssh control` and `cchq --control staging deploy`, etc. all work as they did before; the difference is to do anything that request connecting to a machine other than control, you first have to run `cchq staging ssh control`, and then run the command from there.

The first time you do this (or anytime it's not already installed) it'll ask you to install a necessary plugin from AWS:

![Screen Shot 2021-07-23 at 5 01 15 PM](https://user-images.githubusercontent.com/137212/126846154-d6e74251-e4b4-4562-8342-5f4fdda08564.png)


## Forward Port command
In addition, this PR adds a `forward-port` command that is designed to allow you to connect securely to browser-based management consoles like couch fauxton, celery flower, and elasticsearch head—all without connecting to the VPN.

Using this command will require some first-time setup. Here's a screenshot of the interactive setup experience

![Screen Shot 2021-07-23 at 2 49 37 PM](https://user-images.githubusercontent.com/137212/126834031-7414f802-181d-4215-880e-aa71f14007b2.png)

You'll notice that it requires root access, but it doesn't run any of those commands itself, letting you examine what you're running before you run it.

Subsequent runs are then much smoother:

![Screen Shot 2021-07-23 at 2 52 15 PM](https://user-images.githubusercontent.com/137212/126834358-1ec594b6-c0b3-41b9-afc6-68b489695b3c.png)

My hope is that the setup will be fairly straightforward, and the ongoing experience afterwards will be very nice, nicer than what we currently have with the VPN.

##### ENVIRONMENTS AFFECTED
production, india, staging