### PR TITLE
Change the couch apt repo from bintray to jfrog

### DIFF
--- a/src/commcare_cloud/ansible/roles/couchdb2-preinstall/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/couchdb2-preinstall/tasks/main.yml
@@ -31,8 +31,8 @@
 
 - name: Add Couch apt repo (for libmozjs dependency)
   block:
-    - apt_key: url=https://couchdb.apache.org/repo/bintray-pubkey.asc state=present
-    - apt_repository: repo="deb https://apache.bintray.com/couchdb-deb bionic main" state=present
+    - apt_key: url=https://couchdb.apache.org/repo/keys.asc state=present
+    - apt_repository: repo="deb https://apache.jfrog.io/artifactory/couchdb-deb bionic main" state=present
   when: ansible_distribution_version == '18.04'
 
 - name: Add Erlang apt repo


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
This is the repo listed in the couchdb docs: https://docs.couchdb.org/en/stable/install/unix.html 
The previous bintray address has been sunset: https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
