### PR TITLE
Don't error on key_type-key pairs

### DIFF
--- a/src/commcare_cloud/commands/ansible/ops_tool.py
+++ b/src/commcare_cloud/commands/ansible/ops_tool.py
@@ -416,11 +416,14 @@ def _get_host_key_map(known_host_lines):
     for line in known_host_lines:
         if not line:
             continue
-        csv_hosts, key_type, key = line.split(' ')
+        # line is formatted "<hosts> <key_type> <key> <key_type> <key> ..."
+        csv_hosts, *key_types_keys_list = line.split(' ')
+        key_type_key_pairs = chunked(key_types_keys_list, 2)
         # filter out empty hosts ('[]:port' is empty host with non-standard port)
         hosts = [h for h in csv_hosts.split(',') if h and '[]' not in h]
         for host in hosts:
-            keys_by_host[(host, key_type)] = key
+            for key_type, key in key_type_key_pairs:
+                keys_by_host[(host, key_type)] = key
     return keys_by_host
 
 
@@ -437,3 +440,17 @@ def _get_lines(proc):
         return str(color_error('timeout\n')), []
     else:
         return None, out.splitlines()
+
+
+def chunked(iterable, n, fillvalue=None):
+    """
+    Collect data into fixed-length chunks
+
+    >>> list(chunked('ABCDEFG', 3, 'x'))
+    [('A', 'B', 'C'), ('D', 'E', 'F'), ('G', 'x', 'x')]
+
+    """
+    # Pulled shamelessly from itertools recipes
+    # https://docs.python.org/3/library/itertools.html#itertools-recipes
+    args = [iter(iterable)] * n
+    return itertools.zip_longest(*args, fillvalue=fillvalue)

--- a/tests/test_ops_tool.py
+++ b/tests/test_ops_tool.py
@@ -1,0 +1,39 @@
+import doctest
+
+from nose.tools import assert_equal
+
+from commcare_cloud.commands.ansible.ops_tool import chunked, _get_host_key_map
+
+
+def test_chunked():
+    line = 'foo.example.com ssh-rsa AAAABRI= ecdsa-sha2-nistp256 AAAAE2Q='
+    hosts, *key_types_keys_list = line.split(' ')
+    key_type_key_pairs = chunked(key_types_keys_list, 2)
+    assert_equal(list(key_type_key_pairs), [
+        ('ssh-rsa', 'AAAABRI='),
+        ('ecdsa-sha2-nistp256', 'AAAAE2Q='),
+    ])
+
+
+def test_get_host_key_map():
+    known_host_lines = [
+        '10.0.0.10 ecdsa-sha2-nistp256 AAAAE2V=',
+        '10.0.0.10 ssh-ed25519 AAAATppj',
+        '10.0.0.10 ssh-rsa AAAACT5P',
+        'foo.example.com ssh-rsa AAAABRI= ecdsa-sha2-nistp256 AAAAE2Q=',
+    ]
+    keys_by_host = _get_host_key_map(known_host_lines)
+    assert_equal(keys_by_host, {
+        ('10.0.0.10', 'ecdsa-sha2-nistp256'): 'AAAAE2V=',
+        ('10.0.0.10', 'ssh-ed25519'): 'AAAATppj',
+        ('10.0.0.10', 'ssh-rsa'): 'AAAACT5P',
+        ('foo.example.com', 'ssh-rsa'): 'AAAABRI=',
+        ('foo.example.com', 'ecdsa-sha2-nistp256'): 'AAAAE2Q=',
+    })
+
+
+def test_doctests():
+    from commcare_cloud.commands.ansible import ops_tool
+
+    results = doctest.testmod(ops_tool)
+    assert results.failed == 0


### PR DESCRIPTION
A self-hosting partner has a `known_hosts` file that has multiple key_type-key pairs on the same line. (See **tests/test_ops_tool.py:23** `test_get_host_key_map()` for an example.)

This change is to support that. Current behavior is preserved.


##### ENVIRONMENTS AFFECTED

No Dimagi environments are affected.
