### PR TITLE
Find and remove all but last 2 formplayer releases

### DIFF
--- a/src/commcare_cloud/ansible/deploy_formplayer.yml
+++ b/src/commcare_cloud/ansible/deploy_formplayer.yml
@@ -25,3 +25,19 @@
       tags: kinesis-agent
   handlers:
     - include: roles/monit/handlers/main.yml
+
+- name: Cleanup formplayer releases
+  hosts: formplayer
+  tasks:
+    - name: List of releases
+      find:
+        paths="{{ formplayer_build_dir }}"
+        file_type=directory
+      register: releases
+
+    - name: Keep the last 2 releases
+      file:
+        path="{{ item.path }}"
+        state=absent
+      with_items:
+        - "{{ (releases.files | sort(attribute='ctime'))[:-2] }}"

--- a/src/commcare_cloud/ansible/group_vars/formplayer.yml
+++ b/src/commcare_cloud/ansible/group_vars/formplayer.yml
@@ -1,1 +1,2 @@
 datadog_integration_jmx: true
+formplayer_build_dir: '/home/cchq/www/staging/formplayer_build/releases'


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-11939

This adds a cleanup task to the `deploy_formplayer` playbook, which keeps all but the last 2 formplayer releases sorted by last modified time. 

I'm not quite sure how to properly organize/structure something like this. Is the cleaner approach to put these tasks in their own file that the deploy playbook can call? Definitely looking for feedback here. Thanks.
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
