### PR TITLE
Renamed user_case to usercase

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -130,7 +130,7 @@ localsettings:
   AUDIT_ALL_VIEWS: True
   AUDIT_TRACE_ID_HEADER: "X-Amzn-Trace-Id"
   AVAILABLE_CUSTOM_RULE_CRITERIA:
-    COVID_US_ASSOCIATED_USER_CASES: custom.covid.rules.custom_criteria.associated_user_case_closed
+    COVID_US_ASSOCIATED_USER_CASES: custom.covid.rules.custom_criteria.associated_usercase_closed
   AVAILABLE_CUSTOM_RULE_ACTIONS:
     COVID_US_CLOSE_CASES_ASSIGNED_CHECKIN: custom.covid.rules.custom_actions.close_cases_assigned_to_checkin
   BANK_ADDRESS: { 'first_line': "1 Citizens Drive", 'city': "Riverside", 'region': "RI", 'postal_code': "02915" }


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
[Ticket](https://dimagi-dev.atlassian.net/browse/SUPPORT-10242) and another installment of changing "user_case" to "usercase"

This now matches in hq [here](https://github.com/dimagi/commcare-hq/blob/master/custom/covid/rules/custom_criteria.py#L12) when before it was preventing this rule to run.
