### PR TITLE
use batch size of 1 for low volume bulk pillows

### DIFF
--- a/environments/india/app-processes.yml
+++ b/environments/india/app-processes.yml
@@ -51,6 +51,7 @@ pillows:
       num_processes: 1
     SqlSMSPillow:
       num_processes: 1
+      processor_chunk_size: 1
     UpdateUserSyncHistoryPillow:
       num_processes: 1
     UserCacheInvalidatePillow:
@@ -67,3 +68,4 @@ pillows:
       num_processes: 1
     user-pillow:
       num_processes: 1
+      processor_chunk_size: 1

--- a/environments/swiss/app-processes.yml
+++ b/environments/swiss/app-processes.yml
@@ -45,6 +45,7 @@ pillows:
       num_processes: 1
     SqlSMSPillow:
       num_processes: 1
+      processor_chunk_size: 1
     UnknownUsersPillow:
       num_processes: 1
     UpdateUserSyncHistoryPillow:


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-11496
Minor. There are far fewer bulk pillows than I thought on these environments, but I still think this is worth doing. All swiss ones now have batch size of 1. I left the case and form pillows on india bulk, because I think they have enough volume there to avoid the bad situations (the swiss ones were already not bulk since they use the old and not combined form and case pillows).

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
India
Swiss
