### PR TITLE
Updating RDS,server,internal_alb terraform modules .ref: SAAS-12440

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -289,12 +289,15 @@ rds_instances:
     storage: 10000
     multi_az: true
     engine_version: 9.6.20
+    backup_window: "23:00-01:00"
+    backup_retention: 7
     params:
       shared_preload_libraries: pg_stat_statements
       log_min_duration_statement: 1000
       # This is for autovacuuming the huge TOAST table for formplayer.formplayer_sessions table.
       # When 'commcarehq' and 'formplayer' dbs are split, this should move to formplayer db instance
       maintenance_work_mem: 4172000kB
+      max_connections: "least({dbinstanceclassmemory/9531392},5000)"
 
   - identifier: "pgucr0-production"
     instance_type: "db.t3.xlarge"  # increased from db.t3.large due to unused db.t3 RIs
@@ -302,6 +305,10 @@ rds_instances:
     max_storage: 5000
     multi_az: true
     engine_version: 9.6.20
+    backup_window: "23:00-01:00"
+    backup_retention: 7
+    params:
+      max_connections: "least({dbinstanceclassmemory/9531392},5000)"
 
   - identifier: "pgshard1-production"
     instance_type: "db.m5.4xlarge"
@@ -309,45 +316,60 @@ rds_instances:
     max_storage: 2500
     multi_az: true
     engine_version: 9.6.20
+    backup_window: "23:00-01:00"
+    backup_retention: 7
     params:
       shared_preload_libraries: pg_stat_statements
-      log_min_duration_statement: 5000
+      log_min_duration_statement: ""
+      max_connections: "least({dbinstanceclassmemory/9531392},5000)"
   - identifier: "pgshard2-production"
     instance_type: "db.m5.4xlarge"
     storage: 500
     max_storage: 2500
     multi_az: true
     engine_version: 9.6.20
+    backup_window: "23:00-01:00"
+    backup_retention: 7
     params:
       shared_preload_libraries: pg_stat_statements
-      log_min_duration_statement: 5000
+      log_min_duration_statement: ""
+      max_connections: "least({dbinstanceclassmemory/9531392},5000)"
   - identifier: "pgshard3-production"
     instance_type: "db.m5.4xlarge"
     storage: 500
     max_storage: 2500
     multi_az: true
     engine_version: 9.6.20
+    backup_window: "23:00-01:00"
+    backup_retention: 7
     params:
       shared_preload_libraries: pg_stat_statements
-      log_min_duration_statement: 5000
+      log_min_duration_statement: ""
+      max_connections: "least({dbinstanceclassmemory/9531392},5000)"
   - identifier: "pgshard4-production"
     instance_type: "db.m5.4xlarge"
     storage: 500
     max_storage: 2500
     multi_az: true
     engine_version: 9.6.20
+    backup_window: "23:00-01:00"
+    backup_retention: 7
     params:
       shared_preload_libraries: pg_stat_statements
-      log_min_duration_statement: 5000
+      log_min_duration_statement: ""
+      max_connections: "least({dbinstanceclassmemory/9531392},5000)"
   - identifier: "pgshard5-production"
     instance_type: "db.m5.4xlarge"
     storage: 500
     max_storage: 2500
     multi_az: true
     engine_version: 9.6.20
+    backup_window: "23:00-01:00"
+    backup_retention: 7
     params:
       shared_preload_libraries: pg_stat_statements
-      log_min_duration_statement: 5000
+      log_min_duration_statement: ""
+      max_connections: "least({dbinstanceclassmemory/9531392},5000)"
 
   - identifier: "pgsynclog0-production"
     instance_type: "db.t3.xlarge"
@@ -360,6 +382,7 @@ rds_instances:
       shared_buffers: 3840MB
       effective_cache_size: 11520MB
       maintenance_work_mem: 960MB
+      max_connections: "least({dbinstanceclassmemory/9531392},5000)"
 
   - identifier: "pgformplayer0-production"
     instance_type: "db.m5.2xlarge"
@@ -378,6 +401,9 @@ rds_instances:
     storage: 1000
     multi_az: true
     engine_version: 9.6.20
+    backup_window: "23:00-01:00"
+    backup_retention: 7
+    monitoring_interval: 0
     params:
       shared_preload_libraries: pg_stat_statements
       log_min_duration_statement: 1000
@@ -408,6 +434,7 @@ internal_albs:
   - name: "couch_alb-production"
     listener_port: 25984
     target_port: 15984
+    health_check_interval: 29
     targets:
       - couch11-production
       - couch12-production

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -320,7 +320,7 @@ rds_instances:
     backup_retention: 7
     params:
       shared_preload_libraries: pg_stat_statements
-      log_min_duration_statement: ""
+      log_min_duration_statement: null
       max_connections: "least({dbinstanceclassmemory/9531392},5000)"
   - identifier: "pgshard2-production"
     instance_type: "db.m5.4xlarge"
@@ -332,7 +332,7 @@ rds_instances:
     backup_retention: 7
     params:
       shared_preload_libraries: pg_stat_statements
-      log_min_duration_statement: ""
+      log_min_duration_statement: null
       max_connections: "least({dbinstanceclassmemory/9531392},5000)"
   - identifier: "pgshard3-production"
     instance_type: "db.m5.4xlarge"
@@ -344,7 +344,7 @@ rds_instances:
     backup_retention: 7
     params:
       shared_preload_libraries: pg_stat_statements
-      log_min_duration_statement: ""
+      log_min_duration_statement: null
       max_connections: "least({dbinstanceclassmemory/9531392},5000)"
   - identifier: "pgshard4-production"
     instance_type: "db.m5.4xlarge"
@@ -356,7 +356,7 @@ rds_instances:
     backup_retention: 7
     params:
       shared_preload_libraries: pg_stat_statements
-      log_min_duration_statement: ""
+      log_min_duration_statement: null
       max_connections: "least({dbinstanceclassmemory/9531392},5000)"
   - identifier: "pgshard5-production"
     instance_type: "db.m5.4xlarge"
@@ -368,7 +368,7 @@ rds_instances:
     backup_retention: 7
     params:
       shared_preload_libraries: pg_stat_statements
-      log_min_duration_statement: ""
+      log_min_duration_statement: null
       max_connections: "least({dbinstanceclassmemory/9531392},5000)"
 
   - identifier: "pgsynclog0-production"
@@ -434,7 +434,7 @@ internal_albs:
   - name: "couch_alb-production"
     listener_port: 25984
     target_port: 15984
-    health_check_interval: 29
+    health_check_interval: 30
     targets:
       - couch11-production
       - couch12-production

--- a/src/commcare_cloud/commands/terraform/postgresql_units.py
+++ b/src/commcare_cloud/commands/terraform/postgresql_units.py
@@ -58,6 +58,7 @@ UNITS_BY_PARAM = {
     'deadlock_timeout': MS,
     'lock_timeout': MS,
     'log_autovacuum_min_duration': MS,
+    'log_min_duration_statement': MS,
     'max_standby_archive_delay': MS,
     'max_standby_streaming_delay': MS,
     'statement_timeout': MS,

--- a/src/commcare_cloud/commands/terraform/postgresql_units.py
+++ b/src/commcare_cloud/commands/terraform/postgresql_units.py
@@ -58,7 +58,6 @@ UNITS_BY_PARAM = {
     'deadlock_timeout': MS,
     'lock_timeout': MS,
     'log_autovacuum_min_duration': MS,
-    'log_min_duration_statement': MS,
     'max_standby_archive_delay': MS,
     'max_standby_streaming_delay': MS,
     'statement_timeout': MS,

--- a/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
@@ -289,6 +289,7 @@ module "internal_alb__{{ internal_alb.name }}" {
   alb_identifier = "{{ internal_alb.identifier }}"
   target_port = "{{ internal_alb.target_port }}"
   listener_port = "{{ internal_alb.listener_port }}"
+  health_check_interval = "{{ internal_alb.health_check_interval }}"
   security_groups = ["${module.network.db-private-sg}"]
   subnets = [
     {%- for az in az_codes %}{% if not loop.first %}, {% endif %}

--- a/src/commcare_cloud/commands/terraform/templates/postgresql.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/postgresql.tf.j2
@@ -15,7 +15,7 @@ module "postgresql__{{ rds_instance.identifier }}" {
     backup_retention = {{ rds_instance.backup_retention|tojson }}
     maintenance_window = {{ rds_instance.maintenance_window|tojson }}
     port = {{ rds_instance.port|tojson }}
-    monitoring_interval = 60
+    monitoring_interval = {{ rds_instance.monitoring_interval|tojson }}
   }
   parameters = [
     {%- for param in postgresql_params[rds_instance.identifier] %}

--- a/src/commcare_cloud/commands/terraform/terraform.py
+++ b/src/commcare_cloud/commands/terraform/terraform.py
@@ -115,7 +115,7 @@ class UnauthorizedUser(Exception):
 def format_param_for_terraform(param_name, param_value):
     return {
         'name': param_name,
-        'value': postgresql_units.convert_to_standard_unit(param_name, param_value),
+        'value': '' if param_value is None else postgresql_units.convert_to_standard_unit(param_name, param_value),
         # Anything listed as "dynamic" in
         #   https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.PostgreSQL.CommonDBATasks.html
         # will be applied *immediately*, ignoring this flag. See:

--- a/src/commcare_cloud/environment/schemas/terraform.py
+++ b/src/commcare_cloud/environment/schemas/terraform.py
@@ -134,8 +134,9 @@ class RdsInstanceConfig(jsonobject.JsonObject):
     max_storage = jsonobject.IntegerProperty(default=0)
     create = jsonobject.BooleanProperty(default=True)
     username = "root"
-    backup_window = "06:27-06:57"
-    backup_retention = 30
+    backup_window = jsonobject.StringProperty(default="06:27-06:57")
+    backup_retention = jsonobject.IntegerProperty(default=30)
+    monitoring_interval = jsonobject.IntegerProperty(default=60)
     maintenance_window = "sat:08:27-sat:08:57"
     port = 5432
     params = jsonobject.DictProperty()
@@ -179,7 +180,7 @@ class InternalAlbs(jsonobject.JsonObject):
     targets = jsonobject.ListProperty(str)
     target_port = jsonobject.IntegerProperty(required=True)
     listener_port = jsonobject.IntegerProperty(required=True)
-
+    health_check_interval = jsonobject.IntegerProperty(default=30)
     @classmethod
     def wrap(cls, data):
         self = super(InternalAlbs, cls).wrap(data)

--- a/src/commcare_cloud/terraform/modules/internal_alb/main.tf
+++ b/src/commcare_cloud/terraform/modules/internal_alb/main.tf
@@ -30,6 +30,7 @@ resource "aws_lb_target_group" "this" {
     enabled = true
     healthy_threshold = 2
     unhealthy_threshold = 2
+    interval = "${var.health_check_interval}"
   }
 }
 

--- a/src/commcare_cloud/terraform/modules/internal_alb/variables.tf
+++ b/src/commcare_cloud/terraform/modules/internal_alb/variables.tf
@@ -14,3 +14,4 @@ variable "listener_port" {}
 variable "security_groups" {
   type = "list"
 }
+variable "health_check_interval" {}

--- a/src/commcare_cloud/terraform/modules/server/main.tf
+++ b/src/commcare_cloud/terraform/modules/server/main.tf
@@ -50,7 +50,12 @@ resource "aws_ebs_volume" "ebs_volume" {
     GroupDetail = "${var.group_tag}:data"
   }
    lifecycle {
-    ignore_changes = ["type", "ebs_optimized", "tags"]
+    ignore_changes = [
+      "type",
+      # temporarily ignore the "BackupPlan" tag until it's managed properly
+      "tags.BackupPlan",
+      "tags.%"
+      ]
   }
 }
 

--- a/src/commcare_cloud/terraform/modules/server/main.tf
+++ b/src/commcare_cloud/terraform/modules/server/main.tf
@@ -49,6 +49,9 @@ resource "aws_ebs_volume" "ebs_volume" {
     VolumeType = "data"
     GroupDetail = "${var.group_tag}:data"
   }
+   lifecycle {
+    ignore_changes = ["type", "ebs_optimized", "tags"]
+  }
 }
 
 resource "aws_volume_attachment" "ebs_att" {


### PR DESCRIPTION
Updating RDS,server,internal_alb terraform modules & templates. ref: SAAS-12440.
- updating the param value for log_min_duration_statement
- including backup_window,backup_retention,monitoring_interval and parameter value for max_connections based on original state of RDS resources
- including the temporarily ignore changes in server terraform module-level related to EBS volume-type & "BackupPlan" tag until it's managed properly
- Adding variable based attribute to internal_alb target_group : _health_check_interval_ 

Reference: https://github.com/dimagi/commcare-cloud/pull/4846

Verified on Production env. 

Review Request @dannyroberts @shyamkumarlchauhan 