### PR TITLE
Add new route to terraform constants.py

### DIFF
--- a/src/commcare_cloud/commands/terraform/constants.py
+++ b/src/commcare_cloud/commands/terraform/constants.py
@@ -38,6 +38,7 @@ COMMCAREHQ_XML_POST_URLS_REGEX = r"""
 ^/jserror/$
 ^/log_email_event/([\w]+)/?$
 ^/telerivet/in/?$
+^/telerivet/status/([\w\-]+)/$
 """.strip().split()
 
 COMMCAREHQ_XML_QUERYSTRING_URLS_REGEX = """


### PR DESCRIPTION
[Here's](https://dimagi-dev.atlassian.net/browse/SC-1640) the ticket for the original feature.
Summary:
I added a route which we tell Telerivit to send the status of a SMS to (failed, delivered, etc.), but the route gives a 405 when I test it, although locally it works fine, so I suspect it might be AWS which blocks it for some reason.

##### ENVIRONMENTS AFFECTED
All
