### PR TITLE
Adding auto-recovery, gp3 default EBS type

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -181,6 +181,7 @@ servers:
     group: "formplayer"
     os: ubuntu_pro_bionic
     count: 37
+    server_auto_recovery: true
 
   - server_name: "kafka1-production"
     server_instance_type: t3.medium

--- a/src/commcare_cloud/environment/schemas/terraform.py
+++ b/src/commcare_cloud/environment/schemas/terraform.py
@@ -74,7 +74,7 @@ class ServerConfig(jsonobject.JsonObject):
     network_tier = jsonobject.StringProperty(choices=['app-private', 'public', 'db-private'])
     az = jsonobject.StringProperty()
     volume_size = jsonobject.IntegerProperty(default=20)
-    volume_type = jsonobject.StringProperty(default='gp2')
+    volume_type = jsonobject.StringProperty(default='gp3')
     volume_encrypted = jsonobject.BooleanProperty(default=True, required=True)
     block_device = jsonobject.ObjectProperty(lambda: BlockDevice, default=None)
     group = jsonobject.StringProperty()

--- a/src/commcare_cloud/terraform/modules/ga_alb_waf/main.tf
+++ b/src/commcare_cloud/terraform/modules/ga_alb_waf/main.tf
@@ -664,5 +664,12 @@ resource "aws_globalaccelerator_endpoint_group" "front_end" {
   // these are unused because when pointing to an ALB it uses those health checks instead
   health_check_port = 80
   health_check_path = "/"
+  lifecycle {
+    ignore_changes = [
+      // Present Health_check_path value is undefined. In latest AWS provider, default value is '/' If the protocol is HTTP/S
+      // reference: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/globalaccelerator_endpoint_group
+      health_check_path
+      ]
+  }
 }
 

--- a/src/commcare_cloud/terraform/modules/server/main.tf
+++ b/src/commcare_cloud/terraform/modules/server/main.tf
@@ -57,8 +57,8 @@ resource "aws_ebs_volume" "ebs_volume" {
   }
    lifecycle {
     ignore_changes = [
-      type,
       # temporarily ignore the "BackupPlan" tag until it's managed properly
+      tags,
       tags.BackupPlan
       ]
   }


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-12037
https://dimagi-dev.atlassian.net/browse/SAAS-11592

Adding auto-recovery, gp3 default EBS type:
- Adding **_server_auto_recovery_** option to the formplayer instance group
- Updating terraform server volume by removing EBS volume **_type_** from ignore_changes
- updating ga_alb_waf terraform module by adding **_health_check_path_**  in the ignore_changes block
- Updating default EBS volume type - **_gp3_** for all volumes [boot & secondary]

Review request: @dannyroberts @shyamkumarlchauhan 

Validated on Production. 