### PR TITLE
Ce/deploy success emails

### DIFF
--- a/src/commcare_cloud/commands/deploy/utils.py
+++ b/src/commcare_cloud/commands/deploy/utils.py
@@ -57,7 +57,7 @@ def announce_deploy_success(environment, service_name, diff_ouptut):
         environment,
         subject=f"{service_name} deploy successful - {environment.name}",
         message=diff_ouptut,
-        to_admins=not recipient,
+        to_admins=True,
         recipients=[recipient] if recipient else None
     )
 

--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -402,7 +402,6 @@ def deploy_checkpoint(command_index, command_name, fn, *args, **kwargs):
 
 def _deploy_without_asking(skip_record):
     try:
-        raise PreindexNotFinished()
         for index, command in enumerate(ONLINE_DEPLOY_COMMANDS):
             deploy_checkpoint(index, command.__name__, execute_with_timing, command)
     except PreindexNotFinished:

--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -402,6 +402,7 @@ def deploy_checkpoint(command_index, command_name, fn, *args, **kwargs):
 
 def _deploy_without_asking(skip_record):
     try:
+        raise PreindexNotFinished()
         for index, command in enumerate(ONLINE_DEPLOY_COMMANDS):
             deploy_checkpoint(index, command.__name__, execute_with_timing, command)
     except PreindexNotFinished:
@@ -411,6 +412,7 @@ def _deploy_without_asking(skip_record):
              "and wait for an email saying it's done. "
              "Thank you for using AWESOME DEPLOY.")
         )
+        raise
     except Exception:
         execute_with_timing(
             send_email,


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
This fixes two issues noticed in the recent confusion around an unsuccessful production deploy.

The first commit makes it so that the success email does not send when deploy stops to allow preindex to complete, by raising the exception. I could have just changed the exit code for the command, but this makes it a lot more obvious that the deploy was not successful, hopefully limiting confusing, and bringing it into line with other types of errors.

The second commit changes the success email to always go to admins even if another group is specified, which I think is the correct behavior. For the past 4 months, very few developers have been getting these emails (only those on product@ and Farid), and I think generally it makes sense for these to always go to the same list as other envs.


##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
