### PR TITLE
updating secondary_volume_type default type & EFS part to create multiple file-systems

### DIFF
--- a/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
@@ -336,7 +336,7 @@ module "efs_file_system__{{ efs_file_system.efs_name }}" {
 {% endfor %}
 
 {%- for az in az_codes %}
-{%- for efs_file_system_mount in efs_file_systems %}{% if not loop.first %}, {% endif %} 
+{%- for efs_file_system_mount in efs_file_systems %}
 module "efs_mount__{{ efs_file_system_mount.efs_name }}__{{ az }}" {
   source = "./modules/efs_file_system/mount-point"
   create_mount   = "{{ efs_file_system_mount.create_mount|tojson }}"
@@ -347,7 +347,7 @@ module "efs_mount__{{ efs_file_system_mount.efs_name }}__{{ az }}" {
 {% endfor %}
 {% endfor %}
 
-{%- for efs_file_system_route53 in efs_file_systems %}{% if not loop.first %}, {% endif %}
+{%- for efs_file_system_route53 in efs_file_systems %}
     module "efs_route53__{{ efs_file_system_route53.efs_name }}" {
         source = "./modules/r53-record-create-update"
         create_record   = "{{ efs_file_system_route53.create_record|tojson }}"

--- a/src/commcare_cloud/environment/schemas/terraform.py
+++ b/src/commcare_cloud/environment/schemas/terraform.py
@@ -122,7 +122,7 @@ class ServerConfig(jsonobject.JsonObject):
 
 class BlockDevice(jsonobject.JsonObject):
     _allow_dynamic_properties = False
-    volume_type = jsonobject.StringProperty(default='gp2', choices=['gp2', 'gp3', 'io1', 'standard'])
+    volume_type = jsonobject.StringProperty(default='gp3', choices=['gp2', 'gp3', 'io1', 'standard'])
     volume_size = jsonobject.IntegerProperty(required=True)
     encrypted = jsonobject.BooleanProperty(default=True, required=True)
 


### PR DESCRIPTION
Updating secondary_volume_type default type & EFS part to create multiple file-systems
- secondary_volume_type EBS default - gp3
- removing commas(,) when we are creating EFS multiple file-systems [ identified in v12 validation process ]

https://dimagi-dev.atlassian.net/browse/SAAS-11946
https://dimagi-dev.atlassian.net/browse/SAAS-12535

review request: @shyamkumarlchauhan @dannyroberts 