### PR TITLE
terminating stopped couchproxy3 production server.

### DIFF
--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -216,8 +216,6 @@ couch_alb
 [couchdb2:vars]
 swap_size=8G
 
-{{ __couchproxy3__ }}
-
 [couchdb2_proxy:children]
 couch_alb
 

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -93,14 +93,6 @@ servers:
     os: ubuntu_pro_bionic
     count: 11
 
-  - server_name: "couchproxy3-production"
-    server_instance_type: m3.medium
-    network_tier: "db-private"
-    az: "a"
-    volume_size: 80
-    group: "couchdb2_proxy"
-    os: ubuntu_pro_bionic
-
   - server_name: "couch11-production"
     server_instance_type: c5a.24xlarge
     network_tier: "db-private"


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-12426
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production 

Couchproxy3 server has been replaced with Aws Application Loadbalancer one month ago. 
 We have moved all datadog monitoring metrics to couch11 server and we are no longer using this machine.