### PR TITLE
shuffle india celery queues

### DIFF
--- a/environments/india/app-processes.yml
+++ b/environments/india/app-processes.yml
@@ -24,10 +24,12 @@ celery_processes:
     email_queue,repeat_record_queue,sumologic_logs_queue,reminder_case_update_queue,icds_aggregation_queue,analytics_queue:
       pooling: gevent
       concurrency: 100
-    ucr_queue,ucr_indicator_queue,celery,export_download_queue,reminder_rule_queue,case_import_queue,case_rule_queue,icds_dashboard_reports_queue,async_restore_queue,celery_periodic:
+    celery,export_download_queue,reminder_rule_queue,case_import_queue,icds_dashboard_reports_queue,async_restore_queue,celery_periodic:
+      concurrency: 4
+    ucr_queue,ucr_indicator_queue,case_rule_queue:
       concurrency: 2
     linked_domain_queue:
-      concurrency: 20
+      concurrency: 10
     saved_exports_queue:
       concurrency: 1
       optimize: True


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-12473

I made a few changes to the india celery workers with this PR. To address the linked ticket, I pulled the UCR queues, and the case rule queue, two queues that can spin off very long running tasks, into their own worker so as not to affect the queues that whose throughput is more critical. Second, I increased the concurrency of the more critical workers so that clogs were less likely and would be resolved sooner. Finally, to make room for all these new workers, I cut the linked domain queue concurrency since it did not seem super necessary. I checked the resources for the india celery machines and they do have a lot of headroom, so I don't think the reduction was needed, but I do think it adds a bit of safety. 

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
India