### PR TITLE
increase kafka retention on india and swiss

### DIFF
--- a/environments/india/public.yml
+++ b/environments/india/public.yml
@@ -41,6 +41,7 @@ kafka_scala_version: 2.12
 kafka_inter_broker_protocol_version: 2.4
 kafka_log_message_format_version: 2.4
 kafka_log_dir: "{{ encrypted_root }}/kafka"
+kafka_log_retention: 1344 # 56 days
 
 rabbitmq_version: 3.8.5-1
 

--- a/environments/swiss/public.yml
+++ b/environments/swiss/public.yml
@@ -35,6 +35,8 @@ aws_versioning_enabled: false
 
 KSPLICE_ACTIVE: yes
 
+kafka_log_retention: 1344 # 56 days
+
 nameservers:
   - 8.8.8.8
   - 8.8.4.4


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-12473
This is my first attempt at making the kafka checkpoint warnings on deploy more meaningful. Retaining messages for longer should minimize the odds that the change corresponding to the last checkpoint is deleted, especially when combined with my previous PR to lower the chunk size for bulk processing in these domains.

I did a quick look at space on both machines, and total kafka data size was less than 1gb in both places

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
India
Swiss