### PR TITLE
Skip setup on --control for commands that don't need it

### DIFF
--- a/docs/commcare-cloud/commands/index.md
+++ b/docs/commcare-cloud/commands/index.md
@@ -9,7 +9,7 @@
 All `commcare-cloud` commands take the following form:
 
 ```
-commcare-cloud [--control]
+commcare-cloud [--control] [--control-setup {yes,no}]
                <env>
                {after-reboot,ansible-playbook,ap,aws-fill-inventory,aws-list,aws-sign-in,bootstrap-users,celery-resource-report,copy-files,couchdb-cluster-info,deploy,deploy-stack,aps,django-manage,downtime,export-sentry-events,fab,forward-port,list-postgresql-dbs,lookup,migrate-couchdb,migrate_couchdb,migrate-secrets,mosh,openvpn-activate-user,openvpn-claim-user,pillow-resource-report,pillow-topic-assignments,ping,run-module,run-shell-command,secrets,send-datadog-event,service,ssh,terraform,terraform-migrate-state,tmux,update-config,update-local-known-hosts,update-supervisor-confs,update-user-key,update-users,validate-environment-settings}
                ...
@@ -38,6 +38,16 @@ update the code, and run the same command entered locally but with
 `--control` removed. For long-running commands,
 you will have to remain connected to the the control machine
 for the entirety of the run.
+
+### `--control-setup {yes,no}`
+
+Implies --control, and overrides the command's skip_setup_on_control_by_default value.
+
+If set to 'yes', the latest version of the branch will be pulled and commcare-cloud will
+have all its dependencies updated before the command is run.
+If set to 'no', the command will be run on whatever checkout/install of commcare-cloud
+is already on the control machine.
+Otherwise, this defaults to 'no' if command.skip_setup_on_control_by_default is True, otherwise to 'yes'.
 
 
 ## `cchq` alias

--- a/docs/commcare-cloud/commands/index.md
+++ b/docs/commcare-cloud/commands/index.md
@@ -188,6 +188,9 @@ when `<server>` is `control`.
 
 All trailing arguments are passed directly to `ssh`.
 
+When used with --control, this command skips the slow setup.
+To force setup, use --control-setup=yes instead.
+
 ##### Positional Arguments
 
 ###### `server`
@@ -374,6 +377,9 @@ Run an arbitrary command via the Ansible shell module.
 commcare-cloud <env> run-shell-command [--silence-warnings] [--use-factory-auth] inventory_group shell_command
 ```
 
+When used with --control, this command skips the slow setup.
+To force setup, use --control-setup=yes instead.
+
 ##### Example
 
 ```
@@ -531,6 +537,9 @@ runs `./manage.py ...` on the first django_manage machine of &lt;env&gt; or
 server you specify.
 Omit &lt;command&gt; to see a full list of possible commands.
 
+When used with --control, this command skips the slow setup.
+To force setup, use --control-setup=yes instead.
+
 ##### Example
 
 To open a django shell in a tmux window using the `2018-04-13_18.16` release.
@@ -582,6 +591,9 @@ Connect to a remote host with ssh and open a tmux session.
 ```
 commcare-cloud <env> tmux [--quiet] [server] [remote_command]
 ```
+
+When used with --control, this command skips the slow setup.
+To force setup, use --control-setup=yes instead.
 
 ##### Example
 
@@ -655,6 +667,9 @@ Print out the list of Kafka partitions assigned to each pillow process.
 ```
 commcare-cloud <env> pillow-topic-assignments [--csv] pillow_name
 ```
+
+When used with --control, this command skips the slow setup.
+To force setup, use --control-setup=yes instead.
 
 ##### Positional Arguments
 

--- a/docs/commcare-cloud/commands/index.md
+++ b/docs/commcare-cloud/commands/index.md
@@ -41,13 +41,13 @@ for the entirety of the run.
 
 ### `--control-setup {yes,no}`
 
-Implies --control, and overrides the command's skip_setup_on_control_by_default value.
+Implies --control, and overrides the command's run_setup_on_control_by_default value.
 
 If set to 'yes', the latest version of the branch will be pulled and commcare-cloud will
 have all its dependencies updated before the command is run.
 If set to 'no', the command will be run on whatever checkout/install of commcare-cloud
 is already on the control machine.
-This defaults to 'no' if command.skip_setup_on_control_by_default is True, otherwise to 'yes'.
+This defaults to 'yes' if command.run_setup_on_control_by_default is True, otherwise to 'no'.
 
 
 ## `cchq` alias

--- a/docs/commcare-cloud/commands/index.md
+++ b/docs/commcare-cloud/commands/index.md
@@ -47,7 +47,7 @@ If set to 'yes', the latest version of the branch will be pulled and commcare-cl
 have all its dependencies updated before the command is run.
 If set to 'no', the command will be run on whatever checkout/install of commcare-cloud
 is already on the control machine.
-Otherwise, this defaults to 'no' if command.skip_setup_on_control_by_default is True, otherwise to 'yes'.
+This defaults to 'no' if command.skip_setup_on_control_by_default is True, otherwise to 'yes'.
 
 
 ## `cchq` alias

--- a/src/commcare_cloud/commands/ansible/ops_tool.py
+++ b/src/commcare_cloud/commands/ansible/ops_tool.py
@@ -206,6 +206,8 @@ class PillowTopicAssignments(CommandBase):
     Print out the list of Kafka partitions assigned to each pillow process.
     """
 
+    skip_setup_on_control_by_default = True
+
     arguments = (
         Argument('pillow_name', help=(
             "Name of the pillow."

--- a/src/commcare_cloud/commands/ansible/ops_tool.py
+++ b/src/commcare_cloud/commands/ansible/ops_tool.py
@@ -206,7 +206,7 @@ class PillowTopicAssignments(CommandBase):
     Print out the list of Kafka partitions assigned to each pillow process.
     """
 
-    skip_setup_on_control_by_default = True
+    run_setup_on_control_by_default = False
 
     arguments = (
         Argument('pillow_name', help=(

--- a/src/commcare_cloud/commands/ansible/run_module.py
+++ b/src/commcare_cloud/commands/ansible/run_module.py
@@ -162,7 +162,7 @@ class RunShellCommand(CommandBase):
     to get disk usage stats for `/opt/data` on every machine.
     """
 
-    skip_setup_on_control_by_default = True
+    run_setup_on_control_by_default = False
 
     arguments = (
         shared_args.INVENTORY_GROUP_ARG,

--- a/src/commcare_cloud/commands/ansible/run_module.py
+++ b/src/commcare_cloud/commands/ansible/run_module.py
@@ -162,6 +162,8 @@ class RunShellCommand(CommandBase):
     to get disk usage stats for `/opt/data` on every machine.
     """
 
+    skip_setup_on_control_by_default = True
+
     arguments = (
         shared_args.INVENTORY_GROUP_ARG,
         Argument('shell_command', help="""

--- a/src/commcare_cloud/commands/command_base.py
+++ b/src/commcare_cloud/commands/command_base.py
@@ -16,7 +16,7 @@ class CommandBase(object):
     aliases = ()
     arguments = ()
 
-    skip_setup_on_control_by_default = False
+    run_setup_on_control_by_default = True
 
     def __init__(self, parser):
         self.parser = parser

--- a/src/commcare_cloud/commands/command_base.py
+++ b/src/commcare_cloud/commands/command_base.py
@@ -16,6 +16,8 @@ class CommandBase(object):
     aliases = ()
     arguments = ()
 
+    skip_setup_on_control_by_default = False
+
     def __init__(self, parser):
         self.parser = parser
 

--- a/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -101,7 +101,7 @@ class Ssh(_Ssh):
     All trailing arguments are passed directly to `ssh`.
     """
 
-    skip_setup_on_control_by_default = True
+    run_setup_on_control_by_default = False
 
     def run(self, args, ssh_args):
         environment = get_environment(args.env_name)
@@ -161,7 +161,7 @@ class Tmux(_Ssh):
     ```
     """
 
-    skip_setup_on_control_by_default = True
+    run_setup_on_control_by_default = False
 
     arguments = _Ssh.arguments + (
         Argument('remote_command', nargs='?', help="""
@@ -224,7 +224,7 @@ class DjangoManage(CommandBase):
     ```
     """
 
-    skip_setup_on_control_by_default = True
+    run_setup_on_control_by_default = False
 
     arguments = (
         Argument('--tmux', action='store_true', default=False, help="""

--- a/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -101,6 +101,8 @@ class Ssh(_Ssh):
     All trailing arguments are passed directly to `ssh`.
     """
 
+    skip_setup_on_control_by_default = True
+
     def run(self, args, ssh_args):
         environment = get_environment(args.env_name)
         use_aws_ssm_with_instance_id = None
@@ -158,6 +160,9 @@ class Tmux(_Ssh):
     commcare-cloud <env> tmux -
     ```
     """
+
+    skip_setup_on_control_by_default = True
+
     arguments = _Ssh.arguments + (
         Argument('remote_command', nargs='?', help="""
             Command to run in the tmux.
@@ -218,6 +223,8 @@ class DjangoManage(CommandBase):
     commcare-cloud <env> django-manage --tmux shell --server web0
     ```
     """
+
+    skip_setup_on_control_by_default = True
 
     arguments = (
         Argument('--tmux', action='store_true', default=False, help="""

--- a/src/commcare_cloud/commcare_cloud.py
+++ b/src/commcare_cloud/commcare_cloud.py
@@ -171,11 +171,21 @@ def make_command_parser(available_envs, formatter_class=RawTextHelpFormatter,
 
     for command_type in COMMAND_TYPES:
         assert issubclass(command_type, CommandBase), command_type
+        description = inspect.cleandoc(command_type.help)
+        if command_type.skip_setup_on_control_by_default:
+            parts = description.split('Example:\n')
+
+            description = 'Example:\n'.join([parts[0] + (
+                "\n\n"
+                "When used with --control, this command skips the slow setup.\n"
+                "To force setup, use --control-setup=yes instead.\n\n"
+            )] + parts[1:])
+
         cmd = command_type(subparsers.add_parser(
             command_type.command,
             help=inspect.cleandoc(command_type.help).splitlines()[0],
             aliases=command_type.aliases,
-            description=inspect.cleandoc(command_type.help),
+            description=description,
             formatter_class=subparser_formatter_class,
             add_help=add_help)
         )

--- a/src/commcare_cloud/commcare_cloud.py
+++ b/src/commcare_cloud/commcare_cloud.py
@@ -157,13 +157,13 @@ def make_command_parser(available_envs, formatter_class=RawTextHelpFormatter,
         for the entirety of the run.
     """).add_to_parser(parser)
     Argument('--control-setup', choices=['yes', 'no'], help="""
-        Implies --control, and overrides the command's skip_setup_on_control_by_default value.
+        Implies --control, and overrides the command's run_setup_on_control_by_default value.
 
         If set to 'yes', the latest version of the branch will be pulled and commcare-cloud will
         have all its dependencies updated before the command is run.
         If set to 'no', the command will be run on whatever checkout/install of commcare-cloud
         is already on the control machine.
-        This defaults to 'no' if command.skip_setup_on_control_by_default is True, otherwise to 'yes'.
+        This defaults to 'yes' if command.run_setup_on_control_by_default is True, otherwise to 'no'.
     """).add_to_parser(parser),
     subparsers = parser.add_subparsers(dest='command')
 
@@ -172,7 +172,7 @@ def make_command_parser(available_envs, formatter_class=RawTextHelpFormatter,
     for command_type in COMMAND_TYPES:
         assert issubclass(command_type, CommandBase), command_type
         description = inspect.cleandoc(command_type.help)
-        if command_type.skip_setup_on_control_by_default:
+        if not command_type.run_setup_on_control_by_default:
             parts = description.split('Example:\n')
 
             description = 'Example:\n'.join([parts[0] + (
@@ -220,7 +220,7 @@ def call_commcare_cloud(input_argv=sys.argv):
 
     if args.control or args.control_setup:
         if args.control_setup is None:
-            force_latest_code = not command.skip_setup_on_control_by_default
+            force_latest_code = command.run_setup_on_control_by_default
         else:
             force_latest_code = args.control_setup == 'yes'
 

--- a/src/commcare_cloud/commcare_cloud.py
+++ b/src/commcare_cloud/commcare_cloud.py
@@ -163,7 +163,7 @@ def make_command_parser(available_envs, formatter_class=RawTextHelpFormatter,
         have all its dependencies updated before the command is run.
         If set to 'no', the command will be run on whatever checkout/install of commcare-cloud
         is already on the control machine.
-        Otherwise, this defaults to 'no' if command.skip_setup_on_control_by_default is True, otherwise to 'yes'.
+        This defaults to 'no' if command.skip_setup_on_control_by_default is True, otherwise to 'yes'.
     """).add_to_parser(parser),
     subparsers = parser.add_subparsers(dest='command')
 
@@ -221,10 +221,8 @@ def call_commcare_cloud(input_argv=sys.argv):
     if args.control or args.control_setup:
         if args.control_setup is None:
             force_latest_code = not command.skip_setup_on_control_by_default
-        elif args.control_setup == 'yes':
-            force_latest_code = True
         else:
-            force_latest_code = False
+            force_latest_code = args.control_setup == 'yes'
 
         argv = _get_cleaned_args_for_control(args, input_argv)
         run_on_control_instead(args, argv, force_latest_code)
@@ -253,13 +251,7 @@ def _get_cleaned_args_for_control(args, input_argv):
         try:
             i = argv.index('--control-setup')
         except ValueError:
-            if '--control-setup=yes' in argv:
-                argv.remove('--control-setup=yes')
-            elif '--control-setup=no' in argv:
-                argv.remove('--control-setup=no')
-            else:
-                raise ValueError(
-                    'Something went wrong with the parsing. --control-setup should be set to yes or no.')
+            argv = [a for a in argv if not a.startswith('--control-setup=')]
         else:
             # delete '--control-setup', and then delete the value that comes after it
             del argv[i:i + 2]


### PR DESCRIPTION
The assumption is that for ~commands that don't have a branch arg~ some commands (django-manage, ssh, etc.) ~the branch it's run on doesn't matter that much: that's why it doesn't use the --branch mechanism to force the user to think about what branch they're on. For such commands, then,~ pulling the latest code on the control machine and re-running the install steps
is an unnecessary waste of time.

~Commands that do have the --branch option ('ansible-playbook', 'deploy', etc.) have essentially declared that they are sensitive to the latest changes. These commands will continue to trigger --control to do a full reset on the control environment as it has been doing.~

I've tested it locally with `cchq --control staging django-manage shell` and `cchq --control staging update-users` and it appears to work as described, with the former skipping setup and running quickly, and the latter doing the full setup that we're currently used to.

Update:
This PR also introduces an optional arg `--control-setup={yes,no}` that can be used with (or instead of) `--control` to override a command's default and force setup to be run or not run explicitly.

The commands that skip setup by default are: `ssh`, `tmux`, `django-manage`, `run-shell-command`, and `pillow-topic-assignments`.

##### ENVIRONMENTS AFFECTED
None