### PR TITLE
reducing rabbitmq instance size from c5.4xlarge to m5.2xlarge

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -129,7 +129,7 @@ servers:
     os: bionic
 
   - server_name: "rabbit2-production"
-    server_instance_type: c5.4xlarge
+    server_instance_type: m5.2xlarge
     network_tier: "db-private"
     az: "c"
     volume_size: 80
@@ -138,7 +138,7 @@ servers:
     os: ubuntu_pro_bionic
 
   - server_name: "rabbit5-production"
-    server_instance_type: c5.4xlarge
+    server_instance_type: m5.2xlarge
     network_tier: "db-private"
     az: "b"
     volume_size: 80


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-12565
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production.

During Cost optimization planning we observed that resources are underutilized. Therefore, we have planned to right-size the instance.
