### PR TITLE
India: resizing the webworkers instances from t3.2xlarge to r5a.xlarge

### DIFF
--- a/environments/india/terraform.yml
+++ b/environments/india/terraform.yml
@@ -39,7 +39,7 @@ servers:
     group: control
     os: bionic
   - server_name: "web0-india"
-    server_instance_type: "t3.2xlarge"
+    server_instance_type: "r5a.xlarge"
     network_tier: "app-private"
     az: "a"
     volume_size: 500
@@ -48,7 +48,7 @@ servers:
     group: control
     os: bionic
   - server_name: "web1-india"
-    server_instance_type: "t3.2xlarge"
+    server_instance_type: "r5a.xlarge"
     network_tier: "app-private"
     az: "a"
     volume_size: 80


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-12563
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
India

During Cost optimization planning we observed that resources are underutilized. Therefore, we have planned to right-size the instance.