### PR TITLE
lower compaction ratio

### DIFF
--- a/src/commcare_cloud/ansible/roles/couchdb2/templates/extras.ini.j2
+++ b/src/commcare_cloud/ansible/roles/couchdb2/templates/extras.ini.j2
@@ -14,3 +14,10 @@ use_kill_all = {{ couchdb_rexi_use_kill_all }}
 os_process_timeout = 20000
 ; set limit to previous default of 4GB on 2.3.1
 max_document_size = 4000000000
+
+; compaction settings
+[smoosh.ratio_dbs]
+min_priority = 1.3
+
+[smoosh.ratio_views]
+min_priority = 1.3


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-12222

This makes couch compaction more aggressive (when the ratio of total to live docs is lower than the current setting).

Yes, couch calls their compaction process `smoosh`. No, I did not laugh either.

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All