### PR TITLE
remove formplayer_deploy tag from datadog task

### DIFF
--- a/src/commcare_cloud/ansible/roles/datadog/tasks/add_integrations.yml
+++ b/src/commcare_cloud/ansible/roles/datadog/tasks/add_integrations.yml
@@ -21,7 +21,6 @@
   notify: restart datadog
   tags:
     - datadog_integrations
-    - formplayer_deploy
   when: item is defined and item.enabled
   with_items:
     - {"name": "airflow", "enabled": "{{ datadog_integration_airflow }}"}


### PR DESCRIPTION
@dannyroberts is there a reason we need to run this during formplayer deploy?