### PR TITLE
clean staticfiles before collecting

### DIFF
--- a/src/commcare_cloud/fab/operations/staticfiles.py
+++ b/src/commcare_cloud/fab/operations/staticfiles.py
@@ -53,6 +53,8 @@ def collectstatic(use_current_release=False):
     """
     venv = env.py3_virtualenv_root if not use_current_release else env.py3_virtualenv_current
     with cd(env.code_root if not use_current_release else env.code_current):
+        if not use_current_release:
+            sudo('rm -rf staticfiles')
         sudo('{}/bin/python manage.py collectstatic --noinput -v 0'.format(venv))
         sudo('{}/bin/python manage.py fix_less_imports_collectstatic'.format(venv))
         sudo('{}/bin/python manage.py compilejsi18n'.format(venv))


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-12555

I am not certain this would have prevented the issue in the ticket, and it is probably too late to know for sure, but it seems plausible. Specifically, I have confirmed that if copying a file is interrupted (with `cp`), a partially copied file is left, and I have confirmed that if a partial file exists in the staticfiles directory, it is not replaced with the full file when you run `collectstatic` again.

Beyond that, this seems pretty safe. I don't love that the directory is hardcoded, but we use it elsewhere, and because its hardcoded rather than interpolated there is no risk of it ending up null and trying to delete root.