### PR TITLE
format string with directory name

### DIFF
--- a/src/commcare_cloud/fab/operations/staticfiles.py
+++ b/src/commcare_cloud/fab/operations/staticfiles.py
@@ -75,7 +75,7 @@ def push_manifest(use_current_release=False):
     if env.use_shared_dir_for_staticfiles:
         with cd(env.code_root if not use_current_release else env.code_current):
             git_hash = _get_git_hash()
-            sudo('mkdir -p {env.shared_dir_for_staticfiles}/{git_hash}')
+            sudo('mkdir -p {env.shared_dir_for_staticfiles}/{git_hash}'.format(env=env, git_hash=git_hash))
             # copy staticfiles/CACHE/** to {env.shared_dir_for_staticfiles}/{git_hash}/staticfiles/CACHE/**
             sudo("rsync -r --delete"
                  " --include='staticfiles/' --include='CACHE/' --include='staticfiles/CACHE/**' --exclude='*'"


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Longstanding bug that was not affecting deploy but causing directory `{env.shared_dir_for_staticfiles}` with subdirectory `{git_hash}` to be created.

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
