### PR TITLE
switching back to r5.4xlarge from r5.8xlarge instanceType.

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -40,7 +40,7 @@ servers:
     count: 17
 
   - server_name: "web_b{i}-production"
-    server_instance_type: r5.8xlarge
+    server_instance_type: r5.4xlarge
     network_tier: "app-private"
     az: "b"
     volume_size: 40


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-12617
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production

Yesterday we have increased the instance size to prevent OOM errors and handle the requests. Since the requirement is completed and resources utilization is also under 20% of the total, we are switching back to the previous version of the instance type.