### PR TITLE
reduce couch13 EBS volume size to 8TB and enabling encryption

### DIFF
--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -533,7 +533,7 @@ es_data
 [couch12]
 10.202.40.52 hostname=couch12-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-0e9aaeea3a117206e datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes
 [couch13]
-10.202.40.154 hostname=couch13-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-00a287226e9555670 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes
+10.202.40.154 hostname=couch13-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-00a287226e9555670 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws
 
 [couchdb2:children]
 couch11

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -123,8 +123,8 @@ servers:
     volume_size: 60
     volume_encrypted: no
     block_device:
-      volume_size: 15360
-      encrypted: no
+      volume_size: 8000
+      encrypted: yes
     group: "couchdb2"
     os: bionic
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-12549
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production 
Couch13 enabling data volume encryption and volume size. 