### PR TITLE
fixed issue with create_db_subnet_group var value mismatching.

### DIFF
--- a/src/commcare_cloud/terraform/modules/postgresql/main.tf
+++ b/src/commcare_cloud/terraform/modules/postgresql/main.tf
@@ -1,5 +1,5 @@
 locals {
-  create = "${(var.create && lookup(var.rds_instance, "create", true)) ? 1 : 0}"
+  create = "${(var.create && lookup(var.rds_instance, "create", true)) ? true : false}"
 
   version_parts = regex("^(?P<major>[0-9]+)(?:\\.(?P<minor>[0-9]+))?", var.rds_instance["engine_version"])
   version_parts_number = {


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-11793
ENVIRONMENTS AFFECTED
All

Additions to PR: https://github.com/dimagi/commcare-cloud/pull/4796

We have observed that the `create_db_subnet_group` parameter value is only considering bool value and failing due to the recent changes I have made. Therefore I changed 1, 0 to True and False and it is working as expected. 

```
Error:
The given value is not suitable for child module variable
"create_db_subnet_group" defined at
.terraform/modules/postgresql__pg0-staging.postgresql/variables.tf:251,1-34:
bool required.
```

