### PR TITLE
fixing root volume tags removal issue when new state imported

### DIFF
--- a/src/commcare_cloud/terraform/modules/server/main.tf
+++ b/src/commcare_cloud/terraform/modules/server/main.tf
@@ -32,7 +32,6 @@ resource aws_instance "server" {
     Environment = var.environment
     Group = var.group_tag
   }
-
   metadata_options {
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1

--- a/src/commcare_cloud/terraform/modules/server/main.tf
+++ b/src/commcare_cloud/terraform/modules/server/main.tf
@@ -16,6 +16,12 @@ resource aws_instance "server" {
     encrypted             = var.volume_encrypted
     volume_type           = var.volume_type
     delete_on_termination = true
+    tags = {
+      Name = "vol-${var.server_name}"
+      ServerName = var.server_name
+      Environment = var.environment
+      Group = var.group_tag
+    }
   }
   lifecycle {
     ignore_changes = [user_data, key_name, root_block_device.0.delete_on_termination,
@@ -26,12 +32,7 @@ resource aws_instance "server" {
     Environment = var.environment
     Group = var.group_tag
   }
-  volume_tags = {
-    Name = "vol-${var.server_name}"
-    ServerName = var.server_name
-    Environment = var.environment
-    Group = var.group_tag
-  }
+
   metadata_options {
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-12081
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All

We identified that root volume tags are set to `null` when ebs_vol and ebs_vol_att state is removed and imported back to tfstate. Therefore, we have fixed it in a proper way. 

```
~ root_block_device {
            delete_on_termination = true
            device_name           = "/dev/sda1"
            encrypted             = true
            iops                  = 3000
            kms_key_id            = "arn:aws:kms:us-east-1:737236193635:key/8cd2c194-9e71-492f-9b0d-7c36f49ae892"
          ~ tags                  = {
              - "Environment" = "staging" -> null
              - "Group"       = "couchdb2" -> null
              - "Name"        = "vol-couch15-staging" -> null
              - "ServerName"  = "couch15-staging" -> null
            }
            throughput            = 125
            volume_id             = "vol-0dadba609d5743504"
            volume_size           = 30
            volume_type           = "gp3"
        }

```

@dannyroberts WIP commit: https://github.com/dimagi/commcare-cloud/commit/942a48afc0b11f92507db66b8defbe27fb5353d8
