### PR TITLE
consolidating production pgbouncer servers.

### DIFF
--- a/environments/production/postgresql.yml
+++ b/environments/production/postgresql.yml
@@ -42,7 +42,7 @@ dbs:
     host: rds_pgmain0
     pgbouncer_endpoint: pgmain_nlb
     pgbouncer_hosts:
-      - pgbouncer7
+      - pgbouncer9
       - pgbouncer6
   formplayer:
     host: rds_pgformplayer0
@@ -54,7 +54,7 @@ dbs:
     host: rds_pgucr0
     pgbouncer_endpoint: pgucr_nlb
     pgbouncer_hosts:
-      - pgbouncer7
+      - pgbouncer9
       - pgbouncer6
     query_stats: True
   synclogs:
@@ -62,12 +62,12 @@ dbs:
     pgbouncer_endpoint: pgsynclogs_nlb
     pgbouncer_hosts:
       - pgbouncer6
-      - pgbouncer7
+      - pgbouncer9
   auditcare:
     host: rds_pgauditcare0
     pgbouncer_endpoint: pgmain_nlb
     pgbouncer_hosts:
-      - pgbouncer7
+      - pgbouncer9
       - pgbouncer6
   form_processing:
     proxy:

--- a/environments/production/postgresql.yml
+++ b/environments/production/postgresql.yml
@@ -42,6 +42,7 @@ dbs:
     host: rds_pgmain0
     pgbouncer_endpoint: pgmain_nlb
     pgbouncer_hosts:
+      - pgbouncer7
       - pgbouncer9
       - pgbouncer6
   formplayer:
@@ -54,6 +55,7 @@ dbs:
     host: rds_pgucr0
     pgbouncer_endpoint: pgucr_nlb
     pgbouncer_hosts:
+      - pgbouncer7
       - pgbouncer9
       - pgbouncer6
     query_stats: True
@@ -62,12 +64,14 @@ dbs:
     pgbouncer_endpoint: pgsynclogs_nlb
     pgbouncer_hosts:
       - pgbouncer6
+      - pgbouncer7
       - pgbouncer9
   auditcare:
     host: rds_pgauditcare0
     pgbouncer_endpoint: pgmain_nlb
     pgbouncer_hosts:
       - pgbouncer9
+      - pgbouncer7
       - pgbouncer6
   form_processing:
     proxy:

--- a/environments/production/postgresql.yml
+++ b/environments/production/postgresql.yml
@@ -51,6 +51,9 @@ dbs:
     pgbouncer_hosts:
       - pgbouncer5
       - pgbouncer8
+      - pgbouncer7
+      - pgbouncer9
+      - pgbouncer6
   ucr:
     host: rds_pgucr0
     pgbouncer_endpoint: pgucr_nlb

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -401,16 +401,19 @@ pgbouncer_nlbs:
       - pgbouncer8-production
   - name: pgmain_nlb-production
     targets:
+      - pgbouncer7-production
       - pgbouncer9-production
       - pgbouncer6-production
   - name: pgucr_nlb-production
     targets:
+      - pgbouncer7-production
       - pgbouncer9-production
       - pgbouncer6-production
   - name: pgsynclogs_nlb-production
     targets:
       - pgbouncer6-production
       - pgbouncer9-production
+      - pgbouncer7-production
   - name: pgshard_nlb-production
     targets:
       - pgbouncer9-production

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -401,16 +401,16 @@ pgbouncer_nlbs:
       - pgbouncer8-production
   - name: pgmain_nlb-production
     targets:
-      - pgbouncer7-production
+      - pgbouncer9-production
       - pgbouncer6-production
   - name: pgucr_nlb-production
     targets:
-      - pgbouncer7-production
+      - pgbouncer9-production
       - pgbouncer6-production
   - name: pgsynclogs_nlb-production
     targets:
       - pgbouncer6-production
-      - pgbouncer7-production
+      - pgbouncer9-production
   - name: pgshard_nlb-production
     targets:
       - pgbouncer9-production

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -399,6 +399,9 @@ pgbouncer_nlbs:
     targets:
       - pgbouncer5-production
       - pgbouncer8-production
+      - pgbouncer7-production
+      - pgbouncer9-production
+      - pgbouncer6-production
   - name: pgmain_nlb-production
     targets:
       - pgbouncer7-production


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-12566
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production. 

In the process of "Consolidate the pgbouncer machine to 4 machines," we are replacing pgbouncer5,8 with pgbouncer 6,7,9 server.