### PR TITLE
Make COMMCARE_CLOUD_USE_AWS_SSM=1 the default

### DIFF
--- a/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -113,7 +113,7 @@ class Ssh(_Ssh):
             # Always include ssh agent forwarding on control machine
             ssh_args = ['-A'] + ssh_args
 
-            if os.environ.get('COMMCARE_CLOUD_USE_AWS_SSM') == '1' and \
+            if os.environ.get('COMMCARE_CLOUD_USE_AWS_SSM') != '0' and \
                     is_aws_env(environment) and \
                     not is_ec2_instance_in_account(environment.aws_config.sso_config.sso_account_id):
                 if not is_session_manager_plugin_installed():


### PR DESCRIPTION
Old behavior available with COMMCARE_CLOUD_USE_AWS_SSM=0

This PR is scheduled to be merged on Oct. 1, 2021.

Based on the rollout plan outlined in https://docs.google.com/document/d/1Q8iKWxk2tP9v9jjmcQRcl90gMrCQb0Whx-OIlgGv0U4/edit#.
