### PR TITLE
adding new pgsynclog1 instance to rebuild synclogDB with less storage

### DIFF
--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -49,6 +49,8 @@ mobile_webworkers
 
 {{ __rds_pgsynclog0__ }}
 
+{{ __rds_pgsynclog1__ }}
+
 {{ __rds_pgauditcare0__ }}
 
 {{ __pgformplayer_nlb__ }}

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -372,9 +372,9 @@ rds_instances:
 
   - identifier: "pgsynclog1-production"
     instance_type: "db.t3.xlarge"
-    storage: 20000
+    storage: 5000
     multi_az: true
-    engine_version: 9.6.20
+    engine_version: "10.17"
     params:
       work_mem: 2457kB
       shared_buffers: 3840MB

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -370,6 +370,18 @@ rds_instances:
       maintenance_work_mem: 960MB
       max_connections: "least({dbinstanceclassmemory/9531392},5000)"
 
+  - identifier: "pgsynclog1-production"
+    instance_type: "db.t3.xlarge"
+    storage: 20000
+    multi_az: true
+    engine_version: 9.6.20
+    params:
+      work_mem: 2457kB
+      shared_buffers: 3840MB
+      effective_cache_size: 11520MB
+      maintenance_work_mem: 960MB
+      max_connections: "least({dbinstanceclassmemory/9531392},5000)"
+
   - identifier: "pgformplayer0-production"
     instance_type: "db.m5.2xlarge"
     storage: 24000

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -364,6 +364,12 @@ rds_instances:
     multi_az: true
     engine_version: 9.6.20
     params:
+      shared_preload_libraries: pg_stat_statements,pg_transport
+      pg_transport.work_mem: 131072
+      pg_transport.timing: 1
+      max_worker_processes: 40
+      pg_transport.num_workers: 8
+      track_io_timing: 1
       work_mem: 2457kB
       shared_buffers: 3840MB
       effective_cache_size: 11520MB
@@ -376,6 +382,12 @@ rds_instances:
     multi_az: true
     engine_version: "10.17"
     params:
+      shared_preload_libraries: pg_stat_statements,pg_transport
+      pg_transport.work_mem: 131072
+      pg_transport.timing: 1
+      max_worker_processes: 40
+      pg_transport.num_workers: 8
+      track_io_timing: 1
       work_mem: 2457kB
       shared_buffers: 3840MB
       effective_cache_size: 11520MB


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-12493
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production 

Added new RDS instance `pgsynclog1` with less disk storage i.e 20TB. To this instance, we will copy the data from the `pgsynclog0` instance using the AWS DMS service.

@dannyroberts could you please suggest the name of the new instance if `pgsynclog1` is not the right one here?