### PR TITLE
Consolidate pgbouncers nodes

### DIFF
--- a/environments/production/postgresql.yml
+++ b/environments/production/postgresql.yml
@@ -43,16 +43,12 @@ dbs:
     pgbouncer_endpoint: pgmain_nlb
     pgbouncer_hosts:
       - pgbouncer7
-      - pgbouncer9
       - pgbouncer6
   formplayer:
     host: rds_pgformplayer0
     pgbouncer_endpoint: pgformplayer_nlb
     pgbouncer_hosts:
-      - pgbouncer5
-      - pgbouncer8
       - pgbouncer7
-      - pgbouncer9
       - pgbouncer6
   ucr:
     host: rds_pgucr0
@@ -91,6 +87,8 @@ dbs:
         pgbouncer_hosts:
           - pgbouncer3
           - pgbouncer9
+          - pgbouncer7
+          - pgbouncer6
       p2:
         shards: [205, 409]
         host: rds_pgshard2
@@ -98,6 +96,8 @@ dbs:
         pgbouncer_hosts:
           - pgbouncer3
           - pgbouncer9
+          - pgbouncer7
+          - pgbouncer6
       p3:
         shards: [410, 614]
         host: rds_pgshard3
@@ -105,6 +105,8 @@ dbs:
         pgbouncer_hosts:
           - pgbouncer3
           - pgbouncer9
+          - pgbouncer7
+          - pgbouncer6
       p4:
         shards: [615, 819]
         host: rds_pgshard4
@@ -112,6 +114,8 @@ dbs:
         pgbouncer_hosts:
           - pgbouncer3
           - pgbouncer9
+          - pgbouncer7
+          - pgbouncer6
       p5:
         shards: [820, 1023]
         host: rds_pgshard5
@@ -119,3 +123,5 @@ dbs:
         pgbouncer_hosts:
           - pgbouncer3
           - pgbouncer9
+          - pgbouncer7
+          - pgbouncer6

--- a/environments/production/postgresql.yml
+++ b/environments/production/postgresql.yml
@@ -89,6 +89,8 @@ dbs:
           - pgbouncer9
           - pgbouncer7
           - pgbouncer6
+          - pgbouncer5
+          - pgbouncer8
       p2:
         shards: [205, 409]
         host: rds_pgshard2
@@ -98,6 +100,8 @@ dbs:
           - pgbouncer9
           - pgbouncer7
           - pgbouncer6
+          - pgbouncer5
+          - pgbouncer8
       p3:
         shards: [410, 614]
         host: rds_pgshard3
@@ -107,6 +111,8 @@ dbs:
           - pgbouncer9
           - pgbouncer7
           - pgbouncer6
+          - pgbouncer5
+          - pgbouncer8
       p4:
         shards: [615, 819]
         host: rds_pgshard4
@@ -116,6 +122,8 @@ dbs:
           - pgbouncer9
           - pgbouncer7
           - pgbouncer6
+          - pgbouncer5
+          - pgbouncer8
       p5:
         shards: [820, 1023]
         host: rds_pgshard5
@@ -125,3 +133,5 @@ dbs:
           - pgbouncer9
           - pgbouncer7
           - pgbouncer6
+          - pgbouncer5
+          - pgbouncer8

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -397,8 +397,6 @@ rds_instances:
 pgbouncer_nlbs:
   - name: pgformplayer_nlb-production
     targets:
-      - pgbouncer5-production
-      - pgbouncer8-production
       - pgbouncer7-production
       - pgbouncer6-production
   - name: pgmain_nlb-production
@@ -418,6 +416,8 @@ pgbouncer_nlbs:
   - name: pgshard_nlb-production
     targets:
       - pgbouncer9-production
+      - pgbouncer6-production
+      - pgbouncer7-production
 
 
 internal_albs:

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -418,6 +418,8 @@ pgbouncer_nlbs:
       - pgbouncer9-production
       - pgbouncer6-production
       - pgbouncer7-production
+      - pgbouncer5-production
+      - pgbouncer8-production
 
 
 internal_albs:


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-12566
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->

Production

- We recently removed pgbouncer9 from formplayer and main NLB. updating the same in postgresql.yml (https://dimagi-dev.atlassian.net/browse/SAAS-12656)
- marking pgbouncer5, 8 for decommissioning, based on cost optimization plan. 
- Adding Pgbouncer6,7 to the Pgshards_nlb for HA.
