### PR TITLE
Refer commcare-cloud users to commcare-perf

### DIFF
--- a/docs/howto/perf_testing.md
+++ b/docs/howto/perf_testing.md
@@ -1,0 +1,12 @@
+Performance benchmarking
+========================
+
+Some useful tooling has been built for evaluating the performance of
+CommCare HQ.
+
+Dimagi uses Locust for performance benchmarking. The code Dimagi uses is
+available at https://github.com/dimagi/commcare-perf . See the
+[README](https://github.com/dimagi/commcare-perf/blob/main/README.rst)
+for installation instructions, and further
+[documentation](https://github.com/dimagi/commcare-perf/blob/main/docs/index.rst)
+on how to test with form submissions that mimic those of your project.

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,6 +65,7 @@ that machine is also the control machine.
 ### Optional
 - [Slack for notifications](monitoring/slack.md)
 - [Airflow](services/airflow.md)
+- [Performance benchmarking](howto/perf_testing.md)
 
 ## Specialized howtos
 - [White label a CommCare instance](howto/white-label.md)


### PR DESCRIPTION
Refer commcare-cloud users to commcare-perf for performance testing.

Context: [SC-1735](https://dimagi-dev.atlassian.net/browse/SC-1735)

##### ENVIRONMENTS AFFECTED
None. This is a documentation change.
