### PR TITLE
Add deploy_event_url for production

### DIFF
--- a/environments/production/fab-settings.yml
+++ b/environments/production/fab-settings.yml
@@ -1,6 +1,7 @@
 tag_deploy_commits: True
 use_shared_dir_for_staticfiles: True
 shared_dir_for_staticfiles: /mnt/shared/temp
+deploy_event_url: https://api.github.com/repos/dimagi/dimagi-qa/dispatches
 acceptable_maintenance_window:
   hour_start: 2
   hour_end: 4


### PR DESCRIPTION
Enables publication of production deploy events to the dimagi-qa repo, which will cause QA tests to run.

In addition to this PR, a new _dimagi-qa-production-deploy-event_ token was created on the @dimagi/qa account, and the [confluence page](https://confluence.dimagi.com/display/saas/SaaS+Env+Secrets+and+Accounts) was updated. The value of that token was set on the production `deploy_event_token` secret.

<!--- Provide a link to the ticket or document which prompted this change -->

##### ENVIRONMENTS AFFECTED
production
