### PR TITLE
Fix nodejs repository

### DIFF
--- a/src/commcare_cloud/ansible/roles/nodejs/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/nodejs/tasks/main.yml
@@ -9,7 +9,7 @@
 
 - name: Add git nodejs repo
   apt_repository:
-    repo: 'deb https://deb.nodesource.com/node_12.x bionic main'
+    repo: 'deb http://deb.nodesource.com/node_12.x bionic main'
     state: present
   become: yes
   when: ansible_distribution_version == '18.04'


### PR DESCRIPTION
Use http instead of https.
Note that packages are signed and apt will verify their validity.

##### ENVIRONMENTS AFFECTED
All
