### PR TITLE
Remove unnecessary CouchDB dependency

### DIFF
--- a/src/commcare_cloud/ansible/roles/couchdb2-preinstall/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/couchdb2-preinstall/tasks/main.yml
@@ -50,6 +50,5 @@
   apt:
     name:
       - esl-erlang={{ couchdb_erlang_version }}
-      - erlang-mode={{ couchdb_erlang_version }}
     force: yes
 


### PR DESCRIPTION
erlang-mode is not needed and the version set for CouchDB 2.3.1 is currently unavailable in the erlang-solutions repository.

##### ENVIRONMENTS AFFECTED
All
