### PR TITLE
add sync couch views to initial migrate

### DIFF
--- a/src/commcare_cloud/ansible/migrate_on_fresh_install.yml
+++ b/src/commcare_cloud/ansible/migrate_on_fresh_install.yml
@@ -2,6 +2,14 @@
   hosts: "{{ groups.webworkers.0 }}"
   become: true
   tasks:
+    - name: Sync couch views
+      become: yes
+      become_user: "{{ cchq_user }}"
+      django_manage:
+        command: 'sync_couch_views'
+        app_path: "{{ code_home }}"
+        virtualenv: "{{ py3_virtualenv_home }}"
+      when: CCHQ_IS_FRESH_INSTALL is defined and CCHQ_IS_FRESH_INSTALL
     - name: Migrate DB
       become: yes
       become_user: "{{ cchq_user }}"


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-12601

commcare-cloud analogue to https://github.com/dimagi/commcare-hq/pull/30555

Since couch views are no longer synced during `migrate` this does so explicitly, matching our instructions in https://github.com/dimagi/commcare-hq/blob/master/DEV_SETUP.md#initial-database-population

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None