### PR TITLE
Remove UCLAPatientFluffPillow

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -110,8 +110,6 @@ pillows:
       num_processes: 1
     SqlSMSPillow:
       num_processes: 1
-    UCLAPatientFluffPillow:
-      num_processes: 1
     UpdateUserSyncHistoryPillow:
       num_processes: 4
     UserCacheInvalidatePillow:


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/pull/30590 removes this pillow, so to prevent (probably harmless) FATAL status on starting this pillow, we can just remove it.

##### ENVIRONMENTS AFFECTED
production