### PR TITLE
increase vacuum cost limit

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -370,6 +370,7 @@ rds_instances:
       effective_cache_size: 11520MB
       maintenance_work_mem: 960MB
       max_connections: "least({dbinstanceclassmemory/9531392},5000)"
+      vacuum_cost_limit: 1000
 
   - identifier: "pgformplayer0-production"
     instance_type: "db.m5.2xlarge"


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-12674

`autovacuum_vacuum_cost_limit` sets a threshold such that after a vacuum process does that amount of work, it pauses for a defined period. By increasing the threshold we make the pauses less frequent (allow more processing before a pause).

This should increase the throughput of our vacuum processes which right now can take weeks to finish. Higher throughput is beneficial on two fronts, finish a vacuum faster, but also allowing us to vacuum more frequently since each takes less time.

The current value is the default value of 200, so this is a 5X increase.

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production