### PR TITLE
Update firefighting docs for es to use consistent commands to enable …

### DIFF
--- a/docs/firefighting/index.md
+++ b/docs/firefighting/index.md
@@ -844,7 +844,7 @@ Currently on ICDS (maybe on prod/india) shard allocation is disabled. In case a 
   - Wait for replicas to get assigned.
 - Finally **remember to turn off** auto shard allocation using
     ```
-    curl 'http://<es_url>/_cluster/settings/' -X PUT  --data '{"persistent":{"cluster.routing.allocation.enable":"none"}}'
+    curl 'http://<es_url>/_cluster/settings/' -X PUT  --data '{"transient":{"cluster.routing.allocation.enable":"none"}}'
     ```
 
 


### PR DESCRIPTION
…and disable ES shard allocation

If you enable using transient but disable using persistent, that leaves
transient saying enable, and transient overrides persistent.

https://dimagi-dev.atlassian.net/browse/SAAS-12765

##### ENVIRONMENTS AFFECTED
None
