### PR TITLE
Add --to-backend option to migrate-secrets

### DIFF
--- a/docs/commcare-cloud/commands/index.md
+++ b/docs/commcare-cloud/commands/index.md
@@ -708,12 +708,16 @@ commcare-cloud <env> secrets {view,edit,list-append,list-remove} secret_name
 Migrate secrets from one backend to another
 
 ```
-commcare-cloud <env> migrate-secrets from_backend
+commcare-cloud <env> migrate-secrets [--to-backend TO_BACKEND] from_backend
 ```
 
 ##### Positional Arguments
 
 ###### `from_backend`
+
+##### Optional Arguments
+
+###### `--to-backend TO_BACKEND`
 
 ---
 

--- a/src/commcare_cloud/commands/secrets.py
+++ b/src/commcare_cloud/commands/secrets.py
@@ -85,12 +85,16 @@ class MigrateSecrets(CommandBase):
 
     arguments = (
         Argument(dest='from_backend'),
+        Argument('--to-backend', default=None),
     )
 
     def run(self, args, unknown_args):
         environment = get_environment(args.env_name)
         from_backend = all_secrets_backends_by_name[args.from_backend].from_environment(environment)
-        to_backend = environment.secrets_backend
+        if args.to_backend:
+            to_backend = all_secrets_backends_by_name[args.to_backend].from_environment(environment)
+        else:
+            to_backend = environment.secrets_backend
         if from_backend.name == to_backend.name:
             puts(color_error(
                 'Refusing to copy from {from_backend.name} to {to_backend.name}: backends must differ'


### PR DESCRIPTION
which can be used to override the value set in meta.yml. This is useful for taking a backup of secrets values.

https://dimagi-dev.atlassian.net/browse/SAAS-12773

##### ENVIRONMENTS AFFECTED
None
