### PR TITLE
Bump HSTS value to 1 year for all envs

### DIFF
--- a/environments/india/proxy.yml
+++ b/environments/india/proxy.yml
@@ -5,6 +5,6 @@ J2ME_SITE_HOST: 'j2me-india.commcarehq.org'
 tableau_server: 'tableau2.internal.commcarehq.org'
 TABLEAU_HOST: 'icds.commcarehq.org'
 primary_ssl_env: "india"
-nginx_hsts_max_age: 9676800 # 4 months
+nginx_hsts_max_age: 31536000 # 1 year
 trusted_proxies:
   - 10.203.0.0/16

--- a/environments/production/proxy.yml
+++ b/environments/production/proxy.yml
@@ -7,7 +7,7 @@ primary_ssl_env: "production"
 trusted_proxies:
   - 10.202.0.0/16
 
-nginx_hsts_max_age: 9676800 # 4 months
+nginx_hsts_max_age: 31536000 # 1 year
 nginx_ssl_protocols: "TLSv1.2"
 nginx_ssl_ciphers: 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384'
 

--- a/environments/staging/proxy.yml
+++ b/environments/staging/proxy.yml
@@ -2,7 +2,7 @@ fake_ssl_cert: yes
 SITE_HOST: 'staging.commcarehq.org'
 J2ME_SITE_HOST: 'j2mestaging.commcarehq.org'
 primary_ssl_env: "staging"
-nginx_hsts_max_age: 9676800 # 4 months
+nginx_hsts_max_age: 31536000 # 1 year
 
 trusted_proxies:
   - 10.201.0.0/16

--- a/environments/swiss/proxy.yml
+++ b/environments/swiss/proxy.yml
@@ -1,4 +1,4 @@
 SITE_HOST: 'swiss.commcarehq.org'
 letsencrypt_cchq_ssl: True
 primary_ssl_env: 'swiss'
-nginx_hsts_max_age: 9676800 # 4 months
+nginx_hsts_max_age: 31536000 # 1 year


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-12042

1 year is the minimum value needed to be eligible for the HSTS preload list, so this should be the last of these PRs that bump the hsts value.
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production, India, Swiss, Staging