### PR TITLE
Add docs for bitly

### DIFF
--- a/commcare-cloud-bootstrap/environment/private.yml.j2
+++ b/commcare-cloud-bootstrap/environment/private.yml.j2
@@ -32,8 +32,7 @@ localsettings_private:
   BOOKKEEPER_CONTACT_EMAILS: []
   COUCH_USERNAME: 'commcarehq'
   COUCH_PASSWORD: '{{ generate_uuid() }}'
-  BITLY_APIKEY: ''
-  BITLY_LOGIN: ''
+  BITLY_OAUTH_TOKEN: ''
   DROPBOX_KEY: ''
   DROPBOX_SECRET: ''
   FORMPLAYER_INTERNAL_AUTH_KEY: '{{ generate_uuid() }}'

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,6 +61,7 @@ that machine is also the control machine.
 - [Firefighting](firefighting/index.md)
 - [Backup and Restore](./commcare-cloud/backup.md)
 - [Deploying code changes to CommCareHQ](./commcare-cloud/deploy.md)
+- [BitLy for App shortcodes](services/bitly.md)
 
 ### Optional
 - [Slack for notifications](monitoring/slack.md)

--- a/docs/services/bitly.md
+++ b/docs/services/bitly.md
@@ -1,0 +1,11 @@
+# Set up Bitly for generating app codes
+
+To enable generating app shortcodes to install builds on CommCare mobile, you will need a [Bitly API key](https://app.bitly.com/settings/api/). 
+
+You should add these in the ansible vault file as follows:
+
+**vault.yml**
+```yaml
+localsettings_private:
+  BITLY_OAUTH_TOKEN: ''
+```


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SC-1871

Users deploying locally might not know they need to add a bitly oauth token. 

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None