### PR TITLE
Revert "Python 3.9 on staging"

### DIFF
--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -190,6 +190,3 @@ shared_dir_gid: 1500
 # for better time syncronization on aws servers
 # replace ntp with chrony.
 use_chrony: True
-
-python_version: '3.9'
-use_deadsnakes: '{{ ansible_distribution_version <= "18.04" }}'


### PR DESCRIPTION
Reverts dimagi/commcare-cloud#4965

Rolling back to 3.6 to test the workflow of rolling back.

Once rolled back, the pickle protocol will be pinned at a version that is supported by both 3.6 and 3.9 to decouple the Python version change from the pickle protocol change, making future rollbacks smoother. In the mean time, some celery tasks that were created by Python 3.9 processes will not be able to be processed after rolling back to 3.6.