### PR TITLE
Make --control use -tt to pass through stdin

### DIFF
--- a/src/commcare_cloud/commcare_cloud.py
+++ b/src/commcare_cloud/commcare_cloud.py
@@ -116,7 +116,7 @@ def run_on_control_instead(args, argv, force_latest_code):
             '&& {cchq} {cchq_args}'
         )
     cmd_parts = [
-        executable, args.env_name, 'ssh', 'control[0]', '-t',
+        executable, args.env_name, 'ssh', 'control[0]', '-tt',
         bash_commands_template.format(
             env=('export CCHQ_VIRTUALENV=%s; ' % venv if venv else ''),
             branch=branch,


### PR DESCRIPTION
According to the ssh docs:
> force tty allocation, even if ssh has no local tty.

<!--- Provide a link to the ticket or document which prompted this change -->

##### ENVIRONMENTS AFFECTED
None
