### PR TITLE
creating a custom role to copying historic waflogs to new folder  - DoNotMerge

### DIFF
--- a/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
@@ -103,7 +103,11 @@ module "server__{{ server_name }}" {
   secondary_volume_type = {{ server_spec.block_device.volume_type|default("")|tojson }}
   secondary_volume_encrypted = {{ server_spec.block_device.encrypted|default(False)|tojson }}
   server_auto_recovery = {{ server_spec.server_auto_recovery|default(False)|tojson }}
-  iam_instance_profile = "${module.server_iam_role.commcare_server_instance_profile}"
+  {% if server_name == "djangomanage2-production" %}
+    iam_instance_profile = "${module.server_iam_role.commcare_server_custom_instance_profile}"
+  {% else %}
+    iam_instance_profile = "${module.server_iam_role.commcare_server_instance_profile}"
+  {% endif %}
 
 {% if server_spec.os == 'ubuntu_pro_bionic' %}
   server_image = "${data.aws_ami.ubuntu_pro_bionic.id}"

--- a/src/commcare_cloud/terraform/modules/server/iam/custom_role.tf
+++ b/src/commcare_cloud/terraform/modules/server/iam/custom_role.tf
@@ -1,0 +1,122 @@
+resource "aws_iam_role" "commcare_server_custom_role" {
+  name = "CommCareServerCustomRole"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "custom_server_role_attach_cloudwatch_policy" {
+  role       = aws_iam_role.commcare_server_custom_role.name
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "custom_server_role_attach_awsmanagedinstance_policy" {
+  role       = aws_iam_role.commcare_server_custom_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_role_policy" "custom_request_response_stream_put_policy" {
+  name = "RequestResponseStreamPutPolicy"
+  role = aws_iam_role.commcare_server_custom_role.id
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "firehose:PutRecord",
+        "firehose:PutRecordBatch"
+      ],
+      "Resource": [
+        "${var.formplayer_request_response_logs_firehose_stream_arn}"
+      ]
+    }
+  ]
+}
+  POLICY
+}
+
+resource "aws_iam_role_policy" "custom_commcare_secrets_access_policy" {
+  name = "CommCareSecretsAccess"
+  role = aws_iam_role.commcare_server_custom_role.id
+
+  policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": [
+                "secretsmanager:GetRandomPassword",
+                "secretsmanager:ListSecrets"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "VisualEditor1",
+            "Effect": "Allow",
+            "Action": "secretsmanager:*",
+            "Resource": "arn:aws:secretsmanager:${var.region_name}:${var.account_id}:secret:${var.account_alias}/*"
+        }
+    ]
+}
+  POLICY
+}
+
+
+resource "aws_iam_role_policy" "commcare_logsbucket_access_policy" {
+  name = "CommCareLogBucketAccess"
+  role = aws_iam_role.commcare_server_custom_role.id
+
+  policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "ListAllBuckets",
+            "Effect": "Allow",
+            "Action": [
+							"s3:ListAllMyBuckets"
+						],
+            "Resource": "arn:aws:s3:::*"
+        },
+        {
+            "Sid": "LogsBucketRestrictedAccess",
+            "Effect": "Allow",
+            "Action": [
+							"s3:GetObject",
+							"s3:ListBucket",
+							"s3:PutObject",
+							"s3:PutObjectAcl",
+							"s3:RestoreObject"
+						],
+						"Resource": [
+							"arn:aws:s3:::dimagi-commcare-${var.environment}-logs",
+							"arn:aws:s3:::dimagi-commcare-${var.environment}-logs/*"
+						]
+        }
+    ]
+}
+  POLICY
+}
+
+resource "aws_iam_instance_profile" "commcare_server_custom_instance_profile" {
+  name = "CommCareServerCustomRole"
+  role = aws_iam_role.commcare_server_custom_role.name
+}

--- a/src/commcare_cloud/terraform/modules/server/iam/outputs.tf
+++ b/src/commcare_cloud/terraform/modules/server/iam/outputs.tf
@@ -5,3 +5,11 @@ output "commcare_server_role_arn" {
 output "commcare_server_instance_profile" {
   value = "${aws_iam_instance_profile.commcare_server_instance_profile.name}"
 }
+
+output "commcare_server_custom_role_arn" {
+  value = "${aws_iam_role.commcare_server_custom_role.arn}"
+}
+
+output "commcare_server_custom_instance_profile" {
+  value = "${aws_iam_instance_profile.commcare_server_custom_instance_profile.name}"
+}

--- a/src/commcare_cloud/terraform/modules/server/main.tf
+++ b/src/commcare_cloud/terraform/modules/server/main.tf
@@ -19,7 +19,7 @@ resource aws_instance "server" {
   }
   lifecycle {
     ignore_changes = [user_data, key_name, root_block_device.0.delete_on_termination,
-      ebs_optimized, ami, volume_tags, iam_instance_profile]
+      ebs_optimized, ami, volume_tags]
   }
   tags = {
     Name        = var.server_name


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-12491
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production 
   - Django machine.
 
Adding a custom role which is attached with new policy along with existing permissions. 
We would like to add this role to the Django machine only and once added we will then start the data copying process. 
