### PR TITLE
Add includeSubDomains to Strict-Transport-Security header

### DIFF
--- a/src/commcare_cloud/ansible/roles/nginx/vars/cchq_ssl.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/cchq_ssl.yml
@@ -55,7 +55,7 @@ nginx_sites:
    - "X-Forwarded-Protocol  $scheme"
    access_log: "{{ log_home }}/{{ deploy_env }}-timing.log timing"
    add_header:
-    - 'Strict-Transport-Security "max-age={{ nginx_hsts_max_age|default(0) }}"'
+    - 'Strict-Transport-Security "max-age={{ nginx_hsts_max_age|default(0) }}; includeSubDomains"'
     - 'X-XSS-Protection "1; mode=block"'
     - 'X-Content-Type-Options nosniff'
    locations:


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Followup to [the PR](https://github.com/dimagi/commcare-cloud/pull/4971) that moved all security related header setup to nginx. I was cautious about including `includeSubDomains` in the header, but in hindsight I'm not sure why since we were already doing this at the django level. Alas, here we are so this is a very small PR that I plan to roll out by running `cchq --control <env> ansible-playbook deploy_proxy.yml --tags=nginx_sites --limit proxy`
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None