### PR TITLE
temporarily disable deploy database checks

### DIFF
--- a/src/commcare_cloud/fab/checks/check_servers.py
+++ b/src/commcare_cloud/fab/checks/check_servers.py
@@ -53,4 +53,5 @@ def perform_system_checks(current=False):
     venv = env.virtualenv_current if current else env.virtualenv_root
     with cd(path):
         sudo('%s/bin/python manage.py check --deploy' % venv)
-        sudo('%s/bin/python manage.py check --deploy -t database' % venv)
+        # temporarily disabled due to hanging queries
+        # sudo('%s/bin/python manage.py check --deploy -t database' % venv)


### PR DESCRIPTION
Disable these for now since these are causing the deploy to fail. This is safe to have disabled as long as there are no config changes that affect DB routing.
