### PR TITLE
use correct flway config property

### DIFF
--- a/src/commcare_cloud/ansible/roles/formplayer/templates/application.properties.j2
+++ b/src/commcare_cloud/ansible/roles/formplayer/templates/application.properties.j2
@@ -25,7 +25,7 @@ spring.datasource.password={{ postgres_users.commcare.password }}
 # separate DS for flyway which bypasses pgbouncer to avoid session locking issues
 spring.flyway.driver-class-name=org.postgresql.Driver
 spring.flyway.url=jdbc:postgresql://{{ postgresql_dbs.formplayer.host }}:5432/{{ formplayer_db_name }}?prepareThreshold=0
-spring.flyway.username={{ postgres_users.commcare.username }}
+spring.flyway.user={{ postgres_users.commcare.username }}
 spring.flyway.password={{ postgres_users.commcare.password }}
 
 spring.jpa.hibernate.ddl-auto


### PR DESCRIPTION
This was not the correct property name. It is working with the current version of Spring because Spring falls back to the main datasource properties. From Spring v2.5 the fallback is removed: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.5-Release-Notes#flyway-and-liquibase-jdbc-urls

Docs for correct property: https://docs.spring.io/spring-boot/docs/current/reference/html/application-properties.html#application-properties.data-migration.spring.flyway.user

See also [Spring Upgrade PR](https://github.com/dimagi/formplayer/pull/1023)