### PR TITLE
enabling pg_repack extension on formplayer db

### DIFF
--- a/environments/production/postgresql.yml
+++ b/environments/production/postgresql.yml
@@ -23,6 +23,12 @@ pg_repack:
       password: "{{ postgres_users.root.password }}"
       port: 5432
       skip_superuser_check: True
+    - database: formplayer
+      host: pgformplayer0-production.cl9dmuo3ok4h.us-east-1.rds.amazonaws.com
+      username: "{{ postgres_users.root.username }}"
+      password: "{{ postgres_users.root.password }}"
+      port: 5432
+      skip_superuser_check: True
 
 # We're temporarily disabling read replicas
 # and will revisit after migration to RDS


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-12832
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
production
RDS: pgformplayer

Like for commcare_synclogs, We have disabled the cronjob that runs pg_repacking on formplayer DB from the pgbouncer3 machine after enabling the extension.