### PR TITLE
Use ~/.profile instead of ~/.bash_profile

### DIFF
--- a/docs/setup/new_environment.md
+++ b/docs/setup/new_environment.md
@@ -219,10 +219,10 @@ Even though we will be running all commands locally, we still need to add the us
     Would you like to use environments at that location? [y/N]y
     ```
 
-1. As prompted, add the commcare-cloud config to your bash profile to set the correct paths:
+1. As prompted, add the commcare-cloud config to your profile to set the correct paths:
 
     ``` bash
-    $ echo "source ~/.commcare-cloud/load_config.sh" >> ~/.bash_profile
+    $ echo "source ~/.commcare-cloud/load_config.sh" >> ~/.profile
     ```
 
 1. Load the commcare-cloud config so it takes effect immediately:

--- a/src/commcare_cloud/manage_commcare_cloud/configure.py
+++ b/src/commcare_cloud/manage_commcare_cloud/configure.py
@@ -94,7 +94,7 @@ class Configure(CommandBase):
                     virtualenv_path=get_virtualenv_bin_path(),
                     PACKAGE_BASE=PACKAGE_BASE,
                 )).strip())
-        puts(color_notice("Add the following to your ~/.bash_profile:"))
+        puts(color_notice("Append the following to your ~/.profile:"))
         puts(color_code("source ~/.commcare-cloud/load_config.sh"))
         puts(color_notice(
             "and then open a new shell. "


### PR DESCRIPTION
Debian derivatives, incl. Ubuntu, use ~/.profile. The default ~/.profile in Debian and Ubuntu calls ~/.bashrc. If ~/.bash_profile (or ~/.bash_login) exists, then ~/.profile is ignored. ([More details on bash startup files here](https://www.golinuxcloud.com/bashrc-vs-bash-profile/).)

CommCare Cloud already calls ~/init-ansible from ~/.profile. The existing instruction creates a new ~/.bash_profile, so ~/.bashrc and ~/init-ansible are no longer called.

If ~/.commcare-cloud/load_config.sh should be called *before* ~/init-ansible, then this line should be appended to ~/.bashrc, not ~/.profile. If it should be called *after* ~/init-ansible, or if it doesn't matter, then the change in this commit should be correct.

##### ENVIRONMENTS AFFECTED

None. This PR only affects instructions to the user.
