### PR TITLE
Updated calls to record_deploy_failed

### DIFF
--- a/src/commcare_cloud/commands/deploy/commcare.py
+++ b/src/commcare_cloud/commands/deploy/commcare.py
@@ -45,7 +45,7 @@ def deploy_commcare(environment, args, unknown_args):
         '--set', ','.join(fab_settings), branch=args.branch, *unknown_args
     )
     if rc != 0:
-        record_deploy_failed(environment, context.service_name)
+        record_deploy_failed(environment, context)
         return rc
 
     if not args.skip_record:

--- a/src/commcare_cloud/commands/deploy/formplayer.py
+++ b/src/commcare_cloud/commands/deploy/formplayer.py
@@ -70,7 +70,7 @@ def deploy_formplayer(environment, args):
 
     rc = run_ansible_playbook_command(environment, args)
     if rc != 0:
-        record_deploy_failed(environment, context.service_name)
+        record_deploy_failed(environment, context)
         return rc
 
     rc = commcare_cloud(
@@ -83,7 +83,7 @@ def deploy_formplayer(environment, args):
         ), '-b',
     )
     if rc != 0:
-        record_deploy_failed(environment, context.service_name)
+        record_deploy_failed(environment, context)
         return rc
 
     record_deploy_success(environment, context)


### PR DESCRIPTION
Minor followup for https://github.com/dimagi/commcare-cloud/pull/4848/ - deploy failure notifications are failing with `AttributeError: 'str' object has no attribute 'get_meta_value'`

##### ENVIRONMENTS AFFECTED
None
