### PR TITLE
Bump concurrency from 20 to 40 for the reminder_queue

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -47,7 +47,7 @@ celery_processes:
       concurrency: 1
     reminder_queue:
       pooling: gevent
-      concurrency: 20
+      concurrency: 40
     reminder_rule_queue:
       concurrency: 1
     repeat_record_queue:


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
The reminder_queue takes ~an hour to process. Last week, we bumped concurrency to 40 to handle a larger than usual backlog, but that change was reverted. Now that we are consistently seeing slower times, it makes sense to bump this value permanently.  
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production