### PR TITLE
Revert "undo temporary increase in reminder processing"

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -87,6 +87,10 @@ celery_processes:
       concurrency: 50
     ush_background_tasks:
       concurrency: 8
+    reminder_queue:
+      pooling: gevent
+      concurrency: 40
+      num_workers: 2
 
 
 pillows:


### PR DESCRIPTION
Reverts dimagi/commcare-cloud#5002

It looks like we actually still need these.