### PR TITLE
adding pgsynclog1 new instance and updating pgtransport extension params on pgsynclog0

### DIFF
--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -136,6 +136,9 @@ pgshard5-production.cl9dmuo3ok4h.us-east-1.rds.amazonaws.com
 [rds_pgsynclog0]
 pgsynclog0-production.cl9dmuo3ok4h.us-east-1.rds.amazonaws.com
 
+[rds_pgsynclog1]
+pgsynclog1-production.cl9dmuo3ok4h.us-east-1.rds.amazonaws.com
+
 [rds_pgauditcare0]
 pgauditcare0-production.cl9dmuo3ok4h.us-east-1.rds.amazonaws.com
 
@@ -167,6 +170,7 @@ rds_pgshard3
 rds_pgshard4
 rds_pgshard5
 rds_pgsynclog0
+rds_pgsynclog1
 rds_pgauditcare0
 
 [postgresql:children]

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -49,6 +49,8 @@ mobile_webworkers
 
 {{ __rds_pgsynclog0__ }}
 
+{{ __rds_pgsynclog1__ }}
+
 {{ __rds_pgauditcare0__ }}
 
 {{ __pgformplayer_nlb__ }}
@@ -73,6 +75,7 @@ rds_pgshard3
 rds_pgshard4
 rds_pgshard5
 rds_pgsynclog0
+rds_pgsynclog1
 rds_pgauditcare0
 
 [postgresql:children]

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -396,6 +396,31 @@ rds_instances:
     multi_az: true
     engine_version: "10.17"
     params:
+      shared_preload_libraries: pg_stat_statements,pg_transport
+      pg_transport.work_mem: 131072
+      pg_transport.timing: 1
+      max_worker_processes: 40
+      pg_transport.num_workers: 8
+      track_io_timing: 1
+      work_mem: 2457kB
+      shared_buffers: 3840MB
+      effective_cache_size: 11520MB
+      maintenance_work_mem: 960MB
+      max_connections: "LEAST({DBInstanceClassMemory/9531392},5000)"
+      vacuum_cost_limit: 2000
+
+  - identifier: "pgsynclog1-production"
+    instance_type: "db.t3.xlarge"
+    storage: 5000
+    multi_az: true
+    engine_version: "10.17"
+    params:
+      shared_preload_libraries: pg_stat_statements,pg_transport
+      pg_transport.work_mem: 131072
+      pg_transport.timing: 1
+      max_worker_processes: 40
+      pg_transport.num_workers: 8
+      track_io_timing: 1
       work_mem: 2457kB
       shared_buffers: 3840MB
       effective_cache_size: 11520MB

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -409,24 +409,24 @@ rds_instances:
       max_connections: "LEAST({DBInstanceClassMemory/9531392},5000)"
       vacuum_cost_limit: 2000
 
-  - identifier: "pgsynclog1-production"
-    instance_type: "db.t3.xlarge"
-    storage: 5000
-    multi_az: true
-    engine_version: "10.17"
-    params:
-      shared_preload_libraries: pg_stat_statements,pg_transport
-      pg_transport.work_mem: 131072
-      pg_transport.timing: 1
-      max_worker_processes: 40
-      pg_transport.num_workers: 8
-      track_io_timing: 1
-      work_mem: 2457kB
-      shared_buffers: 3840MB
-      effective_cache_size: 11520MB
-      maintenance_work_mem: 960MB
-      max_connections: "LEAST({DBInstanceClassMemory/9531392},5000)"
-      vacuum_cost_limit: 2000
+  # - identifier: "pgsynclog1-production"
+  #   instance_type: "db.t3.xlarge"
+  #   storage: 5000
+  #   multi_az: true
+  #   engine_version: "10.17"
+  #   params:
+  #     shared_preload_libraries: pg_stat_statements,pg_transport
+  #     pg_transport.work_mem: 131072
+  #     pg_transport.timing: 1
+  #     max_worker_processes: 40
+  #     pg_transport.num_workers: 8
+  #     track_io_timing: 1
+  #     work_mem: 2457kB
+  #     shared_buffers: 3840MB
+  #     effective_cache_size: 11520MB
+  #     maintenance_work_mem: 960MB
+  #     max_connections: "LEAST({DBInstanceClassMemory/9531392},5000)"
+  #     vacuum_cost_limit: 2000
 
   - identifier: "pgformplayer0-production"
     instance_type: "db.m5.2xlarge"


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-12493
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Adding new RDS instance pgsynclog1 with less disk storage i.e 5TB. To this instance, we will copy the data from the pgsynclog0 instance using the pg_transport extension

Old PR: https://github.com/dimagi/commcare-cloud/pull/4920