### PR TITLE
Check more thoroughly when deploying from master (without --branch=...)

### DIFF
--- a/src/commcare_cloud/cli_utils.py
+++ b/src/commcare_cloud/cli_utils.py
@@ -56,21 +56,41 @@ def has_arg(unknown_args, short_form, long_form):
 
 def git_branch():
     # https://stackoverflow.com/a/19585361/10840
+    status = git("status")
+    return status.splitlines()[0].strip().split()[-1] if status else status
+
+
+def require_clean_working_tree(abort=sys.exit):
+    # http://stackoverflow.com/a/3879077/10840
+    git("update-index", "-q", "--ignore-submodules", "--refresh")
+
+    # Disallow unstaged changes in the working tree
     try:
-        git_status = subprocess.check_output(
-            "git status",
-            cwd=ANSIBLE_DIR,
-            shell=True,
-            stderr=open('/dev/null', 'w', encoding='utf-8'),
-            universal_newlines=True,
-        )
+        git("diff-files", "--quiet", "--ignore-submodules", "--")
+    except subprocess.CalledProcessError:
+        abort("Aborting. You have unstaged changes.")
+
+    # Disallow uncommitted changes in the index
+    try:
+        git("diff-index", "--cached", "--quiet", "HEAD", "--ignore-submodules", "--")
+    except subprocess.CalledProcessError:
+        abort("Aborting. You have uncommitted changes.")
+
+
+def git(*args):
+    try:
+        with open('/dev/null', 'w', encoding='utf-8') as devnull:
+            return subprocess.check_output(
+                ["git"] + list(args),
+                cwd=ANSIBLE_DIR,
+                stderr=devnull,
+                universal_newlines=True,
+            )
     except subprocess.CalledProcessError as e:
         if e.returncode == 128:
             # We are not in a git repo; most likely pip installed
             return None
-        else:
-            raise
-    return git_status.splitlines()[0].strip().split()[-1]
+        raise
 
 
 def check_branch(args):
@@ -84,6 +104,20 @@ def check_branch(args):
         puts(color_error("You are not currently on the branch specified with the --branch tag. To deploy on "
                          "this branch, use --branch={}, otherwise, change branches".format(branch)))
         exit(-1)
+    elif branch == 'master' and not any(a.startswith("--branch") for a in sys.argv):
+        require_clean_working_tree()
+        local_rev = git("rev-parse", branch).strip()
+        remote = "https://github.com/dimagi/commcare-cloud.git"
+        remote_rev = git("ls-remote", remote, "refs/heads/master").split(maxsplit=1)[0]
+        if local_rev != remote_rev:
+            print("Your local 'master' branch has diverged from upstream")
+            print(f"local:  {local_rev}")
+            print(f"remote: {remote_rev}")
+            print("")
+            print("Run 'git pull' to get the latest code, then try again.")
+            print("Create a pull request if you have new commits to contribute.")
+            print("Or add --branch=master to use your local branch (not recommended).")
+            exit(-1)
 
 
 def print_command(command):

--- a/src/commcare_cloud/commcare_cloud.py
+++ b/src/commcare_cloud/commcare_cloud.py
@@ -257,6 +257,7 @@ def _get_cleaned_args_for_control(args, input_argv):
             del argv[i:i + 2]
     return argv
 
+
 def main():
     exit_code = call_commcare_cloud()
     if exit_code != 0:


### PR DESCRIPTION
For commands that check the branch before running the command:
- Error if there are unstaged or uncommitted changes.
- Error if local master has diverged from upstream.
- Suggest how to recover.

<!--- Provide a link to the ticket or document which prompted this change -->

##### ENVIRONMENTS AFFECTED
All.
