### PR TITLE
Reject `cchq <env> service commcare restart`

### DIFF
--- a/docs/firefighting/index.md
+++ b/docs/firefighting/index.md
@@ -75,7 +75,10 @@ You can use this graph on [datadog](https://app.datadoghq.com/dashboard/ewu-jyr-
 
 # Service Information
 
-Restarting services: `cchq <env> service <service_name> restart`
+Restarting services:
+- Webworkers: `cchq <env> fab restart_webworkers`
+- All services running commcare-hq code (webworkers, celery, pillowtop, etc): `cchq <env> fab restart_services`
+- Other (db, formplayer, etc): `cchq <env> service <service_name> restart`
 
 Stopping services: `cchq <env> service <service_name> stop`
 

--- a/docs/services/blobdb/migrate-fs-to-s3.md
+++ b/docs/services/blobdb/migrate-fs-to-s3.md
@@ -22,7 +22,7 @@ you have configured the correct access to allow connections from the IPs where C
     ```
 4. Restart CommCare services
    ```bash
-   commcare-cloud <env> service commcare resetart
+   commcare-cloud <env> fab restart_services
    ```
 
 {% include_relative _blobdb_backfill.md %}
@@ -37,5 +37,5 @@ you have configured the correct access to allow connections from the IPs where C
    ```
 4. Restart CommCare services
    ```bash
-   commcare-cloud <env> service commcare resetart
+   commcare-cloud <env> fab restart_services
    ```

--- a/docs/services/postgresql/migrating_plproxy.md
+++ b/docs/services/postgresql/migrating_plproxy.md
@@ -14,14 +14,14 @@ This Migration doesn't require downtime since the databases do not contain any d
         *   ` python manage.py check_services`
         *   ` python manage.py check --deploy -t database`
 5.  Run `cchq <env> update-config` (no limit)
-6.  Restart mobile webworkers
-    *   `cchq <env> service commcare restart --limit=mobile_webworkers`
+6.  Restart webworkers
+    *   `cchq <env> fab restart_webworkers`
 7.  Check for errors
     *   Load the site in a browser
     *   Watch monitoring dashboards for errors
     *   Watch Sentry for errors
-8.  Restart remaining services
-    *   `cchq <env> service commcare restart --limit= 'all:!mobile_webworkers'`
+8.  Restart remaining services (this also redundantly restarts webworkers again)
+    *   `cchq <env> fab restart_services`
 9.  Check for errors again (see step 7)
 10. Cleanup:
     *   Remove old plproxy nodes from env config (inventory etc)

--- a/src/commcare_cloud/commands/ansible/service.py
+++ b/src/commcare_cloud/commands/ansible/service.py
@@ -467,7 +467,7 @@ class CommCare(SingleSupervisorService):
             puts(color_notice("To restart formplayer, which always causes downtime, use the 'formplayer' service command."))
             puts(color_error("Refusing to run commcare service command with action 'restart'."))
             return 1
-        super().run(action, host_pattern=host_pattern, process_pattern=process_pattern)
+        return super().run(action, host_pattern=host_pattern, process_pattern=process_pattern)
 
 
 class Webworker(SingleSupervisorService):
@@ -488,7 +488,7 @@ class Webworker(SingleSupervisorService):
             puts(color_code(f"  cchq {self.environment.name} fab restart_webworkers"))
             puts(color_error("Refusing to run webworkers service command with action 'restart'."))
             return 1
-        super().run(action, host_pattern=host_pattern, process_pattern=process_pattern)
+        return super().run(action, host_pattern=host_pattern, process_pattern=process_pattern)
 
 
 class Formplayer(SingleSupervisorService):

--- a/src/commcare_cloud/commands/ansible/service.py
+++ b/src/commcare_cloud/commands/ansible/service.py
@@ -480,6 +480,16 @@ class Webworker(SingleSupervisorService):
     def supervisor_process_name(self):
         return get_django_webworker_name(self.environment)
 
+    def run(self, action, host_pattern=None, process_pattern=None):
+        if action == 'restart':
+            puts(color_warning("The 'webworker' service command rejects the 'restart' action"))
+            puts(color_warning("in order to protect against accidental downtime."))
+            puts(color_notice("For a no-downtime restart of webworkers, please use"))
+            puts(color_code(f"  cchq {self.environment.name} fab restart_webworkers"))
+            puts(color_error("Refusing to run webworkers service command with action 'restart'."))
+            return 1
+        super().run(action, host_pattern=host_pattern, process_pattern=process_pattern)
+
 
 class Formplayer(SingleSupervisorService):
     name = 'formplayer'

--- a/src/commcare_cloud/commands/ansible/service.py
+++ b/src/commcare_cloud/commands/ansible/service.py
@@ -11,7 +11,7 @@ import attr
 import six
 from clint.textui import puts, indent
 
-from commcare_cloud.colors import color_error
+from commcare_cloud.colors import color_error, color_warning, color_code, color_notice
 from commcare_cloud.commands.ansible.helpers import (
     AnsibleContext, get_django_webworker_name,
     get_formplayer_spring_instance_name,
@@ -456,6 +456,18 @@ class CommCare(SingleSupervisorService):
     @property
     def supervisor_process_name(self):
         return 'all'
+
+    def run(self, action, host_pattern=None, process_pattern=None):
+        if action == 'restart':
+            puts(color_warning("The 'commcare' service command rejects the 'restart' action"))
+            puts(color_warning("in order to protect against accidental downtime."))
+            puts(color_notice("For a no-downtime restart of commcare-hq services, please use one of the following"))
+            puts(color_code(f"  cchq {self.environment.name} fab restart_services  # for all processes that run commcare-hq code."))
+            puts(color_code(f"  cchq {self.environment.name} fab restart_webworkers  # for webworkers only"))
+            puts(color_notice("To restart formplayer, which always causes downtime, use the 'formplayer' service command."))
+            puts(color_error("Refusing to run commcare service command with action 'restart'."))
+            return 1
+        super().run(action, host_pattern=host_pattern, process_pattern=process_pattern)
 
 
 class Webworker(SingleSupervisorService):


### PR DESCRIPTION
This was prompted by a history of occasional operation errors resulting from unclear guidance (both on the team and from the tool itself) on which command to use to restart webworkers and/or services based on commcare-hq code. `cchq <env> service commcare restart` is a trap because (1) it does a non-rolling restart of webworkers, resulting in webworker downtime (2) it does a formplayer restart which always causes downtime. Similarly `cchq <env> service webworkers restart` has problem 1 as well.

This change makes those two commands (specifically/only with the restart action) to display an error message suggesting alternatives and then refuse to proceed (exiting with return code 1).

![Screen Shot 2021-12-17 at 2 13 33 PM](https://user-images.githubusercontent.com/137212/146602452-0f650c3a-f02f-4efa-906e-a327b9a7e7d1.png)


##### ENVIRONMENTS AFFECTED
None