### PR TITLE
Temporarily remove malt_generation_queue altogether

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -91,11 +91,6 @@ celery_processes:
       pooling: gevent
       concurrency: 40
       num_workers: 2
-    malt_generation_queue:
-      pooling: gevent
-      concurrency: 40
-      num_workers: 2
-
 
 pillows:
   pillow_a000:


### PR DESCRIPTION
I'm applying this to capture more persistently the current state that `malt_generation_queue`. @skodde @gherceg please review this retroactively, and give it approval but then we can just close it.

##### ENVIRONMENTS AFFECTED
production