### PR TITLE
reverting back to formplayer to route via NLB and adding pg5 all dbs

### DIFF
--- a/environments/production/postgresql.yml
+++ b/environments/production/postgresql.yml
@@ -42,18 +42,26 @@ dbs:
     host: rds_pgmain0
     pgbouncer_endpoint: pgmain_nlb
     pgbouncer_hosts:
+      - pgbouncer5
       - pgbouncer6
       - pgbouncer7
       - pgbouncer8
       - pgbouncer9
   formplayer:
     host: rds_pgformplayer0
-    pgbouncer_host: pgbouncer5
+    pgbouncer_endpoint: pgformplayer_nlb
+    pgbouncer_hosts:
+      - pgbouncer5
+      - pgbouncer6
+      - pgbouncer7
+      - pgbouncer8
+      - pgbouncer9
 
   ucr:
     host: rds_pgucr0
     pgbouncer_endpoint: pgucr_nlb
     pgbouncer_hosts:
+      - pgbouncer5
       - pgbouncer6
       - pgbouncer7
       - pgbouncer8
@@ -63,6 +71,7 @@ dbs:
     host: rds_pgsynclog0
     pgbouncer_endpoint: pgsynclogs_nlb
     pgbouncer_hosts:
+      - pgbouncer5
       - pgbouncer6
       - pgbouncer7
       - pgbouncer8
@@ -71,6 +80,7 @@ dbs:
     host: rds_pgauditcare0
     pgbouncer_endpoint: pgmain_nlb
     pgbouncer_hosts:
+      - pgbouncer5
       - pgbouncer6
       - pgbouncer7
       - pgbouncer8
@@ -87,6 +97,7 @@ dbs:
         host: rds_pgshard1
         pgbouncer_endpoint: pgshard_nlb
         pgbouncer_hosts:
+          - pgbouncer5
           - pgbouncer6
           - pgbouncer7
           - pgbouncer8
@@ -96,6 +107,7 @@ dbs:
         host: rds_pgshard2
         pgbouncer_endpoint: pgshard_nlb
         pgbouncer_hosts:
+          - pgbouncer5
           - pgbouncer6
           - pgbouncer7
           - pgbouncer8
@@ -105,6 +117,7 @@ dbs:
         host: rds_pgshard3
         pgbouncer_endpoint: pgshard_nlb
         pgbouncer_hosts:
+          - pgbouncer5
           - pgbouncer6
           - pgbouncer7
           - pgbouncer8
@@ -114,6 +127,7 @@ dbs:
         host: rds_pgshard4
         pgbouncer_endpoint: pgshard_nlb
         pgbouncer_hosts:
+          - pgbouncer5
           - pgbouncer6
           - pgbouncer7
           - pgbouncer8
@@ -123,6 +137,7 @@ dbs:
         host: rds_pgshard5
         pgbouncer_endpoint: pgshard_nlb
         pgbouncer_hosts:
+          - pgbouncer5
           - pgbouncer6
           - pgbouncer7
           - pgbouncer8


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-12891

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production.

During P2 we switched formplayer routing directly to pgbouncer5 and now since things back to normal we are reverting the change.

P1 PR: https://github.com/dimagi/commcare-cloud/pull/5049