### PR TITLE
Decrease num_processes from 33 to 24

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -95,7 +95,7 @@ celery_processes:
 pillows:
   pillow_a000:
     case-pillow:
-      num_processes: 33
+      num_processes: 24
       dedicated_migration_process: True
     user-pillow:
       num_processes: 1


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Rather than [revert](https://github.com/dimagi/commcare-cloud/pull/5044) https://github.com/dimagi/commcare-cloud/pull/5042 to set `num_processes` back to 17 for the case_pillow, we are meeting in the middle to decrease load on pillow_a000 while still having enough processes to keep up with case pillow load. 
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production