### PR TITLE
Scale up pgucr0-production

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -327,7 +327,7 @@ rds_instances:
       max_connections: "LEAST({DBInstanceClassMemory/9531392},5000)"
 
   - identifier: "pgucr0-production"
-    instance_type: "db.m5.xlarge"
+    instance_type: "db.m5.2xlarge"
     storage: 500
     max_storage: 5000
     multi_az: true


### PR DESCRIPTION
Change (again) RDS instance type from m5.xlarge to m5.2xlarge, due
to CPU usage.

https://dimagi-dev.atlassian.net/browse/SAAS-12880

##### ENVIRONMENTS AFFECTED
Production
