### PR TITLE
Change CouchDB instance type

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -125,7 +125,7 @@ servers:
     os: ubuntu_pro_bionic
 
   - server_name: "couch11-production"
-    server_instance_type: c5a.24xlarge
+    server_instance_type: c5n.18xlarge
     network_tier: "db-private"
     az: "c"
     volume_size: 90
@@ -137,7 +137,7 @@ servers:
     os: bionic
 
   - server_name: "couch12-production"
-    server_instance_type: c5a.24xlarge
+    server_instance_type: c5n.18xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 90
@@ -148,7 +148,7 @@ servers:
     group: "couchdb2"
     os: bionic
   - server_name: "couch13-production"
-    server_instance_type: c5a.24xlarge
+    server_instance_type: c5n.18xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 90


### PR DESCRIPTION
Apparently we may be hitting the bandwidth limit with the current
instance type (c5a.24xlarge, 20Gbps).
Let's test the theory and witch to c5n.18xlarge (100Gbps).

https://dimagi-dev.atlassian.net/browse/SAAS-12880

##### ENVIRONMENTS AFFECTED
Production