### PR TITLE
enable explict gc for es

### DIFF
--- a/src/commcare_cloud/ansible/roles/elasticsearch/tasks/misc_v2.yml
+++ b/src/commcare_cloud/ansible/roles/elasticsearch/tasks/misc_v2.yml
@@ -16,6 +16,12 @@
     regexp: '^JAVA_OPTS="\$JAVA_OPTS -XX:\+HeapDumpOnOutOfMemoryError"'
     replace: '#JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"'
 
+- name: Enable Explicit GC
+  replace:
+    path: "{{ elasticsearch_home }}/bin/elasticsearch.in.sh"
+    regexp: '^JAVA_OPTS="\$JAVA_OPTS -XX:\+DisableExplicitGC"'
+    replace: '#JAVA_OPTS="$JAVA_OPTS -XX:+DisableExplicitGC"'
+
 - name: Install elasticsearch python client
   become: yes
   pip:


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-12847

This should help with the recurring `java.lang.OutOfMemoryError: Direct buffer memory` errors we get on production (and sometimes india) ES nodes, and is the solution adopted by ES itself in later versions (https://github.com/elastic/elasticsearch/pull/25759)

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All