### PR TITLE
increase shared buffers to 40%

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -435,6 +435,7 @@ rds_instances:
     backup_retention: 7
     monitoring_interval: 0
     params:
+      shared_buffers: 6554MB
       shared_preload_libraries: pg_stat_statements
       log_min_duration_statement: 1000
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-12885

40% of 16GB is 6.4GB, raising this from our default of 25% or 4GB

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Prod