### PR TITLE
Add pgtransport extension params in pgsynclog0 parameter group

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -436,6 +436,12 @@ rds_instances:
     multi_az: true
     engine_version: "10.17"
     params:
+      shared_preload_libraries: pg_stat_statements,pg_transport
+      pg_transport.work_mem: 131072
+      pg_transport.timing: 1
+      max_worker_processes: 40
+      pg_transport.num_workers: 8
+      track_io_timing: 1
       work_mem: 2457kB
       shared_buffers: 3840MB
       effective_cache_size: 11520MB


### PR DESCRIPTION
This PR incorporates changes from https://github.com/dimagi/commcare-cloud/pull/5026 that have already been approved and applied as part of the migration work in https://dimagi-dev.atlassian.net/browse/SAAS-12493. Getting this in before the whole thing is complete will let us continue to manage chagnes to pgsynclog0-production consistently in the interim.

##### ENVIRONMENTS AFFECTED
production
