### PR TITLE
Ce/auditcare pool size

### DIFF
--- a/environments/production/postgresql.yml
+++ b/environments/production/postgresql.yml
@@ -78,7 +78,7 @@ dbs:
   auditcare:
     host: rds_pgauditcare0
     pgbouncer_endpoint: pgmain_nlb
-    pgbouncer_pool_size: 25
+    pgbouncer_pool_size: 50
     pgbouncer_hosts:
       - pgbouncer5
       - pgbouncer6

--- a/environments/production/postgresql.yml
+++ b/environments/production/postgresql.yml
@@ -78,6 +78,7 @@ dbs:
   auditcare:
     host: rds_pgauditcare0
     pgbouncer_endpoint: pgmain_nlb
+    pgbouncer_pool_size: 25
     pgbouncer_hosts:
       - pgbouncer5
       - pgbouncer6

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -437,6 +437,7 @@ rds_instances:
     params:
       shared_preload_libraries: pg_stat_statements
       log_min_duration_statement: 1000
+      max_wal_size: 4GB
 
 pgbouncer_nlbs:
   - name: pgformplayer_nlb-production

--- a/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer.ini.j2
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer.ini.j2
@@ -10,7 +10,7 @@
 {% set current_host = inventory_hostname %}
 {% if is_monolith %}{% set current_host = DEFAULT_POSTGRESQL_HOST %}{% endif %}
 {% for db in postgresql_dbs.by_pgbouncer_host.get(current_host, []) %}
-{{ db.name }} = host={{ "localhost" if db.host == inventory_hostname else db.host }} port={{ postgresql_port }}{% if db.pgbouncer_pool_size %} pool_size={{ db.pgbouncer_pool_size }}{% endif %}
+{{ db.name }} = host={{ "localhost" if db.host == inventory_hostname else db.host }} port={{ postgresql_port }}{% if db.pgbouncer_pool_size %} pool_size={{ db.pgbouncer_pool_size // pgbouncer_processes }}{% endif %}
 {% endfor %}
 
 ;; Configuration section

--- a/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer.ini.j2
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer.ini.j2
@@ -10,7 +10,7 @@
 {% set current_host = inventory_hostname %}
 {% if is_monolith %}{% set current_host = DEFAULT_POSTGRESQL_HOST %}{% endif %}
 {% for db in postgresql_dbs.by_pgbouncer_host.get(current_host, []) %}
-{{ db.name }} = host={{ "localhost" if db.host == inventory_hostname else db.host }} port={{ postgresql_port }}
+{{ db.name }} = host={{ "localhost" if db.host == inventory_hostname else db.host }} port={{ postgresql_port }}{% if db.pgbouncer_pool_size %} pool_size={{ db.pgbouncer_pool_size }}{% endif %}
 {% endfor %}
 
 ;; Configuration section

--- a/src/commcare_cloud/environment/schemas/postgresql.py
+++ b/src/commcare_cloud/environment/schemas/postgresql.py
@@ -318,6 +318,7 @@ class DBOptions(jsonobject.JsonObject):
     host = jsonobject.StringProperty()
     pgbouncer_hosts = jsonobject.ListProperty(str)
     pgbouncer_endpoint = jsonobject.StringProperty(default=None)
+    pgbouncer_pool_size = jsonobject.IntegerProperty(default=None)
     port = jsonobject.IntegerProperty(default=None)
     user = jsonobject.StringProperty()
     password = jsonobject.StringProperty()

--- a/tests/test_envs/2018-04-04-development-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-development-snapshot/.generated.yml
@@ -12,6 +12,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 192.168.33.16
     pgbouncer_hosts:
     - 192.168.33.16
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -27,6 +28,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 192.168.33.16
     pgbouncer_hosts:
     - 192.168.33.16
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -42,6 +44,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 192.168.33.16
     pgbouncer_hosts:
     - 192.168.33.16
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -65,6 +68,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 192.168.33.16
     pgbouncer_hosts:
     - 192.168.33.16
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -80,6 +84,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 192.168.33.16
     pgbouncer_hosts:
     - 192.168.33.16
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -97,6 +102,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 192.168.33.16
     pgbouncer_hosts:
     - 192.168.33.16
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'

--- a/tests/test_envs/2018-04-04-enikshay-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-enikshay-snapshot/.generated.yml
@@ -12,6 +12,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -27,6 +28,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -45,6 +47,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -63,6 +66,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -81,6 +85,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -99,6 +104,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -117,6 +123,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -135,6 +142,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -153,6 +161,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -171,6 +180,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -189,6 +199,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -207,6 +218,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -222,6 +234,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -237,6 +250,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: true
     user: '{{ postgres_users.commcare.username }}'
@@ -252,6 +266,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -288,6 +303,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 172.25.3.5
         pgbouncer_hosts:
         - 172.25.3.5
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -306,6 +322,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 172.25.3.5
         pgbouncer_hosts:
         - 172.25.3.5
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -324,6 +341,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 172.25.3.5
         pgbouncer_hosts:
         - 172.25.3.5
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -342,6 +360,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 172.25.3.5
         pgbouncer_hosts:
         - 172.25.3.5
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -360,6 +379,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 172.25.3.5
         pgbouncer_hosts:
         - 172.25.3.5
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -378,6 +398,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 172.25.3.5
         pgbouncer_hosts:
         - 172.25.3.5
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -396,6 +417,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 172.25.3.5
         pgbouncer_hosts:
         - 172.25.3.5
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -414,6 +436,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 172.25.3.5
         pgbouncer_hosts:
         - 172.25.3.5
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -432,6 +455,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 172.25.3.5
         pgbouncer_hosts:
         - 172.25.3.5
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -450,6 +474,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 172.25.3.5
         pgbouncer_hosts:
         - 172.25.3.5
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -468,6 +493,7 @@ postgresql_dbs:
       pgbouncer_endpoint: 172.25.3.5
       pgbouncer_hosts:
       - 172.25.3.5
+      pgbouncer_pool_size: null
       port: 6432
       query_stats: false
       user: '{{ postgres_users.commcare.username }}'
@@ -482,6 +508,7 @@ postgresql_dbs:
       pg_config: []
       pgbouncer_endpoint: null
       pgbouncer_hosts: []
+      pgbouncer_pool_size: null
       port: null
       query_stats: false
       user: null
@@ -497,6 +524,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -512,6 +540,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -528,6 +557,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -543,6 +573,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: true
     user: '{{ postgres_users.commcare.username }}'

--- a/tests/test_envs/2018-04-04-icds-new-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-icds-new-snapshot/.generated.yml
@@ -12,6 +12,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.26
     pgbouncer_hosts:
     - 10.247.164.26
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -27,6 +28,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.25
     pgbouncer_hosts:
     - 10.247.164.25
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: true
     user: '{{ postgres_users.commcare.username }}'
@@ -43,6 +45,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.24
     pgbouncer_hosts:
     - 10.247.164.24
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -58,6 +61,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.66
     pgbouncer_hosts:
     - 10.247.164.66
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -76,6 +80,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.64
     pgbouncer_hosts:
     - 10.247.164.64
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -94,6 +99,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.66
     pgbouncer_hosts:
     - 10.247.164.66
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -112,6 +118,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.21
     pgbouncer_hosts:
     - 10.247.164.21
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -130,6 +137,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.21
     pgbouncer_hosts:
     - 10.247.164.21
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -148,6 +156,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.21
     pgbouncer_hosts:
     - 10.247.164.21
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -166,6 +175,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.20
     pgbouncer_hosts:
     - 10.247.164.20
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -184,6 +194,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.20
     pgbouncer_hosts:
     - 10.247.164.20
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -202,6 +213,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.20
     pgbouncer_hosts:
     - 10.247.164.20
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -220,6 +232,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.64
     pgbouncer_hosts:
     - 10.247.164.64
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -238,6 +251,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.56
     pgbouncer_hosts:
     - 10.247.164.56
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -253,6 +267,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.70
     pgbouncer_hosts:
     - 10.247.164.70
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -268,6 +283,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.25
     pgbouncer_hosts:
     - 10.247.164.25
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -283,6 +299,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.25
     pgbouncer_hosts:
     - 10.247.164.25
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -333,6 +350,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.25
     pgbouncer_hosts:
     - 10.247.164.25
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: true
     user: '{{ postgres_users.commcare.username }}'
@@ -350,6 +368,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 10.247.164.66
         pgbouncer_hosts:
         - 10.247.164.66
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -368,6 +387,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 10.247.164.64
         pgbouncer_hosts:
         - 10.247.164.64
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -386,6 +406,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 10.247.164.66
         pgbouncer_hosts:
         - 10.247.164.66
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -404,6 +425,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 10.247.164.21
         pgbouncer_hosts:
         - 10.247.164.21
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -422,6 +444,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 10.247.164.21
         pgbouncer_hosts:
         - 10.247.164.21
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -440,6 +463,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 10.247.164.21
         pgbouncer_hosts:
         - 10.247.164.21
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -458,6 +482,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 10.247.164.20
         pgbouncer_hosts:
         - 10.247.164.20
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -476,6 +501,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 10.247.164.20
         pgbouncer_hosts:
         - 10.247.164.20
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -494,6 +520,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 10.247.164.20
         pgbouncer_hosts:
         - 10.247.164.20
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -512,6 +539,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 10.247.164.64
         pgbouncer_hosts:
         - 10.247.164.64
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -530,6 +558,7 @@ postgresql_dbs:
       pgbouncer_endpoint: 10.247.164.56
       pgbouncer_hosts:
       - 10.247.164.56
+      pgbouncer_pool_size: null
       port: 6432
       query_stats: false
       user: '{{ postgres_users.commcare.username }}'
@@ -544,6 +573,7 @@ postgresql_dbs:
       pg_config: []
       pgbouncer_endpoint: null
       pgbouncer_hosts: []
+      pgbouncer_pool_size: null
       port: null
       query_stats: false
       user: null
@@ -559,6 +589,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.25
     pgbouncer_hosts:
     - 10.247.164.25
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -574,6 +605,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.26
     pgbouncer_hosts:
     - 10.247.164.26
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -591,6 +623,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.24
     pgbouncer_hosts:
     - 10.247.164.24
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -606,6 +639,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.70
     pgbouncer_hosts:
     - 10.247.164.70
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -621,6 +655,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.25
     pgbouncer_hosts:
     - 10.247.164.25
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'

--- a/tests/test_envs/2018-04-04-pna-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-pna-snapshot/.generated.yml
@@ -12,6 +12,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -27,6 +28,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -45,6 +47,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -63,6 +66,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -81,6 +85,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -99,6 +104,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -117,6 +123,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -135,6 +142,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -153,6 +161,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -171,6 +180,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -189,6 +199,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -207,6 +218,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -222,6 +234,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -237,6 +250,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -252,6 +266,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -288,6 +303,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 196.207.230.171
         pgbouncer_hosts:
         - 196.207.230.171
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -306,6 +322,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 196.207.230.171
         pgbouncer_hosts:
         - 196.207.230.171
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -324,6 +341,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 196.207.230.171
         pgbouncer_hosts:
         - 196.207.230.171
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -342,6 +360,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 196.207.230.171
         pgbouncer_hosts:
         - 196.207.230.171
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -360,6 +379,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 196.207.230.171
         pgbouncer_hosts:
         - 196.207.230.171
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -378,6 +398,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 196.207.230.171
         pgbouncer_hosts:
         - 196.207.230.171
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -396,6 +417,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 196.207.230.171
         pgbouncer_hosts:
         - 196.207.230.171
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -414,6 +436,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 196.207.230.171
         pgbouncer_hosts:
         - 196.207.230.171
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -432,6 +455,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 196.207.230.171
         pgbouncer_hosts:
         - 196.207.230.171
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -450,6 +474,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 196.207.230.171
         pgbouncer_hosts:
         - 196.207.230.171
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -468,6 +493,7 @@ postgresql_dbs:
       pgbouncer_endpoint: 196.207.230.171
       pgbouncer_hosts:
       - 196.207.230.171
+      pgbouncer_pool_size: null
       port: 6432
       query_stats: false
       user: '{{ postgres_users.commcare.username }}'
@@ -482,6 +508,7 @@ postgresql_dbs:
       pg_config: []
       pgbouncer_endpoint: null
       pgbouncer_hosts: []
+      pgbouncer_pool_size: null
       port: null
       query_stats: false
       user: null
@@ -497,6 +524,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -512,6 +540,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -528,6 +557,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -543,6 +573,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'

--- a/tests/test_envs/2018-04-04-production-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-production-snapshot/.generated.yml
@@ -12,6 +12,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb0.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb0.internal-va.commcarehq.org
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -27,6 +28,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb0.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb0.internal-va.commcarehq.org
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -42,6 +44,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb1.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb1.internal-va.commcarehq.org
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -60,6 +63,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb1.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb1.internal-va.commcarehq.org
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -78,6 +82,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb2.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb2.internal-va.commcarehq.org
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -96,6 +101,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb2.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb2.internal-va.commcarehq.org
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -114,6 +120,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb2.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb2.internal-va.commcarehq.org
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -132,6 +139,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb1.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb1.internal-va.commcarehq.org
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -147,6 +155,7 @@ postgresql_dbs:
     pgbouncer_endpoint: pgsynclog.internal-va.commcarehq.org
     pgbouncer_hosts:
     - pgsynclog.internal-va.commcarehq.org
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -162,6 +171,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb0.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb0.internal-va.commcarehq.org
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: true
     user: '{{ postgres_users.commcare.username }}'
@@ -177,6 +187,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb0.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb0.internal-va.commcarehq.org
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -192,6 +203,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb0.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb0.internal-va.commcarehq.org
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -226,6 +238,7 @@ postgresql_dbs:
         pgbouncer_endpoint: hqdb1.internal-va.commcarehq.org
         pgbouncer_hosts:
         - hqdb1.internal-va.commcarehq.org
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -244,6 +257,7 @@ postgresql_dbs:
         pgbouncer_endpoint: hqdb1.internal-va.commcarehq.org
         pgbouncer_hosts:
         - hqdb1.internal-va.commcarehq.org
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -262,6 +276,7 @@ postgresql_dbs:
         pgbouncer_endpoint: hqdb2.internal-va.commcarehq.org
         pgbouncer_hosts:
         - hqdb2.internal-va.commcarehq.org
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -280,6 +295,7 @@ postgresql_dbs:
         pgbouncer_endpoint: hqdb2.internal-va.commcarehq.org
         pgbouncer_hosts:
         - hqdb2.internal-va.commcarehq.org
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -298,6 +314,7 @@ postgresql_dbs:
         pgbouncer_endpoint: hqdb2.internal-va.commcarehq.org
         pgbouncer_hosts:
         - hqdb2.internal-va.commcarehq.org
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -316,6 +333,7 @@ postgresql_dbs:
       pgbouncer_endpoint: hqdb1.internal-va.commcarehq.org
       pgbouncer_hosts:
       - hqdb1.internal-va.commcarehq.org
+      pgbouncer_pool_size: null
       port: 6432
       query_stats: false
       user: '{{ postgres_users.commcare.username }}'
@@ -330,6 +348,7 @@ postgresql_dbs:
       pg_config: []
       pgbouncer_endpoint: null
       pgbouncer_hosts: []
+      pgbouncer_pool_size: null
       port: null
       query_stats: false
       user: null
@@ -345,6 +364,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb0.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb0.internal-va.commcarehq.org
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -360,6 +380,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb0.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb0.internal-va.commcarehq.org
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -376,6 +397,7 @@ postgresql_dbs:
     pgbouncer_endpoint: pgsynclog.internal-va.commcarehq.org
     pgbouncer_hosts:
     - pgsynclog.internal-va.commcarehq.org
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -391,6 +413,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb0.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb0.internal-va.commcarehq.org
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: true
     user: '{{ postgres_users.commcare.username }}'

--- a/tests/test_envs/2018-04-04-softlayer-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-softlayer-snapshot/.generated.yml
@@ -12,6 +12,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
     - 10.162.36.205
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -27,6 +28,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
     - 10.162.36.205
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -45,6 +47,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
     - 10.162.36.205
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -63,6 +66,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
     - 10.162.36.205
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -81,6 +85,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
     - 10.162.36.205
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -99,6 +104,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
     - 10.162.36.205
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     shards:
@@ -117,6 +123,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
     - 10.162.36.205
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -132,6 +139,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
     - 10.162.36.205
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -147,6 +155,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
     - 10.162.36.205
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -162,6 +171,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
     - 10.162.36.205
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -177,6 +187,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
     - 10.162.36.205
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -206,6 +217,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
     - 10.162.36.205
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -223,6 +235,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 10.162.36.205
         pgbouncer_hosts:
         - 10.162.36.205
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -241,6 +254,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 10.162.36.205
         pgbouncer_hosts:
         - 10.162.36.205
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -259,6 +273,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 10.162.36.205
         pgbouncer_hosts:
         - 10.162.36.205
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -277,6 +292,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 10.162.36.205
         pgbouncer_hosts:
         - 10.162.36.205
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -295,6 +311,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 10.162.36.205
         pgbouncer_hosts:
         - 10.162.36.205
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: false
         shards:
@@ -313,6 +330,7 @@ postgresql_dbs:
       pgbouncer_endpoint: 10.162.36.205
       pgbouncer_hosts:
       - 10.162.36.205
+      pgbouncer_pool_size: null
       port: 6432
       query_stats: false
       user: '{{ postgres_users.commcare.username }}'
@@ -327,6 +345,7 @@ postgresql_dbs:
       pg_config: []
       pgbouncer_endpoint: null
       pgbouncer_hosts: []
+      pgbouncer_pool_size: null
       port: null
       query_stats: false
       user: null
@@ -342,6 +361,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
     - 10.162.36.205
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -357,6 +377,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
     - 10.162.36.205
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -373,6 +394,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
     - 10.162.36.205
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -388,6 +410,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
     - 10.162.36.205
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'

--- a/tests/test_envs/2018-04-04-staging-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-staging-snapshot/.generated.yml
@@ -12,6 +12,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: true
     user: '{{ postgres_users.commcare.username }}'
@@ -27,6 +28,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: true
     shards:
@@ -45,6 +47,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: true
     shards:
@@ -63,6 +66,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: true
     shards:
@@ -81,6 +85,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: true
     shards:
@@ -99,6 +104,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: true
     shards:
@@ -117,6 +123,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -132,6 +139,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -147,6 +155,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: true
     user: '{{ postgres_users.commcare.username }}'
@@ -162,6 +171,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -193,6 +203,7 @@ postgresql_dbs:
         pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
         pgbouncer_hosts:
         - hqdb1-staging.internal-va.commcarehq.org
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: true
         shards:
@@ -211,6 +222,7 @@ postgresql_dbs:
         pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
         pgbouncer_hosts:
         - hqdb1-staging.internal-va.commcarehq.org
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: true
         shards:
@@ -229,6 +241,7 @@ postgresql_dbs:
         pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
         pgbouncer_hosts:
         - hqdb1-staging.internal-va.commcarehq.org
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: true
         shards:
@@ -247,6 +260,7 @@ postgresql_dbs:
         pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
         pgbouncer_hosts:
         - hqdb1-staging.internal-va.commcarehq.org
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: true
         shards:
@@ -265,6 +279,7 @@ postgresql_dbs:
         pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
         pgbouncer_hosts:
         - hqdb1-staging.internal-va.commcarehq.org
+        pgbouncer_pool_size: null
         port: 6432
         query_stats: true
         shards:
@@ -283,6 +298,7 @@ postgresql_dbs:
       pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
       pgbouncer_hosts:
       - hqdb1-staging.internal-va.commcarehq.org
+      pgbouncer_pool_size: null
       port: 6432
       query_stats: false
       user: '{{ postgres_users.commcare.username }}'
@@ -297,6 +313,7 @@ postgresql_dbs:
       pg_config: []
       pgbouncer_endpoint: null
       pgbouncer_hosts: []
+      pgbouncer_pool_size: null
       port: null
       query_stats: false
       user: null
@@ -312,6 +329,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -327,6 +345,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: true
     user: '{{ postgres_users.commcare.username }}'
@@ -343,6 +362,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -358,6 +378,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: true
     user: '{{ postgres_users.commcare.username }}'

--- a/tests/test_envs/2018-04-04-swiss-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-swiss-snapshot/.generated.yml
@@ -12,6 +12,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 127.0.0.1
     pgbouncer_hosts:
     - 127.0.0.1
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -27,6 +28,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 127.0.0.1
     pgbouncer_hosts:
     - 127.0.0.1
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -42,6 +44,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 127.0.0.1
     pgbouncer_hosts:
     - 127.0.0.1
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: true
     user: '{{ postgres_users.commcare.username }}'
@@ -57,6 +60,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 127.0.0.1
     pgbouncer_hosts:
     - 127.0.0.1
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -81,6 +85,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 127.0.0.1
     pgbouncer_hosts:
     - 127.0.0.1
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -96,6 +101,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 127.0.0.1
     pgbouncer_hosts:
     - 127.0.0.1
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -112,6 +118,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 127.0.0.1
     pgbouncer_hosts:
     - 127.0.0.1
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
@@ -127,6 +134,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 127.0.0.1
     pgbouncer_hosts:
     - 127.0.0.1
+    pgbouncer_pool_size: null
     port: 6432
     query_stats: true
     user: '{{ postgres_users.commcare.username }}'


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-12885

This PR adds the ability to set pgbouncer pool size at the db level, and reduces the auditcare pool size. This will result in a total pool size of 150 (3 machinces * 2 processes * 25 connections), a sharp reduction from the 1000 we currently allow, but still well above our usage except during the outages.

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production