### PR TITLE
set CHECK_REPEATERS_PARTITION_COUNT to 2 in prod

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -135,6 +135,7 @@ localsettings:
   BIGCOUCH: True
   BIGCOUCH_QUORUM_COUNT: 2
   CELERY_REMINDER_CASE_UPDATE_BULK_QUEUE: "reminder_case_update_bulk_queue"
+  CHECK_REPEATERS_PARTITION_COUNT: 2
   COUCH_CACHE_DOCS: True
   COUCH_CACHE_VIEWS: True
   COUCH_REINDEX_SCHEDULE: {'timedelta': {'minutes': 5}}


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-12852

This is a followup to [this PR](https://github.com/dimagi/commcare-hq/pull/28650), which improves our process for queueing repeat records. This sets the partition count used by that improvement. We are going to conservatively start at 2 to ensure we do not overload any part of the system, and carefully bump this value to a point where overdue repeat records are no longer piling up.
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production