### PR TITLE
Fix min/max_wal_size unit to MB

### DIFF
--- a/src/commcare_cloud/commands/terraform/postgresql_units.py
+++ b/src/commcare_cloud/commands/terraform/postgresql_units.py
@@ -78,8 +78,8 @@ UNITS_BY_PARAM = {
     'wal_receiver_status_interval': SECOND,
 
     # Surmised from parameter description in aws console
-    'min_wal_size': BLOCK_16MB,
-    'max_wal_size': BLOCK_16MB,
+    'min_wal_size': MB,
+    'max_wal_size': MB,
 }
 
 


### PR DESCRIPTION
Apparently the unit changed between PostgreSQL 9.6 and 10. Rather than fork it,
I chose to just update the unit to match version 10.

<!--- Provide a link to the ticket or document which prompted this change -->

##### ENVIRONMENTS AFFECTED
aws envs