### PR TITLE
Add enableOpenTracing flag to formplayer_command_args

### DIFF
--- a/environments/staging/app-processes.yml
+++ b/environments/staging/app-processes.yml
@@ -1,4 +1,4 @@
-formplayer_command_args: '-javaagent:/home/cchq/dd-java-agent.jar'
+formplayer_command_args: '-javaagent:/home/cchq/dd-java-agent.jar -Dsrc.main.java.org.javarosa.enableOpenTracing=true'
 management_commands:
   celery3:
     run_sms_queue:


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/USH-1403

This adds a flag to enable/disable OpenTracing globally so we can limit it to staging.

See conversation on https://github.com/dimagi/commcare-core/pull/1063

This can be merged any time but will not be read until https://github.com/dimagi/commcare-core/pull/1063 is merged.

##### ENVIRONMENTS AFFECTED
staging
