### PR TITLE
Lower connection limits for auditcare

### DIFF
--- a/environments/production/postgresql.yml
+++ b/environments/production/postgresql.yml
@@ -78,7 +78,7 @@ dbs:
   auditcare:
     host: rds_pgauditcare0
     pgbouncer_endpoint: pgmain_nlb
-    pgbouncer_pool_size: 8
+    pgbouncer_pool_size: 16
     pgbouncer_hosts:
       - pgbouncer5
       - pgbouncer6

--- a/environments/production/postgresql.yml
+++ b/environments/production/postgresql.yml
@@ -78,7 +78,7 @@ dbs:
   auditcare:
     host: rds_pgauditcare0
     pgbouncer_endpoint: pgmain_nlb
-    pgbouncer_pool_size: 50
+    pgbouncer_pool_size: 8
     pgbouncer_hosts:
       - pgbouncer5
       - pgbouncer6

--- a/environments/production/postgresql.yml
+++ b/environments/production/postgresql.yml
@@ -78,7 +78,7 @@ dbs:
   auditcare:
     host: rds_pgauditcare0
     pgbouncer_endpoint: pgmain_nlb
-    pgbouncer_pool_size: 16
+    pgbouncer_pool_size: 8
     pgbouncer_hosts:
       - pgbouncer5
       - pgbouncer6


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
We have 3 pgbouncer machines, so this limits connections from 150 (3 * 50) to 48 (3 * 16), in an effort to make sure that at the limit, the machine is still functional.

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production