### PR TITLE
replacing rds_pgsynclog0 with rds_pgsynclog1 rds instance in yaml

### DIFF
--- a/environments/production/postgresql.yml
+++ b/environments/production/postgresql.yml
@@ -1,4 +1,4 @@
-DEFAULT_POSTGRESQL_HOST: rds_pgsynclog0
+DEFAULT_POSTGRESQL_HOST: rds_pgsynclog1
 
 postgres_override:
   allow_dump_from_pgstandby: yes
@@ -67,7 +67,7 @@ dbs:
       - pgbouncer9
     query_stats: True
   synclogs:
-    host: rds_pgsynclog0
+    host: rds_pgsynclog1
     pgbouncer_endpoint: pgsynclogs_nlb
     pgbouncer_hosts:
       - pgbouncer5


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-12493
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production.

replacing rds_pgsynclog0 with rds_pgsynclog1 rds instance in PostgreSQL configurations. This task is already completed. 
@dannyroberts @shyamkumarlchauhan could you please merge this PR? 
Thanks