### PR TITLE
terminating pgsynclog0 rds instance

### DIFF
--- a/environments/production/aws-resources.yml
+++ b/environments/production/aws-resources.yml
@@ -229,7 +229,6 @@ pgshard3-production: pgshard3-production.cl9dmuo3ok4h.us-east-1.rds.amazonaws.co
 pgshard4-production: pgshard4-production.cl9dmuo3ok4h.us-east-1.rds.amazonaws.com
 pgshard5-production: pgshard5-production.cl9dmuo3ok4h.us-east-1.rds.amazonaws.com
 pgshard_nlb-production: pgshard-nlb-production-46239ca59f830bfc.elb.us-east-1.amazonaws.com
-pgsynclog0-production: pgsynclog0-production.cl9dmuo3ok4h.us-east-1.rds.amazonaws.com
 pgsynclog1-production: pgsynclog1-production.cl9dmuo3ok4h.us-east-1.rds.amazonaws.com
 pgsynclogs_nlb-production: pgsynclogs-nlb-production-a0590d45cd55994b.elb.us-east-1.amazonaws.com
 pgucr0-production: pgucr0-production.cl9dmuo3ok4h.us-east-1.rds.amazonaws.com

--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -139,9 +139,6 @@ pgshard4-production.cl9dmuo3ok4h.us-east-1.rds.amazonaws.com
 [rds_pgshard5]
 pgshard5-production.cl9dmuo3ok4h.us-east-1.rds.amazonaws.com
 
-[rds_pgsynclog0]
-pgsynclog0-production.cl9dmuo3ok4h.us-east-1.rds.amazonaws.com
-
 [rds_pgsynclog1]
 pgsynclog1-production.cl9dmuo3ok4h.us-east-1.rds.amazonaws.com
 
@@ -175,7 +172,6 @@ rds_pgshard2
 rds_pgshard3
 rds_pgshard4
 rds_pgshard5
-rds_pgsynclog0
 rds_pgsynclog1
 rds_pgauditcare0
 

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -59,8 +59,6 @@ mobile_webworkers
 
 {{ __rds_pgshard5__ }}
 
-{{ __rds_pgsynclog0__ }}
-
 {{ __rds_pgsynclog1__ }}
 
 {{ __rds_pgauditcare0__ }}
@@ -86,7 +84,6 @@ rds_pgshard2
 rds_pgshard3
 rds_pgshard4
 rds_pgshard5
-rds_pgsynclog0
 rds_pgsynclog1
 rds_pgauditcare0
 

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -443,26 +443,6 @@ rds_instances:
       log_min_duration_statement: -1
       max_connections: "LEAST({DBInstanceClassMemory/9531392},5000)"
 
-  - identifier: "pgsynclog0-production"
-    instance_type: "db.m5.2xlarge"
-    storage: 1000
-    max_storage: 60500
-    multi_az: true
-    engine_version: "10.17"
-    params:
-      shared_preload_libraries: pg_stat_statements,pg_transport
-      pg_transport.work_mem: 131072
-      pg_transport.timing: 1
-      max_worker_processes: 40
-      pg_transport.num_workers: 8
-      track_io_timing: 1
-      work_mem: 2457kB
-      shared_buffers: 3840MB
-      effective_cache_size: 11520MB
-      maintenance_work_mem: 960MB
-      max_connections: "LEAST({DBInstanceClassMemory/9531392},5000)"
-      vacuum_cost_limit: 2000
-
   - identifier: "pgsynclog1-production"
     instance_type: "db.m5.2xlarge"
     storage: 5000


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-12493
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production

We have recently replaced this rds instance with new one `pgsynclog1`. And also stopped `pgsynclog0` instance yesterday. Now, we are planning to terminate the old instance.