### PR TITLE
Revert "Lower the pgbouncer reserve pool size for auditcare db"

### DIFF
--- a/environments/production/postgresql.yml
+++ b/environments/production/postgresql.yml
@@ -80,7 +80,6 @@ dbs:
     host: rds_pgauditcare0
     pgbouncer_endpoint: pgmain_nlb
     pgbouncer_pool_size: 8
-    pgbouncer_reserve_pool_size: 2
     pgbouncer_hosts:
       - pgbouncer5
       - pgbouncer6


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-12885


This reverts commit a765a68e24fee1fda7d02b753786ac4a0e2ab77b.

This commit from https://github.com/dimagi/commcare-cloud/pull/5111 appears to have caused serious problems for reasons I don't fully understand. Reverting it should make the rest of that PR safe to apply.

##### ENVIRONMENTS AFFECTED
Production