### PR TITLE
Update public.yml file ALTERNATE_HOSTS

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -25,6 +25,7 @@ soft_assert_email: commcarehq-ops+soft_asserts@dimagi.com
 new_domain_email: inquiries@dimagi.com
 ALTERNATE_HOSTS:
   - rec-mobile.sante.gov.bf
+  - commcare.health.gov.mw
 
 DATADOG_ENABLED: True
 


### PR DESCRIPTION
Update made to `ALTERNATE_HOSTS` to allow for proxy URLs to be used on mobile devices in preparation for the data migration for the onse-iss domain (instructions [here](https://commcare-cloud.readthedocs.io/en/latest/reference/howto/transfer-domain.html)).

##### ENVIRONMENTS AFFECTED
Production
