### PR TITLE
Fix table def

### DIFF
--- a/docs/Commcare_Ports_information.md
+++ b/docs/Commcare_Ports_information.md
@@ -1,16 +1,16 @@
-|Process|Port|Internal<br>Access|External<br>Access|Allow in Iptables?<br><sub>Monolith Env</sub>|Allow in Iptables?<br><sub>Non-Monolith OR<br>On-Premises Env</sub>|Comments|
-|:--|:--|:--|:--|:--|:--|:--|
-|SSH|22|yes|Restricted<br>IPaddress|yes|yes||
-|Nginx https| 443 |-|yes|yes|yes|           |
-|Nginx http| 80 |-|yes|yes|yes||
-|Monolith Commcare|9010|yes|no|no|depends |<sub>routed via nginx </sub>|
-|Formplayer|8181|yes|no|no|depends|<sub>Accessible to private network</sub>|
-|Kafka|9092|yes|no|no|depends|<sub>Accessible to private network</sub>|
-|Zookeeper|2181|yes|no|no|depends|<sub>Accessible to private network</sub>|
-|Redis|6379|yes|no|no|depends|<sub>Accessible to private network</sub>|
-|PostgreSQL<br>PgBouncer|5432<br>6432|yes|no|no|depends|<sub>Accessible to private network</sub>|
-|RabbitMQ   | 5672|  yes|  no |  no   |  depends |<sub>Accessible to private network</sub>|
-|ElasticSearch <br> ES Cluster | 9200 <br> 9300 |  yes|  no |  no   |  depends |<sub>Accessible to private network</sub>|
-|CouchDB    | 5984<br>4369  |  yes|  no |  no   |  depends |<sub>Accessible to private network</sub>|
-|Celery port          |      |    |  no |  no   |          |           |
-|Mail/SMTP ports      | 25<br>465<br>587      |    |  yes         |  no   |          |           |
+| Process                  | Port       | Internal Access | External Access      | Allow in Iptables? Monolith Env | Allow in Iptables? Non-Monolith OR On-Premises Env | Comments                      |
+|--------------------------|------------|-----------------|----------------------|---------------------------------|----------------------------------------------------|-------------------------------|
+| SSH                      | 22         | yes             | Restricted IPaddress | yes                             | yes                                                |                               |
+| Nginx https              | 443        | -               | yes                  | yes                             | yes                                                |                               |
+| Nginx http               | 80         | -               | yes                  | yes                             | yes                                                |                               |
+| Monolith Commcare        | 9010       | yes             | no                   | no                              | depends                                            | routed via nginx              |
+| Formplayer               | 8181       | yes             | no                   | no                              | depends                                            | Accessible to private network |
+| Kafka                    | 9092       | yes             | no                   | no                              | depends                                            | Accessible to private network |
+| Zookeeper                | 2181       | yes             | no                   | no                              | depends                                            | Accessible to private network |
+| Redis                    | 6379       | yes             | no                   | no                              | depends                                            | Accessible to private network |
+| PostgreSQL PgBouncer     | 5432 6432  | yes             | no                   | no                              | depends                                            | Accessible to private network |
+| RabbitMQ                 | 5672       | yes             | no                   | no                              | depends                                            | Accessible to private network |
+| ElasticSearch ES Cluster | 9200 9300  | yes             | no                   | no                              | depends                                            | Accessible to private network |
+| CouchDB                  | 5984 4369  | yes             | no                   | no                              | depends                                            | Accessible to private network |
+| Celery port              |            |                 | no                   | no                              |                                                    |                               |
+| Mail/SMTP ports          | 25 465 587 |                 | yes                  | no                              |                                                    |                               |


### PR DESCRIPTION
The table definition for the CommCare Ports table seemed to be broken (no biggy, it's available [here](https://github.com/dimagi/commcare-cloud/blob/master/docs/Commcare_Ports_information.md)), but this is the fix.

##### ENVIRONMENTS AFFECTED
This is docs, so none.