### PR TITLE
Lower the pgbouncer pool size (reserve & normal) for auditcare db

### DIFF
--- a/environments/production/postgresql.yml
+++ b/environments/production/postgresql.yml
@@ -79,7 +79,7 @@ dbs:
   auditcare:
     host: rds_pgauditcare0
     pgbouncer_endpoint: pgmain_nlb
-    pgbouncer_pool_size: 8
+    pgbouncer_pool_size: 6
     pgbouncer_reserve_pool_size: 2
     pgbouncer_hosts:
       - pgbouncer5

--- a/environments/production/postgresql.yml
+++ b/environments/production/postgresql.yml
@@ -80,6 +80,7 @@ dbs:
     host: rds_pgauditcare0
     pgbouncer_endpoint: pgmain_nlb
     pgbouncer_pool_size: 8
+    pgbouncer_reserve_pool_size: 2
     pgbouncer_hosts:
       - pgbouncer5
       - pgbouncer6


### PR DESCRIPTION
This reverts commit 6017d3d96441c5a43303729dd39bf20ffddb6e66.

https://dimagi-dev.atlassian.net/browse/SAAS-12885

This will lower the normal pool size to 18 and the reserve pool size to 6, total. That would put the max "burst" connection limit at 24, which is the current size of the "normal" pool.

##### ENVIRONMENTS AFFECTED
Production