### PR TITLE
Enable Enhanced Monitoring on pgauditcare0-production RDS instance

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -483,7 +483,6 @@ rds_instances:
     engine_version: "10.17"
     backup_window: "23:00-01:00"
     backup_retention: 7
-    monitoring_interval: 0
     enable_cross_region_backup: true
     params:
       shared_preload_libraries: pg_stat_statements


### PR DESCRIPTION
This was one of AWS Supports suggestions in https://dimagi-dev.atlassian.net/browse/SAAS-12885

```
  # module.postgresql__pgauditcare0-production.module.postgresql.module.db_instance.aws_db_instance.this[0] will be updated in-place
  ~ resource "aws_db_instance" "this" {
      ...
      ~ monitoring_interval                   = 0 -> 60
      ...
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```
##### ENVIRONMENTS AFFECTED
production