### PR TITLE
Correctly identify the celery host for datadog

### DIFF
--- a/src/commcare_cloud/ansible/roles/datadog/defaults/main.yml
+++ b/src/commcare_cloud/ansible/roles/datadog/defaults/main.yml
@@ -4,7 +4,7 @@ datadog_custom_integrations:
   - name: celery
     url: https://raw.githubusercontent.com/dimagi/datadog-checks/90abf6a347348c78bcca8d908ee2e3d31b77bd26/celery/celery.py
     sha256sum: 492362bde07d16d1f4664ef84a0bba971b75fa46156e90501fedf8310b651661
-    enabled: "{{ inventory_hostname == groups.celery[0] }}"
+    enabled: "{{ app_processes_config.celery_processes.get(inventory_hostname).flower is defined }}"
   - name: shell
     url: https://raw.githubusercontent.com/dimagi/datadog-checks/a468595913fa30abeea0bb3bba16448157871481/shell/shell.py
     sha256sum: ff6933fedded6c169a7dbfc4d962595250ec9b6586752648f8df848c7183ad10

--- a/src/commcare_cloud/ansible/roles/datadog/tasks/add_integrations.yml
+++ b/src/commcare_cloud/ansible/roles/datadog/tasks/add_integrations.yml
@@ -37,7 +37,7 @@
     - {"name": "redisdb", "enabled": "{{ datadog_integration_redisdb }}"}
     - {"name": "zk", "enabled": "{{ datadog_integration_zk }}"}
     - {"name": "jmx", "enabled": "{{ datadog_integration_jmx }}"}
-    - {"name": "celery", "enabled": "{{ inventory_hostname == groups.celery[0] }}"}
+    - {"name": "celery", "enabled": "{{ app_processes_config.celery_processes.get(inventory_hostname).flower is defined }}"}
     - {"name": "couch", "enabled": "{{ inventory_hostname == couchdb2_first_host }}"}
     - {"name": "couch_custom", "enabled": "{{ inventory_hostname == couchdb2_first_host }}"}
     - {"name": "shell", "enabled": "{{ datadog_integration_vmware }}"}

--- a/src/commcare_cloud/ansible/roles/datadog/tasks/remove_integrations.yml
+++ b/src/commcare_cloud/ansible/roles/datadog/tasks/remove_integrations.yml
@@ -30,7 +30,7 @@
     - {"name": "redisdb", "enabled": "{{ datadog_integration_redisdb }}"}
     - {"name": "zk", "enabled": "{{ datadog_integration_zk }}"}
     - {"name": "jmx", "enabled": "{{ datadog_integration_jmx }}"}
-    - {"name": "celery", "enabled": "{{ inventory_hostname == groups.celery[0] }}"}
+    - {"name": "celery", "enabled": "{{ app_processes_config.celery_processes.get(inventory_hostname).flower is defined }}"}
     - {"name": "couch", "enabled": "{{ inventory_hostname == couchdb2_first_host }}"}
     - {"name": "couch_custom", "enabled": "{{ inventory_hostname == couchdb2_first_host }}"}
     - {"name": "http_check", "enabled": "{{ datadog_integration_http and inventory_hostname == groups.proxy[0] }}"}


### PR DESCRIPTION
With multiple subgroups under the main celery group, the old syntax to
choose the celery host where to install the datadog agent stops working.

Let's explicitly select the one where flower is running.

https://dimagi-dev.atlassian.net/browse/SAAS-12911

##### ENVIRONMENTS AFFECTED
All
