### PR TITLE
Temporarily add celery queues to Staging

### DIFF
--- a/environments/staging/app-processes.yml
+++ b/environments/staging/app-processes.yml
@@ -29,10 +29,15 @@ celery_processes:
     sms_queue:
       pooling: gevent
       concurrency: 4
+    sumologic_logs_queue:
+      pooling: gevent
+      concurrency: 1
     ucr_queue:
       concurrency: 1
     user_import_queue:
       concurrency: 3
+    ush_background_tasks:
+      concurrency: 1
     malt_generation_queue:
       concurrency: 1
     flower: {}


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

This is part of the [broad pickle removal efforts](https://dimagi-dev.atlassian.net/browse/SAAS-11385), specifically focusing on the reports and phonelog apps. These apps have tasks that use dedicated celery queues and need them for proper testing on staging (QA). 

Unless there's a reason staging didn't have/support these queues, I could also keep these changes after testing. 

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->

Staging