### PR TITLE
Temporarily bump concurrency to help swiss get through a backlog

### DIFF
--- a/environments/swiss/app-processes.yml
+++ b/environments/swiss/app-processes.yml
@@ -17,7 +17,7 @@ celery_processes:
     email_queue,reminder_rule_queue:
       concurrency: 1
     malt_generation_queue:
-      concurrency: 1
+      concurrency: 2
     beat: {}
     saved_exports_queue:
       concurrency: 1


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Just noticed [this](https://app.datadoghq.com/dashboard/bdu-k5b-bz5/celery-overview?fullscreen_end_ts=1644537853285&fullscreen_paused=false&fullscreen_section=overview&fullscreen_start_ts=1641859453285&fullscreen_widget=185712938&tpl_var_celery_queue=malt_generation_queue&tpl_var_environment=swiss&from_ts=1641859450000&to_ts=1644537850000&live=true), which was due to a blocking task that creates subtasks it depends on on the same queue (has since been resolved), but when concurrency is 1 and there is only 1 worker, this is no good. 

Bumping concurrency temporarily should relive this issue.
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Swiss