### PR TITLE
Revert "Temporarily bump concurrency to help swiss get through a backlog"

### DIFF
--- a/environments/swiss/app-processes.yml
+++ b/environments/swiss/app-processes.yml
@@ -17,7 +17,7 @@ celery_processes:
     email_queue,reminder_rule_queue:
       concurrency: 1
     malt_generation_queue:
-      concurrency: 2
+      concurrency: 1
     beat: {}
     saved_exports_queue:
       concurrency: 1


### PR DESCRIPTION
Reverts dimagi/commcare-cloud#5149

[Problem solved](https://app.datadoghq.com/dashboard/bdu-k5b-bz5/celery-overview?fullscreen_end_ts=1644539248000&fullscreen_paused=false&fullscreen_section=overview&fullscreen_start_ts=1644535648000&fullscreen_widget=185712938&tpl_var_celery_queue=malt_generation_queue&tpl_var_environment=swiss&from_ts=1644537387904&to_ts=1644539187904&live=true), and [this PR](https://github.com/dimagi/commcare-hq/pull/31068) ensures the blocking task does not live on the same queue as the tasks is spawns/waits for. In hindsight I probably could have just restarted the worker, but at least this serves as a better historical record. 

Effects Swiss only.