### PR TITLE
fixed incorrect variable and task missing when condition

### DIFF
--- a/src/commcare_cloud/ansible/roles/zookeeper/defaults/main.yml
+++ b/src/commcare_cloud/ansible/roles/zookeeper/defaults/main.yml
@@ -3,5 +3,5 @@ apache_mirror: apache.osuosl.org
 zookeeper_data_dir: "/var/lib/zookeeper"
 zookeeper_conf_dir: "/etc/zookeeper/conf"
 zookeeper_log_dir: "/var/log/zookeeper"
-zookeeper_server_id: "{{ kafka_server_id }}"
+zookeeper_server_id: "{{ kafka_broker_id }}"
 zookeeper_cluster: False

--- a/src/commcare_cloud/ansible/roles/zookeeper/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/zookeeper/tasks/main.yml
@@ -12,8 +12,13 @@
   template: src=myid.j2 dest="{{ zookeeper_data_dir }}/myid"
   tags: zookeeper_cluster_conf
 
+- name: Create Kafka conf directory
+  file: path="{{ zookeeper_data_dir }}/conf" state=directory owner=root group=root mode=755
+  when: zookeeper_cluster
+
 - name: configure Zookeeper properties
   template: src=zoo.cfg.j2 dest="{{ zookeeper_data_dir }}/conf/zoo.cfg"
+  when: zookeeper_cluster
   tags: zookeeper_cluster_conf
 
 # Allows to excecute task only when a tag is specified: https://serverfault.com/a/748864


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All.

We are facing the below error due to an incorrect variable set to `zookeeper_server_id`. I have corrected it and also add when the condition to ignore tasks when `zookeeper_cluster: False`