### PR TITLE
Increase celery hard kill timeout

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -210,9 +210,9 @@ kinesis_flows:
 
 enable_cloudwatch_logs: true
 
-# celery variables to soft/hard kill tasks running for long hours.
-# hard_kill: 46, soft_kill: 36, False will remove the cron.
-celery_hours_before_hard_kill: 46
+# celery variables to soft/hard kill workers running for long hours.
+# hard_kill: 72, soft_kill: 36, False will remove the cron.
+celery_hours_before_hard_kill: 72
 celery_hours_before_soft_kill: 36
 
 efs_shared_mount_dir: "shared{{ '_' ~ deploy_env if deploy_env != 'production' else '' }}"


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-12956

Only kill celery workers after waiting 36 hours for their last task to finish, rather than current 10

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production