### PR TITLE
Add --skip-check to command

### DIFF
--- a/docs/howto/wipe_persistent_data.md
+++ b/docs/howto/wipe_persistent_data.md
@@ -54,7 +54,7 @@ Rebuilding environment
 
 2. Run Ansible playbook to recreate databases
 
-       $ cchq monolith ap deploy_db.yml
+       $ cchq monolith ap deploy_db.yml --skip-check
 
 3. Run management commands to create Kafka topics, create Postgres
    tables, and Elasticsearch indices.


### PR DESCRIPTION
Add the `--skip-check` flag to command which is used to recreate the db's after a db wipe.

##### ENVIRONMENTS AFFECTED
This change only concerns the docs