### PR TITLE
Cs/sc 1918 restore docs

### DIFF
--- a/docs/commcare-cloud/backup.md
+++ b/docs/commcare-cloud/backup.md
@@ -229,8 +229,12 @@ The `blobdb` is our binary data store.
 BlobDB backups create a compressed version of the blobdb data directory.
 
 ### Restoring BlobDB Backups
-The BlobDB restore process is the same as the couchdb restore process in that it involves extracting the backed up data
-to the data directory.
+The BlobDB restore process depends on what BlobDB system you're using.
+- If you're using the default file system BlobDB, the restore process is the same as the couchdb restore process in that it involves extracting the backed up data 
+to the data directory. 
+- If you're using some other (distributed) system you should follow that service's provided instructions on restoration.
+
+The file system BlobDB restore process will be explained below.
 
 - Become the `cchq` user
   ``` bash

--- a/docs/commcare-cloud/backup.md
+++ b/docs/commcare-cloud/backup.md
@@ -66,7 +66,7 @@ PostgreSQL backups are made daily and weekly. Old backups are deleted from the l
 After [adding your credentials](#amazon-s3-credentials) to the vault file, set:
 
 - `postgres_s3: True`
-- `postgres_snapshot_bucket`: The name of the S3 bucket to save postgres backups to (Default: `dimagi-<env>-posgres-backups`).
+- `postgres_snapshot_bucket`: The name of the S3 bucket to save postgres backups to (Default: `dimagi-<env>-postgres-backups`).
 
 ### Restoring PostgreSQL Backups
 
@@ -90,8 +90,8 @@ For example, you can follow a process similar to this one:
     ``` bash
     $ su - ansible
     # enter ansible user password from vault file
-    $ sudo -u posgres bash
-    # enter ansible user password again. You will now be acting as the posgres user
+    $ sudo -u postgres bash
+    # enter ansible user password again. You will now be acting as the postgres user
     ```
 
 - Find the list of current backups and choose the one you want to restore from, for e.g.:
@@ -106,19 +106,19 @@ For example, you can follow a process similar to this one:
     ```
 - Uncompress the one you want:
     ``` bash
-    $ tar -xjf /opt/data/backups/posgresql/postgres_<env>_daily_2019_07_06.gz -C /opt/data/backups/postgresql
+    $ tar -xjf /opt/data/backups/postgresql/postgres_<env>_daily_2019_07_06.gz -C /opt/data/backups/postgresql
     ```
     
 - [Optional] Make a copy of the current data directory, for eg:
 
     ```bash
-    $ tar -czvf /opt/data/backups/postgresql/postgres_data_before_restore.tar.gz /opt/data/posgresql/9.6/main
+    $ tar -czvf /opt/data/backups/postgresql/postgres_data_before_restore.tar.gz /opt/data/postgresql/9.6/main
     ```
 
 -  Copy backup data to the postgres data directory. This will overwrite all the data in this directory.
 
     ``` bash
-    $ rsync -avz --delete /opt/data/backups/posgresql/postgres_<env>_daily_2019_07_06 /opt/data/posgresql/9.6/main
+    $ rsync -avz --delete /opt/data/backups/postgresql/postgres_<env>_daily_2019_07_06 /opt/data/postgresql/9.6/main
     ```
 
 - Restart Postgres and services, from the control machine, e.g.:

--- a/docs/commcare-cloud/backup.md
+++ b/docs/commcare-cloud/backup.md
@@ -229,10 +229,25 @@ The `blobdb` is our binary data store.
 BlobDB backups create a compressed version of the blobdb data directory.
 
 ### Restoring BlobDB Backups
+The BlobDB restore process is the same as the couchdb restore process in that it involves extracting the backed up data
+to the data directory.
 
-You can follow the same instructions as for [restoring couchdb](#restoring-couchdb-backups) (extract the backup file into the blobdb data directory: `/opt/data/blobdb/`). 
+- Become the `cchq` user
+  ``` bash
+  $ sudo -iu cchq
+  ```
 
-The files in the resulting directory should all be owned by the user `cchq` (i.e. you should be the `cchq` user when extracting the files)
+- Now we need to extract the backup data. The BlobDB backups live in the `/opt/data/backups/blobdb` directory by default (if you have specified a different path
+in the `public.yml` file, it will be there instead).
+  ``` bash
+  $ tar -xf /opt/data/backups/blobdb/blobdb_<version>.gz -C /opt/data/backups/blobdb
+  ```
+
+- Move the data to the `/opt/data/blobdb/` directory. 
+  ``` bash
+  $ rsync -avz --delete /opt/data/backups/blobdb/blobdb_<version> /opt/data/blobdb/
+  ```
+
 
 ## Elasticsearch Snapshots
 


### PR DESCRIPTION
[Ticket](https://dimagi-dev.atlassian.net/browse/SC-1918)

Although the changes to the docs are minimal (fixing spelling mistakes and expounding a bit on BlobDB restore), the process to get to that point has taken me a significant amount of time. The main reason being that I, in order to test the restore process, had to 
- spin up a monolith instance
- import some data to it; used my production (dummy) data
- ensure backups are made
- finally restore PostgreSQL, CouchDB and BlobDB (didn't go through Elasticsearch as it can easily be rebuilt)

By going through this more elaborate process above, I was able to uncover a few other issues along the way.

##### ENVIRONMENTS AFFECTED
This only affects the docs.
