### PR TITLE
Increase celery volume size

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -231,7 +231,7 @@ servers:
     server_instance_type: r5.2xlarge
     network_tier: "app-private"
     az: "c"
-    volume_size: 80
+    volume_size: 120
     group: "celery"
     os: ubuntu_pro_bionic
     count: 4


### PR DESCRIPTION
Increase celery_c machines volume size from 80GB to 120GB.

https://dimagi-dev.atlassian.net/browse/SAAS-13215

##### ENVIRONMENTS AFFECTED
Production
