### PR TITLE
Fix format statement for COMMCARE_CLOUD_DEFAULT_USERNAME_ENV_VAR_MESSAGE

### DIFF
--- a/src/commcare_cloud/user_utils.py
+++ b/src/commcare_cloud/user_utils.py
@@ -48,7 +48,7 @@ in your profile to never have to type that in again! 🌈
 
 
 def print_help_message_about_the_commcare_cloud_default_username_env_var(username):
-    puts(color_notice(COMMCARE_CLOUD_DEFAULT_USERNAME_ENV_VAR_MESSAGE.format(username)))
+    puts(color_notice(COMMCARE_CLOUD_DEFAULT_USERNAME_ENV_VAR_MESSAGE.format(username=username)))
 
 
 @memoized


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

While trying run `cchq <env> terraform` commands I noticed that if your username on the AWS machines is different than your dev workstation username, the message that prompts you to run `export COMMCARE_CLOUD_DEFAULT_USERNAME={AWS machine username}` would give an error and exit the process. 

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None