### PR TITLE
changing postgres_version default value to 9.6 from 10 in ansible Roles

### DIFF
--- a/environments/india/postgresql.yml
+++ b/environments/india/postgresql.yml
@@ -11,6 +11,7 @@ pgbouncer_override:
   pgbouncer_reserve_pool: 5
 
 postgres_override:
+  postgresql_version: '10'
   postgresql_max_connections: 300
   postgresql_hba_entries:
     # required for backup

--- a/src/commcare_cloud/ansible/roles/common_installs/defaults/main.yml
+++ b/src/commcare_cloud/ansible/roles/common_installs/defaults/main.yml
@@ -1,2 +1,2 @@
-postgresql_version: '10'
+postgresql_version: '9.6'
 use_chrony: False

--- a/src/commcare_cloud/ansible/roles/pg_backup/defaults/main.yml
+++ b/src/commcare_cloud/ansible/roles/pg_backup/defaults/main.yml
@@ -1,4 +1,4 @@
-postgresql_version: '10'
+postgresql_version: '9.6'
 postgresql_port: 5432
 postgresql_backup_dir: "{{ encrypted_root }}/backups/postgresql"
 postgresql_user_home: /var/lib/postgresql

--- a/src/commcare_cloud/ansible/roles/postgresql_base/defaults/main.yml
+++ b/src/commcare_cloud/ansible/roles/postgresql_base/defaults/main.yml
@@ -1,4 +1,4 @@
-postgresql_version: '10'
+postgresql_version: '9.6'
 postgresql_cluster_name: 'main'
 postgresql_port: 5432
 postgresql_ssl_enabled: False


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-12875
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All.

Since my previous modification to default values will impact third-party users who have not yet updated the PostgreSQL version to 10. Therefore reverting back my changes to default values and as we can also control this variable from public.yml `postgresql_version: '9.6'` updated India files and production will do when performing it. 

Old PR: https://github.com/dimagi/commcare-cloud/pull/5062
