### PR TITLE
net-tools not in Ubuntu 18.04.6 LTS by default

### DIFF
--- a/src/commcare_cloud/ansible/roles/ufw/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/ufw/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: "make sure the specified private interface actually exists"
   # a bit of a hack, but just hopefully prevents turning off access on all interfaces!
-  shell: "ifconfig | grep {{ ufw_private_interface }}"
+  shell: "ip addr show dev {{ ufw_private_interface }}"
   changed_when: no
 
 - name: allow incoming traffic on private interface

--- a/src/commcare_cloud/ansible/roles/ufw/tasks/proxy_ufw.yml
+++ b/src/commcare_cloud/ansible/roles/ufw/tasks/proxy_ufw.yml
@@ -1,6 +1,6 @@
 - name: "make sure the specified private interface actually exists"
   # a bit of a hack, but just hopefully prevents turning off access on all interfaces!
-  shell: "ifconfig | grep {{ ufw_private_interface }}"
+  shell: "ip addr show dev {{ ufw_private_interface }}"
   changed_when: no
 
 # Rules for proxies


### PR DESCRIPTION
From Ubuntu 18.04.6 LTS, users must install the net-tools package to use `ifconfig`. It is deprecated in favor of `ip`.

This change uses `ip` instead of `ifconfig`.

Stupidly, I tested the happy path first, and now I can't go back to test the unhappy path (an incorrectly configured interface) on that particular VM. I have not yet tested the unhappy path on a new VM. But I figured I'd open the PR in the meantime. (I do expect it to work though. `ip addr show dev invaliddevice` returns nothing to STDOUT, and an error message to STDERR.)

##### ENVIRONMENTS AFFECTED

Affects new environments, and provisioning new VMs in existing environments, when VMs have a fresh Ubuntu 18.04 image.
