### PR TITLE
fixed zookeeper user error

### DIFF
--- a/src/commcare_cloud/ansible/roles/zookeeper/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/zookeeper/tasks/main.yml
@@ -15,6 +15,12 @@
     state: absent
   when: zookeeper_cluster
 
+- name: create zookeeper group
+  group: name="{{ zookeeper_group }}" system=yes state=present
+
+- name: add user "zookeeper"
+  user: name="{{ zookeeper_group }}" group="{{ zookeeper_group }}" shell=/sbin/nologin system=yes state=present
+
 - name: Download Zookeeper
   get_url:
     url: "https://archive.apache.org/dist/zookeeper/zookeeper-{{ zookeeper_version }}/zookeeper-{{ zookeeper_version }}.tar.gz"


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-12484
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All new envs

The commcare installation is failing with the following error in the new environments.
```
"fatal: [172.31.22.36]: FAILED! => {\\"changed\\": false, \\"gid\\": 0, \\"group\\": \\"root\\", \\"mode\\": \\"0755\\", \\"msg\\": \\"chown failed: failed to look up user zookeeper\\", \\"owner\\": \\"root\\", \\"path\\": \\"/opt/zookeeper/logs\\", \\"size\\": 4096, \\"state\\": \\"directory\\", \\"uid\\": 0}",
```
This is happening in new installations only. The existing servers wherein zookeeper is already installed using `apt` has user, group created automatically. Zip file-based installation doesn't get created by default so faced this issue. Sorry for the inconvenience. 
@proteusvacuum please review and let me know your suggestions. Tested the changes on a server and it worked 

![image](https://user-images.githubusercontent.com/11612356/159254658-48400a26-4bb4-4f04-a37d-76a2107457a6.png)

