### PR TITLE
Make sure the log directory exists

### DIFF
--- a/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
@@ -1,3 +1,6 @@
+- name: Make sure the log directory exists
+  import_tasks: roles/commcarehq/tasks/www_log_dir.yml
+
 - name: Install formplayer packages
   become: yes
   apt:


### PR DESCRIPTION
To manage Formplayer, Supervisord needs the log directory to exist, otherwise it will not start. But the log directory is not created on a Formplayer-only VM:

    (cluster) cchq@formplayer2:~$ supervisord
    Error: The directory named as part of the path /home/cchq/www/cluster/log/formp
    layer-spring.log does not exist in section 'program:commcare-hq-cluster-formspl
    ayer-spring' (file: '/home/cchq/www/cluster/services/cluster_supervisor_formpla
    yer_spring.conf')
    For help, use /usr/local/bin/supervisord -h

I copied the approach [used for installing nginx](https://github.com/dimagi/commcare-cloud/blob/71f659dbef8d260e076f5eabd1d02eeb524116c5/src/commcare_cloud/ansible/roles/nginx/tasks/install.yml#L67).

##### ENVIRONMENTS AFFECTED

Only affects new deploys where Formplayer is running on its own VM.
