### PR TITLE
Formplaye DB host must trust Formplayer hosts

### DIFF
--- a/src/commcare_cloud/ansible/roles/postgresql_base/templates/pg_hba.conf.j2
+++ b/src/commcare_cloud/ansible/roles/postgresql_base/templates/pg_hba.conf.j2
@@ -57,7 +57,7 @@ host    all             all             127.0.0.1/32            md5
 # IPv6 local connections:
 host    all             all             ::1/128                 md5
 
-
+# Allow connections from PgBouncer hosts
 {% for db in postgresql_dbs.all %}
 {% if db.host == inventory_hostname %}
 {% for host in db.pgbouncer_hosts %}
@@ -67,5 +67,15 @@ host   all	all	{{ host }}/32   trust
 host   all	all	{{ lookup('dig', host, wantlist=True)[0] }}/32	trust
 {% endif %}
 {% endfor %}
+{% if db.name == 'formplayer' %}
+# Allow connections from Formplayer hosts
+{% for host in groups.formplayer %}
+{% if host | ipaddr %}
+host   all	all	{{ host }}/32   trust
+{% else %}
+host   all	all	{{ lookup('dig', host, wantlist=True)[0] }}/32	trust
+{% endif %}
+{% endfor %}
+{% endif %}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
Jira: [SC-2011](https://dimagi-dev.atlassian.net/browse/SC-2011)

Formplayer needs to connect to both PgBouncer and Postgres. Connecting to PgBouncer using the details stored in  **/home/cchq/www/cluster/formplayer_build/current/application.properties** succeeds, but connecting to Postgres fails.

This change adds entries to **pg_hba.conf** to trust Formplayer hosts.

**BEFORE**

Postgres configuration:

    ansible@db1:~$ sudo cat /etc/postgresql/9.6/main/pg_hba.conf
    # ...
    # IPv4 local connections:
    host    all             all             127.0.0.1/32            md5

    # IPv6 local connections:
    host    all             all             ::1/128                 md5

    host   all	all	192.168.122.4/32   trust
    host   all	all	192.168.122.4/32   trust
    host   all	all	192.168.122.4/32   trust
    host   all	all	192.168.122.4/32   trust
    host   all	all	192.168.122.4/32   trust
    host   all	all	192.168.122.4/32   trust
    host   all	all	192.168.122.4/32   trust

Connection attempt:

    cchq@formplayer2:~$ psql -h 192.168.122.4 -p 5432 -U commcarehq -d formplayer
    psql: connection to server at "192.168.122.4", port 5432 failed: FATAL:  no pg_hba.conf entry for host "192.168.122.7", user "commcarehq", database "formplayer", SSL off


**AFTER**

Postgres configuration:

    ansible@db1:~$ sudo cat /etc/postgresql/9.6/main/pg_hba.conf
    # ...
    # IPv4 local connections:
    host    all             all             127.0.0.1/32            md5

    # IPv6 local connections:
    host    all             all             ::1/128                 md5

    # Allow connections from PgBouncer hosts
    host   all	all	192.168.122.4/32   trust
    host   all	all	192.168.122.4/32   trust
    host   all	all	192.168.122.4/32   trust
    host   all	all	192.168.122.4/32   trust
    host   all	all	192.168.122.4/32   trust
    host   all	all	192.168.122.4/32   trust
    host   all	all	192.168.122.4/32   trust
    # Allow connections from Formplayer hosts
    host   all	all	192.168.122.7/32   trust

Connection attempt:

    cchq@formplayer2:~$ psql -h 192.168.122.4 -p 5432 -U commcarehq -d formplayer
    psql (10.20 (Ubuntu 10.20-1.pgdg18.04+1), server 9.6.24)
    Type "help" for help.

    formplayer=> 

Check services:

    (cchq) nhooper@control1:~/commcare-cloud$ cchq cluster django-manage check_services
    ...
    SUCCESS (Took   0.30s) formplayer     : Formplayer returned a 200 status code: https://cluster.commcarehq.local/formplayer/serverup


##### ENVIRONMENTS AFFECTED

Tdh
