### PR TITLE
Add SUMOLOGIC_URL to staging

### DIFF
--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -163,6 +163,7 @@ localsettings:
   REMINDERS_QUEUE_ENABLED: False
   SMS_GATEWAY_URL: 'http://gw1.promessaging.com/sms.php'
   SMS_QUEUE_ENABLED: True
+  SUMOLOGIC_URL: "{{ SUMOLOGIC_URL }}"
   USE_KAFKA_SHORTEST_BACKLOG_PARTITIONER: True
   WS4REDIS_CONNECTION_HOST: "redis.staging.commcare.local"
   ENABLE_NEW_TRIAL_EXPERIENCE: True


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

Part of our [efforts to remove pickles](https://dimagi-dev.atlassian.net/browse/SAAS-11385) from HQ. In order to properly test the changes made to the `phonelog` app on staging, which has one task that handles sending logs to SumoLogic, the endpoint url for the staging needs to be added as a secret. 

The steps for adding secrets [outlined here](https://confluence.dimagi.com/pages/viewpage.action?spaceKey=saas&title=How+to+add+new+secrets+or+other+local+settings) were followed but since the `sumologic_url` for other environments were already in place most of it was already done. 

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Staging