### PR TITLE
lookup deploy version without sudo

### DIFF
--- a/src/commcare_cloud/commands/deploy/commcare.py
+++ b/src/commcare_cloud/commands/deploy/commcare.py
@@ -180,14 +180,14 @@ def call_record_deploy_success(environment, context, end_time):
 
 
 def _get_deployed_version(environment):
-    from fabric.api import cd, sudo
+    from fabric.api import cd, run
 
     def _task():
         with cd(environment.remote_conf.code_current):
-            return sudo('git rev-parse HEAD')
+            return run('git rev-parse HEAD')
 
     host = environment.sshable_hostnames_by_group["django_manage"][0]
-    res = run_fab_task(_task, host, 'ansible', environment.get_ansible_user_password())
+    res = run_fab_task(_task, host, 'ansible')
     return res[host]
 
 

--- a/src/commcare_cloud/commands/utils.py
+++ b/src/commcare_cloud/commands/utils.py
@@ -36,7 +36,7 @@ class PrivilegedCommand():
         return run_fab_task(_task, hosts, self.user_name, self.password, parallel_pool_size=parallel_pool_size)
 
 
-def run_fab_task(task_fn, hosts, username, password, parallel_pool_size=1):
+def run_fab_task(task_fn, hosts, username, password=None, parallel_pool_size=1):
     from fabric.api import execute, env, parallel
     if env.ssh_config_path and os.path.isfile(os.path.expanduser(env.ssh_config_path)):
         env.use_ssh_config = True


### PR DESCRIPTION
When this command was moved out of `fab` the `sudo` function changed from `sudo -u cchq` to just plain `sudo`, and there is no need to be root to get the latest commit hash. This has the added bonus of no longer requiring the swiss vault password to deploy swiss, which should never have been necessary.