### PR TITLE
Update pip in common_installs

### DIFF
--- a/src/commcare_cloud/ansible/roles/common_installs/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/common_installs/tasks/main.yml
@@ -125,7 +125,6 @@
       - sh
       - httplib2
       - pexpect
-    executable: pip3
     umask: "0022"
   become: yes
 
@@ -134,5 +133,4 @@
   pip:
     name: virtualenv-clone
     version: 0.5.1
-    executable: pip3
     umask: "0022"

--- a/src/commcare_cloud/ansible/roles/couchdb2-preinstall/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/couchdb2-preinstall/tasks/main.yml
@@ -13,9 +13,6 @@
   debug:
     var: couchdb_version_current
 
-- name: Update setuptools
-  pip: name=setuptools state=latest
-
 - name: Install ndg-httpsclient so we can download couch
   pip:
     name:

--- a/src/commcare_cloud/ansible/roles/python/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/python/tasks/main.yml
@@ -1,7 +1,22 @@
+# This role is declared as a dependency in common_installs/meta/main.yml.
+# It allows all other roles to use the latest setuptools and pip
+# executable for Python 3.6. This is the version of Python that Ansible
+# is running on, and Ansible's default pip executable.
+---
+
 - name: Install Python packages
   become: yes
   apt:
     name:
-      - python3-pip
+      - python3-pip  # Creates /usr/bin/pip3
       - python3-dev
       - python3-setuptools
+
+- name: Update pip & setuptools
+  become: yes
+  pip:
+    name:
+      - pip  # Creates/updates /usr/local/bin/pip
+      - setuptools
+    state: latest
+    executable: pip3  # Use /usr/bin/pip3 this time only

--- a/src/commcare_cloud/ansible/roles/sentry/tasks/snuba.yml
+++ b/src/commcare_cloud/ansible/roles/sentry/tasks/snuba.yml
@@ -11,11 +11,6 @@
     path: "{{ snuba_virtualenv_path }}"
     state: directory
 
-- name: Install virtualenv via pip
-  pip:
-    name: virtualenv
-    executable: pip3
-
 - name: Create virtual env for Snuba
   pip:
     name: pyuwsgi


### PR DESCRIPTION
This PR replaces PR #5211 

It updates the default pip used by Ansible, so that it is available universally and can be used consistently.

##### ENVIRONMENTS AFFECTED

Affects new deploys.
