### PR TITLE
Add link to wipe_persisted_data page

### DIFF
--- a/docs/howto/transfer-domain.md
+++ b/docs/howto/transfer-domain.md
@@ -94,6 +94,7 @@ will be unable to submit forms or sync with the server.
   `./manage.py flush_caches`
 - Clear kafka
 
+You can also follow [this](https://commcare-cloud.readthedocs.io/en/latest/reference/howto/wipe_persistent_data.html) page's steps to wipe the environment's persisted data.
 
 ## 4. Import the data to the new environment
 


### PR DESCRIPTION
No ticket; just general improvement.

Change:
Add link from [Prepare the new environment to be populated](https://commcare-cloud.readthedocs.io/en/latest/installation/migration/1-migrating-project.html#prepare-the-new-environment-to-be-populated) to [How to Wipe Persisted Data](https://commcare-cloud.readthedocs.io/en/latest/reference/howto/wipe_persistent_data.html).

##### ENVIRONMENTS AFFECTED
Only docs
