### PR TITLE
PgBouncer various fixes and cleanups

### DIFF
--- a/src/commcare_cloud/ansible/roles/pgbouncer/defaults/main.yml
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/defaults/main.yml
@@ -21,4 +21,5 @@ postgresql_port: 5432
 
 pgbouncer_processes: 1
 pgbouncer_current_processes: [0]
-pgbouncer_min_version: "1.12"
+pgbouncer_version: "1.17.0-1.pgdg18.04+1"
+pgbouncer_min_version: "1.13"

--- a/src/commcare_cloud/ansible/roles/pgbouncer/handlers/main.yml
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/handlers/main.yml
@@ -1,6 +1,5 @@
 ---
 - name: Restart pgbouncer (classic)
-  become: yes
 ## unfortunately -R (online restart) is not sufficient
 ## to make so_reuseport effective
 # shell: su -c "/usr/sbin/pgbouncer -R -d /etc/pgbouncer/pgbouncer.ini" - postgres
@@ -9,7 +8,6 @@
     state: restarted
 
 - name: Stop and disable pgbouncer (classic)
-  become: yes
   systemd:
     name: "pgbouncer"
     state: stopped
@@ -17,12 +15,16 @@
     masked: yes
 
 - name: Reload systemd
-  become: yes
   systemd:
     daemon_reload: yes
 
+- name: Restart pgbouncer
+  systemd:
+    name: "pgbouncer-multiprocess@{{ item }}"
+    state: restarted
+  with_sequence: count={{ pgbouncer_processes | default(1) }}
+
 - name: Start and enable pgbouncer
-  become: yes
   systemd:
     name: "pgbouncer-multiprocess@{{ item }}"
     state: started
@@ -30,15 +32,7 @@
     masked: no
   with_sequence: count={{ pgbouncer_processes | default(1) }}
 
-- name: Restart pgbouncer
-  become: yes
-  systemd:
-    name: "pgbouncer-multiprocess@{{ item }}"
-    state: restarted
-  with_sequence: count={{ pgbouncer_processes | default(1) }}
-
 - name: Reload pgbouncer
-  become: yes
   systemd:
     name: "pgbouncer-multiprocess@{{ item }}"
     state: reloaded

--- a/src/commcare_cloud/ansible/roles/pgbouncer/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/tasks/main.yml
@@ -1,15 +1,15 @@
 ---
 
 - name: pgbouncer install
-  package: name=pgbouncer state=present
-  tags:
-    - pgbouncer
+  package:
+    name: "pgbouncer={{ pgbouncer_version }}"
+    state: present
 
 - name: pgbouncer gather package facts
   package_facts:
     manager: auto
   tags:
-    - pgbouncer
+    - configure
 
 - name: pgbouncer quit if version is too old
   fail:
@@ -18,43 +18,34 @@
       - "{{ ansible_facts.packages['pgbouncer'][0].version }} < {{ pgbouncer_min_version }}"  
   when: ansible_facts.packages['pgbouncer'][0].version is version(pgbouncer_min_version, '<')
   tags:
-    - pgbouncer
+    - configure
 
 - name: pgbouncer defaults (classic)
-  template: src=pgbouncer-classic.defaults.j2 dest=/etc/default/pgbouncer
-  tags:
-    - pgbouncer
+  template:
+    src: pgbouncer-classic.defaults.j2
+    dest: /etc/default/pgbouncer
 
 - name: pgbouncer configuration (classic)
-  template: src=pgbouncer-classic.ini.j2 dest=/etc/pgbouncer/pgbouncer.ini
-  tags:
-    - pgbouncer
+  template:
+    src: pgbouncer-classic.ini.j2
+    dest: /etc/pgbouncer/pgbouncer.ini
 
 - name: pgbouncer gather state
   service_facts:
   tags:
-    - pgbouncer
     - configure
 
-- name: pgbouncer restart if running (classic)
-  shell: /bin/true
-  changed_when: true
-  notify: Restart pgbouncer (classic)
-  when: ansible_facts.services["pgbouncer"].state == "running"
-  tags:
-    - pgbouncer
-
 - name: pgbouncer systemd unit install
-  template: src=pgbouncer-multiprocess@.service.j2 dest=/etc/systemd/system/pgbouncer-multiprocess@.service
+  template:
+    src: pgbouncer-multiprocess@.service.j2
+    dest: /etc/systemd/system/pgbouncer-multiprocess@.service
   notify:
    - Reload systemd
    - Restart pgbouncer
   tags:
-   - pgbouncer
    - configure
 
 - name: pgbouncer kernel settings
-  become: yes
   sysctl:
     name: "{{ item.key }}"
     value: "{{ item.value }}"
@@ -62,14 +53,13 @@
     reload: yes
   with_dict: "{{ pgbouncer_kernel_settings }}"
 
-- name: pgbouncer enumerate current processes
+- name: pgbouncer number current processes
   set_fact:
     pgbouncer_current_processes: "{{ pgbouncer_current_processes | union([item.value.name | regex_search('pgbouncer-multiprocess\\@(\\d+)\\.service', '\\1') | first | int]) }}"
   loop: "{{ lookup('dict', ansible_facts.services) }}"
   when: item.key | regex_search('pgbouncer-multiprocess@(\d+)\.service')
   no_log: true
   tags:
-    - pgbouncer
     - configure
 
 - name: pgbouncer clean up tasks for excess processes
@@ -79,76 +69,61 @@
         name: "pgbouncer-multiprocess@{{ item }}"
         state: stopped
         enabled: no
-      with_sequence: start="{{ pgbouncer_processes + 1 }}" end="{{ pgbouncer_current_processes | max }}"
+      with_sequence: start={{ pgbouncer_processes + 1 }} end={{ pgbouncer_current_processes | max if pgbouncer_current_processes | max > pgbouncer_processes else pgbouncer_processes + 1 }}
     - name: pgbouncer remove conf for excess processes
       file:
         path: "{{ pgbouncer_ini }}"
         state: absent
-      with_sequence: start="{{ pgbouncer_processes + 1 }}" end="{{ pgbouncer_current_processes | max }}"
+      with_sequence: start={{ pgbouncer_processes + 1 }} end={{ pgbouncer_current_processes | max if pgbouncer_current_processes | max > pgbouncer_processes else pgbouncer_processes + 1 }}
     - name: pgbouncer remove unix socket directory for excess processes
       file:
         path: "{{ pgbouncer_socket_dir }}"
         state: absent
-      with_sequence: start="{{ pgbouncer_processes + 1 }}" end="{{ pgbouncer_current_processes | max }}"
+      with_sequence: start={{ pgbouncer_processes + 1 }} end={{ pgbouncer_current_processes | max if pgbouncer_current_processes | max > pgbouncer_processes else pgbouncer_processes + 1 }}
   when: pgbouncer_current_processes | max > pgbouncer_processes
-  become: yes
-  ignore_errors: yes
   tags:
-    - pgbouncer
     - configure
 
 - name: pgbouncer create unix socket directory
-  become: yes
   file:
     path: "{{ pgbouncer_socket_dir }}"
     state: directory
     owner: postgres
     group: postgres
     mode: '755'
-  with_sequence: count="{{ pgbouncer_processes }}"
+  with_sequence: count={{ pgbouncer_processes }}
   tags:
-    - pgbouncer
     - configure
 
 - name: pgbouncer tmpfiles configuration
-  template: src=tmpfiles.postgresql-pgbouncer.conf.j2 dest=/etc/tmpfiles.d/postgresql-pgbouncer.conf
+  template:
+    src: tmpfiles.postgresql-pgbouncer.conf.j2
+    dest: /etc/tmpfiles.d/postgresql-pgbouncer.conf
   tags:
-    - pgbouncer
     - configure
 
 - name: pgbouncer configuration
-  template: src=pgbouncer.ini.j2 dest="{{ pgbouncer_ini }}"
+  template:
+    src: pgbouncer.ini.j2
+    dest: "{{ pgbouncer_ini }}"
   notify:
     - Start and enable pgbouncer
     - Reload pgbouncer
-  with_sequence: count="{{ pgbouncer_processes }}"
+  with_sequence: count={{ pgbouncer_processes }}
   tags:
-    - pgbouncer
     - configure
 
 - name: pgbouncer users
-  template: src=pgbouncer.users.j2 dest="{{ pgbouncer_users }}"
+  template:
+    src: pgbouncer.users.j2
+    dest: "{{ pgbouncer_users }}"
   notify:
     - Start and enable pgbouncer
     - Reload pgbouncer
   tags:
-    - pgbouncer
     - configure
 
-## Allows to execute task only when a tag is specified:
-## https://serverfault.com/a/748864
-- shell: /bin/true
-  changed_when: false
-  register: no_tags
-
-- name: pgbouncer restart (affect max open files limit)
-  command: /bin/true
-  notify: Restart pgbouncer
-  when: no_tags is not defined
-  tags: after-reboot
-
 - name: pgbouncer monit config
-  become: yes
   template:
     src: "monit.pgbouncer.j2"
     dest: "/etc/monit/conf.d/pgbouncer"
@@ -165,7 +140,6 @@
     - Stop and disable pgbouncer (classic)
     - Start and enable pgbouncer
   tags:
-    - pgbouncer
     - configure
 
 - meta: flush_handlers

--- a/src/commcare_cloud/ansible/roles/pgbouncer/templates/monit.pgbouncer.j2
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/templates/monit.pgbouncer.j2
@@ -1,6 +1,6 @@
  check process pgbouncer matching "pgbouncer"
    group database
    group pgbouncer
-   start program = "/bin/systemctl stop pgbouncer-multiprocess@*"
-   stop program = "/bin/systemctl start pgbouncer-multiprocess@*"
+   start program = "/bin/systemctl start pgbouncer-multiprocess@*"
+   stop program = "/bin/systemctl stop pgbouncer-multiprocess@*"
    if failed host {{ inventory_hostname }} port {{ pgbouncer_port }} then restart

--- a/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer-classic.defaults.j2
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer-classic.defaults.j2
@@ -10,4 +10,4 @@ START=1
 
 #OPTS="-d /etc/pgbouncer/pgbouncer.ini"
 
-ULIMIT="-n 65536"
+ULIMIT="-n {{ pgbouncer_ulimit_fd }}"

--- a/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer-classic.ini.j2
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer-classic.ini.j2
@@ -206,11 +206,11 @@ tcp_keepalive = 1
 ;; they also require tcp_keepalive=1
 
 ;; count of keepaliva packets
-tcp_keepcnt = 9
+tcp_keepcnt = 27
 
 ;; how long the connection can be idle,
 ;; before sending keepalive packets
-tcp_keepidle = 900
+tcp_keepidle = 120
 
 ;; The time between individual keepalive probes.
 tcp_keepintvl = 30

--- a/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer-multiprocess@.service.j2
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer-multiprocess@.service.j2
@@ -3,8 +3,8 @@ Description=Lightweight connection pooler for PostgreSQL (#: %i)
 After=network-online.target
 
 [Service]
-## notify not supported on 1.13
-#Type=notify
+## notify not supported on < 1.13
+Type=notify
 User=postgres
 Group=postgres
 LimitNOFILE={{ pgbouncer_ulimit_fd }}


### PR DESCRIPTION
Changes prompted by https://dimagi-dev.atlassian.net/browse/SAAS-12182

 - Bump the minimum required version to 1.13 so that we can use `Type=notify` with systemd
 - Add a `pgbouncer_version` variable that can be set per environment if necessary, and set the default to the currently latest available version (1.17)
 - Remove unnecessary `become` keywords and "pgbouncer" tags, which are already set in the playbook
 - Reorder the handlers to avoid unnecessary multiple restarts
 - Remove unnecessary hardcoded pgbouncer "classic" restart
 - Remove outdated after-reboot actions (open fd limit is set in the systemd unit)
 - Uniform configurations for "classic" and "multiprocess"
 - Correct the start/stop commands for monit, which were inverted
 - Adjust `with_sequence` to avoid "to count backwards make stride negative" errors (`with_sequence` is always parsed regardless of the `when` condition, even if applied only when that is true)
 - General format and syntax cleanups

##### ENVIRONMENTS AFFECTED
All
