### PR TITLE
adding separate resource section for aws_s3_bucket_acl & server_side encryption

### DIFF
--- a/src/commcare_cloud/commands/terraform/templates/terraform.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/terraform.tf.j2
@@ -10,7 +10,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 3.75.1"
+  version = "~> 4.8.0"
   region  = {{ region|tojson }}
 }
 

--- a/src/commcare_cloud/terraform/modules/logshipping/main.tf
+++ b/src/commcare_cloud/terraform/modules/logshipping/main.tf
@@ -8,15 +8,27 @@ locals {
 
 resource "aws_s3_bucket" "log_bucket" {
   bucket = local.log_bucket_name
-  acl = "private"
+  #https://github.com/hashicorp/terraform-provider-aws/issues/23888
+  lifecycle {
+    ignore_changes = [
+    acl,
+    server_side_encryption_configuration
+  ]
+}
+}
+#https://registry.terraform.io/providers/hashicorp/aws/3.75.1/docs/resources/s3_bucket_server_side_encryption_configuration#usage-notes
+resource "aws_s3_bucket_server_side_encryption_configuration" "log_bucket" {
+  bucket = aws_s3_bucket.log_bucket.id
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
     }
   }
+}
+resource "aws_s3_bucket_acl" "log_bucket" {
+  bucket = aws_s3_bucket.log_bucket.id
+  acl    = "private"
 }
 
 module "formplayer_request_response_logs_firehose_stream" {

--- a/src/commcare_cloud/terraform/modules/logshipping/main.tf
+++ b/src/commcare_cloud/terraform/modules/logshipping/main.tf
@@ -8,15 +8,17 @@ locals {
 
 resource "aws_s3_bucket" "log_bucket" {
   bucket = local.log_bucket_name
-  #https://github.com/hashicorp/terraform-provider-aws/issues/23888
+
+  # https://github.com/hashicorp/terraform-provider-aws/issues/23888
   lifecycle {
-    ignore_changes = [
-    acl,
-    server_side_encryption_configuration
+      ignore_changes = [
+      acl,
+      server_side_encryption_configuration
   ]
 }
 }
-#https://registry.terraform.io/providers/hashicorp/aws/3.75.1/docs/resources/s3_bucket_server_side_encryption_configuration#usage-notes
+
+# https://registry.terraform.io/providers/hashicorp/aws/3.75.1/docs/resources/s3_bucket_server_side_encryption_configuration#usage-notes
 resource "aws_s3_bucket_server_side_encryption_configuration" "log_bucket" {
   bucket = aws_s3_bucket.log_bucket.id
 
@@ -26,6 +28,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "log_bucket" {
     }
   }
 }
+
 resource "aws_s3_bucket_acl" "log_bucket" {
   bucket = aws_s3_bucket.log_bucket.id
   acl    = "private"


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-13313
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All

Adding comment lines only for this review and once approved I will remove them if suggested.

--
When these resources were added in .tf file we don't have to apply them since they are already, instead we have to import them using terraform import commands. 
Whereas, for acl it is asking us to apply the change even after importing. And I see that it is safe to apply,


