### PR TITLE
Add ec2_metadata_tokens_required option and set to True on staging

### DIFF
--- a/environments/india/terraform.yml
+++ b/environments/india/terraform.yml
@@ -21,6 +21,7 @@ vpn_connections: []
 
 external_routes: []
 
+ec2_metadata_tokens_required: no
 servers:
   - server_name: "control0-india"
     server_instance_type: "t3.medium"

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -13,6 +13,7 @@ vpc_begin_range: "10.202"
 
 openvpn_image: ami-5e73b923
 
+ec2_metadata_tokens_required: no
 servers:
   - server_name: "control2-production"
     server_instance_type: "t3a.large"

--- a/environments/staging/terraform.yml
+++ b/environments/staging/terraform.yml
@@ -13,6 +13,7 @@ vpc_begin_range: "10.201"
 
 openvpn_image: ami-5e73b923
 
+ec2_metadata_tokens_required: no
 servers:
   - server_name: "control1-staging"
     server_instance_type: "t3.medium"

--- a/environments/staging/terraform.yml
+++ b/environments/staging/terraform.yml
@@ -13,7 +13,6 @@ vpc_begin_range: "10.201"
 
 openvpn_image: ami-5e73b923
 
-ec2_metadata_tokens_required: no
 servers:
   - server_name: "control1-staging"
     server_instance_type: "t3.medium"

--- a/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
@@ -105,6 +105,7 @@ module "server__{{ server_name }}" {
   secondary_volume_encrypted = {{ server_spec.block_device.encrypted|default(False)|tojson }}
   server_auto_recovery = {{ server_spec.server_auto_recovery|default(False)|tojson }}
   iam_instance_profile = "${module.server_iam_role.commcare_server_instance_profile}"
+  metadata_tokens = "{{ 'required' if ec2_metadata_tokens_required else 'optional' }}"
 
 {% if server_spec.os == 'ubuntu_pro_bionic' %}
   server_image = "${data.aws_ami.ubuntu_pro_bionic.id}"

--- a/src/commcare_cloud/environment/schemas/terraform.py
+++ b/src/commcare_cloud/environment/schemas/terraform.py
@@ -29,6 +29,7 @@ class TerraformConfig(jsonobject.JsonObject):
     vpc_begin_range = jsonobject.StringProperty()
     vpn_connections = jsonobject.ListProperty(lambda: VpnConnectionConfig)
     external_routes = jsonobject.ListProperty(lambda: ExternalRouteConfig)
+    ec2_metadata_tokens_required = jsonobject.BooleanProperty(default=False)
     servers = jsonobject.ListProperty(lambda: ServerConfig)
     proxy_servers = jsonobject.ListProperty(lambda: ServerConfig)
     rds_instances = jsonobject.ListProperty(lambda: RdsInstanceConfig)

--- a/src/commcare_cloud/environment/schemas/terraform.py
+++ b/src/commcare_cloud/environment/schemas/terraform.py
@@ -29,7 +29,7 @@ class TerraformConfig(jsonobject.JsonObject):
     vpc_begin_range = jsonobject.StringProperty()
     vpn_connections = jsonobject.ListProperty(lambda: VpnConnectionConfig)
     external_routes = jsonobject.ListProperty(lambda: ExternalRouteConfig)
-    ec2_metadata_tokens_required = jsonobject.BooleanProperty(default=False)
+    ec2_metadata_tokens_required = jsonobject.BooleanProperty(default=True)
     servers = jsonobject.ListProperty(lambda: ServerConfig)
     proxy_servers = jsonobject.ListProperty(lambda: ServerConfig)
     rds_instances = jsonobject.ListProperty(lambda: RdsInstanceConfig)


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-11914

Perhaps easiest to follow when reviewed commit-by-commit.

This is an alternative approach to https://github.com/dimagi/commcare-cloud/pull/5244 that allows for different environments to have different values as we roll it out, without keeping a PR open for the duration of the rollout.

##### ENVIRONMENTS AFFECTED
Only the value for staging is changed
