### PR TITLE
[EOL] Update node.js to 14.x and npm to 7.x

### DIFF
--- a/src/commcare_cloud/ansible/roles/nodejs/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/nodejs/tasks/main.yml
@@ -30,7 +30,7 @@
   npm: name="{{ item.name }}" version="{{ item.version }}" state=present global=yes
   become: yes
   with_items:
-    - {name: 'n', version: '14.19.1'}
+    - {name: 'n', version: '2.1.12'}
     - {name: 'less', version: '3.10.3'}
     - {name: 'yarn', version: '1.22.4'}
     - {name: 'bower', version: '1.8.4'}


### PR DESCRIPTION
This PR will upgrade the version of Node.js that we use to `14.19.1` and `npm` to `7.24.2` (the two libraries are tightly coupled). Node.js `v12` is reaching it's EOL on April 30th.

https://dimagi-dev.atlassian.net/browse/SAAS-13399

We will also need to roll out changes to commcare-cloud to ensure that node.js is upgraded in our build process and that third party developers are notified.

see corresponding HQ PR here https://github.com/dimagi/commcare-hq/pull/31408

##### ENVIRONMENTS AFFECTED
all environments

There will also be a PR with a changelog alerting third parties of the upgrade.
