### PR TITLE
Always install the latest pgbouncer version

### DIFF
--- a/src/commcare_cloud/ansible/roles/pgbouncer/defaults/main.yml
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/defaults/main.yml
@@ -21,5 +21,4 @@ postgresql_port: 5432
 
 pgbouncer_processes: 1
 pgbouncer_current_processes: [0]
-pgbouncer_version: "1.17.0-1.pgdg18.04+1"
 pgbouncer_min_version: "1.13"

--- a/src/commcare_cloud/ansible/roles/pgbouncer/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/tasks/main.yml
@@ -1,9 +1,10 @@
 ---
 
 - name: pgbouncer install
-  package:
-    name: "pgbouncer={{ pgbouncer_version }}"
-    state: present
+  apt:
+    name: pgbouncer
+    update_cache: yes
+    state: latest
 
 - name: pgbouncer gather package facts
   package_facts:


### PR DESCRIPTION
The pgbouncer package from postgresql.org is only available for the
latest version. We cannot set it to an arbitrary version as it would
break new installations.

The 'configure' tag allows us to perform normal operations without
upgrading the package, so let's set the version to 'latest' to avoid
manual interventions when we actually want to upgrade it.

##### ENVIRONMENTS AFFECTED
All
