### PR TITLE
adding virtualenv path for upload script. It is failing with default python

### DIFF
--- a/src/commcare_cloud/ansible/roles/backups/templates/create_blobdb_backup.sh.j2
+++ b/src/commcare_cloud/ansible/roles/backups/templates/create_blobdb_backup.sh.j2
@@ -3,11 +3,13 @@ BACKUP_TYPE=$1
 MINUTES_TO_RETAIN_BACKUPS=$2
 DAYS_TO_RETAIN_BACKUPS=$2
 HOSTNAME=$(hostname)
+ENV="{{ env_name }}"
 TODAY=$(date +"%Y_%m_%d")
 HOUR=$(date +"%Y_%m_%d_%H")
 BACKUP_FILE="blobdb_${BACKUP_TYPE}_${TODAY}.tar.gz"
 HOURLY_BACKUP_FILE="blobdb_${BACKUP_TYPE}_${HOUR}.tar.gz"
 BLOBDB_BACKUP_HOURLY={{ blobdb_backup_hourly }}
+PYTHON_ENV="/home/cchq/www/${ENV}/current/python_env/bin/python"
 
 {% if not aws_versioning_enabled %}
 UPLOAD_NAME="${BACKUP_FILE}"
@@ -31,5 +33,5 @@ else
 fi
 
 {% if blobdb_s3 %}
-( cd {{ blobdb_backup_dir }} && /usr/local/sbin/backup_snapshots.py "${BACKUP_FILE}" "${UPLOAD_NAME}" {{ blobdb_snapshot_bucket }} {{aws_endpoint}} )
+( cd {{ blobdb_backup_dir }} && "${PYTHON_ENV}" /usr/local/sbin/backup_snapshots.py "${BACKUP_FILE}" "${UPLOAD_NAME}" {{ blobdb_snapshot_bucket }} {{aws_endpoint}} )
 {% endif %}

--- a/src/commcare_cloud/ansible/roles/couchdb2/templates/create_couchdb_backup.sh.j2
+++ b/src/commcare_cloud/ansible/roles/couchdb2/templates/create_couchdb_backup.sh.j2
@@ -3,8 +3,10 @@ BACKUP_TYPE=$1
 DAYS_TO_RETAIN_BACKUPS=$2
 MINUTES_TO_RETAIN_BACKUPS=$2
 HOSTNAME=$(hostname)
+ENV="{{ env_name }}"
 TODAY=$(date +"%Y_%m_%d")
 HOUR=$(date +"%Y_%m_%d_%H")
+PYTHON_ENV="/home/cchq/www/${ENV}/current/python_env/bin/python"
 
 BACKUP_FILE="couchdb_${BACKUP_TYPE}_${TODAY}.tar.gz"
 HOURLY_BACKUP_FILE="couchdb_${BACKUP_TYPE}_${HOUR}.tar.gz"
@@ -37,5 +39,5 @@ rsync -avH --delete --exclude="commcarehq__synclogs.*.couch" {{ couch_backup_dir
 {% endif %}
 
 {% if couch_s3 %}
-( cd {{ couch_backup_dir }} && /usr/local/sbin/backup_snapshots.py "${BACKUP_FILE}" "${UPLOAD_NAME}" {{ couchdb_snapshot_bucket }} {{aws_endpoint}} )
+( cd {{ couch_backup_dir }} && "${PYTHON_ENV}" /usr/local/sbin/backup_snapshots.py "${BACKUP_FILE}" "${UPLOAD_NAME}" {{ couchdb_snapshot_bucket }} {{aws_endpoint}} )
 {% endif %}

--- a/src/commcare_cloud/ansible/roles/pg_backup/templates/plain/create_postgres_dump.sh.j2
+++ b/src/commcare_cloud/ansible/roles/pg_backup/templates/plain/create_postgres_dump.sh.j2
@@ -6,6 +6,7 @@ ENV="{{ deploy_env }}"
 HOSTNAME=$(hostname)
 TODAY=$(date +"%Y_%m_%d")
 HOUR=$(date +"%Y_%m_%d_%H")
+PYTHON_ENV="/home/cchq/www/${ENV}/current/python_env/bin/python"
 
 POSTGRES_BACKUP_HOURLY={{ postgres_backup_hourly }}
 
@@ -71,10 +72,10 @@ fi
 
 {% if postgres_s3 %}
 if [ -f "${DIRECTORY}.gz" ]; then
-    ( cd {{ postgresql_backup_dir }} && /usr/local/sbin/backup_snapshots.py "${FILENAME}.gz" "${UPLOAD_NAME}.gz" {{ postgres_snapshot_bucket }} {{aws_endpoint}}  )
+    ( cd {{ postgresql_backup_dir }} && "${PYTHON_ENV}" /usr/local/sbin/backup_snapshots.py "${FILENAME}.gz" "${UPLOAD_NAME}.gz" {{ postgres_snapshot_bucket }} {{aws_endpoint}}  )
 fi
 if [ -f "${DIRECTORY}.tar.gz" ]; then
-    ( cd {{ postgresql_backup_dir }} && /usr/local/sbin/backup_snapshots.py "${FILENAME}.tar.gz" "${UPLOAD_NAME}.tar.gz" {{ postgres_snapshot_bucket }} {{aws_endpoint}}  )
+    ( cd {{ postgresql_backup_dir }} && "${PYTHON_ENV}" /usr/local/sbin/backup_snapshots.py "${FILENAME}.tar.gz" "${UPLOAD_NAME}.tar.gz" {{ postgres_snapshot_bucket }} {{aws_endpoint}}  )
 fi
 {% endif %}
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-13494
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All

@dannyroberts @shyamkumarlchauhan 
It seems like the Previous swiss backup scripts were edited on the server directly. Because of that when we ran the `deploy-stack` command on the swiss server recently, it has replaced the existing backup scripts, and backups were not `uploaded` to the s3 bucket. 

As a fix, I'm adding the cchq python virtualenv path to the python script as the using the default Python (2.7) the scripts are failing. Tested this process on the server and it is working as expected. 
![image](https://user-images.githubusercontent.com/11612356/165027660-d11f0bdc-3644-4f02-8b9b-9634b0474ac4.png)

--
Need Suggestions: 
adding {{ deploy_env }} is right option or {{ virtualenv_home }} which one is the right option to choose. Please suggest.