### PR TITLE
Revert "Update public.yml file ALTERNATE_HOSTS"

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -25,7 +25,6 @@ soft_assert_email: commcarehq-ops+soft_asserts@dimagi.com
 new_domain_email: inquiries@dimagi.com
 ALTERNATE_HOSTS:
   - rec-mobile.sante.gov.bf
-  - commcare.health.gov.mw
 
 DATADOG_ENABLED: True
 


### PR DESCRIPTION
Reverts dimagi/commcare-cloud#5114

This was creating a hard-to-resolve terraform diff. Offlined with @Charl1996; looks like this was a little premature and the project team can redo this change when they're ready.