### PR TITLE
Ce/redis read replica

### DIFF
--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -158,7 +158,7 @@ localsettings:
   SES_CONFIGURATION_SET: staging-email-events
   SNS_EMAIL_EVENT_SECRET: "{{ SNS_EMAIL_EVENT_SECRET }}"
   REDIS_ENDPOINTS:
-    - host: "redis.production.commcare.local"
+    - host: "redis.staging.commcare.local"
       port: '6379'
     - host: "staging-elasticache-cluster-ro.ormqor.ng.0001.use1.cache.amazonaws.com"
       port: '6379'

--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -157,9 +157,12 @@ localsettings:
   RATE_LIMIT_SUBMISSIONS: yes
   SES_CONFIGURATION_SET: staging-email-events
   SNS_EMAIL_EVENT_SECRET: "{{ SNS_EMAIL_EVENT_SECRET }}"
+  REDIS_ENDPOINTS:
+    - host: "redis.production.commcare.local"
+      port: '6379'
+    - host: "staging-elasticache-cluster-ro.ormqor.ng.0001.use1.cache.amazonaws.com"
+      port: '6379'
   REDIS_DB: '0'
-  REDIS_HOST: "redis.staging.commcare.local"
-  REDIS_PORT: '6379'
   REMINDERS_QUEUE_ENABLED: False
   SMS_GATEWAY_URL: 'http://gw1.promessaging.com/sms.php'
   SMS_QUEUE_ENABLED: True

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -419,15 +419,24 @@ REPORT_CACHE = 'redis'
 
 redis_cache = {
     'BACKEND': 'django_redis.cache.RedisCache',
-{% set redis_url = 'redis://' ~ localsettings.REDIS_HOST ~ ':' ~ localsettings.REDIS_PORT %}
-{% if localsettings.get('REDIS_PASSWORD') %}
-{% set redis_url = 'redis://:' ~ localsettings.REDIS_PASSWORD ~ '@' ~ localsettings.REDIS_HOST ~ ':' ~ localsettings.REDIS_PORT %}
-{% endif %}
-{% if 'REDIS_DB' in localsettings %}
-    'LOCATION': '{{ redis_url }}/{{ localsettings.REDIS_DB }}',
+{% if not 'REDIS_ENDPOINTS' in localsettings %}
+   {% set redis_endpoints = [{"host": localsettings.REDIS_HOST, "port": localsettings.REDIS_PORT}] %}
 {% else %}
-    'LOCATION': '{{ redis_url }}',
+   {% set redis_endpoints = localsettings.REDIS_ENDPOINTS %}
 {% endif %}
+    'LOCATION' : [
+{% for endpoint in redis_endpoints -%}
+   {% set redis_url = 'redis://' ~ endpoint.host ~ ':' ~ endpoint.port %}
+   {% if localsettings.get('REDIS_PASSWORD') %}
+   {% set redis_url = 'redis://:' ~ localsettings.REDIS_PASSWORD ~ '@' ~ endpoint.host ~ ':' ~ endpoint.port %}
+   {% endif %}
+{% if 'REDIS_DB' in localsettings %}
+        '{{ redis_url }}/{{ localsettings.REDIS_DB }}',
+{% else %}
+        '{{ redis_url }}',
+{% endif %}
+{% endfor -%}
+    ],
     'OPTIONS': {
         'PARSER_CLASS': 'redis.connection.HiredisParser',
         'REDIS_CLIENT_KWARGS': {

--- a/src/commcare_cloud/ansible/roles/formplayer/templates/application.properties.j2
+++ b/src/commcare_cloud/ansible/roles/formplayer/templates/application.properties.j2
@@ -45,8 +45,10 @@ smtp.to.address=commcarehq-ops+formplayer@dimagi.com
 // Redis for locking
 {% if is_redis_cluster %}
 redis.clusterString={{ groups.redis_cluster_master | join(":" + localsettings.REDIS_PORT + ",") }}:{{ localsettings.REDIS_PORT }}
-{% else %}
+{% elif 'REDIS_HOST' in localsettings %}
 redis.hostname={{ localsettings.REDIS_HOST }}
+{% else %}
+redis.hostname={{ localsettings.REDIS_ENDPOINTS[0].host }}
 {% endif %}
 
 {% if localsettings.get('REDIS_PASSWORD') %}


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
This allows us to specify multiple redis hosts in localsettings, where the first is the primary and the others are read replicas, to share load across our cluster. It also configures staging to use that setup.

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Staging