### PR TITLE
only fetch the required branch

### DIFF
--- a/src/commcare_cloud/fab/operations/release.py
+++ b/src/commcare_cloud/fab/operations/release.py
@@ -75,7 +75,7 @@ def _update_code_from_previous_release(code_repo, subdir, git_env):
             sudo('git remote set-url origin {}'.format(code_repo))
     else:
         with shell_env(**git_env):
-            sudo('git clone {} {} --single-branch'.format(code_repo, code_root))
+            sudo('git clone --single-branch {} {}'.format(code_repo, code_root))
 
 
 def _get_submodule_list(path):
@@ -125,7 +125,7 @@ def _clone_code_from_local_path(from_path, to_path, run_as_sudo=True):
     ]
 
     with cd(from_path):
-        cmd_fn('git clone {}/.git {}'.format(
+        cmd_fn('git clone --single-branch {}/.git {}'.format(
             from_path,
             to_path
         ))
@@ -134,7 +134,7 @@ def _clone_code_from_local_path(from_path, to_path, run_as_sudo=True):
         cmd_fn('git config receive.denyCurrentBranch updateInstead')
         if git_local_submodule_config:
             cmd_fn(' && '.join(git_local_submodule_config))
-        cmd_fn('git submodule update --init --recursive')
+        cmd_fn('git submodule update --init --recursive --single-branch')
         if git_remote_submodule_config:
             cmd_fn(' && '.join(git_remote_submodule_config))
 

--- a/src/commcare_cloud/fab/operations/release.py
+++ b/src/commcare_cloud/fab/operations/release.py
@@ -68,8 +68,6 @@ def _update_code_from_previous_release(code_repo, subdir, git_env):
         code_root = os.path.join(code_root, subdir)
 
     if files.exists(code_current, use_sudo=True):
-        with cd(code_current), shell_env(**git_env):
-            sudo('git submodule foreach "git fetch origin"')
         _clone_code_from_local_path(code_current, code_root)
         with cd(code_root):
             sudo('git remote set-url origin {}'.format(code_repo))

--- a/src/commcare_cloud/fab/operations/release.py
+++ b/src/commcare_cloud/fab/operations/release.py
@@ -47,11 +47,11 @@ def update_code(full_cluster=True):
             sudo('git remote prune origin')
             # this can get into a state where running it once fails
             # but primes it to succeed the next time it runs
-            sudo('git fetch origin --tags -q || git fetch origin --tags -q')
+            sudo(f'git fetch origin {env.code_branch} --tags -q || git fetch origin {env.code_branch} --tags -q')
             sudo('git checkout {}'.format(git_tag))
             sudo('git reset --hard {}'.format(git_tag))
             sudo('git submodule sync')
-            sudo('git submodule update --init --recursive -q')
+            sudo('git submodule update --init --recursive --single-branch -q')
             # remove all untracked files, including submodules
             sudo("git clean -ffd")
             # remove all .pyc files in the project
@@ -75,7 +75,7 @@ def _update_code_from_previous_release(code_repo, subdir, git_env):
             sudo('git remote set-url origin {}'.format(code_repo))
     else:
         with shell_env(**git_env):
-            sudo('git clone {} {}'.format(code_repo, code_root))
+            sudo('git clone {} {} --single-branch'.format(code_repo, code_root))
 
 
 def _get_submodule_list(path):


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-13513

Followup from a recent deploy issue where a bad branch in a submodule caused the repo size to baloon, but also just good practice. This may even make creating releases marginally faster by cutting down what needs to be fetched over the network from github each time.

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All