### PR TITLE
Correct domain migration docs

### DIFF
--- a/hosting_docs/source/installation/migration/1-migrating-project.rst
+++ b/hosting_docs/source/installation/migration/1-migrating-project.rst
@@ -98,7 +98,7 @@ During the downtime, mobile users will still be able to collect data, but they
 will be unable to submit forms or sync with the server.
 
 
-* Block data access by turning on the ``DATA_MIGRATION`` feature flag.
+* Block data access by turning on the ``DATA_MIGRATION`` feature flag (via HQ Web UI).
 * Print information about the numbers in the database for later reference.
   This will take a while (15 mins) even on small domains. Tip: add ``--csv`` to
   the command to save the output in a csv file.
@@ -117,25 +117,15 @@ will be unable to submit forms or sync with the server.
 3. Prepare the new environment to be populated
 ----------------------------------------------
 
+* Setup a new environment by following :ref:`deploy-commcarehq`
+* Do a commcare-hq deploy using :ref:`operations/2-deploys:Deploying CommCare HQ code changes`
+* And now proceed to step 4.
 
-* Stop all services
-  ``$ commcare-cloud <env> downtime start``
-* Delete any blob data
-* Delete the PostgreSQL database
-* Delete the CouchDB database
-* Delete all elasticsearch indices
+If you have performed any tests on your new environment that has created test data, to delete 
+the data you can rebuild your environment using 
+:ref:`reference/howto/wipe_persistent_data:How To Rebuild a CommCareHQ environment` 
+before importing data from the old environment.
 
-  * Figure out what the elasticearch IP is:
-    ``ES_IP=$(commcare-cloud ${ENV} lookup elasticsearch:0)``
-  * Go ahead and check the size of the forms index to make sure this is the
-    correct cluster.  Be VERY sure this is correct.
-    ``curl -XGET "${ES_IP}:9200/xforms/_stats/docs?pretty``
-  * Delete all elasticsearch data in that cluster
-    ``curl -X DELETE ${ES_IP}:9200/_all?pretty``
-
-* Clear the redis cache data
-  ``./manage.py flush_caches``
-* Clear kafka
 
 4. Import the data to the new environment
 -----------------------------------------
@@ -156,12 +146,15 @@ will be unable to submit forms or sync with the server.
 
   * ``./manage.py print_domain_stats <domain_name>``
 
-* Rebuild case ownership cleanliness flags
+* Rebuild user configrable reports by running.
 
-  * ``./manage.py set_cleanliness_flags --force <domain_name>``
+  * ``./manage.py rebuild_tables_by_domain <domain_name> --initiated-by=<your-name>``
 
 * Bring the site back up
   ``$ commcare-cloud <env> downtime end``
+
+* Enable domain access by turning off the ``DATA_MIGRATION`` feature flag on the new environment (via HQ Web UI).
+
 
 5. Ensure the new environment is fully functional. Test all critical workflows at this stage.
 ---------------------------------------------------------------------------------------------

--- a/hosting_docs/source/installation/migration/1-migrating-project.rst
+++ b/hosting_docs/source/installation/migration/1-migrating-project.rst
@@ -119,7 +119,7 @@ will be unable to submit forms or sync with the server.
 
 * Setup a new environment by following :ref:`deploy-commcarehq`
 * Do a commcare-hq deploy using :ref:`operations/2-deploys:Deploying CommCare HQ code changes`
-* And now proceed to step 4.
+* Proceed to step 4.
 
 If you have performed any tests on your new environment that has created test data, to delete 
 the data you can rebuild your environment using 

--- a/hosting_docs/source/reference/howto/wipe_persistent_data.rst
+++ b/hosting_docs/source/reference/howto/wipe_persistent_data.rst
@@ -1,35 +1,36 @@
+How To Rebuild a CommCareHQ environment
+=======================================
+
+This step deletes all of the CommCare data from your environment and resets to as if it's a new environment.
+In practice, you will likely need this only to delete test environments and not production data. Please understand fully
+before you proceed to perform this as it will permenantly delete all of your data.
+
 
 How To Wipe Persistent Data
-===========================
+---------------------------
+
+This step deletes all of the persistent data in BlobDB, Postgres, Couch and Elasticsearch. Note that this works only 
+in the sequence given below, so you shouldn't proceed to next steps until the prior steps are successful.
 
 
-#. 
-   Wipe BlobDB, ES, Couch using management commands.
-
-   .. code-block::
-
-      $ cchq monolith django-manage wipe_blobdb --commit
-      $ cchq monolith django-manage wipe_es --commit
-      $ cchq monolith django-manage delete_couch_dbs --commit
-
-#. 
-   Prepend "wipe_environment_enabled: True" to public.yml (because it
-   is easier to spot if it's prepended than appended).
+#. Wipe BlobDB, ES, Couch using management commands.
 
    .. code-block::
 
-      $ printf '%s\n%s\n' "wipe_environment_enabled: True" \
-        "$(cat ~/environments/monolith/public.yml)" \
-        > ~/environments/monolith/public.yml
+      $ cchq <env_name> django-manage wipe_blobdb --commit
+      $ cchq <env_name> django-manage wipe_es --commit
+      $ cchq <env_name> django-manage delete_couch_dbs --commit
 
-#. 
-   Stop CommCare and close Postgres sessions.
+#. Add "wipe_environment_enabled: True" to `public.yml` file.
+
+
+#. Stop CommCare and close Postgres sessions.
 
    .. code-block::
 
-      $ cchq monolith service commcare stop
-      $ cchq monolith service postgresql stop
-      $ cchq monolith service postgresql status
+      $ cchq <env_name> service commcare stop
+      $ cchq <env_name> service postgresql stop
+      $ cchq <env_name> service postgresql status
 
 
    If that doesn't stop Postgres and PgBouncer, and if Postgres is
@@ -43,19 +44,23 @@ How To Wipe Persistent Data
       $ sudo service postgresql start
       $ sudo service pgbouncer start
 
-#. 
-   Wipe PostgreSQL databases
+#. Wipe PostgreSQL databases
 
    .. code-block::
 
-      $ cchq monolith ap wipe_postgres.yml
+      $ cchq <env_name> ap wipe_postgres.yml
 
-#. 
-   Wipe Kafka topics
+#. Clear the redis cache data
 
    .. code-block::
 
-      $ cchq monolith ap wipe_kafka.yml
+      $ cchq <env_name> django-manage flush_caches
+
+#. Wipe Kafka topics
+
+   .. code-block::
+
+      $ cchq <env_name> ap wipe_kafka.yml
 
 
    You can check they have been removed by confirming that the following shows
@@ -69,42 +74,25 @@ Rebuilding environment
 ----------------------
 
 
-#. 
-   Drop the first line public.yml. This step assumes the first line is
-   "wipe_environment_enabled: True", prepended in the steps above.
+#. Remove the "wipe_environment_enabled: True" line in your `public.yml` file.
+
+#. Run Ansible playbook to recreate databases
 
    .. code-block::
 
-      $ tail -n +2 ~/environments/monolith/public.yml > public.yml.tmp
-      $ mv public.yml.tmp ~/environments/monolith/public.yml
+      $ cchq <env_name> ap deploy_db.yml
 
-#. 
-   Run Ansible playbook to recreate databases
-
-   .. code-block::
-
-      $ cchq monolith ap deploy_db.yml
-
-#. 
-   Run management commands to create Kafka topics, create Postgres
+#. Run a code deploy to create Kafka topics, create Postgres
    tables, and Elasticsearch indices.
 
    .. code-block::
 
-      $ cchq monolith django-manage create_kafka_topics
-      $ cchq monolith django-manage preindex_everything
-      $ cchq monolith django-manage ptop_es_manage --flip_all_aliases
-      $ cchq monolith django-manage check_services
-      $ sudo -iu cchq  # Required to set CCHQ_IS_FRESH_INSTALL=1
-      (cchq) $ cd www/monolith/current
-      (cchq) $ source python_env/bin/activate
-      (cchq) $ env CCHQ_IS_FRESH_INSTALL=1 ./manage.py migrate_multi
-      (cchq) $ exit
+      $ cchq <env_name> deploy
 
-#. 
-   Recreate a superuser (where you substitute your address in place of
-   "you@your.domain").
+
+#. Recreate a superuser (where you substitute your address in place of
+   "you@your.domain"). (Optional)
 
    .. code-block::
 
-      $ cchq monolith django-manage make_superuser you@your.domain
+      $ cchq <env_name> django-manage make_superuser you@your.domain

--- a/hosting_docs/source/reference/howto/wipe_persistent_data.rst
+++ b/hosting_docs/source/reference/howto/wipe_persistent_data.rst
@@ -76,11 +76,11 @@ Rebuilding environment
 
 #. Remove the "wipe_environment_enabled: True" line in your `public.yml` file.
 
-#. Run Ansible playbook to recreate databases
+#. Run Ansible playbook to recreate databases.
 
    .. code-block::
 
-      $ cchq <env_name> ap deploy_db.yml
+      $ cchq <env_name> ap deploy_db.yml --skip-check
 
 #. Run a code deploy to create Kafka topics, create Postgres
    tables, and Elasticsearch indices.
@@ -91,7 +91,8 @@ Rebuilding environment
 
 
 #. Recreate a superuser (where you substitute your address in place of
-   "you@your.domain"). (Optional)
+   "you@your.domain"). This is optional and should not be performed if
+   you are planning to migrate domain from other environment.
 
    .. code-block::
 


### PR DESCRIPTION
This PR updates the [migration docs](https://commcare-cloud.readthedocs.io/en/latest/installation/migration/1-migrating-project.html#import-the-data-to-the-new-environment) specifically with the understanding that an env needs to be code-deployed before migration and the DBs to be reset only if there is test data that the user wants to be deleted. There are also other updates to rebuild UCRs and to remove cleanliness_flag command (it's not needed anymore).



@proteusvacuum @Charl1996 