### PR TITLE
Make init-ansible default for quick-install

### DIFF
--- a/quick_monolith_install/cchq-install.sh
+++ b/quick_monolith_install/cchq-install.sh
@@ -50,7 +50,7 @@ printf "\n"
 # install comcare-cloud
 DIR="${BASH_SOURCE%/*}"
 if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
-source "$DIR/../control/init.sh"
+echo y | source "$DIR/../control/init.sh"
 sudo touch /var/log/ansible.log && sudo chmod 666 /var/log/ansible.log
 
 printf "\n"


### PR DESCRIPTION
Recently this prompt was updated to timeout after 30 seconds, so make the init-ansible default for those who use quick-install.

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->

@proteusvacuum 