### PR TITLE
Update celery and django runner scripts to exit with their child's code

### DIFF
--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/celery_bash_runner.sh.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/celery_bash_runner.sh.j2
@@ -48,5 +48,7 @@ HOSTNAME=${HOSTNAME_PARTS[1]}
 PID=$!
 BASH_PID=$$
 echo "Started ${HOSTNAME} on PID: ${PID}"
-wait $PID
+wait -n $PID
+rcode=$?
 echo "Exiting Bash Process: ${BASH_PID}"
+exit $rcode

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/django_bash_runner.sh.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/django_bash_runner.sh.j2
@@ -25,5 +25,7 @@ trap 'echo "Cleaning Prometheus metrics from ${prometheus_multiproc_dir} for PID
 PID=$!
 BASH_PID=$$
 echo "Started Django process with PID: ${PID}"
-wait $PID
+wait -n $PID
+rcode=$?
 echo "Exiting Bash Process: ${BASH_PID}"
+exit $rcode


### PR DESCRIPTION
I observed that `supervisord` logs don't reflect the actual celery or django exit codes because of these wrapper "runner" scripts. This PR fixes that.

##### ENVIRONMENTS AFFECTED
- **all**
