### PR TITLE
adding disk space for c1 prod.

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -385,7 +385,7 @@ proxy_servers:
     server_instance_type: "t3.large"
     network_tier: "app-private"
     az: "c"
-    volume_size: 40
+    volume_size: 80
     group: "proxy"
     os: ubuntu_pro_bionic
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
We had increased the disk space for c1 production last time when we faced disk space issues. 

Now, in order to fix the terraform diff, I'm raising the PR with that change.