### PR TITLE
Remove unnecessary queues from 'SOLO_QUEUES'

### DIFF
--- a/src/commcare_cloud/environment/schemas/app_processes.py
+++ b/src/commcare_cloud/environment/schemas/app_processes.py
@@ -148,9 +148,6 @@ OPTIONAL_CELERY_PROCESSES = [process.name for process in CELERY_PROCESSES
 SOLO_QUEUES = [
     # because these don't actually run normal celery processes
     'flower', 'beat',
-    # because these run management commands in addition to normal celery processes
-    # (see commcare_cloud/ansible/roles/commcarehq/tasks/celery.yml)
-    'reminder_queue', 'submission_reprocessing_queue', 'sms_queue',
 ]
 
 


### PR DESCRIPTION
The management part was removed long ago from 'reminder_queue',
'submission_reprocessing_queue', and 'sms_queue'.
It is now safe to remove them from 'SOLO_QUEUES'.

##### ENVIRONMENTS AFFECTED
All
