### PR TITLE
Remove commit from changelog entry

### DIFF
--- a/changelog/0048-update-supervisor-confs.yml
+++ b/changelog/0048-update-supervisor-confs.yml
@@ -2,7 +2,7 @@ title: update-supervisor-confs
 key: update-supervisor-confs
 date: 2022-05-25
 optional_per_env: no
-min_commcare_version: 0b1ff6e1111f3280b56fa66ff2fd94bd8d46e55c
+min_commcare_version:
 max_commcare_version:
 context: |
   Run command to update shell runner scripts for django and celery.

--- a/docs/changelog/0048-update-supervisor-confs.md
+++ b/docs/changelog/0048-update-supervisor-confs.md
@@ -8,8 +8,7 @@
 
 
 ## CommCare Version Dependency
-The following version of CommCare must be deployed before rolling out this change:
-[0b1ff6e1](https://github.com/dimagi/commcare-hq/commit/0b1ff6e1111f3280b56fa66ff2fd94bd8d46e55c)
+This change is not known to be dependent on any particular version of CommCare.
 
 
 ## Change Context


### PR DESCRIPTION
Fix for changelog added by #5298.

The commit in this changelog was a commcare-cloud commit SHA, there is no commcare-hq change associated with this changelog entry.

##### ENVIRONMENTS AFFECTED
- all