### PR TITLE
Update github actions to include testing on Python 3.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,24 +26,12 @@ jobs:
       TEST: main
 
     steps:
-    # setup 3.9 for deploy-stack
-    # may be removed when this file is updated to match global_vars/all.yml:python_version
-    - name: Setup HQ Python Version
-      uses: actions/setup-python@v3
-      with:
-        python-version: "3.9"
-
-    - name: Unset Python Env Variables
-      run: |
-        unset pythonLocation
-        unset LD_LIBRARY_PATH
+    - uses: actions/checkout@v3
 
     - name: Set up Cloud Python Version
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.versions.python }}
-
-    - uses: actions/checkout@v3
 
     - name: Install dependencies
       run: |
@@ -53,6 +41,12 @@ jobs:
         # Note: the installs must be done in the following order, otherwise the installation of commcare-cloud
         # tries to install from the commcare-cloud-bootstrap.egg_info directory
         pip install -e .[test]
+
+        # setup 3.9 for deploy-stack
+        # may be removed when this file is updated to match global_vars/all.yml:python_version
+        sudo add-apt-repository ppa:deadsnakes/ppa
+        sudo apt update
+        sudo apt install python3.9
 
         # Install virtualenv as an isolated global executable for deploy-stack in .tests/tests.sh
         python3 -m pip install --user pipx

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
         # may be removed when this file is updated to match global_vars/all.yml:python_version
         sudo add-apt-repository ppa:deadsnakes/ppa
         sudo apt update
-        sudo apt install python3.9
+        sudo apt install python3.9 python3.9-venv
 
         # Install virtualenv as an isolated global executable for deploy-stack in .tests/tests.sh
         python3 -m pip install --user pipx

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,11 @@ jobs:
       with:
         python-version: "3.9"
 
+    - name: Unset Python Env Variables
+      run: |
+        unset pythonLocation
+        unset LD_LIBRARY_PATH
+
     - name: Set up Cloud Python Version
       uses: actions/setup-python@v3
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,15 +28,17 @@ jobs:
     steps:
     # setup 3.9 for deploy-stack
     # may be removed when this file is updated to match global_vars/all.yml:python_version
-    - uses: actions/setup-python@v3
-      with:
-        python-version: "3.9"
+      - name: Setup HQ Python Version
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.9"
 
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.x
+    - name: Set up Cloud Python Version
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.versions.python }}
+
+    - uses: actions/checkout@v3
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,12 +14,11 @@ permissions:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.versions.os }}
 
     strategy:
       matrix:
-        os: [ ubuntu-18.04, ubuntu-22.04 ]
-        python-version: ["3.6", "3.10"]
+        versions: [ {os: ubuntu-18.04, python: "3.6"}, {os: ubuntu-22.04, python: "3.10"} ]
 
     env:
       ANSIBLE_ROLES_PATH: "~/.ansible/roles"
@@ -27,11 +26,17 @@ jobs:
       TEST: main
 
     steps:
+    # setup 3.9 for deploy-stack
+    # may be removed when this file is updated to match global_vars/all.yml:python_version
+    - uses: actions/setup-python@v3
+      with:
+        python-version: "3.9"
+
     - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python 3.x
       uses: actions/setup-python@v3
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{ matrix.versions.python }}
 
     - name: Install dependencies
       run: |
@@ -41,11 +46,6 @@ jobs:
         # Note: the installs must be done in the following order, otherwise the installation of commcare-cloud
         # tries to install from the commcare-cloud-bootstrap.egg_info directory
         pip install -e .[test]
-
-        # Python for deploy-stack in .tests/tests.sh
-        # May be removed when this file is updated to match global_vars/all.yml:python_version
-        curl -sSf --retry 5 -o python-3.9.tar.bz2 'https://storage.googleapis.com/travis-ci-language-archives/python/binaries/ubuntu/18.04/x86_64/python-3.9.tar.bz2'
-        sudo tar xjf python-3.9.tar.bz2 --directory /
 
         # Install virtualenv as an isolated global executable for deploy-stack in .tests/tests.sh
         python3 -m pip install --user pipx

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,8 +14,12 @@ permissions:
 
 jobs:
   build:
+    runs-on: ${{ matrix.os }}
 
-    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        os: [ ubuntu-18.04, ubuntu-22.04 ]
+        python-version: ["3.6", "3.10"]
 
     env:
       ANSIBLE_ROLES_PATH: "~/.ansible/roles"
@@ -24,10 +28,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.6
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:
-        python-version: "3.6"
+        python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,10 +28,10 @@ jobs:
     steps:
     # setup 3.9 for deploy-stack
     # may be removed when this file is updated to match global_vars/all.yml:python_version
-      - name: Setup HQ Python Version
-        uses: actions/setup-python@v3
-        with:
-          python-version: "3.9"
+    - name: Setup HQ Python Version
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.9"
 
     - name: Set up Cloud Python Version
       uses: actions/setup-python@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,11 +14,11 @@ permissions:
 
 jobs:
   build:
-    runs-on: ${{ matrix.versions.os }}
+    runs-on: ubuntu-18.04
 
     strategy:
       matrix:
-        versions: [ {os: ubuntu-18.04, python: "3.6"}, {os: ubuntu-22.04, python: "3.10"} ]
+        python-version: ["3.6", "3.10"]
 
     env:
       ANSIBLE_ROLES_PATH: "~/.ansible/roles"
@@ -31,7 +31,7 @@ jobs:
     - name: Set up Cloud Python Version
       uses: actions/setup-python@v3
       with:
-        python-version: ${{ matrix.versions.python }}
+        python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
       run: |

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ install_deps = [
 ]
 test_deps = [
     'modernize',
-    'nose>=1.3.7',
+    'nose @ git+https://github.com/dimagi/nose.git@06dff28bbe661b9d032ce839ea0ec8e9eaf6f337',
     'parameterized>=0.6.1',
     'requests-mock',
 ]

--- a/src/commcare_cloud/ansible/roles/supervisor/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/supervisor/tasks/main.yml
@@ -68,7 +68,7 @@
   template:
     src: supervisord.systemd.service.j2
     dest: /etc/systemd/system/supervisord.service
-  when: ansible_distribution_version == '18.04'
+  when: ansible_distribution_version == '18.04' || ansible_distribution_version == '22.04'
   register: service_conf
 
 - name: stop supervisor to pick up configuration changes

--- a/src/commcare_cloud/ansible/roles/supervisor/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/supervisor/tasks/main.yml
@@ -4,8 +4,8 @@
   apt: name=supervisor state=absent
   become: yes
 
-- name: install supervisor 4.0.4
-  pip: name=supervisor state=present version=4.0.4
+- name: install supervisor 4.2.1
+  pip: name=supervisor state=present version=4.2.1
   become: yes
 
 - name: link supervisor

--- a/src/commcare_cloud/ansible/roles/supervisor/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/supervisor/tasks/main.yml
@@ -68,7 +68,7 @@
   template:
     src: supervisord.systemd.service.j2
     dest: /etc/systemd/system/supervisord.service
-  when: ansible_distribution_version == '18.04' || ansible_distribution_version == '22.04'
+  when: ansible_distribution_version == '18.04' or ansible_distribution_version == '22.04'
   register: service_conf
 
 - name: stop supervisor to pick up configuration changes


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Update the yml to include running tests on 3.10. Python 3.9 still needs to be installed so deploy-stack is successful, and should match the version of HQ.

More updates: 
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
