### PR TITLE
Make COMMCARE_CLOUD_USE_AWS_SSM=1 the only available behavior

### DIFF
--- a/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -159,8 +159,7 @@ class Ssh(_Ssh):
 
     def should_use_ssm(self, environment):
         return (
-            os.environ.get('COMMCARE_CLOUD_USE_AWS_SSM') != '0'
-            and is_aws_env(environment)
+            is_aws_env(environment)
             and not is_ec2_instance_in_account(environment.aws_config.sso_config.sso_account_id)
         )
 


### PR DESCRIPTION
This is purely cleanup of an env var there is no longer any reason to use

