### PR TITLE
Bump jsonobject to 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -78,7 +78,7 @@ jmespath==0.10.0
     # via
     #   boto3
     #   botocore
-jsonobject==0.9.10
+jsonobject==2.0.0
     # via
     #   commcare-cloud (setup.py)
     #   couchdb-cluster-admin

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ install_deps = [
     'idna==2.6',
     'importlib-metadata==3.1.0',
     'jinja2-cli',
-    'jsonobject>=0.9.0',
+    'jsonobject',
     'netaddr',
     'passlib',
     'pycryptodome>=3.6.6',  # security update


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Need to upgrade to at least v1.0.0 of jsonobject which added support for python 3.10. couchdb-cluster-admin also depends on jsonobject, and has been upgraded to support v2.0.0 so this is the last step.

As far as safety of this goes, the main change to jsonobject is how [ListPropertys accept iterables now](https://github.com/dimagi/jsonobject/blob/master/CHANGES.md) (my understanding). There are lots of ListProperty usages in commcare-cloud, and it is hard to say with confidence that we do not depend on this previous BadValueError exception being raised for iterables. Welcoming any suggestions for gaining a better understanding there.

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
