### PR TITLE
Bump pytz from 2017.2 to 2022.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -104,7 +104,7 @@ pynacl==1.4.0
     #   pygithub
 python-dateutil==2.8.2
     # via botocore
-pytz==2017.2
+pytz==2022.1
     # via commcare-cloud (setup.py)
 pyyaml==5.4.1
     # via

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ install_deps = [
     'passlib',
     'pycryptodome>=3.6.6',  # security update
     'PyGithub>=1.43.3',
-    'pytz==2017.2',
+    'pytz',
     'simplejson',
     'six',
     'tabulate'


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
We use pytz in very standard ways, calling `pytz.timezone(...)` and using `pytz.utc.localize` to localize utc datetimes. I admittedly haven't been able to find a clear changelog for pytz, but reading through documentation [here](https://pypi.org/project/pytz/2022.1/), I have no reason to believe these behaviors have changed.
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
