### PR TITLE
Change Update Translations help text during deploy

### DIFF
--- a/src/commcare_cloud/commands/deploy/commcare.py
+++ b/src/commcare_cloud/commands/deploy/commcare.py
@@ -109,10 +109,13 @@ def _get_diff(environment, deploy_revs):
 def _confirm_translated(environment, quiet=False):
     if datetime.now().isoweekday() != 3 or environment.meta_config.deploy_env != 'production':
         return True
+    github_update_translations_pr_link = \
+        "https://github.com/dimagi/commcare-hq/pulls?q=is%3Apr+Update+Translations+author%3Aapp%2Fgithub-actions+is%3Aopen"
     return ask(
         "It's the weekly Wednesday deploy, did you update the translations "
-        "from transifex? Try running this handy script from the root of your "
-        "commcare-hq directory:\n./scripts/update-translations.sh\n",
+        "from transifex?\n"
+        f"Visit {github_update_translations_pr_link} "
+        'and review and merge the latest automated "Update Translations" pull request.\n',
         quiet=quiet
     )
 


### PR DESCRIPTION
This is an in-line documentation change to match my recent documentation changes in https://confluence.dimagi.com/display/GTD/Deploy+Process and https://confluence.dimagi.com/display/saas/Internationalization+and+Localization+-+Transifex+Translations, based on our consensus from last Friday to make the automated workflow the default process.
