### PR TITLE
[india] Adjust formplayer memory settings

### DIFF
--- a/environments/india/app-processes.yml
+++ b/environments/india/app-processes.yml
@@ -1,5 +1,5 @@
-formplayer_memory: "15g"
-formplayer_g1heapregionsize: "8m"
+formplayer_memory: "8g"
+formplayer_g1heapregionsize: "4m"
 management_commands:
   celery4:
     run_submission_reprocessing_queue:


### PR DESCRIPTION
Adjust formplayer memory settings based on the current instance type
of formplayer1-india, which has 16GB of RAM.

##### ENVIRONMENTS AFFECTED
India
