### PR TITLE
Use subdomain for onse migration

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -25,7 +25,7 @@ soft_assert_email: commcarehq-ops+soft_asserts@dimagi.com
 new_domain_email: inquiries@dimagi.com
 ALTERNATE_HOSTS:
   - rec-mobile.sante.gov.bf
-  - commcare.health.gov.mw
+  - onse-iss.commcarehq.org
 
 DATADOG_ENABLED: True
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

I realized that we needed a separate interim URL for migration. The previous URL should be the final URL, so it shouldn't need to be here.

@shyamkumarlchauhan 

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
