### PR TITLE
configure sentry with formplayer relase name

### DIFF
--- a/src/commcare_cloud/ansible/roles/formplayer/templates/application.properties.j2
+++ b/src/commcare_cloud/ansible/roles/formplayer/templates/application.properties.j2
@@ -15,6 +15,7 @@ sentry.dsn={{ formplayer_sentry_dsn }}
 {% endif %}
 sentry.environment={{ env_monitoring_id }}
 sentry.tags.HQHost={{ host }}
+sentry.release={{ formplayer_release_name }}
 
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.datasource.url=jdbc:postgresql://{{ postgresql_dbs.formplayer.pgbouncer_endpoint }}:{{ postgresql_dbs.formplayer.port

--- a/src/commcare_cloud/ansible/roles/formplayer/vars/main.yml
+++ b/src/commcare_cloud/ansible/roles/formplayer/vars/main.yml
@@ -17,6 +17,8 @@ _formplayer_target_dir: "{{
   else formplayer_release_dir
 }}"
 formplayer_sensitive_data_logging: false
+# used by sentry - should match the sentry release created during deploy
+formplayer_release_name: '{{ new_release_name }}-{{ env_monitoring_id }}'
 
 # Instructs Spring Boot to process X-FORWARDED-FOR headers. Should be set if behind a 
 # trusted load balancer which forwards the original IP in headers.


### PR DESCRIPTION
Current we create the release in Sentry when we deploy using this name but all events from formplayer are tagged with a different release name (the git commit hash). This will tie the events to the correct release.