### PR TITLE
publish a single deploy event instead of multiple

### DIFF
--- a/src/commcare_cloud/commands/deploy/command.py
+++ b/src/commcare_cloud/commands/deploy/command.py
@@ -13,6 +13,7 @@ from commcare_cloud.commands.deploy.commcare import deploy_commcare
 from commcare_cloud.commands.deploy.formplayer import deploy_formplayer
 from commcare_cloud.environment.main import get_environment
 from commcare_cloud.environment.paths import get_available_envs
+from commcare_cloud.events import publish_deploy_event
 from commcare_cloud.fab.utils import retrieve_cached_deploy_env
 
 
@@ -100,6 +101,9 @@ class Deploy(CommandBase):
                 print(color_error("Skipping formplayer because commcare failed"))
             else:
                 rc = deploy_formplayer(environment, args)
+
+        if rc == 0:
+            publish_deploy_event("deploy_success", deploy_component, environment)
         return rc
 
 

--- a/src/commcare_cloud/commands/deploy/commcare.py
+++ b/src/commcare_cloud/commands/deploy/commcare.py
@@ -15,7 +15,6 @@ from commcare_cloud.commands.deploy.utils import (
     record_deploy_failed,
 )
 from commcare_cloud.commands.utils import run_fab_task
-from commcare_cloud.events import publish_deploy_event
 from commcare_cloud.fab.deploy_diff import DeployDiff
 from commcare_cloud.github import github_repo
 
@@ -167,7 +166,6 @@ def record_successful_deploy(environment, context):
     update_sentry_post_deploy(environment, "commcarehq", diff.repo, diff, context.start_time, end_time)
     announce_deploy_success(environment, context)
     call_record_deploy_success(environment, context, end_time)
-    publish_deploy_event("deploy_success", "commcare", environment)
 
 
 def call_record_deploy_success(environment, context, end_time):

--- a/src/commcare_cloud/commands/deploy/formplayer.py
+++ b/src/commcare_cloud/commands/deploy/formplayer.py
@@ -16,7 +16,6 @@ from commcare_cloud.commands.deploy.utils import record_deploy_start, record_dep
     announce_deploy_success, create_release_tag, DeployContext
 from commcare_cloud.user_utils import get_default_username
 from commcare_cloud.commands.utils import timeago
-from commcare_cloud.events import publish_deploy_event
 from commcare_cloud.fab.deploy_diff import DeployDiff
 from commcare_cloud.github import github_repo
 
@@ -98,7 +97,6 @@ def record_deploy_success(environment, context):
     record_deploy_in_datadog(environment, diff, end - context.start_time)
     update_sentry_post_deploy(environment, "formplayer", repo, diff, context.start_time, end)
     announce_deploy_success(environment, context)
-    publish_deploy_event("deploy_success", "formplayer", environment)
 
 
 def get_deploy_diff(environment, repo):

--- a/src/commcare_cloud/events.py
+++ b/src/commcare_cloud/events.py
@@ -4,7 +4,7 @@ import requests
 from fabric.colors import red
 
 
-def publish_deploy_event(name, component, environment):
+def publish_deploy_event(name, components, environment):
     url = environment.fab_settings_config.deploy_event_url
     if not url:
         return
@@ -19,7 +19,7 @@ def publish_deploy_event(name, component, environment):
     data = json.dumps({
         "event_type": name,
         "client_payload": {
-            "component": component,
+            "components": components,
             "environment": environment.meta_config.deploy_env,
         },
     })


### PR DESCRIPTION
This changes the deploy events from 'one per component' to 'one per deploy'
which will prevent triggering unnecessary workflows when both components
are deployed.
