### PR TITLE
Cs/add option to delete kafka

### DIFF
--- a/hosting_docs/source/reference/howto/wipe_persistent_data.rst
+++ b/hosting_docs/source/reference/howto/wipe_persistent_data.rst
@@ -62,6 +62,9 @@ in the sequence given below, so you shouldn't proceed to next steps until the pr
 
       $ cchq <env_name> ap wipe_kafka.yml
 
+   .. note::
+
+      If you encounter any issues executing the wipe_kafka.yml playbook, you can optionally append `--tags reinstall` to the command, which will reinstall Kafka rather than just clearing its topics.
 
    You can check they have been removed by confirming that the following shows
    no output:

--- a/src/commcare_cloud/ansible/wipe_kafka.yml
+++ b/src/commcare_cloud/ansible/wipe_kafka.yml
@@ -2,15 +2,15 @@
 - name: Delete all Kafka topics
   become: true
   hosts: zookeeper  # Doesn't need to run on all Kafka hosts
-  vars_prompt:
-    - name: confirm_wipe
-      prompt: "Are you sure you want to delete all Kafka topics? [yN]"
-      private: no
-
+  tags: delete_topics
   tasks:
+    - pause:
+        prompt: "Are you sure you want to delete all Kafka topics? [y/N]"
+      register: confirm_wipe
+
     - name: Check confirm_wipe
       assert:
-        that: confirm_wipe == 'y'
+        that: confirm_wipe.user_input == 'y'
 
     - name: Check wipe_environment_enabled has been set to True
       assert:
@@ -47,3 +47,72 @@
         --delete
         --zookeeper localhost:{{ zookeeper_client_port }}
         --topic {{ item }}"
+
+- name: Reinstall Kafka
+  hosts: zookeeper
+  become: yes
+  tags:
+    - never
+    - reinstall
+  tasks:
+    - pause:
+        prompt: "Are you sure you want to reinstall Kafka? [y/N]"
+      register: confirm_reinstall
+
+    - name: Check confirm_reinstall
+      assert:
+        that: confirm_reinstall.user_input == 'y'
+
+    - name: Get default vars
+      include_vars: roles/kafka/defaults/main.yml
+
+    - name: Stop kafka-server
+      service: name=kafka-server state=stopped
+      register: kafka_service_stopped
+
+    - debug:
+        var: kafka_service_stopped
+
+    - name: Ensure kafka-server is stopped
+      assert:
+        that: kafka_service_stopped.state == "stopped"
+
+    - name: Remove kafka-server.service
+      file:
+        state: absent
+        path: /etc/systemd/system/kafka-server.service
+
+    - name: Remove Kafka data directory
+      file:
+        state: absent
+        path: "{{ item }}"
+      with_items:
+        - "{{ kafka_data_dir }}"
+
+    - name: Remove Kafka log symlink
+      file:
+        state: absent
+        path: /opt/kafka/logs
+
+    - name: Remove Kafka log
+      file:
+        state: absent
+        path: "{{ kafka_log_dir }}"
+
+    - name: Remove Kafka server directory
+      file:
+        state: absent
+        path: /etc/kafka
+
+    - name: Remove Kafka symlink
+      file:
+        state: absent
+        path: /opt/kafka
+
+    - name: Remove Kafka
+      file:
+        state: absent
+        path: "/opt/kafka_{{ kafka_scala_version }}-{{ kafka_version }}"
+
+    - include_role:
+        name: kafka


### PR DESCRIPTION
TdH has recently experienced some odd issue where they couldn't run the `wipe_kafka.yml` playbook successfully, as the script tried to delete an internal topic (`__consumer_offsets`). As a result of this, we've thought it best to also include the option to reinstall kafka when running the playbook (the _"when your hammer is too small, use a bigger hammer"_ philosophy).

(After thinking about it, is it enough to just reinstall kafka? Should I also be removing Zookeeper, since Zookeeper is the one that actually [keeps track of the list of topics](https://www.cloudkarafka.com/blog/cloudkarafka-what-is-zookeeper.html#:~:text=Zookeeper%20keeps%20track%20of%20status%20of%20the%20Kafka%20cluster%20nodes%20and%20it%20also%20keeps%20track%20of%20Kafka%20topics%2C%20partitions%20etc)?)

##### ENVIRONMENTS AFFECTED
All (I guess)