### PR TITLE
generate the terraform lockfile for all platforms

### DIFF
--- a/src/commcare_cloud/commands/terraform/templates/terraform.lock.hcl.j2
+++ b/src/commcare_cloud/commands/terraform/templates/terraform.lock.hcl.j2
@@ -5,7 +5,9 @@ provider "registry.terraform.io/hashicorp/archive" {
   version     = "2.2.0"
   constraints = "~> 2.2.0"
   hashes = [
+    "h1:2K5LQkuWRS2YN1/YoNaHn9MAzjuTX8Gaqy6i8Mbfv8Y=",
     "h1:CIWi5G6ob7p2wWoThRQbOB8AbmFlCzp7Ka81hR3cVp0=",
+    "h1:Rxkd7mWSvHMLppeKeW6+7BxWGP0h4xZdfb5sd4pGQq8=",
     "zh:06bd875932288f235c16e2237142b493c2c2b6aba0e82e8c85068332a8d2a29e",
     "zh:0c681b481372afcaefddacc7ccdf1d3bb3a0c0d4678a526bc8b02d0c331479bc",
     "zh:100fc5b3fc01ea463533d7bbfb01cb7113947a969a4ec12e27f5b2be49884d6c",
@@ -24,7 +26,9 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.8.0"
   constraints = ">= 2.49.0, ~> 4.8.0"
   hashes = [
+    "h1:28IGImrkJquWBof3t9hNZfXrwBhqEr9rIKvPWLc1a10=",
     "h1:T9Typ5V+dDwecG9USCLbW4oayxN3cxEGsG+OJzzjRgY=",
+    "h1:W2cPGKmqkPbTc91lu42QeC3RFBqB5TnRnS3IxNME2FM=",
     "zh:16cbdbc03ad13358d12433e645e2ab5a615e3a3662a74e3c317267c9377713d8",
     "zh:1d813c5e6c21fe370652495e29f783db4e65037f913ff0d53d28515c36fbb70a",
     "zh:31ad8282e31d0fac62e96fc2321a68ad4b92ab90f560be5f875d1b01a493e491",
@@ -44,6 +48,8 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.1.3"
   constraints = ">= 2.2.0, >= 3.1.0, ~> 3.1.2"
   hashes = [
+    "h1:7+wnAXQM7IpNEAQ6WZXdO0ZfQW/ncQFXYJ5T2KaR+Z8=",
+    "h1:d4M8bOY9r99suD5EYfdZUvbhtq6hzCHa2SeY+T+IRlA=",
     "h1:nLWniS8xhb32qRQy+n4bDPjQ7YWZPVMR3v1vSrx7QyY=",
     "zh:26e07aa32e403303fc212a4367b4d67188ac965c37a9812e07acee1470687a73",
     "zh:27386f48e9c9d849fbb5a8828d461fde35e71f6b6c9fc235bc4ae8403eb9c92d",


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All. 

The current `terraform.lock.hcl` file is generated from a Linux machine and when trying from a mac it is reusing those hashes and not downloading versions for mac systems. This is blocking us from running the tf plan command. 
To fix the problem I have generated a lock file for all platforms using the below command
`terraform providers lock -platform=windows_amd64 -platform=darwin_amd64 -platform=linux_amd64` 

Another way to solve the problem is not to commit lock.hcl itself and generate new ones every time.

References:
https://github.com/hashicorp/terraform/blob/be263151e776e84688f1b0648084a1a6f280d78a/website/docs/commands/providers/lock.html.md#lock-entries-for-in-house-providers

https://github.com/hashicorp/terraform/issues/27135#issuecomment-738679614

![image](https://user-images.githubusercontent.com/11612356/183389799-eb9b8225-3bd4-467b-9af2-c8b1020f4f50.png)

