### PR TITLE
Create playbook to bootstrap python3.10 on deploy_stack

### DIFF
--- a/src/commcare_cloud/ansible/bootstrap_python.yml
+++ b/src/commcare_cloud/ansible/bootstrap_python.yml
@@ -1,0 +1,26 @@
+---
+- hosts: all
+  gather_facts: no
+  tasks:
+
+    - name: Check for Python 3.10
+      raw: test -e /usr/bin/python3.10
+      register: check_python
+      check_mode: no
+      failed_when: false
+      changed_when: false
+
+    - name: Install Python 3.10
+      raw: add-apt-repository -y ppa:deadsnakes/ppa && apt update && apt-get -y install python3.10
+      when: check_python.rc != 0
+
+    - name: Check symlink is setup
+      raw: python3 -c "import platform; print(platform.python_version())"
+      register: check_symlink
+      check_mode: no
+      failed_when: false
+      changed_when: false
+
+    - name: Create symlink for 3.10
+      raw: ln -sf /usr/bin/python3.10 /usr/bin/python3
+      when: (check_symlink.stdout | regex_replace('[\\r\\n]+','')) is version('3.10', '<', strict=True)

--- a/src/commcare_cloud/ansible/bootstrap_python.yml
+++ b/src/commcare_cloud/ansible/bootstrap_python.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: control
+- hosts: all
   gather_facts: no
   tasks:
 

--- a/src/commcare_cloud/ansible/bootstrap_python.yml
+++ b/src/commcare_cloud/ansible/bootstrap_python.yml
@@ -11,7 +11,11 @@
       changed_when: false
 
     - name: Install Python 3.10
-      raw: add-apt-repository -y ppa:deadsnakes/ppa && apt update && apt-get -y install python3.10
+      raw: add-apt-repository -y ppa:deadsnakes/ppa && apt update && apt-get -y install python3.10 python3.10-distutils python3.10-dev
+      when: check_python.rc != 0
+
+    - name: Update pip, setuptools, and wheel in 3.10 target
+      raw: pip3 install --upgrade --target=/usr/local/lib/python3.10/dist-packages pip setuptools wheel
       when: check_python.rc != 0
 
     - name: Check symlink is setup

--- a/src/commcare_cloud/ansible/bootstrap_python.yml
+++ b/src/commcare_cloud/ansible/bootstrap_python.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: all
+- hosts: control
   gather_facts: no
   tasks:
 

--- a/src/commcare_cloud/ansible/deploy_stack.yml
+++ b/src/commcare_cloud/ansible/deploy_stack.yml
@@ -2,6 +2,7 @@
 # deploy-stack.yml
 
 - import_playbook: update_apt_cache.yml
+- import_playbook: bootstrap_python.yml
 - import_playbook: deploy_common.yml
 - import_playbook: deploy_ebsnvme_mapping.yml
 - import_playbook: deploy_lvm.yml


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
With this change, running `deploy_stack` on a machine will result in python 3.10 being used instead of 3.6. We are achieving 2 goals with this setup. 1) control machines (aka machines that run commcare-cloud) will run with 3.10 2) non-control machines will use 3.10 when executing ansible roles. 

As far as the installations in addition to python 3.10, this is caused due to an incompatibility with 3.10 in the current pip/setuptools installed on the machine. To borrow from this [SO post](https://stackoverflow.com/a/69573368):
> The problem is caused by an old version of pyparsing that has been vendored into pkg_resources, which is now part of setuptools.

Rather than take the approach recommended in that post which includes cloning the setuptools repo and updating python3.10's pip using `curl`, we instead use the current installation of python3.6/pip to upgrade pip, setuptools, and wheel at the location that python3.10 will reference. This ensures that pip will execute successfully when invoked from python3.10.

##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None