### PR TITLE
Update datadog apt key to the new one from the docs

### DIFF
--- a/src/commcare_cloud/ansible/roles/datadog/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/datadog/tasks/main.yml
@@ -1,10 +1,7 @@
-- name: Remove old datadog apt keys
-  apt_key: id="{{ item }}" keyserver=keyserver.ubuntu.com state=absent
+- name: Remove old datadog apt key
+  apt_key: id=382E94DE keyserver=keyserver.ubuntu.com state=absent
   tags:
     - datadog
-  with_items:
-    - 382E94DE
-    - 33EE313BAD9589B7
 
 - name: Add datadog apt key
   apt_key: id=F14F620E keyserver=keyserver.ubuntu.com state=present

--- a/src/commcare_cloud/ansible/roles/datadog/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/datadog/tasks/main.yml
@@ -1,10 +1,13 @@
-- name: Add datadog apt key
-  apt_key: id=382E94DE keyserver=keyserver.ubuntu.com state=present
+- name: Remove old datadog apt keys
+  apt_key: id="{{ item }}" keyserver=keyserver.ubuntu.com state=absent
   tags:
     - datadog
+  with_items:
+    - 382E94DE
+    - 33EE313BAD9589B7
 
 - name: Add datadog apt key
-  apt_key: id=33EE313BAD9589B7 keyserver=keyserver.ubuntu.com state=present
+  apt_key: id=F14F620E keyserver=keyserver.ubuntu.com state=present
   tags:
     - datadog
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-13167

Docs: https://docs.datadoghq.com/agent/guide/linux-agent-2022-key-rotation/?tab=debianubuntu

See also https://forum.dimagi.com/t/error-installing-datadog-on-new-server/9207 for context. 

##### ENVIRONMENTS AFFECTED
all that use datadog
