### PR TITLE
Check if VENV is set, otherwise default

### DIFF
--- a/quick_monolith_install/cchq-install.sh
+++ b/quick_monolith_install/cchq-install.sh
@@ -60,6 +60,9 @@ printf "storing your CommCareHQ instance's configuration \n"
 printf "#################################################"
 printf "\n"
 # VENV should have been set by init.sh
+DEFAULT_VENV=~/.virtualenvs/cchq
+VENV=${VENV:-$DEFAULT_VENV}
+
 ansible-playbook --connection=local --extra-vars "@$config_file_path" --extra-vars "cchq_venv=$VENV" "$DIR/bootstrap-env-playbook.yml"
 printf "\n Encrypting your environment's passwords file using ansible-vault.\n"
 printf "Please store this password safely as it will be asked multiple times during the install.\n"


### PR DESCRIPTION
It seems sometimes the VENV variable is not set (i.e. is blank) when `cchq-install.sh` is executed, which is weird, because `echo y | source "$DIR/../control/init.sh"` is executed correctly according to the output.

This PR attempts to mitigate the VENV issue by defaulting to the value that it's supposed to be when `init.sh` executes and would have set it to.

(not sure if a deeper investigation is warranted?)

##### ENVIRONMENTS AFFECTED
Quick monolith install
