### PR TITLE
Add option to use python3.10 in init.sh

### DIFF
--- a/control/init.sh
+++ b/control/init.sh
@@ -11,7 +11,7 @@ fi
 
 
 function realpath() {
-    python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" $1
+    python -c "import os,sys; print(os.path.realpath(sys.argv[1]))" $1
 }
 
 

--- a/control/init.sh
+++ b/control/init.sh
@@ -1,5 +1,6 @@
 #! /bin/bash
 CCHQ_VIRTUALENV=${CCHQ_VIRTUALENV:-cchq}
+CCHQ_PYTHON=$([ "$CCHQ_VIRTUALENV" == cchq ] && echo 36 || echo 310)
 VENV=~/.virtualenvs/$CCHQ_VIRTUALENV
 
 if [[ $_ == $0 ]]
@@ -16,10 +17,18 @@ function realpath() {
 
 
 if [ -z ${CI_TEST} ]; then
-    if [ ! -f $VENV/bin/activate ]; then
-        # use virtualenv because `python3 -m venv` is broken on Ubuntu 18.04
-        python3 -m pip install --user --upgrade virtualenv
-        python3 -m virtualenv $VENV
+    if [ "$CCHQ_PYTHON" == 310 ]; then
+      if [ ! -f $VENV/bin/activate ]; then
+          # use virtualenv because `python3 -m venv` is broken on Ubuntu 18.04
+          python3.10 -m pip install --user --upgrade virtualenv
+          python3.10 -m virtualenv $VENV
+      fi
+    else
+      if [ ! -f $VENV/bin/activate ]; then
+          # use virtualenv because `python3 -m venv` is broken on Ubuntu 18.04
+          python3 -m pip install --user --upgrade virtualenv
+          python3 -m virtualenv $VENV
+      fi
     fi
     source $VENV/bin/activate
 fi

--- a/control/init.sh
+++ b/control/init.sh
@@ -1,6 +1,5 @@
 #! /bin/bash
 CCHQ_VIRTUALENV=${CCHQ_VIRTUALENV:-cchq}
-CCHQ_PYTHON=$([ "$CCHQ_VIRTUALENV" == cchq ] && echo 36 || echo 310)
 VENV=~/.virtualenvs/$CCHQ_VIRTUALENV
 
 if [[ $_ == $0 ]]
@@ -17,18 +16,14 @@ function realpath() {
 
 
 if [ -z ${CI_TEST} ]; then
-    if [ "$CCHQ_PYTHON" == 310 ]; then
-      if [ ! -f $VENV/bin/activate ]; then
-          # use virtualenv because `python3 -m venv` is broken on Ubuntu 18.04
-          python3.10 -m pip install --user --upgrade virtualenv
-          python3.10 -m virtualenv $VENV
-      fi
-    else
-      if [ ! -f $VENV/bin/activate ]; then
-          # use virtualenv because `python3 -m venv` is broken on Ubuntu 18.04
-          python3 -m pip install --user --upgrade virtualenv
-          python3 -m virtualenv $VENV
-      fi
+    if [ ! -f $VENV/bin/activate ]; then
+        python_version="python3"
+        if [[ "$CCHQ_VIRTUALENV" == *"3.10"* ]]; then
+          python_version="python3.10"
+        fi
+        # use virtualenv because `python3 -m venv` is broken on Ubuntu 18.04
+        $python_version -m pip install --user --upgrade virtualenv
+        $python_version -m virtualenv $VENV
     fi
     source $VENV/bin/activate
 fi


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
We want to upgrade commcare-cloud to support 3.10, and this is a step needed to test cchq commands on 3.10.
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
