### PR TITLE
Add access to s3 blobdb bucket to CommCareServerRole

### DIFF
--- a/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
@@ -86,6 +86,7 @@ module "server_iam_role" {
   region_name = var.region
   formplayer_request_response_logs_firehose_stream_arn = module.logshipping.formplayer_request_response_logs_firehose_stream_arn
   account_alias =  var.account_alias
+  s3_blob_db_s3_bucket = var.s3_blob_db_s3_bucket
 }
 
 {% for server_spec in servers + proxy_servers %}

--- a/src/commcare_cloud/commands/terraform/templates/terraform.tfvars.j2
+++ b/src/commcare_cloud/commands/terraform/templates/terraform.tfvars.j2
@@ -59,3 +59,4 @@ proxy_servers = [
 ]
 
 account_alias = {{ (account_alias or "")|tojson }}
+s3_blob_db_s3_bucket = {{ s3_blob_db_s3_bucket|tojson }}

--- a/src/commcare_cloud/commands/terraform/templates/variables.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/variables.tf.j2
@@ -107,3 +107,5 @@ variable "proxy_servers" {
   type = list
   default = []
 }
+
+variable "s3_blob_db_s3_bucket" {}

--- a/src/commcare_cloud/commands/terraform/terraform.py
+++ b/src/commcare_cloud/commands/terraform/terraform.py
@@ -168,6 +168,7 @@ def generate_terraform_entrypoint(environment, key_name, run_dir, apply_immediat
         'postgresql_params': get_postgresql_params_by_rds_instance(environment),
         'commcarehq_xml_post_urls_regex': compact_waf_regexes(COMMCAREHQ_XML_POST_URLS_REGEX),
         'commcarehq_xml_querystring_urls_regex': compact_waf_regexes(COMMCAREHQ_XML_QUERYSTRING_URLS_REGEX),
+        's3_blob_db_s3_bucket': environment.public_vars.get('s3_blob_db_s3_bucket'),
     })
 
     context.update({

--- a/src/commcare_cloud/terraform/modules/server/iam/main.tf
+++ b/src/commcare_cloud/terraform/modules/server/iam/main.tf
@@ -79,6 +79,38 @@ resource "aws_iam_role_policy" "commcare_secrets_access_policy" {
   POLICY
 }
 
+resource "aws_iam_role_policy" "access_s3_commcare_blobdb" {
+  name = "AccessS3CommcareBlobdb"
+  role = aws_iam_role.commcare_server_role.id
+
+  policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": [
+                "s3:DeleteObjectTagging",
+                "s3:PutObject",
+                "s3:GetObject",
+                "s3:ListBucketVersions",
+                "s3:GetObjectTagging",
+                "s3:ListBucket",
+                "s3:PutObjectTagging",
+                "s3:DeleteObject",
+                "s3:GetObjectVersion"
+            ],
+            "Resource": [
+                "arn:aws:s3:::${var.s3_blob_db_s3_bucket}/*",
+                "arn:aws:s3:::${var.s3_blob_db_s3_bucket}"
+            ]
+        }
+    ]
+}
+  POLICY
+}
+
 resource "aws_iam_instance_profile" "commcare_server_instance_profile" {
   name = "CommCareServerRole"
   role = aws_iam_role.commcare_server_role.name

--- a/src/commcare_cloud/terraform/modules/server/iam/variables.tf
+++ b/src/commcare_cloud/terraform/modules/server/iam/variables.tf
@@ -3,3 +3,4 @@ variable "account_id" {}
 variable "environment" {}
 variable "region_name" {}
 variable "account_alias" {}
+variable "s3_blob_db_s3_bucket" {}


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-13894

This is the other side of https://github.com/dimagi/commcare-hq/pull/32071. Both are required before we can set s3 credentials to `None` and rely on EC2 roles.

##### ENVIRONMENTS AFFECTED
staging, india, production
