### PR TITLE
Use venv instead of virtualenv on 3.10

### DIFF
--- a/control/init.sh
+++ b/control/init.sh
@@ -17,13 +17,14 @@ function realpath() {
 
 if [ -z ${CI_TEST} ]; then
     if [ ! -f $VENV/bin/activate ]; then
-        python_version="python3"
-        if [[ "$CCHQ_VIRTUALENV" == *"3.10"* ]]; then
-          python_version="python3.10"
+        if [[ $CCHQ_VIRTUALENV == *3.10* ]]; then
+          # use venv because 3.10 setup includes installing python3.10-venv
+          python3.10 -m venv $VENV
+        else
+          # use virtualenv because `python3 -m venv` requires python3-venv
+          python3 -m pip install --user --upgrade virtualenv
+          python3 -m virtualenv $VENV
         fi
-        # use virtualenv because `python3 -m venv` is broken on Ubuntu 18.04
-        $python_version -m pip install --user --upgrade virtualenv
-        $python_version -m virtualenv $VENV
     fi
     source $VENV/bin/activate
 fi

--- a/quick_monolith_install/cchq-install.sh
+++ b/quick_monolith_install/cchq-install.sh
@@ -41,7 +41,7 @@ sudo apt --assume-yes -qq install python3-pip sshpass
 sudo -H pip3 -q install --upgrade pip
 sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 if [[ $CCHQ_VIRTUALENV == *3.10* ]]; then
-  sudo add-apt-repository --assume-yes -qq ppa:deadsnakes/ppa
+  sudo add-apt-repository -y ppa:deadsnakes/ppa
   sudo apt update
   sudo apt-get --assume-yes -q install python3.10 python3.10-dev python3.10-distutils python3.10-venv libffi-dev
 else

--- a/quick_monolith_install/cchq-install.sh
+++ b/quick_monolith_install/cchq-install.sh
@@ -40,7 +40,13 @@ sudo apt --assume-yes -qq update
 sudo apt --assume-yes -qq install python3-pip sshpass
 sudo -H pip3 -q install --upgrade pip
 sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 10
-sudo -H pip -q install ansible virtualenv virtualenvwrapper --ignore-installed six
+if [[ $CCHQ_VIRTUALENV == *3.10* ]]; then
+  sudo add-apt-repository --assume-yes -qq ppa:deadsnakes/ppa
+  sudo apt update
+  sudo apt-get --assume-yes -q install python3.10 python3.10-dev python3.10-distutils python3.10-venv libffi-dev
+else
+  sudo -H pip -q install ansible virtualenv virtualenvwrapper --ignore-installed six
+fi
 
 printf "\n"
 printf "#################################################"


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
This should allow us to switch from `virtualenv` to `venv` as users move onto 3.10, without breaking any existing 3.6 workflows. 
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
