### PR TITLE
Remove virtualenvwrapper dependency

### DIFF
--- a/hosting_docs/source/installation/2-manual-install.rst
+++ b/hosting_docs/source/installation/2-manual-install.rst
@@ -173,7 +173,10 @@ Prepare all machines for automated deploy
 
       ::
 
-         $ sudo -H pip install ansible virtualenv virtualenvwrapper --ignore-installed six
+         $ sudo -H pip install ansible virtualenv --ignore-installed six
+
+      .. note ::
+        We no longer depend on virtualenvwrapper, but you are welcome to install and manage it manually.
 
 Create a user for yourself
 --------------------------

--- a/provisioning/control.sh
+++ b/provisioning/control.sh
@@ -7,7 +7,7 @@ ssh-keyscan 192.168.33.17 >> /home/vagrant/.ssh/known_hosts
 sudo chown vagrant:vagrant /home/vagrant/.ssh/known_hosts
 
 ln -s /vagrant /home/vagrant/commcare-cloud
-sudo pip install virtualenv virtualenvwrapper
+sudo pip install virtualenv
 sudo -H -u vagrant /vagrant/control/init.sh
 echo '[ -t 1 ] && source ~/init-ansible' >> /home/vagrant/.profile
 

--- a/quick_monolith_install/cchq-install.sh
+++ b/quick_monolith_install/cchq-install.sh
@@ -45,7 +45,7 @@ if [[ $CCHQ_VIRTUALENV == *3.10* ]]; then
   sudo apt update
   sudo apt-get --assume-yes -q install python3.10 python3.10-dev python3.10-distutils python3.10-venv libffi-dev
 else
-  sudo -H pip -q install ansible virtualenv virtualenvwrapper --ignore-installed six
+  sudo -H pip -q install ansible virtualenv --ignore-installed six
 fi
 
 printf "\n"

--- a/src/commcare_cloud/ansible/roles/ansible-control/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/ansible-control/tasks/main.yml
@@ -31,7 +31,6 @@
   pip:
     name:
       - virtualenv
-      - virtualenvwrapper
     extra_args: '--ignore-installed six'
     umask: "0022"
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
We no longer use any virtualenvwrapper syntax in commcare-cloud, so the dependency is unnecessary. If a user wishes to install it for their own use, they are welcome to do so.
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
