### PR TITLE
Set default nginx_version to current stable

### DIFF
--- a/src/commcare_cloud/ansible/roles/nginx/defaults/main.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/defaults/main.yml
@@ -7,3 +7,4 @@ primary_ssl_env: ""
 nginx_hsts_max_age: null
 nginx_worker_rlimit_nofile: null
 couch_excluded_hosts: null
+nginx_version: "1.22.0-1~bionic"

--- a/src/commcare_cloud/ansible/roles/nginx/tasks/install.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/tasks/install.yml
@@ -9,13 +9,17 @@
   become: yes
   apt_key: url=https://nginx.org/keys/nginx_signing.key state=present
 
-- name: Add nginx repository
+- name: Remove nginx mainline repository
   become: yes
-  apt_repository: repo='deb http://nginx.org/packages/mainline/ubuntu/ bionic nginx' state=present
+  apt_repository: repo='deb http://nginx.org/packages/mainline/ubuntu/ bionic nginx' state=absent
+
+- name: Add nginx stable repository
+  become: yes
+  apt_repository: repo='deb http://nginx.org/packages/ubuntu bionic nginx' state=present
 
 - name: Install nginx
   become: yes
-  apt: name="nginx={{ nginx_version|default('1.17.3-1~bionic') }}" state=present update_cache=yes cache_valid_time=3600
+  apt: name="nginx={{ nginx_version }}" state=present update_cache=yes cache_valid_time=3600
   notify: 'quick start nginx'
 
 - meta: flush_handlers  # need to start nginx as quickly as possible for minimal downtime


### PR DESCRIPTION
This change ...
* removes nginx's mainline repo
* adds nginx's stable repo
* sets "nginx_version" in defaults/main.yml to the current stable version

##### ENVIRONMENTS AFFECTED

All
