### PR TITLE
Fix VENV issue in cchq-install script

### DIFF
--- a/control/init.sh
+++ b/control/init.sh
@@ -1,6 +1,7 @@
 #! /bin/bash
 CCHQ_VIRTUALENV=${CCHQ_VIRTUALENV:-cchq}
 VENV=~/.virtualenvs/$CCHQ_VIRTUALENV
+NO_INPUT=0
 
 if [[ $_ == $0 ]]
 then
@@ -140,10 +141,13 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 SITE_PACKAGES=$(python -c 'import site; print(site.getsitepackages()[0])')
 
-if ! grep -q init-ansible ~/.profile 2>/dev/null; then
-    printf "${YELLOW}Do you want to have the CommCare Cloud environment setup on login?${NC}\n"
-    if [ -z ${CI_TEST} ]; then
-        read -t 30 -p "(y/n): " yn
+if [ -z ${CI_TEST} ]; then
+  if ! grep -q init-ansible ~/.profile 2>/dev/null; then
+    if [ $NO_INPUT == 1 ]; then
+      yn='y'
+    else
+      printf "${YELLOW}Do you want to have the CommCare Cloud environment setup on login?${NC}\n"
+      read -t 30 -p "(y/n): " yn
     fi
     case $yn in
         [Yy]* )
@@ -159,6 +163,7 @@ if ! grep -q init-ansible ~/.profile 2>/dev/null; then
             printf "${BLUE}echo '[ -t 1 ] && source ~/init-ansible' >> ~/.profile${NC}\n"
         ;;
     esac
+  fi
 fi
 
 # It aint pretty, but it gets the job done

--- a/quick_monolith_install/cchq-install.sh
+++ b/quick_monolith_install/cchq-install.sh
@@ -56,7 +56,7 @@ printf "\n"
 # install comcare-cloud
 DIR="${BASH_SOURCE%/*}"
 if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
-echo y | source "$DIR/../control/init.sh"
+NO_INPUT=1 source "$DIR/../control/init.sh"
 sudo touch /var/log/ansible.log && sudo chmod 666 /var/log/ansible.log
 
 printf "\n"
@@ -65,9 +65,6 @@ printf "\nStep 3: Initializing environments directory for "
 printf "storing your CommCareHQ instance's configuration \n"
 printf "#################################################"
 printf "\n"
-# VENV should have been set by init.sh
-DEFAULT_VENV=~/.virtualenvs/cchq
-VENV=${VENV:-$DEFAULT_VENV}
 
 ansible-playbook --connection=local --extra-vars "@$config_file_path" --extra-vars "cchq_venv=$VENV" "$DIR/bootstrap-env-playbook.yml"
 printf "\n Encrypting your environment's passwords file using ansible-vault.\n"


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Followup to https://github.com/dimagi/commcare-cloud/pull/5409

Daniel flagged the above PR as I happen to be working in this area as well. I ran some tests locally, creating parent.sh and child.sh bash scripts to test the scope of variables between the two. It appears the crux of the issue is that we invoke the init script with a pipe: `echo y | source "$DIR/../control/init.sh"`.

The problem with the pipe is that it results in the init script running in a forked process, and variables defined in the this child process are not available in the parent process. I figured the `echo y | ...` portion of that line is to answer yes to the prompt about setting up commcare-cloud on login when running the init script.

My solution is to create a new variable in the init script named `NO_INPUT` which can be set to true/1 if the desire is to default answer(s) to yes. This way we can:
1) skip the prompt if we'd prefer to choose for the user 
2) run the init script within the current bash process to scope the variables defined in the init script correctly

Here are the results of my local tests and the content of the scripts I used to test this.

```
➜  commcare-cloud git:(gh/fix-venv-issue) ✗ bash parent.sh pipe
TEST_VAR:
➜  commcare-cloud git:(gh/fix-venv-issue) ✗ bash parent.sh no-pipe
TEST_VAR:  set in child.sh
```

parent.sh
```
#! /bin/bash

if [ $1 == "pipe" ]; then
  echo y | source child.sh
elif [ $1 == "no-pipe" ]; then
  source child.sh
fi

echo "TEST_VAR: " $TEST_VAR
```

child.sh
```
#! /bin/bash

TEST_VAR="set in child.sh"
```
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
