### PR TITLE
Add missing pyOpenSSL dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,11 +45,12 @@ clint==0.5.1
     # via commcare-cloud (setup.py)
 couchdb-cluster-admin==0.7.2
     # via commcare-cloud (setup.py)
-cryptography==35.0.0
+cryptography==38.0.1
     # via
     #   ansible-core
     #   commcare-cloud (setup.py)
     #   paramiko
+    #   pyopenssl
 datadog==0.42.0
     # via commcare-cloud (setup.py)
 deprecated==1.2.13
@@ -118,6 +119,8 @@ pynacl==1.4.0
     # via
     #   paramiko
     #   pygithub
+pyopenssl==22.0.0
+    # via commcare-cloud (setup.py)
 pyparsing==3.0.9
     # via packaging
 python-dateutil==2.8.2

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_deps = [
     'boto3>=1.9.131',
     'clint',
     'couchdb-cluster-admin',
-    'cryptography>=3.2',
+    'cryptography~=38.0',
     'datadog>=0.2.0',
     'dimagi-memoized>=1.1.0',
     'dnspython',
@@ -26,6 +26,7 @@ install_deps = [
     'passlib',
     'pycryptodome>=3.6.6',  # security update
     'PyGithub>=1.43.3',
+    'pyOpenSSL~=22.0',
     'pytz',
     'simplejson',
     'six',


### PR DESCRIPTION
Add missing pyOpenSSL dependency (22.x), as we've been relying on a system
package that gets installed indirectly, and bump cryptography to 38.x.

The current system provided version of pyOpenSSL (python3-openssl) is no
longer compatible with the authorized_key ansible module.

##### ENVIRONMENTS AFFECTED
All
