### PR TITLE
Create and use 3.10 venv if 3.10 is installed

### DIFF
--- a/control/init.sh
+++ b/control/init.sh
@@ -2,7 +2,7 @@
 CCHQ_VIRTUALENV=${CCHQ_VIRTUALENV:-cchq}
 VENV=~/.virtualenvs/$CCHQ_VIRTUALENV
 NO_INPUT=0
-USE_SYSTEM_PYTHON=${USE_SYSTEM_PYTHON:-false}
+BIONIC_USE_SYSTEM_PYTHON=${BIONIC_USE_SYSTEM_PYTHON:-false}
 
 if [[ $_ == $0 ]]
 then
@@ -18,14 +18,14 @@ function realpath() {
 
 
 if [ -z ${CI_TEST} ]; then
-    if [[ $USE_SYSTEM_PYTHON == true ]] && hash python3.10 2>/dev/null && [[ $( source /etc/os-release; echo $VERSION_ID ) == 18.04 ]]; then
-        # if on 18.04 with 3.10 installed, use cchq-3.10 unless $USE_SYSTEM_PYTHON is true
+    if [[ $BIONIC_USE_SYSTEM_PYTHON == false ]] && hash python3.10 2>/dev/null && [[ $( source /etc/os-release; echo $VERSION_ID ) == 18.04 ]]; then
+        # if on 18.04 with 3.10 installed, use cchq-3.10 unless $BIONIC_USE_SYSTEM_PYTHON is true
         CCHQ_VIRTUALENV=$CCHQ_VIRTUALENV-3.10
         VENV=~/.virtualenvs/$CCHQ_VIRTUALENV
     fi
     # check if a virtualenv at $VENV exists yet, and create if not
     if [[ ! -f $VENV/bin/activate ]]; then
-        if hash python3.10 2>/dev/null; then
+        if [[ $BIONIC_USE_SYSTEM_PYTHON == false ]] && hash python3.10 2>/dev/null; then
             echo "Creating a python3.10 virtual environment named ${CCHQ_VIRTUALENV}"
             # use venv because 3.10 setup includes installing python3.10-venv
             python3.10 -m venv $VENV

--- a/control/init.sh
+++ b/control/init.sh
@@ -17,7 +17,7 @@ function realpath() {
 
 
 if [ -z ${CI_TEST} ]; then
-    if [[ $(cat /etc/os-release | grep '^VERSION=' | tr -dc '0-9.') == *18.04* && hash python3.10 2>/dev/null ]]; then
+    if [[ $(cat /etc/os-release | grep '^VERSION=' | tr -dc '0-9.') == *18.04* ]] && hash python3.10 2>/dev/null; then
         # if on 18.04 and 3.10 is installed, figure out which name to use for a 3.10 virtualenv
         if [[ -f $VENV/bin/python3.6 ]]; then
             # if a 3.6 environment with the $CCHQ_VIRTUALENV name already exists, append '-3.10'

--- a/control/init.sh
+++ b/control/init.sh
@@ -17,8 +17,8 @@ function realpath() {
 
 
 if [ -z ${CI_TEST} ]; then
-    if hash python3.10 2>/dev/null; then
-        # figure out which name to use for a 3.10 virtualenv, defaulting to $CCHQ_VIRTUALENV
+    if [[ $(cat /etc/os-release | grep '^VERSION=' | tr -dc '0-9.') == *18.04* && hash python3.10 2>/dev/null ]]; then
+        # if on 18.04 and 3.10 is installed, figure out which name to use for a 3.10 virtualenv
         if [[ -f $VENV/bin/python3.6 ]]; then
             # if a 3.6 environment with the $CCHQ_VIRTUALENV name already exists, append '-3.10'
             CCHQ_VIRTUALENV=$CCHQ_VIRTUALENV-3.10

--- a/control/init.sh
+++ b/control/init.sh
@@ -23,6 +23,7 @@ if [ -z ${CI_TEST} ]; then
             if [[ -f $VENV/bin/python3.6 ]]; then
                 # if a 3.6 environment with the $CCHQ_VIRTUALENV name already exists, append '-3.10'
                 CCHQ_VIRTUALENV=$CCHQ_VIRTUALENV-3.10
+                VENV=~/.virtualenvs/$CCHQ_VIRTUALENV
             fi
             # check if a virtualenv at $VENV exists yet, and create if not
             if [[ ! -f $VENV/bin/activate ]]; then

--- a/control/init.sh
+++ b/control/init.sh
@@ -17,13 +17,10 @@ function realpath() {
 
 
 if [ -z ${CI_TEST} ]; then
-    if [[ $(cat /etc/os-release | grep '^VERSION=' | tr -dc '0-9.') == *18.04* ]] && hash python3.10 2>/dev/null; then
-        # if on 18.04 and 3.10 is installed, figure out which name to use for a 3.10 virtualenv
-        if [[ -f $VENV/bin/python3.6 ]]; then
-            # if a 3.6 environment with the $CCHQ_VIRTUALENV name already exists, append '-3.10'
-            CCHQ_VIRTUALENV=$CCHQ_VIRTUALENV-3.10
-            VENV=~/.virtualenvs/$CCHQ_VIRTUALENV
-        fi
+    if hash python3.10 2>/dev/null && [[ $( source /etc/os-release; echo $VERSION_ID ) == 18.04 ]]; then
+        # if on 18.04 with 3.10 installed, use cchq-3.10
+        CCHQ_VIRTUALENV=$CCHQ_VIRTUALENV-3.10
+        VENV=~/.virtualenvs/$CCHQ_VIRTUALENV
     fi
     # check if a virtualenv at $VENV exists yet, and create if not
     if [[ ! -f $VENV/bin/activate ]]; then

--- a/control/init.sh
+++ b/control/init.sh
@@ -38,6 +38,11 @@ if [ -z ${CI_TEST} ]; then
     source $VENV/bin/activate
 fi
 
+if [[ $BIONIC_USE_SYSTEM_PYTHON == true ]]; then
+    echo "BIONIC_USE_SYSTEM_PYTHON should only be used temporarily when it is necessary to use Python 3.6 on 18.04."
+    echo "Please remove this variable from your environment when you are able to use Python 3.10 again."
+fi
+
 if [ -n "${BASH_SOURCE[0]}" ] && [ -z "${BASH_SOURCE[0]##*init.sh*}" ]
 then
     # this script is being run from a file on disk, presumably from within commcare-cloud repo

--- a/control/init.sh
+++ b/control/init.sh
@@ -2,6 +2,7 @@
 CCHQ_VIRTUALENV=${CCHQ_VIRTUALENV:-cchq}
 VENV=~/.virtualenvs/$CCHQ_VIRTUALENV
 NO_INPUT=0
+USE_SYSTEM_PYTHON=${USE_SYSTEM_PYTHON:-false}
 
 if [[ $_ == $0 ]]
 then
@@ -17,8 +18,8 @@ function realpath() {
 
 
 if [ -z ${CI_TEST} ]; then
-    if hash python3.10 2>/dev/null && [[ $( source /etc/os-release; echo $VERSION_ID ) == 18.04 ]]; then
-        # if on 18.04 with 3.10 installed, use cchq-3.10
+    if ! $USE_SYSTEM_PYTHON && hash python3.10 2>/dev/null && [[ $( source /etc/os-release; echo $VERSION_ID ) == 18.04 ]]; then
+        # if on 18.04 with 3.10 installed, use cchq-3.10 unless $USE_SYSTEM_PYTHON is true
         CCHQ_VIRTUALENV=$CCHQ_VIRTUALENV-3.10
         VENV=~/.virtualenvs/$CCHQ_VIRTUALENV
     fi

--- a/control/init.sh
+++ b/control/init.sh
@@ -17,7 +17,7 @@ function realpath() {
 
 
 if [ -z ${CI_TEST} ]; then
-    if [[ -f /usr/bin/python3.10 ]]; then
+    if hash python3.10 2>/dev/null; then
         # figure out which name to use for a 3.10 virtualenv, defaulting to $CCHQ_VIRTUALENV
         if [[ -f $VENV/bin/python3.6 ]]; then
             # if a 3.6 environment with the $CCHQ_VIRTUALENV name already exists, append '-3.10'
@@ -27,7 +27,7 @@ if [ -z ${CI_TEST} ]; then
     fi
     # check if a virtualenv at $VENV exists yet, and create if not
     if [[ ! -f $VENV/bin/activate ]]; then
-        if [[ -f /usr/bin/python3.10 ]]; then
+        if hash python3.10 2>/dev/null; then
             echo "Creating a python3.10 virtual environment named ${CCHQ_VIRTUALENV}"
             # use venv because 3.10 setup includes installing python3.10-venv
             python3.10 -m venv $VENV

--- a/control/init.sh
+++ b/control/init.sh
@@ -18,7 +18,7 @@ function realpath() {
 
 
 if [ -z ${CI_TEST} ]; then
-    if ! $USE_SYSTEM_PYTHON && hash python3.10 2>/dev/null && [[ $( source /etc/os-release; echo $VERSION_ID ) == 18.04 ]]; then
+    if [[ $USE_SYSTEM_PYTHON == true ]] && hash python3.10 2>/dev/null && [[ $( source /etc/os-release; echo $VERSION_ID ) == 18.04 ]]; then
         # if on 18.04 with 3.10 installed, use cchq-3.10 unless $USE_SYSTEM_PYTHON is true
         CCHQ_VIRTUALENV=$CCHQ_VIRTUALENV-3.10
         VENV=~/.virtualenvs/$CCHQ_VIRTUALENV

--- a/control/init.sh
+++ b/control/init.sh
@@ -39,7 +39,8 @@ if [ -z ${CI_TEST} ]; then
 fi
 
 if [[ $BIONIC_USE_SYSTEM_PYTHON == true ]]; then
-    echo "BIONIC_USE_SYSTEM_PYTHON should only be used temporarily when it is necessary to use Python 3.6 on 18.04."
+    echo "The variable BIONIC_USE_SYSTEM_PYTHON is set in your environment."
+    echo "This variable should only be used temporarily when it is absolutely necessary to use Python 3.6 on 18.04."
     echo "Please remove this variable from your environment when you are able to use Python 3.10 again."
 fi
 

--- a/control/init.sh
+++ b/control/init.sh
@@ -17,10 +17,19 @@ function realpath() {
 
 
 if [ -z ${CI_TEST} ]; then
-    if [ ! -f $VENV/bin/activate ]; then
-        if [[ $CCHQ_VIRTUALENV == *3.10* ]]; then
-          # use venv because 3.10 setup includes installing python3.10-venv
-          python3.10 -m venv $VENV
+    if [[ ! -f $VENV/bin/activate ]]; then
+        if [[ -f /usr/bin/python3.10 ]]; then
+            # figure out which name to use for a 3.10 virtualenv, defaulting to $CCHQ_VIRTUALENV
+            if [[ -f $VENV/bin/python3.6 ]]; then
+                # if a 3.6 environment with the $CCHQ_VIRTUALENV name already exists, append '-3.10'
+                CCHQ_VIRTUALENV=$CCHQ_VIRTUALENV-3.10
+            fi
+            # check if a virtualenv at $VENV exists yet, and create if not
+            if [[ ! -f $VENV/bin/activate ]]; then
+                echo "Creating a python3.10 virtual environment named ${CCHQ_VIRTUALENV}"
+                # use venv because 3.10 setup includes installing python3.10-venv
+                python3.10 -m venv $VENV
+            fi
         else
           # use virtualenv because `python3 -m venv` requires python3-venv
           python3 -m pip install --user --upgrade virtualenv

--- a/control/init.sh
+++ b/control/init.sh
@@ -17,24 +17,24 @@ function realpath() {
 
 
 if [ -z ${CI_TEST} ]; then
+    if [[ -f /usr/bin/python3.10 ]]; then
+        # figure out which name to use for a 3.10 virtualenv, defaulting to $CCHQ_VIRTUALENV
+        if [[ -f $VENV/bin/python3.6 ]]; then
+            # if a 3.6 environment with the $CCHQ_VIRTUALENV name already exists, append '-3.10'
+            CCHQ_VIRTUALENV=$CCHQ_VIRTUALENV-3.10
+            VENV=~/.virtualenvs/$CCHQ_VIRTUALENV
+        fi
+    fi
+    # check if a virtualenv at $VENV exists yet, and create if not
     if [[ ! -f $VENV/bin/activate ]]; then
         if [[ -f /usr/bin/python3.10 ]]; then
-            # figure out which name to use for a 3.10 virtualenv, defaulting to $CCHQ_VIRTUALENV
-            if [[ -f $VENV/bin/python3.6 ]]; then
-                # if a 3.6 environment with the $CCHQ_VIRTUALENV name already exists, append '-3.10'
-                CCHQ_VIRTUALENV=$CCHQ_VIRTUALENV-3.10
-                VENV=~/.virtualenvs/$CCHQ_VIRTUALENV
-            fi
-            # check if a virtualenv at $VENV exists yet, and create if not
-            if [[ ! -f $VENV/bin/activate ]]; then
-                echo "Creating a python3.10 virtual environment named ${CCHQ_VIRTUALENV}"
-                # use venv because 3.10 setup includes installing python3.10-venv
-                python3.10 -m venv $VENV
-            fi
+            echo "Creating a python3.10 virtual environment named ${CCHQ_VIRTUALENV}"
+            # use venv because 3.10 setup includes installing python3.10-venv
+            python3.10 -m venv $VENV
         else
-          # use virtualenv because `python3 -m venv` requires python3-venv
-          python3 -m pip install --user --upgrade virtualenv
-          python3 -m virtualenv $VENV
+            # use virtualenv because `python3 -m venv` requires python3-venv
+            python3 -m pip install --user --upgrade virtualenv
+            python3 -m virtualenv $VENV
         fi
     fi
     source $VENV/bin/activate


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
This is a minor update that I was initially going to make on https://github.com/dimagi/commcare-cloud/pull/5424, but it felt more fitting to keep it separate as it leaves 3.10 optional (easier for internal testing).

This will make it so that when we do upgrade to 22.04, because 3.10 will already exist, the virtualenvs will be named 'cchq', rather than 'cchq-3.10' which is minor, but convenient.
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
