### PR TITLE
log slow ucr queries

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -394,6 +394,8 @@ rds_instances:
     enable_cross_region_backup: true
     params:
       max_connections: "LEAST({DBInstanceClassMemory/9531392},5000)"
+      # five minutes
+      log_min_duration_statement: 300000
 
   - identifier: "pgshard1-production"
     instance_type: "db.m5.4xlarge"


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
This turns on logging for queries to the UCR db that last longer than five minutes, to help with the investigation of https://dimagi-dev.atlassian.net/browse/USH-2498
 
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production