### PR TITLE
temporary backfill pillow for case search ES

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -132,6 +132,8 @@ pillows:
       num_processes: 1
     UserGroupsDbKafkaPillow:
       num_processes: 1
+    CaseSearchToElasticsearchPillowBackfill:
+      num_processes: 12
   pillow_b000:
     xform-pillow:
       num_processes: 33

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -179,6 +179,14 @@ localsettings:
     auditcare: auditcare
   LOCAL_MIDDLEWARE:
     - 'django.middleware.security.SecurityMiddleware'
+  LOCAL_PILLOWS:
+    reindex:
+      - name: 'CaseSearchToElasticsearchPillowBackfill'
+        class: 'pillowtop.pillow.interface.ConstructedPillow'
+        instance: 'corehq.pillows.case_search.get_case_search_to_elasticsearch_pillow'
+        params:
+          index_name: 'case_search_2022-10-04'
+          index_alias: 'case_search-1'
   PILLOWTOP_MACHINE_ID: hqdb0
   ALLOW_PHONE_AS_DEFAULT_TWO_FACTOR_DEVICE: True
   RATE_LIMIT_SUBMISSIONS: yes


### PR DESCRIPTION
Temporary pillow to backfill the new case search index and keep it up to date until we switch.

See plan doc: https://docs.google.com/document/d/1OlU3k5bEjQydUIIwDaAfKdHr_vvZuzMFLO_iIP6vGpQ/edit#

ENVIRONMENTS AFFECTED
Production