### PR TITLE
Revert "Create and use 3.10 venv if 3.10 is installed"

### DIFF
--- a/control/init.sh
+++ b/control/init.sh
@@ -2,7 +2,6 @@
 CCHQ_VIRTUALENV=${CCHQ_VIRTUALENV:-cchq}
 VENV=~/.virtualenvs/$CCHQ_VIRTUALENV
 NO_INPUT=0
-BIONIC_USE_SYSTEM_PYTHON=${BIONIC_USE_SYSTEM_PYTHON:-false}
 
 if [[ $_ == $0 ]]
 then
@@ -18,30 +17,17 @@ function realpath() {
 
 
 if [ -z ${CI_TEST} ]; then
-    if [[ $BIONIC_USE_SYSTEM_PYTHON == false ]] && hash python3.10 2>/dev/null && [[ $( source /etc/os-release; echo $VERSION_ID ) == 18.04 ]]; then
-        # if on 18.04 with 3.10 installed, use cchq-3.10 unless $BIONIC_USE_SYSTEM_PYTHON is true
-        CCHQ_VIRTUALENV=$CCHQ_VIRTUALENV-3.10
-        VENV=~/.virtualenvs/$CCHQ_VIRTUALENV
-    fi
-    # check if a virtualenv at $VENV exists yet, and create if not
-    if [[ ! -f $VENV/bin/activate ]]; then
-        if [[ $BIONIC_USE_SYSTEM_PYTHON == false ]] && hash python3.10 2>/dev/null; then
-            echo "Creating a python3.10 virtual environment named ${CCHQ_VIRTUALENV}"
-            # use venv because 3.10 setup includes installing python3.10-venv
-            python3.10 -m venv $VENV
+    if [ ! -f $VENV/bin/activate ]; then
+        if [[ $CCHQ_VIRTUALENV == *3.10* ]]; then
+          # use venv because 3.10 setup includes installing python3.10-venv
+          python3.10 -m venv $VENV
         else
-            # use virtualenv because `python3 -m venv` requires python3-venv
-            python3 -m pip install --user --upgrade virtualenv
-            python3 -m virtualenv $VENV
+          # use virtualenv because `python3 -m venv` requires python3-venv
+          python3 -m pip install --user --upgrade virtualenv
+          python3 -m virtualenv $VENV
         fi
     fi
     source $VENV/bin/activate
-fi
-
-if [[ $BIONIC_USE_SYSTEM_PYTHON == true ]]; then
-    echo "The variable BIONIC_USE_SYSTEM_PYTHON is set in your environment."
-    echo "This variable should only be used temporarily when it is absolutely necessary to use Python 3.6 on 18.04."
-    echo "Please remove this variable from your environment when you are able to use Python 3.10 again."
 fi
 
 if [ -n "${BASH_SOURCE[0]}" ] && [ -z "${BASH_SOURCE[0]##*init.sh*}" ]


### PR DESCRIPTION
Reverts dimagi/commcare-cloud#5478

The script can aggressively append `-3.10` to a virtualenv name, so I'm going to resolve that later today but reverting for now. If `CCHQ_VIRTUALENV` is already set to `cchq-3.10` when the script is run, it will still create a new virtualenv `cchq-3.10-3.10`