### PR TITLE
Save 3.10 venv to a new var

### DIFF
--- a/control/init.sh
+++ b/control/init.sh
@@ -1,5 +1,6 @@
 #! /bin/bash
 CCHQ_VIRTUALENV=${CCHQ_VIRTUALENV:-cchq}
+CCHQ_VIRTUALENV_310=$CCHQ_CCHQ_VIRTUALENV-3.10
 VENV=~/.virtualenvs/$CCHQ_VIRTUALENV
 NO_INPUT=0
 BIONIC_USE_SYSTEM_PYTHON=${BIONIC_USE_SYSTEM_PYTHON:-false}
@@ -20,13 +21,12 @@ function realpath() {
 if [ -z ${CI_TEST} ]; then
     if [[ $BIONIC_USE_SYSTEM_PYTHON == false ]] && hash python3.10 2>/dev/null && [[ $( source /etc/os-release; echo $VERSION_ID ) == 18.04 ]]; then
         # if on 18.04 with 3.10 installed, use cchq-3.10 unless $BIONIC_USE_SYSTEM_PYTHON is true
-        CCHQ_VIRTUALENV=$CCHQ_VIRTUALENV-3.10
-        VENV=~/.virtualenvs/$CCHQ_VIRTUALENV
+        VENV=~/.virtualenvs/$CCHQ_VIRTUALENV_310
     fi
     # check if a virtualenv at $VENV exists yet, and create if not
     if [[ ! -f $VENV/bin/activate ]]; then
         if [[ $BIONIC_USE_SYSTEM_PYTHON == false ]] && hash python3.10 2>/dev/null; then
-            echo "Creating a python3.10 virtual environment named ${CCHQ_VIRTUALENV}"
+            echo "Creating a python3.10 virtual environment named ${CCHQ_VIRTUALENV_310}"
             # use venv because 3.10 setup includes installing python3.10-venv
             python3.10 -m venv $VENV
         else


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Fix venv naming issue. See https://github.com/dimagi/commcare-cloud/pull/5526 for more context.


##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
