### PR TITLE
allow git file transport

### DIFF
--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/main.yml
@@ -76,6 +76,11 @@
   stat: path="{{ code_home }}/localsettings.py"
   register: current_localsettings
 
+- name: allow git file transport
+  command: 'git config --global protocol.file.allow always'
+  become: yes
+  become_user: "{{ cchq_user }}"
+
 - name: Clone source repositories
   when: not current_localsettings.stat.exists
   block:


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Deploy was failing with the errors described in https://bbs.archlinux.org/viewtopic.php?id=280571 on new machines that had an updated version of git. The root cause of that is a change to the most recent version of git referenced in the release notes [here](https://lore.kernel.org/lkml/xmqq4jw1uku5.fsf@gitster.g/). This changes the config back to the old behavior, and existing behavior on all old machines. The reason for the change in git was a security concern about locally cloning malicious repositories. Since we are only cloning our own repositories, this seems like less of a concern.