### PR TITLE
archive deploy

### DIFF
--- a/environments/staging/fab-settings.yml
+++ b/environments/staging/fab-settings.yml
@@ -7,3 +7,5 @@ deploy_event_url: https://api.github.com/repos/dimagi/dimagi-qa/dispatches
 generate_deploy_diffs: False
 custom_deploy_details:
   View staging branches here: https://github.com/dimagi/commcare-hq/blob/autostaging/scripts/staging.yml
+archive_release: True
+release_bucket: dimagi-commcare-staging-release

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/main.yml
@@ -17,6 +17,7 @@
       - libxml2-dev
       - libxmlsec1-dev
       - libxmlsec1-openssl
+      - awscli
   tags:
     - hq-apt-requirements
 
@@ -161,3 +162,15 @@
       force: True
     tags:
       - services
+
+- name: copy archive
+  become: yes
+  template:
+    src: "fetch_release.sh.j2"
+    dest: "/usr/local/sbin/fetch_release.sh"
+    group: "{{ cchq_user }}"
+    owner: "{{ cchq_user }}"
+    mode: 0700
+    backup: yes
+  tags:
+    - cron

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/fetch_release.sh.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/fetch_release.sh.j2
@@ -1,0 +1,3 @@
+cd {{ code_releases }}
+aws s3 cp {{ release_bucket }}/current_release.tar.gz
+tar -xzf current_release.tar.gz

--- a/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
@@ -225,6 +225,12 @@ module "logshipping" {
   account_id = {{ account_id|tojson }}
 }
 
+module "autoscaling" {
+  source = "./modules/autoscaling"
+  release_bucket = var.release_bucket
+  commcare_server_role_id = module.server_iam_role.commcare_server_role_id
+}
+
 module "ga_alb_waf" {
   source = "./modules/ga_alb_waf"
   environment = var.environment

--- a/src/commcare_cloud/commands/terraform/terraform.py
+++ b/src/commcare_cloud/commands/terraform/terraform.py
@@ -169,6 +169,7 @@ def generate_terraform_entrypoint(environment, key_name, run_dir, apply_immediat
         'commcarehq_xml_post_urls_regex': compact_waf_regexes(COMMCAREHQ_XML_POST_URLS_REGEX),
         'commcarehq_xml_querystring_urls_regex': compact_waf_regexes(COMMCAREHQ_XML_QUERYSTRING_URLS_REGEX),
         's3_blob_db_s3_bucket': environment.public_vars.get('s3_blob_db_s3_bucket'),
+        'release_bucket': environment.public_vars.get('release_bucket'),
     })
 
     context.update({

--- a/src/commcare_cloud/environmental-defaults/fab-settings.yml
+++ b/src/commcare_cloud/environmental-defaults/fab-settings.yml
@@ -9,3 +9,4 @@ ignore_kafka_checkpoint_warning: False
 acceptable_maintenance_window: null
 email_enabled: True
 deploy_event_url: null
+archive_release: False

--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -420,6 +420,8 @@ def _deploy_without_asking(skip_record):
         silent_services_restart()
         if skip_record == 'no':
             execute_with_timing(release.record_successful_release)
+        if env.archive_release:
+            execute_with_timing(release.zip_release)
         clear_cached_deploy()
 
 

--- a/src/commcare_cloud/fab/operations/release.py
+++ b/src/commcare_cloud/fab/operations/release.py
@@ -397,5 +397,12 @@ def reverse_patch(filepath):
     sudo('git apply -R --unsafe-paths {} --directory={}'.format(destination, current_dir))
 
 
+@roles(ROLES_DEPLOY)
+def zip_release():
+    with cd(env.releases):
+        sudo(f'tar -czf current_release.tar.gz {env.ccc_environment.new_release_name()}')
+        sudo(f'aws s3 cp current_release.tar.gz s3://{env.release_bucket}/current_release.tar.gz')
+
+
 def _get_roles(full_cluster):
     return ROLES_ALL_SRC if full_cluster else ROLES_MANAGE

--- a/src/commcare_cloud/terraform/modules/autoscaling/main.tf
+++ b/src/commcare_cloud/terraform/modules/autoscaling/main.tf
@@ -1,0 +1,59 @@
+resource "aws_s3_bucket" "deploy_archive_bucket" {
+  bucket = var.release_bucket
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "deploy_archive_bucket" {
+  bucket = aws_s3_bucket.deploy_archive_bucket.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_acl" "deploy_archive_bucket" {
+  bucket = aws_s3_bucket.deploy_archive_bucket.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_public_access_block" "deploy_archive_bucket" {
+  bucket = aws_s3_bucket.deploy_archive_bucket.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_iam_role_policy" "access_deploy_archive" {
+  name = "AccessDeployArchive"
+  role = ${var.commcare_server_role_id}
+
+  policy = <<POLICY
+{
+    "Version": "2022-09-29",
+    "Statement": [
+        {
+            "Sid": "Terraform0",
+            "Effect": "Allow",
+            "Action": [
+                "s3:DeleteObjectTagging",
+                "s3:PutObject",
+                "s3:GetObject",
+                "s3:ListBucketVersions",
+                "s3:GetObjectTagging",
+                "s3:ListBucket",
+                "s3:PutObjectTagging",
+                "s3:DeleteObject",
+                "s3:GetObjectVersion"
+            ],
+            "Resource": [
+                "arn:aws:s3:::${var.release_bucket}/*",
+                "arn:aws:s3:::${var.release_bucket}"
+            ]
+        }
+    ]
+}
+  POLICY
+}

--- a/src/commcare_cloud/terraform/modules/autoscaling/variables.tf
+++ b/src/commcare_cloud/terraform/modules/autoscaling/variables.tf
@@ -1,0 +1,2 @@
+variable "release_bucket" {}
+variable "commcare_server_role_id" {}

--- a/src/commcare_cloud/terraform/modules/server/iam/outputs.tf
+++ b/src/commcare_cloud/terraform/modules/server/iam/outputs.tf
@@ -2,6 +2,10 @@ output "commcare_server_role_arn" {
   value = aws_iam_role.commcare_server_role.arn
 }
 
+output "commcare_server_role_id" {
+  value = aws_iam_role.commcare_server_role.id
+}
+
 output "commcare_server_instance_profile" {
   value = aws_iam_instance_profile.commcare_server_instance_profile.name
 }


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
This is a first pass at creating deploy artifacts to enable autoscaling. It involves a minor change to the deploy process (adding another step to package up and store the release), and a lot of terraform code to create an s3 bucket to store that. I also added a script to fetch and unpackage the release, but did not include code to put it on the server, since I think it's exact location will be determined by how the rest of autoscaling is set up.

Opening now for review, and to make sure this doesn't conflict with Daniel's work on moving deploy to ansible, while I do further testing.