### PR TITLE
Remove commented out USE_KAFKA_SHORTEST_BACKLOG_PARTITIONER: true

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -212,7 +212,6 @@ localsettings:
         - 'ews-ghana'
         - 'ils-gateway'
         - 'ils-gateway-train'
-#  USE_KAFKA_SHORTEST_BACKLOG_PARTITIONER: True
   USER_REPORTING_METADATA_BATCH_ENABLED: True
   WS4REDIS_CONNECTION_HOST: "redis.production.commcare.local"
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Mainly surfacing so that we can take action on this, whether that is removing it or creating a ticket to investigate. 

https://github.com/dimagi/commcare-cloud/pull/3737 commented this out in what was supposed to be temporary, but must have gotten dropped. @dannyroberts I'm curious to hear your thoughts on if this is still something worth looking into or not. 
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
prod