### PR TITLE
Update WAF regex with most recent version of HQ

### DIFF
--- a/src/commcare_cloud/commands/terraform/constants.py
+++ b/src/commcare_cloud/commands/terraform/constants.py
@@ -46,8 +46,8 @@ COMMCAREHQ_XML_POST_URLS_REGEX = r"""
 ^/log_email_event/([\w]+)/?$
 ^/telerivet/in/?$
 ^/telerivet/status/([\w\-]+)/$
-""".strip().split()
+""".strip().split('\n')
 
 COMMCAREHQ_XML_QUERYSTRING_URLS_REGEX = """
 ^/trumpia/sms/([\w-]+)/?$
-""".strip().split()
+""".strip().split('\n')

--- a/src/commcare_cloud/commands/terraform/constants.py
+++ b/src/commcare_cloud/commands/terraform/constants.py
@@ -6,7 +6,8 @@
 from __future__ import unicode_literals
 COMMCAREHQ_XML_POST_URLS_REGEX = r"""
 ^/a/([\w\.:-]+)/api/v([\d\.]+)/form/$
-^/a/([\w\.:-]+)/api/v0\.6/case(?:/([\w-]+))?/?$
+^/a/([\w\.:-]+)/api/v0\.6/case(?:/([\w\-,]+))?/?$
+^/a/([\w\.:-]+)/api/v0\.6/case/bulk-fetch/$
 ^/a/([\w\.:-]+)/apps/([\w-]+)/multimedia/uploaded/app_logo/([\w\-]+)/$
 ^/a/([\w\.:-]+)/apps/([\w-]+)/multimedia/uploaded/audio/$
 ^/a/([\w\.:-]+)/apps/([\w-]+)/multimedia/uploaded/image/$
@@ -33,8 +34,10 @@ COMMCAREHQ_XML_POST_URLS_REGEX = r"""
 ^/a/([\w\.:-]+)/receiver/secure/([\w-]+)/$
 ^/a/([\w\.:-]+)/receiver/submission/?$
 ^/a/([\w\.:-]+)/reports/export/(case_list_explorer|duplicate_cases)/$
+^/a/([\w\.:-]+)/settings/locations/import/$
 ^/a/([\w\.:-]+)/settings/users/commcare/fields/$
 ^/a/([\w\.:-]+)/settings/users/commcare/upload/$
+^/a/([\w\.:-]+)/settings/users/join/([ \w-]+)/$
 ^/a/([\w\.:-]+)/settings/users/web/upload/$
 ^/formplayer/new-form$
 ^/formplayer/validate_form$

--- a/src/commcare_cloud/commands/terraform/tests/test_compact_regexes.py
+++ b/src/commcare_cloud/commands/terraform/tests/test_compact_regexes.py
@@ -81,6 +81,7 @@ def _generate_matching_example(pattern):
         .replace(r'(?:/([\w-]+))?', '') \
         .replace(r'(\w+)', 'onetwothreefour') \
         .replace(r'([\w]+)', 'onetwothreefour') \
+        .replace(r'([ \w-]+)', 'one two three four') \
         .replace(r'([\w\.:-]+)', 'one.two:three-four') \
         .replace(r'([\d\.]+)', '0.5') \
         .replace(r'([\w-]+)', 'one-two-three-four') \


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-14023

There have been recent changes to HQ to allow more endpoints to bypass the WAF. This updated regex is the output of the command `./manage.py list_waf_allow_patterns`.
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
none