### PR TITLE
Fix comsumer_timeout param by moving rabbitmq.config to rabbitmq.conf (location and format)

### DIFF
--- a/src/commcare_cloud/ansible/roles/rabbitmq/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/rabbitmq/tasks/main.yml
@@ -13,8 +13,15 @@
     owner: rabbitmq
     mode: 0644
   loop:
-    - {"src": "rabbitmq.config.j2", "dest": "rabbitmq.config"}
+    - {"src": "rabbitmq.conf.j2", "dest": "rabbitmq.conf"}
     - {"src": "rabbitmq-env.conf.j2", "dest": "rabbitmq-env.conf"}
+
+- name: Remove old config file
+  file:
+    path: "/etc/rabbitmq/{{ item.dest }}"
+    state: absent
+  loop:
+    - {dest: "rabbitmq.config"}
 
 - name: Create directory for ulimt
   file:

--- a/src/commcare_cloud/ansible/roles/rabbitmq/templates/rabbitmq.conf.j2
+++ b/src/commcare_cloud/ansible/roles/rabbitmq/templates/rabbitmq.conf.j2
@@ -1,0 +1,5 @@
+log.channel.level = warning
+log.connection.level = warning
+log.federation.level = warning
+log.mirroring.level = warning
+consumer_timeout = 86400001

--- a/src/commcare_cloud/ansible/roles/rabbitmq/templates/rabbitmq.config.j2
+++ b/src/commcare_cloud/ansible/roles/rabbitmq/templates/rabbitmq.config.j2
@@ -1,6 +1,0 @@
-[
- {rabbit,
-  [
-     {log_levels, [{channel, warning}, {connection, warning}, {federation, warning}, {mirroring, warning}, {consumer_timeout, 86400001}]}
-  ]}
-].


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-13912

Followup to https://github.com/dimagi/commcare-cloud/pull/5552 which was not successful in setting the `consumer_timeout` rabbitmq param.

According to
  - https://www.rabbitmq.com/logging.html#log-message-categories
  - https://www.rabbitmq.com/configure.html#config-file-formats

Applied on staging with

```
cchq --control staging deploy-stack --tags=rabbitmq --branch=dmr/fix-rabbitmq-conf
```

##### ENVIRONMENTS AFFECTED
staging, india, production