### PR TITLE
Inform user that old virtualenv still exists

### DIFF
--- a/control/init.sh
+++ b/control/init.sh
@@ -31,7 +31,7 @@ if [ -z ${CI_TEST} ]; then
     if [[ ! -f $VENV/bin/activate ]]; then
         if [[ $BIONIC_USE_SYSTEM_PYTHON == false ]] && hash python3.10 2>/dev/null; then
             echo "Creating a python3.10 virtual environment named ${CCHQ_VIRTUALENV}"
-            if [ $OLD_VENV ]; then
+            if [ -n "$OLD_VENV" ]; then
                 echo "Your old virtual environment will remain at ${OLD_VENV}"
                 echo "If you wish to delete it, run 'rm -rf ${OLD_VENV}'"
             fi

--- a/control/init.sh
+++ b/control/init.sh
@@ -3,6 +3,7 @@ CCHQ_VIRTUALENV=${CCHQ_VIRTUALENV:-cchq}
 VENV=~/.virtualenvs/$CCHQ_VIRTUALENV
 NO_INPUT=0
 BIONIC_USE_SYSTEM_PYTHON=${BIONIC_USE_SYSTEM_PYTHON:-false}
+OLD_VENV=''
 
 if [[ $_ == $0 ]]
 then
@@ -22,7 +23,8 @@ if [ -z ${CI_TEST} ]; then
     if [[ $BIONIC_USE_SYSTEM_PYTHON == false ]] && hash python3.10 2>/dev/null && [[ $( source /etc/os-release; echo $VERSION_ID ) == 18.04 ]]; then
         # only append 3.10 if it is not already in the name
         if [[ $CCHQ_VIRTUALENV != *"3.10"* ]]; then
-          CCHQ_VIRTUALENV=$CCHQ_VIRTUALENV-3.10
+            OLD_VENV=$VENV
+            CCHQ_VIRTUALENV=$CCHQ_VIRTUALENV-3.10
         fi
         VENV=~/.virtualenvs/$CCHQ_VIRTUALENV
     fi
@@ -30,6 +32,10 @@ if [ -z ${CI_TEST} ]; then
     if [[ ! -f $VENV/bin/activate ]]; then
         if [[ $BIONIC_USE_SYSTEM_PYTHON == false ]] && hash python3.10 2>/dev/null; then
             echo "Creating a python3.10 virtual environment named ${CCHQ_VIRTUALENV}"
+            if [[ $OLD_VENV != '' ]]; then
+                echo "Your old virtual environment will remain at ${OLD_VENV}"
+                echo "If you wish to delete it, run 'rm -rf ${OLD_VENV}'"
+            fi
             # use venv because 3.10 setup includes installing python3.10-venv
             python3.10 -m venv $VENV
         else

--- a/control/init.sh
+++ b/control/init.sh
@@ -3,7 +3,6 @@ CCHQ_VIRTUALENV=${CCHQ_VIRTUALENV:-cchq}
 VENV=~/.virtualenvs/$CCHQ_VIRTUALENV
 NO_INPUT=0
 BIONIC_USE_SYSTEM_PYTHON=${BIONIC_USE_SYSTEM_PYTHON:-false}
-OLD_VENV=''
 
 if [[ $_ == $0 ]]
 then
@@ -32,7 +31,7 @@ if [ -z ${CI_TEST} ]; then
     if [[ ! -f $VENV/bin/activate ]]; then
         if [[ $BIONIC_USE_SYSTEM_PYTHON == false ]] && hash python3.10 2>/dev/null; then
             echo "Creating a python3.10 virtual environment named ${CCHQ_VIRTUALENV}"
-            if [[ $OLD_VENV != '' ]]; then
+            if [ $OLD_VENV ]; then
                 echo "Your old virtual environment will remain at ${OLD_VENV}"
                 echo "If you wish to delete it, run 'rm -rf ${OLD_VENV}'"
             fi

--- a/control/init.sh
+++ b/control/init.sh
@@ -22,7 +22,11 @@ if [ -z ${CI_TEST} ]; then
     if [[ $BIONIC_USE_SYSTEM_PYTHON == false ]] && hash python3.10 2>/dev/null && [[ $( source /etc/os-release; echo $VERSION_ID ) == 18.04 ]]; then
         # only append 3.10 if it is not already in the name
         if [[ $CCHQ_VIRTUALENV != *"3.10"* ]]; then
-          CCHQ_VIRTUALENV=$CCHQ_VIRTUALENV-3.10
+            # delete the 3.6 virtualenv if it exists
+            if [[ -d $VENV ]]; then
+                rm -rf $VENV
+            fi
+            CCHQ_VIRTUALENV=$CCHQ_VIRTUALENV-3.10
         fi
         VENV=~/.virtualenvs/$CCHQ_VIRTUALENV
     fi

--- a/control/init.sh
+++ b/control/init.sh
@@ -22,7 +22,7 @@ if [ -z ${CI_TEST} ]; then
     if [[ $BIONIC_USE_SYSTEM_PYTHON == false ]] && hash python3.10 2>/dev/null && [[ $( source /etc/os-release; echo $VERSION_ID ) == 18.04 ]]; then
         # only append 3.10 if it is not already in the name
         if [[ $CCHQ_VIRTUALENV != *"3.10"* ]]; then
-            OLD_VENV=$VENV
+            CCHQ_VENV_PATH_OLD=$VENV
             CCHQ_VIRTUALENV=$CCHQ_VIRTUALENV-3.10
         fi
         VENV=~/.virtualenvs/$CCHQ_VIRTUALENV
@@ -31,9 +31,9 @@ if [ -z ${CI_TEST} ]; then
     if [[ ! -f $VENV/bin/activate ]]; then
         if [[ $BIONIC_USE_SYSTEM_PYTHON == false ]] && hash python3.10 2>/dev/null; then
             echo "Creating a python3.10 virtual environment named ${CCHQ_VIRTUALENV}"
-            if [ -n "$OLD_VENV" ]; then
-                echo "Your old virtual environment will remain at ${OLD_VENV}"
-                echo "If you wish to delete it, run 'rm -rf ${OLD_VENV}'"
+            if [ -n "$CCHQ_VENV_PATH_OLD" ]; then
+                echo "Your old virtual environment will remain at ${CCHQ_VENV_PATH_OLD}"
+                echo "If you wish to delete it, run 'rm -rf ${CCHQ_VENV_PATH_OLD}'"
             fi
             # use venv because 3.10 setup includes installing python3.10-venv
             python3.10 -m venv $VENV

--- a/control/init.sh
+++ b/control/init.sh
@@ -22,11 +22,7 @@ if [ -z ${CI_TEST} ]; then
     if [[ $BIONIC_USE_SYSTEM_PYTHON == false ]] && hash python3.10 2>/dev/null && [[ $( source /etc/os-release; echo $VERSION_ID ) == 18.04 ]]; then
         # only append 3.10 if it is not already in the name
         if [[ $CCHQ_VIRTUALENV != *"3.10"* ]]; then
-            # delete the 3.6 virtualenv if it exists
-            if [[ -d $VENV ]]; then
-                rm -rf $VENV
-            fi
-            CCHQ_VIRTUALENV=$CCHQ_VIRTUALENV-3.10
+          CCHQ_VIRTUALENV=$CCHQ_VIRTUALENV-3.10
         fi
         VENV=~/.virtualenvs/$CCHQ_VIRTUALENV
     fi


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Manish raised concern around the old virtualenv taking up unnecessary space which is totally fair. The only reason for not deleting the old directory was to facilitate reverting in urgent situations, but realistically the old virtualenv can be recreated easily, only adding a few additional minutes of setup.

I'm still in favor of keeping the name cchq-3.10 for the 3.10 venvs on 18.04 as a way to distinguish the unique setup that exists, and reserving `cchq` for default system python versions.
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
