### PR TITLE
Initial Ubuntu Jammy 22.04 AWS AMI support

### DIFF
--- a/src/commcare_cloud/commands/terraform/aws.py
+++ b/src/commcare_cloud/commands/terraform/aws.py
@@ -204,11 +204,10 @@ class AwsFillInventoryHelper(object):
         servers = self.environment.terraform_config.servers + self.environment.terraform_config.proxy_servers
         for server_spec in servers:
             for server_name in server_spec.get_all_server_names():
-                is_bionic = server_spec.os in ('bionic', 'ubuntu_pro_bionic')
                 inventory_vars = [
                     ('hostname', server_name.replace('_', '-')),
-                    ('ufw_private_interface', ('ens5' if is_bionic else 'eth0')),
-                    ('ansible_python_interpreter', ('/usr/bin/python3' if is_bionic else None)),
+                    ('ufw_private_interface', 'ens5'),
+                    ('ansible_python_interpreter', '/usr/bin/python3'),
                     ('ec2_instance_id', self.resources['{}.instance_id'.format(server_name)])
                 ]
                 if server_spec.block_device:

--- a/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
@@ -132,10 +132,12 @@ module "server__{{ server_name }}" {
   server_image = data.aws_ami.ubuntu_pro_bionic.id
 {% elif server_spec.os == 'bionic' %}
   server_image = data.aws_ami.ubuntu_bionic.id
+{% elif server_spec.os == 'jammy' %}
+  server_image = data.aws_ami.ubuntu_jammy.id
 {% else %}
-  server_image = var.server_image
+  server_image = data.aws_ami.ubuntu_jammy.id
 {% endif %}
- environment = var.environment
+  environment = var.environment
   vpc_id = module.network.vpc-id
   subnet_options = local.subnet_options
   security_group_options = local.security_group_options

--- a/src/commcare_cloud/commands/terraform/templates/variables.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/variables.tf.j2
@@ -39,7 +39,6 @@ data "aws_ami" "ubuntu_pro_bionic" {
   owners = ["679593333241"] # Amazon Web Services
 }
 
-
 data "aws_ami" "ubuntu_bionic" {
   # Should match what is in
   # https://cloud-images.ubuntu.com/locator/ec2/
@@ -60,10 +59,24 @@ data "aws_ami" "ubuntu_bionic" {
   owners = ["099720109477"] # Canonical
 }
 
+data "aws_ami" "ubuntu_jammy" {
+  # Should match what is in
+  # https://cloud-images.ubuntu.com/locator/ec2/
+  # with search hvm:ebs-ssd jammy amd64
 
-variable "server_image" {
-  # Use 'hvm:ebs-ssd' AMIs from https://cloud-images.ubuntu.com/locator/ec2/
-  default = "{{ {'us-east-1': 'ami-07cf43e1798df5582', 'ap-south-1': 'ami-04242e05c1ebface0'}[region] }}"
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
 }
 
 variable "dns_zone_id" {}

--- a/src/commcare_cloud/environment/schemas/terraform.py
+++ b/src/commcare_cloud/environment/schemas/terraform.py
@@ -110,7 +110,7 @@ class ServerConfig(jsonobject.JsonObject):
     volume_encrypted = jsonobject.BooleanProperty(default=True, required=True)
     block_device = jsonobject.ObjectProperty(lambda: BlockDevice, default=None)
     group = jsonobject.StringProperty()
-    os = jsonobject.StringProperty(required=True, choices=['trusty', 'bionic', 'ubuntu_pro_bionic'])
+    os = jsonobject.StringProperty(required=True, choices=['bionic', 'ubuntu_pro_bionic', 'jammy'])
     server_auto_recovery = jsonobject.BooleanProperty(default=False)
     enable_cross_region_backup = jsonobject.BooleanProperty(default=False)
     count = jsonobject.IntegerProperty(default=None)


### PR DESCRIPTION
Add support for Ubuntu Jammy 22.04 AWS AMI and remove obsolete
default images and variables or conditionals.

https://dimagi-dev.atlassian.net/browse/SAAS-13767

##### ENVIRONMENTS AFFECTED
All
