### PR TITLE
Make "lookup" command show all servers in group

### DIFF
--- a/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -7,9 +7,9 @@ import socket
 import subprocess
 import sys
 from inspect import isfunction
+from shlex import quote as shlex_quote
 
 from clint.textui import puts
-from six.moves import shlex_quote
 
 from commcare_cloud.cli_utils import print_command, ask
 from commcare_cloud.commands.command_base import Argument, CommandBase
@@ -21,8 +21,7 @@ from ..terraform.aws import aws_sign_in, is_aws_env, is_ec2_instance_in_account,
 from ...alias import commcare_cloud
 
 from ...colors import color_error, color_notice, color_link
-from .getinventory import (get_monolith_address, get_server_address,
-                           split_host_group)
+from .getinventory import get_server_address, split_host_group
 
 
 class Lookup(CommandBase):
@@ -43,9 +42,9 @@ class Lookup(CommandBase):
         """),
     )
 
-    def lookup_server_address(self, args):
+    def lookup_server_address(self, args, allow_multiple=False):
         try:
-            return lookup_server_address(args.env_name, args.server)
+            return lookup_server_address(args.env_name, args.server, allow_multiple=allow_multiple)
         except Exception as e:
             self.parser.error("\n" + str(e))
 
@@ -54,13 +53,11 @@ class Lookup(CommandBase):
             sys.stderr.write(
                 "Ignoring extra argument(s): {}\n".format(unknown_args)
             )
-        print(self.lookup_server_address(args))
+        print(self.lookup_server_address(args, allow_multiple=True))
 
 
-def lookup_server_address(env_name, server):
-    if not server:
-        return get_monolith_address(env_name)
-    return get_server_address(env_name, server)
+def lookup_server_address(env_name, server, allow_multiple=False):
+    return get_server_address(env_name, server or "all", allow_multiple=allow_multiple)
 
 
 class _Ssh(Lookup):

--- a/tests/test_getinventory.py
+++ b/tests/test_getinventory.py
@@ -50,3 +50,37 @@ def test_get_server_address(pattern, expected):
 def test_get_server_address_errors(pattern):
     with assert_raises(HostMatchException):
         get_server_address("2018-04-04-icds-new-snapshot", pattern)
+
+
+@patch('commcare_cloud.environment.paths.ENVIRONMENTS_DIR', TEST_ENV_DIR)
+def test_get_server_address_with_groups():
+    address = get_server_address("2018-04-04-icds-new-snapshot", "postgresql", allow_multiple=True)
+    assert_equal(address, "\n".join([
+        "10.247.164.26 - pgmain, postgresql, all",
+        "10.247.164.20 - pgshard1, postgresql, all",
+        "10.247.164.21 - pgshard2, postgresql, all",
+        "10.247.164.64 - pgshard3, postgresql, all",
+        "10.247.164.65 - pgshard4, postgresql, all",
+        "10.247.164.66 - pgshard5, postgresql, all",
+        "10.247.164.70 - pgsynclog, postgresql, all",
+        "10.247.164.25 - pgucr, postgresql, all",
+        "10.247.164.56 - plproxy1, postgresql, all",
+    ]))
+
+
+@patch('commcare_cloud.environment.paths.ENVIRONMENTS_DIR', TEST_ENV_DIR)
+def test_get_server_address_for_monolith_with_groups():
+    address = get_server_address("small_cluster", "all", allow_multiple=True)
+    assert_equal(address, "\n".join([
+        (
+            "172.19.3.0 - demo_server0, proxy, webworkers, couchdb2_proxy, "
+            "formplayer, shared_dir_host, control, mailrelay, django_manage, "
+            "kafka, elasticsearch, couchdb2, all"
+        ),
+        (
+            "172.19.3.1 - demo_server1, postgresql, redis, zookeeper, "
+            "rabbitmq, kafka, elasticsearch, couchdb2, all"
+        ),
+        "172.19.3.2 - demo_server2, celery, all",
+        "172.19.3.3 - demo_server3, pg_standby, pillowtop, couchdb2, all",
+    ]))


### PR DESCRIPTION
Also show group names associated with each server

Sample output:
```
$ cchq staging lookup formplayer
10.201.10.18 - formplayer4, formplayer, all
10.201.10.139 - formplayer5, formplayer, all
```

Previous output:
```
$ cchq staging lookup formplayer
usage: cchq
     {64-test,confluence,development,echis,enikshay-reference,india,jenkins,pna,production,staging,swiss} lookup
       [-h] [server]
cchq
     {64-test,confluence,development,echis,enikshay-reference,india,jenkins,pna,production,staging,swiss} lookup: error: 
There are 2 servers in the 'formplayer' group
Please specify the index of the server. Example: formplayer[0]
```

##### ENVIRONMENTS AFFECTED
None.
