### PR TITLE
Clarify which 3.10 directions are relevant for who

### DIFF
--- a/hosting_docs/source/installation/2-manual-install.rst
+++ b/hosting_docs/source/installation/2-manual-install.rst
@@ -190,13 +190,14 @@ Starting on December 19th, 2022, commcare-cloud will require Python 3.10. Follow
         $ sudo apt update
         $ sudo apt-get -y install python3.10 python3.10-dev python3.10-distutils python3.10-venv libffi-dev
 
-Once Python 3.10 is installed on your control machine, run:
+**The remaining steps for installing Python 3.10 are only relevant if you have already installed commcare-cloud.
+If commcare-cloud has not been installed on this machine yet, please skip to the next section.**
+
+Run the following to pull the latest version of commcare-cloud and trigger the creation and activation of a Python 3.10 virtual environment.
 
 ::
 
         $ update-code
-
-which will pull the latest version of commcare-cloud and trigger the creation and activation of a Python 3.10 virtual environment.
 
 Confirm the active virtual environment is using Python 3.10
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Manish brought up a good point that if someone is navigating these instructions step by step, they won't have the ability to run `update-code` or `manage-commcare-cloud configure`, nor will they need to. However I still want these instructions to apply to those who are retroactively upgrading to 3.10, so I've added a qualifier to state who should run those commands.
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
