### PR TITLE
Ansible connect via AWS SSM through control host

### DIFF
--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -200,3 +200,4 @@ use_chrony: True
 
 python_version: '3.9'
 use_deadsnakes: '{{ ansible_distribution_version <= "18.04" }}'
+allow_aws_ssm_proxy: true

--- a/hosting_docs/source/reference/1-commcare-cloud/commands.md
+++ b/hosting_docs/source/reference/1-commcare-cloud/commands.md
@@ -1287,7 +1287,8 @@ specified user on the source host has permissions to read the files being copied
 The plan file must be formatted as follows:
 
 ```yml
-source_env: env1 (optional if source is different from target)
+source_env: env1 (optional if source is different from target;
+                  SSH access must be allowed from the target host(s) to source host(s))
 copy_files:
   - <target-host>:
       - source_host: <source-host>

--- a/src/commcare_cloud/commands/ansible/ansible_playbook.py
+++ b/src/commcare_cloud/commands/ansible/ansible_playbook.py
@@ -76,9 +76,9 @@ class AnsiblePlaybook(CommandBase):
         ))
 
     def run(self, args, unknown_args, always_skip_check=False, respect_ansible_skip=True):
-        environment = get_environment(args.env_name)
-        environment.create_generated_yml()
         ansible_context = AnsibleContext(args)
+        environment = ansible_context.environment
+        environment.create_generated_yml()
         check_branch(args)
         return run_ansible_playbook(
             environment, args.playbook, ansible_context, args.skip_check, args.quiet,

--- a/src/commcare_cloud/commands/ansible/ansible_playbook.py
+++ b/src/commcare_cloud/commands/ansible/ansible_playbook.py
@@ -138,7 +138,7 @@ def run_ansible_playbook(
         ) + get_limit(environment) + cmd_args
 
         public_vars = environment.public_vars
-        env_vars = ansible_context.env_vars
+        env_vars = ansible_context.build_env()
         cmd_parts += get_user_arg(public_vars, unknown_args, use_factory_auth)
 
         if has_arg(unknown_args, '-D', '--diff') or has_arg(unknown_args, '-C', '--check'):
@@ -154,7 +154,6 @@ def run_ansible_playbook(
         cmd_parts += cmd_parts_with_common_ssh_args
         cmd = ' '.join(shlex.quote(arg) for arg in cmd_parts)
         print_command(cmd)
-        env_vars.update(environment.get_ansible_env_vars())
         return subprocess.call(cmd_parts, env=env_vars)
 
     def run_check():

--- a/src/commcare_cloud/commands/ansible/ansible_playbook.py
+++ b/src/commcare_cloud/commands/ansible/ansible_playbook.py
@@ -154,7 +154,7 @@ def run_ansible_playbook(
         cmd_parts += cmd_parts_with_common_ssh_args
         cmd = ' '.join(shlex.quote(arg) for arg in cmd_parts)
         print_command(cmd)
-        env_vars.update(environment.secrets_backend.get_extra_ansible_env_vars())
+        env_vars.update(environment.get_ansible_env_vars())
         return subprocess.call(cmd_parts, env=env_vars)
 
     def run_check():

--- a/src/commcare_cloud/commands/ansible/downtime.py
+++ b/src/commcare_cloud/commands/ansible/downtime.py
@@ -15,7 +15,6 @@ from commcare_cloud.commands.ansible.helpers import AnsibleContext
 from commcare_cloud.commands.ansible.run_module import run_ansible_module
 from commcare_cloud.commands.ansible.service import COMMCARE_INVENTORY_GROUPS
 from commcare_cloud.commands.command_base import CommandBase, Argument
-from commcare_cloud.environment.main import get_environment
 
 
 class Downtime(CommandBase):
@@ -40,9 +39,9 @@ class Downtime(CommandBase):
     )
 
     def run(self, args, unknown_args):
-        environment = get_environment(args.env_name)
-        environment.create_generated_yml()
         ansible_context = AnsibleContext(args)
+        environment = ansible_context.environment
+        environment.create_generated_yml()
 
         if args.action == 'start':
             start_downtime(environment, ansible_context, args)

--- a/src/commcare_cloud/commands/ansible/downtime.py
+++ b/src/commcare_cloud/commands/ansible/downtime.py
@@ -2,12 +2,10 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 import inspect
-import os
 import time
 from datetime import datetime
 
 import datadog
-import yaml
 from clint.textui import puts, indent
 from memoized import memoized
 
@@ -90,13 +88,13 @@ def wait_for_all_processes_to_stop(environment, ansible_context):
         if not still_running:
             break
 
-        options = ['abort', 'wait', 'continue', 'kill',]
+        options = ['abort', 'wait', 'continue', 'kill']
         response = ask_option(inspect.cleandoc(
-            """Some processes are still running. Do you want to:"
-             - abort downtime"
-             - wait for processes to stop"
-             - continue with downtime regardless"
-             - kill running processes   
+            """Some processes are still running. Do you want to:
+             - abort downtime
+             - wait for processes to stop
+             - continue with downtime regardless
+             - kill running processes
             """),
             options,
             options + ['a', 'w', 'c', 'k']

--- a/src/commcare_cloud/commands/ansible/downtime.py
+++ b/src/commcare_cloud/commands/ansible/downtime.py
@@ -59,7 +59,7 @@ def end_downtime(ansible_context):
         end_downtime = ask("Do you want to start all CommCare services?")
 
     if end_downtime:
-        supervisor_services(environment, ansible_context, 'start')
+        supervisor_services(ansible_context, 'start')
         if downtime:
             cancel_downtime_record(environment, downtime)
 
@@ -78,13 +78,13 @@ def start_downtime(ansible_context, args):
     if go_down:
         if not downtime:
             create_downtime_record(environment, args.message, args.duration)
-        supervisor_services(environment, ansible_context, 'stop')
-        wait_for_all_processes_to_stop(environment, ansible_context)
+        supervisor_services(ansible_context, 'stop')
+        wait_for_all_processes_to_stop(ansible_context)
 
 
-def wait_for_all_processes_to_stop(environment, ansible_context):
+def wait_for_all_processes_to_stop(ansible_context):
     while True:
-        still_running = check_for_running_cchq_processes(environment, ansible_context)
+        still_running = check_for_running_cchq_processes(ansible_context)
         if not still_running:
             break
 
@@ -101,9 +101,9 @@ def wait_for_all_processes_to_stop(environment, ansible_context):
         )
         if response in ('a', 'abort'):
             if ask('This will start all CommCare processes again. Do you want to proceed?'):
-                downtime = get_downtime_record(environment)
-                supervisor_services(environment, ansible_context, 'start')
-                cancel_downtime_record(environment, downtime)
+                downtime = get_downtime_record(ansible_context.environment)
+                supervisor_services(ansible_context, 'start')
+                cancel_downtime_record(ansible_context.environment, downtime)
                 return
         elif response in ('w', 'wait'):
             time.sleep(30)
@@ -114,30 +114,28 @@ def wait_for_all_processes_to_stop(environment, ansible_context):
         elif response in ('k', 'kill'):
             kill = ask('Are you sure you want to kill all remaining processes?', strict=True)
             if kill:
-                kill_remaining_processes(environment, ansible_context)
+                kill_remaining_processes(ansible_context)
 
 
-def kill_remaining_processes(environment, ansible_context):
+def kill_remaining_processes(ansible_context):
     command = 'pkill -u cchq -9; test $? -eq 0 -o $? -eq 1'
-    return _run_command(environment, ansible_context, command, become=True)
+    return _run_command(ansible_context, command, become=True)
 
 
-def check_for_running_cchq_processes(environment, ansible_context, invert_success=True):
+def check_for_running_cchq_processes(ansible_context, invert_success=True):
     command = 'ps -u cchq -U cchq -f'
     if invert_success:
         command = '{}; test $? -eq 1'.format(command)
-    return _run_command(environment, ansible_context, command)
+    return _run_command(ansible_context, command)
 
 
-def supervisor_services(environment, ansible_context, action):
-    return _run_command(environment, ansible_context, 'supervisorctl {} all'.format(action), become=True)
+def supervisor_services(ansible_context, action):
+    return _run_command(ansible_context, 'supervisorctl {} all'.format(action), become=True)
 
 
-def _run_command(environment, ansible_context, command, become=False):
-    return run_ansible_module(
-        environment, ansible_context, ','.join(COMMCARE_INVENTORY_GROUPS), 'shell', command,
-        become=become
-    )
+def _run_command(ansible_context, command, become=False):
+    groups = ','.join(COMMCARE_INVENTORY_GROUPS)
+    return run_ansible_module(ansible_context, groups, 'shell', command, become=become)
 
 
 def print_downtime(downtime):

--- a/src/commcare_cloud/commands/ansible/downtime.py
+++ b/src/commcare_cloud/commands/ansible/downtime.py
@@ -40,17 +40,17 @@ class Downtime(CommandBase):
 
     def run(self, args, unknown_args):
         ansible_context = AnsibleContext(args)
-        environment = ansible_context.environment
-        environment.create_generated_yml()
+        ansible_context.environment.create_generated_yml()
 
         if args.action == 'start':
-            start_downtime(environment, ansible_context, args)
+            start_downtime(ansible_context, args)
 
         if args.action == 'end':
-            end_downtime(environment, ansible_context)
+            end_downtime(ansible_context)
 
 
-def end_downtime(environment, ansible_context):
+def end_downtime(ansible_context):
+    environment = ansible_context.environment
     downtime = get_downtime_record(environment)
     if not downtime:
         puts(color_notice('Downtime record not found.'))
@@ -64,7 +64,8 @@ def end_downtime(environment, ansible_context):
             cancel_downtime_record(environment, downtime)
 
 
-def start_downtime(environment, ansible_context, args):
+def start_downtime(ansible_context, args):
+    environment = ansible_context.environment
     downtime = get_downtime_record(environment)
     if downtime:
         puts(color_notice('Downtime already active'))

--- a/src/commcare_cloud/commands/ansible/helpers.py
+++ b/src/commcare_cloud/commands/ansible/helpers.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 import itertools
 import os
+import shlex
 from collections import namedtuple, defaultdict
 from contextlib import contextmanager
 
@@ -11,9 +12,6 @@ from clint.textui import puts
 from commcare_cloud.cli_utils import has_arg, ask
 from commcare_cloud.colors import color_error, color_success
 from commcare_cloud.environment.paths import ANSIBLE_DIR, ANSIBLE_ROLES_PATH, ANSIBLE_COLLECTIONS_PATHS
-from six.moves import shlex_quote
-from six.moves import range
-from six.moves import map
 
 DEPRECATED_ANSIBLE_ARGS = []
 
@@ -22,7 +20,7 @@ class AnsibleContext(object):
     config = 'ANSIBLE_CONFIG'
     roles_path = 'ANSIBLE_ROLES_PATH'
     stdout_callback = 'ANSIBLE_STDOUT_CALLBACK'
-    collections_paths= 'ANSIBLE_COLLECTIONS_PATHS'
+    collections_paths = 'ANSIBLE_COLLECTIONS_PATHS'
 
     def __init__(self, args):
         self.env_vars = self._build_env(args)
@@ -60,7 +58,8 @@ def get_common_ssh_args(environment, use_factory_auth=False):
     common_ssh_args.extend(get_default_ssh_options_as_cmd_parts(environment))
 
     if common_ssh_args:
-        cmd_parts_with_common_ssh_args += ('--ssh-common-args={}'.format(' '.join(map(shlex_quote, common_ssh_args))),)
+        args = ' '.join(map(shlex.quote, common_ssh_args))
+        cmd_parts_with_common_ssh_args += ('--ssh-common-args={}'.format(args),)
     return cmd_parts_with_common_ssh_args
 
 

--- a/src/commcare_cloud/commands/ansible/helpers.py
+++ b/src/commcare_cloud/commands/ansible/helpers.py
@@ -29,9 +29,9 @@ class AnsibleContext(object):
         if args is not None:
             assert args.env_name == environment.name, (args.env_name, environment.name)
         self.environment = environment
-        self.env_vars = self._build_env(args)
+        self._stdout_callback = getattr(args, 'stdout_callback', None)
 
-    def _build_env(self, args):
+    def build_env(self, need_secrets=True):
         """Look for args that have been flagged as environment variables
         and add them to the env dict with appropriate naming
         """
@@ -40,8 +40,10 @@ class AnsibleContext(object):
         env[self.roles_path] = ANSIBLE_ROLES_PATH
         env[self.collections_paths] = ANSIBLE_COLLECTIONS_PATHS
 
-        if hasattr(args, 'stdout_callback'):
-            env[self.stdout_callback] = args.stdout_callback
+        if self._stdout_callback is not None:
+            env[self.stdout_callback] = self._stdout_callback
+        if need_secrets or self.environment.has_ansible_env_vars():
+            env.update(self.environment.get_ansible_env_vars())
         return env
 
 

--- a/src/commcare_cloud/commands/ansible/helpers.py
+++ b/src/commcare_cloud/commands/ansible/helpers.py
@@ -22,7 +22,14 @@ class AnsibleContext(object):
     stdout_callback = 'ANSIBLE_STDOUT_CALLBACK'
     collections_paths = 'ANSIBLE_COLLECTIONS_PATHS'
 
-    def __init__(self, args):
+    def __init__(self, args, environment=None):
+        from commcare_cloud.environment.main import get_environment
+        assert args is not None or environment is not None, "'args' or 'environment' is required"
+        if environment is None:
+            environment = get_environment(args.env_name)
+        if args is not None:
+            assert args.env_name == environment.name, (args.env_name, environment.name)
+        self.environment = environment
         self.env_vars = self._build_env(args)
 
     def _build_env(self, args):

--- a/src/commcare_cloud/commands/ansible/helpers.py
+++ b/src/commcare_cloud/commands/ansible/helpers.py
@@ -5,7 +5,6 @@ import itertools
 import os
 import shlex
 from collections import namedtuple, defaultdict
-from contextlib import contextmanager
 
 from clint.textui import puts
 
@@ -44,13 +43,6 @@ class AnsibleContext(object):
         if hasattr(args, 'stdout_callback'):
             env[self.stdout_callback] = args.stdout_callback
         return env
-
-    @contextmanager
-    def with_vars(self, vars):
-        current_vars = self.env_vars.copy()
-        self.env_vars.update(vars)
-        yield
-        self.env_vars = current_vars
 
 
 def get_common_ssh_args(environment, use_factory_auth=False):

--- a/src/commcare_cloud/commands/ansible/ops_tool.py
+++ b/src/commcare_cloud/commands/ansible/ops_tool.py
@@ -92,10 +92,8 @@ class ListDatabases(CommandBase):
     @staticmethod
     def get_present_dbs(args):
         dbs_present_in_host = collections.defaultdict(list)
-        ansible_context = AnsibleContext(args)
         hosts = run_ansible_module(
-            ansible_context.environment,
-            ansible_context,
+            AnsibleContext(args),
             "postgresql",
             "shell",
             "python /usr/local/sbin/db-tools.py --list-all",

--- a/src/commcare_cloud/commands/ansible/ops_tool.py
+++ b/src/commcare_cloud/commands/ansible/ops_tool.py
@@ -92,9 +92,10 @@ class ListDatabases(CommandBase):
     @staticmethod
     def get_present_dbs(args):
         dbs_present_in_host = collections.defaultdict(list)
+        ansible_context = AnsibleContext(args)
         hosts = run_ansible_module(
-            get_environment(args.env_name),
-            AnsibleContext(args),
+            ansible_context.environment,
+            ansible_context,
             "postgresql",
             "shell",
             "python /usr/local/sbin/db-tools.py --list-all",

--- a/src/commcare_cloud/commands/ansible/run_module.py
+++ b/src/commcare_cloud/commands/ansible/run_module.py
@@ -85,7 +85,7 @@ class RunAnsibleModule(CommandBase):
 
         def _run_ansible(args, *unknown_args):
             return run_ansible_module(
-                environment, ansible_context,
+                ansible_context,
                 args.inventory_group, args.module, args.module_args,
                 become=args.become, become_user=args.become_user,
                 use_factory_auth=args.use_factory_auth, extra_args=unknown_args
@@ -101,7 +101,7 @@ class RunAnsibleModule(CommandBase):
         return run_action_with_check_mode(run_check, run_apply, args.skip_check, args.quiet)
 
 
-def run_ansible_module(environment, ansible_context, inventory_group, module, module_args,
+def run_ansible_module(ansible_context, inventory_group, module, module_args,
                        become=True, become_user=None, use_factory_auth=False, quiet=False,
                        extra_args=(), run_command=subprocess.call):
     extra_args = tuple(extra_args)
@@ -110,6 +110,7 @@ def run_ansible_module(environment, ansible_context, inventory_group, module, mo
     else:
         extra_args = ("--one-line",) + extra_args
 
+    environment = ansible_context.environment
     cmd_parts = (
         'ansible', inventory_group,
         '-m', module,
@@ -252,7 +253,7 @@ class SendDatadogEvent(CommandBase):
                 agg='commcare-cloud'
             )
         return run_ansible_module(
-            environment, ansible_context,
+            ansible_context,
             '127.0.0.1', args.module, args.module_args,
             become=False, quiet=True
         )

--- a/src/commcare_cloud/commands/ansible/run_module.py
+++ b/src/commcare_cloud/commands/ansible/run_module.py
@@ -138,6 +138,7 @@ def run_ansible_module(ansible_context, inventory_group, module, module_args,
             '-e', '@{}'.format(environment.paths.generated_yml),
         )
         cmd_parts += environment.secrets_backend.get_extra_ansible_args()
+    if needs_secrets or environment.secrets_backend.has_extra_env_vars():
         env_vars.update(environment.secrets_backend.get_extra_ansible_env_vars())
 
     if run_command is ansible_json:

--- a/src/commcare_cloud/commands/ansible/run_module.py
+++ b/src/commcare_cloud/commands/ansible/run_module.py
@@ -138,8 +138,8 @@ def run_ansible_module(ansible_context, inventory_group, module, module_args,
             '-e', '@{}'.format(environment.paths.generated_yml),
         )
         cmd_parts += environment.secrets_backend.get_extra_ansible_args()
-    if needs_secrets or environment.secrets_backend.has_extra_env_vars():
-        env_vars.update(environment.secrets_backend.get_extra_ansible_env_vars())
+    if needs_secrets or environment.has_ansible_env_vars():
+        env_vars.update(environment.get_ansible_env_vars())
 
     if run_command is ansible_json:
         env_vars.setdefault("ANSIBLE_LOAD_CALLBACK_PLUGINS", "1")

--- a/src/commcare_cloud/commands/ansible/service.py
+++ b/src/commcare_cloud/commands/ansible/service.py
@@ -62,8 +62,8 @@ class ServiceBase(six.with_metaclass(ABCMeta)):
         """Location of the service's logs shown on the command line."""
         raise NotImplementedError
 
-    def __init__(self, environment, ansible_context):
-        self.environment = environment
+    def __init__(self, ansible_context):
+        self.environment = ansible_context.environment
         self.ansible_context = ansible_context
 
     def run(self, action, host_pattern=None, process_pattern=None):
@@ -323,7 +323,7 @@ class Elasticsearch(ServiceBase):
 
     def execute_action(self, action, host_pattern=None, process_pattern=None):
         if action == 'status':
-            es = ElasticsearchClassic(self.environment, self.ansible_context)
+            es = ElasticsearchClassic(self.ansible_context)
             return es.execute_action(action, host_pattern, process_pattern)
         else:
             if not ask(
@@ -347,7 +347,7 @@ class Elasticsearch(ServiceBase):
 
     def _act_on_pillows(self, action):
         # Used to stop or start pillows
-        service = Pillowtop(self.environment, AnsibleContext(None, self.environment))
+        service = Pillowtop(AnsibleContext(None, self.environment))
         exit_code = service.run(action=action)
         if not exit_code == 0:
             print("ERROR while trying to {} pillows. Exiting.".format(action))
@@ -702,10 +702,9 @@ class Service(CommandBase):
         ]
 
         ansible_context = AnsibleContext(args)
-        environment = ansible_context.environment
         non_zero_exits = []
         for service_cls in services:
-            service = service_cls(environment, ansible_context)
+            service = service_cls(ansible_context)
             exit_code = service.run(args.action, args.limit, args.process_pattern)
             if exit_code != 0:
                 non_zero_exits.append(exit_code)

--- a/src/commcare_cloud/commands/ansible/service.py
+++ b/src/commcare_cloud/commands/ansible/service.py
@@ -125,7 +125,6 @@ class ServiceBase(six.with_metaclass(ABCMeta)):
 
     def _run_ansible_module(self, host_pattern, module, module_args):
         return run_ansible_module(
-            self.environment,
             self.ansible_context,
             host_pattern,
             module,

--- a/src/commcare_cloud/commands/ansible/service.py
+++ b/src/commcare_cloud/commands/ansible/service.py
@@ -324,7 +324,8 @@ class Elasticsearch(ServiceBase):
 
     def execute_action(self, action, host_pattern=None, process_pattern=None):
         if action == 'status':
-            return ElasticsearchClassic(self.environment, self.ansible_context).execute_action(action, host_pattern, process_pattern)
+            es = ElasticsearchClassic(self.environment, self.ansible_context)
+            return es.execute_action(action, host_pattern, process_pattern)
         else:
             if not ask(
                     "This function does more than stop and start the elasticsearch service. "
@@ -461,10 +462,13 @@ class CommCare(SingleSupervisorService):
         if action == 'restart':
             puts(color_warning("The 'commcare' service command rejects the 'restart' action"))
             puts(color_warning("in order to protect against accidental downtime."))
-            puts(color_notice("For a no-downtime restart of commcare-hq services, please use one of the following"))
-            puts(color_code(f"  cchq {self.environment.name} fab restart_services  # for all processes that run commcare-hq code."))
+            puts(color_notice("For a no-downtime restart of commcare-hq services, "
+                              "please use one of the following"))
+            puts(color_code(f"  cchq {self.environment.name} fab restart_services  "
+                            "# for all processes that run commcare-hq code."))
             puts(color_code(f"  cchq {self.environment.name} fab restart_webworkers  # for webworkers only"))
-            puts(color_notice("To restart formplayer, which always causes downtime, use the 'formplayer' service command."))
+            puts(color_notice("To restart formplayer, which always causes downtime, "
+                              "use the 'formplayer' service command."))
             puts(color_error("Refusing to run commcare service command with action 'restart'."))
             return 1
         return super().run(action, host_pattern=host_pattern, process_pattern=process_pattern)

--- a/src/commcare_cloud/commands/ansible/service.py
+++ b/src/commcare_cloud/commands/ansible/service.py
@@ -357,8 +357,7 @@ class Elasticsearch(ServiceBase):
         extra_args = ['--tags={}'.format(tags)]
         if limit:
             extra_args.extend(['--limit={}'.format(limit)])
-        run_ansible_playbook(environment=self.environment,
-                             playbook='es_rolling_restart.yml',
+        run_ansible_playbook(playbook='es_rolling_restart.yml',
                              ansible_context=AnsibleContext(None, self.environment),
                              unknown_args=extra_args,
                              skip_check=True, quiet=True)

--- a/src/commcare_cloud/commands/deploy/formplayer.py
+++ b/src/commcare_cloud/commands/deploy/formplayer.py
@@ -124,7 +124,7 @@ def get_deploy_diff(environment, repo):
 def run_ansible_playbook_command(environment, args):
     skip_check = True
     environment.create_generated_yml()
-    ansible_context = AnsibleContext(args)
+    ansible_context = AnsibleContext(args, environment)
     return ansible_playbook.run_ansible_playbook(
         environment, 'deploy_stack.yml', ansible_context,
         skip_check=skip_check, quiet=skip_check, always_skip_check=skip_check, limit='formplayer',

--- a/src/commcare_cloud/commands/deploy/formplayer.py
+++ b/src/commcare_cloud/commands/deploy/formplayer.py
@@ -124,9 +124,8 @@ def get_deploy_diff(environment, repo):
 def run_ansible_playbook_command(environment, args):
     skip_check = True
     environment.create_generated_yml()
-    ansible_context = AnsibleContext(args, environment)
     return ansible_playbook.run_ansible_playbook(
-        environment, 'deploy_stack.yml', ansible_context,
+        'deploy_stack.yml', AnsibleContext(args, environment),
         skip_check=skip_check, quiet=skip_check, always_skip_check=skip_check, limit='formplayer',
         use_factory_auth=False, unknown_args=('--tags=formplayer_deploy',),
         respect_ansible_skip=True,

--- a/src/commcare_cloud/commands/deploy/formplayer.py
+++ b/src/commcare_cloud/commands/deploy/formplayer.py
@@ -135,7 +135,7 @@ def run_ansible_playbook_command(environment, args):
 
 def record_deploy_in_datadog(environment, diff, tdelta):
     if environment.public_vars.get('DATADOG_ENABLED', False):
-        print(color_summary(f">> Recording deploy in Datadog"))
+        print(color_summary(">> Recording deploy in Datadog"))
         diff_url = f"\nDiff link: [Git Diff]({diff.url})"
         deploy_notification_text = (
             "Formplayer has been successfully deployed to "
@@ -154,6 +154,7 @@ def record_deploy_in_datadog(environment, diff, tdelta):
             '--alert_type', "success",
             show_command=False
         )
+
 
 def get_current_formplayer_version(environment):
     """Get version of currently deployed Formplayer by querying

--- a/src/commcare_cloud/commands/migrations/copy_files.py
+++ b/src/commcare_cloud/commands/migrations/copy_files.py
@@ -104,12 +104,12 @@ class CopyFiles(CommandBase):
     )
 
     def run(self, args, unknown_args):
-        environment = get_environment(args.env_name)
+        ansible_context = AnsibleContext(args)
+        environment = ansible_context.environment
         environment.create_generated_yml()
 
         plan = read_plan(args.plan_path, environment, args.limit)
         working_directory = _get_working_dir(args.plan_path, environment)
-        ansible_context = AnsibleContext(args)
 
         environment.secrets_backend.prompt_user_input()
         if plan.source_env != environment and args.action in ('prepare', 'cleanup'):

--- a/src/commcare_cloud/commands/migrations/couchdb.py
+++ b/src/commcare_cloud/commands/migrations/couchdb.py
@@ -151,7 +151,7 @@ def clean(migration, target_context, skip_check, limit):
     nodes = generate_shard_prune_playbook(migration)
     if nodes:
         return run_ansible_playbook(
-            migration.target_environment, migration.prune_playbook_path, target_context,
+            migration.prune_playbook_path, target_context,
             skip_check=skip_check,
             limit=limit
         )
@@ -248,7 +248,7 @@ def assert_files(migration, alloc_docs_by_db, target_context):
 
     play_path = os.path.join(PLAY_DIR, 'assert_couch_files.yml')
     return_code = run_ansible_playbook(
-        migration.target_environment, play_path, target_context,
+        play_path, target_context,
         always_skip_check=True,
         quiet=True,
         unknown_args=['-e', '@{}'.format(expected_files_vars)]

--- a/src/commcare_cloud/commands/migrations/couchdb.py
+++ b/src/commcare_cloud/commands/migrations/couchdb.py
@@ -56,7 +56,6 @@ from commcare_cloud.commands.migrations.copy_files import (
     prepare_file_copy_scripts,
 )
 from commcare_cloud.commands.utils import render_template
-from commcare_cloud.environment.main import get_environment
 
 TEMPLATE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'templates')
 PLAY_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'plays')
@@ -101,7 +100,8 @@ class MigrateCouchdb(CommandBase):
     def run(self, args, unknown_args):
         assert args.action == 'migrate' or not args.no_stop, \
             "You can only use --no-stop with migrate"
-        environment = get_environment(args.env_name)
+        ansible_context = AnsibleContext(args)
+        environment = ansible_context.environment
         environment.create_generated_yml()
 
         migration = CouchMigration(environment, args.migration_plan)
@@ -109,7 +109,6 @@ class MigrateCouchdb(CommandBase):
         if migration.separate_source_and_target:
             check_connection(migration.source_couch_config.get_control_node())
 
-        ansible_context = AnsibleContext(args)
         if args.limit and args.action != 'clean':
             puts(color_notice('Ignoring --limit (it only applies to "clean" action).'))
 

--- a/src/commcare_cloud/commands/migrations/couchdb.py
+++ b/src/commcare_cloud/commands/migrations/couchdb.py
@@ -27,7 +27,6 @@ from couchdb_cluster_admin.utils import (
     get_shard_allocation,
     put_shard_allocation,
 )
-from six.moves import map, zip
 from tabulate import tabulate
 
 from commcare_cloud.cli_utils import ask
@@ -93,7 +92,7 @@ class MigrateCouchdb(CommandBase):
             if there are no "pivot" locations for a shard---then running migrate and commit
             without stopping couchdb will result in data loss.
             If your shard reallocation has a pivot location for each shard,
-            then it's acceptable to do live. 
+            then it's acceptable to do live.
         """),
         shared_args.SKIP_CHECK_ARG,
         shared_args.LIMIT_ARG,
@@ -520,6 +519,7 @@ def get_shard_table(shard_allocation_docs):
     for shard_allocation_doc in sorted(shard_allocation_docs, key=lambda doc: doc.db_name):
         this_header = sorted(shard_allocation_doc.by_range)
         change_header = (last_header != this_header)
-        lines.append(shard_allocation_doc.get_printable(include_shard_names=change_header, db_name_len=max_db_name_len))
+        lines.append(shard_allocation_doc.get_printable(
+            include_shard_names=change_header, db_name_len=max_db_name_len))
         last_header = this_header
     return lines

--- a/src/commcare_cloud/environment/main.py
+++ b/src/commcare_cloud/environment/main.py
@@ -438,8 +438,8 @@ class Environment(object):
         """
         from commcare_cloud.commands.ansible.helpers import get_default_ssh_options_as_cmd_parts
         if not self.public_vars.get("allow_aws_ssm_proxy"):
-            print(f"WARNING SSM proxy is not allowed for {self.name}"
-                " (COMMCARE_CLOUD_PROXY_SSM is set)", file=sys.stderr)
+            print(f"WARNING SSM proxy is not allowed for {self.name}. Use "
+                "--control and/or unset COMMCARE_CLOUD_PROXY_SSM.", file=sys.stderr)
             return []
         control = self.sshable_hostnames_by_group.get('control')
         if not control:

--- a/src/commcare_cloud/environment/secrets/backends/abstract_backend.py
+++ b/src/commcare_cloud/environment/secrets/backends/abstract_backend.py
@@ -38,10 +38,6 @@ class AbstractSecretsBackend(object):
         return ()
 
     @staticmethod
-    def has_extra_env_vars():
-        return False
-
-    @staticmethod
     def get_extra_ansible_env_vars():
         """
         Return the extra environment variables to pass to ansible to make this secrets backend work

--- a/src/commcare_cloud/environment/secrets/backends/abstract_backend.py
+++ b/src/commcare_cloud/environment/secrets/backends/abstract_backend.py
@@ -38,6 +38,10 @@ class AbstractSecretsBackend(object):
         return ()
 
     @staticmethod
+    def has_extra_env_vars():
+        return False
+
+    @staticmethod
     def get_extra_ansible_env_vars():
         """
         Return the extra environment variables to pass to ansible to make this secrets backend work

--- a/src/commcare_cloud/environment/secrets/backends/aws_secrets/main.py
+++ b/src/commcare_cloud/environment/secrets/backends/aws_secrets/main.py
@@ -21,7 +21,10 @@ class AwsSecretsBackend(AbstractSecretsBackend):
 
     @classmethod
     def from_environment(cls, environment):
-        return AwsSecretsBackend(secret_name_prefix='commcare-{}'.format(environment.name), environment=environment)
+        return AwsSecretsBackend(
+            secret_name_prefix='commcare-{}'.format(environment.name),
+            environment=environment,
+        )
 
     def prompt_user_input(self):
         from commcare_cloud.commands.terraform.aws import aws_sign_in
@@ -35,7 +38,8 @@ class AwsSecretsBackend(AbstractSecretsBackend):
         # and json decodes them for the caller.
         # It's less elegant than doing it outside, but simplifies the error handling.
         return get_generated_variables(
-            lambda secret_spec: "lookup('cchq_aws_secret', '{}/{}', errors='ignore')".format(self.secret_name_prefix, secret_spec.name))
+            lambda secret_spec: "lookup('cchq_aws_secret', '{}/{}', errors='ignore')".format(
+                self.secret_name_prefix, secret_spec.name))
 
     def get_extra_ansible_env_vars(self):
         from commcare_cloud.commands.terraform.aws import aws_sign_in

--- a/src/commcare_cloud/environment/secrets/backends/aws_secrets/main.py
+++ b/src/commcare_cloud/environment/secrets/backends/aws_secrets/main.py
@@ -21,6 +21,17 @@ class AwsSecretsBackend(AbstractSecretsBackend):
     def __init__(self, secret_name_prefix, environment):
         self.secret_name_prefix = secret_name_prefix
         self.environment = environment
+        self._validate_ssm_proxy()
+
+    def _validate_ssm_proxy(self):
+        if (
+            os.environ.get("COMMCARE_CLOUD_PROXY_SSM")
+            and not self.environment.public_vars.get("allow_aws_ssm_proxy")
+        ):
+            sys.exit(
+                "ERROR: AWS SSM proxy is not allowed for this environment. "
+                "Use --control and/or unset COMMCARE_CLOUD_PROXY_SSM instead."
+            )
 
     @classmethod
     def from_environment(cls, environment):

--- a/src/commcare_cloud/environment/secrets/backends/aws_secrets/main.py
+++ b/src/commcare_cloud/environment/secrets/backends/aws_secrets/main.py
@@ -1,8 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 import json
-import os
-import shlex
 import sys
 
 import boto3
@@ -12,7 +10,6 @@ from memoized import memoized_property
 
 from commcare_cloud.environment.secrets.backends.abstract_backend import AbstractSecretsBackend
 from commcare_cloud.environment.secrets.secrets_schema import get_generated_variables
-from commcare_cloud.commands.ansible.helpers import get_default_ssh_options_as_cmd_parts
 
 
 class AwsSecretsBackend(AbstractSecretsBackend):
@@ -21,17 +18,6 @@ class AwsSecretsBackend(AbstractSecretsBackend):
     def __init__(self, secret_name_prefix, environment):
         self.secret_name_prefix = secret_name_prefix
         self.environment = environment
-        self._validate_ssm_proxy()
-
-    def _validate_ssm_proxy(self):
-        if (
-            os.environ.get("COMMCARE_CLOUD_PROXY_SSM")
-            and not self.environment.public_vars.get("allow_aws_ssm_proxy")
-        ):
-            sys.exit(
-                "ERROR: AWS SSM proxy is not allowed for this environment. "
-                "Use --control and/or unset COMMCARE_CLOUD_PROXY_SSM instead."
-            )
 
     @classmethod
     def from_environment(cls, environment):
@@ -55,9 +41,6 @@ class AwsSecretsBackend(AbstractSecretsBackend):
             lambda secret_spec: "lookup('cchq_aws_secret', '{}/{}', errors='ignore')".format(
                 self.secret_name_prefix, secret_spec.name))
 
-    def has_extra_env_vars(self):
-        return os.environ.get("COMMCARE_CLOUD_PROXY_SSM")
-
     def get_extra_ansible_env_vars(self):
         from commcare_cloud.commands.terraform.aws import aws_sign_in
         aws_profile = aws_sign_in(self.environment)
@@ -69,39 +52,11 @@ class AwsSecretsBackend(AbstractSecretsBackend):
         }
         if aws_profile:
             env_vars.update({'AWS_PROFILE': aws_profile})
-            if os.environ.get("COMMCARE_CLOUD_PROXY_SSM"):
-                env_vars['ANSIBLE_SSH_EXTRA_ARGS'] = _opt_str(self._get_ssm_args())
         if sys.platform == 'darwin':
             # Needed to get the ansible aws_secrets lookup plugin to work on MacOS
             # More on the underlying ansible issue: https://github.com/ansible/ansible/issues/49207
             env_vars.update({'OBJC_DISABLE_INITIALIZE_FORK_SAFETY': 'YES'})
         return env_vars
-
-    def _get_ssm_args(self):
-        """Get SSH arguments to connect via AWS SSM with 'control' as jump host
-
-        These options can be observed and debugged with environment variables:
-
-            ANSIBLE_VERBOSITY=3
-            VERBOSE_TO_STDERR=true
-        """
-        from commcare_cloud.commands.inventory_lookup.getinventory import (
-            HostMatchException,
-            get_server_address,
-        )
-        try:
-            control_ip = get_server_address(self.environment.name, 'control')
-        except HostMatchException:
-            print("cannot find {} 'control' machine".format(self.environment.name), file=sys.stderr)
-            return []
-        hostvars = self.environment.get_host_vars(control_ip)
-        try:
-            control_id = hostvars['ec2_instance_id']
-        except KeyError:
-            print("{} 'control' machine has no 'ec2_instance_id'".format(self.environment.name), file=sys.stderr)
-            return []
-        ssm_proxy = get_default_ssh_options_as_cmd_parts(self.environment, aws_ssm_target=control_id)
-        return ['-o', 'ProxyCommand=' + _opt_str(['ssh', '-W', "%h:%p"] + ssm_proxy + [control_ip])]
 
     def _get_secret(self, var):
         try:
@@ -137,7 +92,3 @@ class AwsSecretsBackend(AbstractSecretsBackend):
         return boto3.session.Session(profile_name=aws_sign_in(self.environment)).client(
             'secretsmanager', region_name=self.environment.terraform_config.region
         )
-
-
-def _opt_str(args):
-    return ' '.join(map(shlex.quote, args))

--- a/src/commcare_cloud/environment/secrets/backends/aws_secrets/main.py
+++ b/src/commcare_cloud/environment/secrets/backends/aws_secrets/main.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 import json
+import os
+import shlex
 import sys
 
 import boto3
@@ -10,6 +12,7 @@ from memoized import memoized_property
 
 from commcare_cloud.environment.secrets.backends.abstract_backend import AbstractSecretsBackend
 from commcare_cloud.environment.secrets.secrets_schema import get_generated_variables
+from commcare_cloud.commands.ansible.helpers import get_default_ssh_options_as_cmd_parts
 
 
 class AwsSecretsBackend(AbstractSecretsBackend):
@@ -41,6 +44,9 @@ class AwsSecretsBackend(AbstractSecretsBackend):
             lambda secret_spec: "lookup('cchq_aws_secret', '{}/{}', errors='ignore')".format(
                 self.secret_name_prefix, secret_spec.name))
 
+    def has_extra_env_vars(self):
+        return os.environ.get("COMMCARE_CLOUD_PROXY_SSM")
+
     def get_extra_ansible_env_vars(self):
         from commcare_cloud.commands.terraform.aws import aws_sign_in
         aws_profile = aws_sign_in(self.environment)
@@ -52,11 +58,39 @@ class AwsSecretsBackend(AbstractSecretsBackend):
         }
         if aws_profile:
             env_vars.update({'AWS_PROFILE': aws_profile})
+            if os.environ.get("COMMCARE_CLOUD_PROXY_SSM"):
+                env_vars['ANSIBLE_SSH_EXTRA_ARGS'] = _opt_str(self._get_ssm_args())
         if sys.platform == 'darwin':
             # Needed to get the ansible aws_secrets lookup plugin to work on MacOS
             # More on the underlying ansible issue: https://github.com/ansible/ansible/issues/49207
             env_vars.update({'OBJC_DISABLE_INITIALIZE_FORK_SAFETY': 'YES'})
         return env_vars
+
+    def _get_ssm_args(self):
+        """Get SSH arguments to connect via AWS SSM with 'control' as jump host
+
+        These options can be observed and debugged with environment variables:
+
+            ANSIBLE_VERBOSITY=3
+            VERBOSE_TO_STDERR=true
+        """
+        from commcare_cloud.commands.inventory_lookup.getinventory import (
+            HostMatchException,
+            get_server_address,
+        )
+        try:
+            control_ip = get_server_address(self.environment.name, 'control')
+        except HostMatchException:
+            print("cannot find {} 'control' machine".format(self.environment.name), file=sys.stderr)
+            return []
+        hostvars = self.environment.get_host_vars(control_ip)
+        try:
+            control_id = hostvars['ec2_instance_id']
+        except KeyError:
+            print("{} 'control' machine has no 'ec2_instance_id'".format(self.environment.name), file=sys.stderr)
+            return []
+        ssm_proxy = get_default_ssh_options_as_cmd_parts(self.environment, aws_ssm_target=control_id)
+        return ['-o', 'ProxyCommand=' + _opt_str(['ssh', '-W', "%h:%p"] + ssm_proxy + [control_ip])]
 
     def _get_secret(self, var):
         try:
@@ -92,3 +126,7 @@ class AwsSecretsBackend(AbstractSecretsBackend):
         return boto3.session.Session(profile_name=aws_sign_in(self.environment)).client(
             'secretsmanager', region_name=self.environment.terraform_config.region
         )
+
+
+def _opt_str(args):
+    return ' '.join(map(shlex.quote, args))


### PR DESCRIPTION
Improve the efficiency of the test/development cycle for features that use ansible by allowing ansible commands to be executed against staging hosts directly from the development machine.

Previously ansible commands could not connect to AWS hosts unless they were run from the _control_ machine. `ProxyCommand` options can be used to route ansible SSH connections through an SSM session on _control_ machine (as a jump host) and then on to the target host. This feature is only enabled if the `COMMCARE_CLOUD_PROXY_SSM` environment variable is set to a non-empty string.

:blowfish: Review by commit.

##### ENVIRONMENTS AFFECTED
None.
