### PR TITLE
Global Accelerator: preserve client IP addresses

### DIFF
--- a/src/commcare_cloud/terraform/modules/ga_alb_waf/main.tf
+++ b/src/commcare_cloud/terraform/modules/ga_alb_waf/main.tf
@@ -782,8 +782,9 @@ resource "aws_globalaccelerator_endpoint_group" "front_end" {
   listener_arn = aws_globalaccelerator_listener.front_end.id
 
   endpoint_configuration {
-    endpoint_id = aws_lb.front_end.arn
-    weight      = 128
+    endpoint_id                    = aws_lb.front_end.arn
+    weight                         = 128
+    client_ip_preservation_enabled = true
   }
 
   // these are unused because when pointing to an ALB it uses those health checks instead


### PR DESCRIPTION
Add client_ip_preservation_enabled to AWS Global Accelerator endpoint,
which is now required by AWS for internal ALBs.

This option is already enforced by AWS on existing endpoints, so this
change won't affect any existing environment, but it will allow Terraform
to correctly create one without failing.

##### ENVIRONMENTS AFFECTED
None
