### PR TITLE
Add COMMCARE_ANALYTICS_HOST setting to localsettings.py.j2 template

### DIFF
--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -157,6 +157,10 @@ BIGCOUCH = '{{ localsettings.BIGCOUCH }}'
 BIGCOUCH_QUORUM_COUNT = '{{ localsettings.BIGCOUCH_QUORUM_COUNT }}'
 {% endif %}
 
+{% if 'COMMCARE_ANALYTICS_HOST' in localsettings %}
+COMMCARE_ANALYTICS_HOST = '{{ localsettings.COMMCARE_ANALYTICS_HOST }}'
+{% endif %}
+
 {% if 'COUCH_CACHE_DOCS' in localsettings %}
 COUCH_CACHE_DOCS = '{{ localsettings.COUCH_CACHE_DOCS }}'
 {% endif %}


### PR DESCRIPTION
[Ticket](https://dimagi-dev.atlassian.net/browse/SC-2396)

I added a new setting to staging and production [previously](https://github.com/dimagi/commcare-cloud/commit/fc66a7564d5e127aa0b6556e09425fe336b29e2a), COMMCARE_ANALYTICS_HOST, which holds the commcare analytics host url for staging and production environments respectively, however, I didn't add the new setting to the localsettings.py.j2 template file, so it was not being populated in the actual localsettings.py file that would sit on the server. 

This PR simply adds this setting to the jinja2 template file. 

##### ENVIRONMENTS AFFECTED
Staging, Production
