### PR TITLE
Fix build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
 
         # setup 3.9 for deploy-stack
         # may be removed when this file is updated to match global_vars/all.yml:python_version
-        sudo add-apt-repository ppa:deadsnakes/ppa -y
+        sudo add-apt-repository -y ppa:deadsnakes/ppa
         sudo apt update
         sudo apt install python3.9 python3.9-venv
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
 
         # setup 3.9 for deploy-stack
         # may be removed when this file is updated to match global_vars/all.yml:python_version
-        sudo add-apt-repository ppa:deadsnakes/ppa
+        sudo add-apt-repository ppa:deadsnakes/ppa -y
         sudo apt update
         sudo apt install python3.9 python3.9-venv
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Noticed this test started to fail in another PR and seemed unrelated to that work. Verified this PR failed with no changes before adding the `-y` option to `add-apt-repository`.

Here was the failure:
```
Cannot add PPA: 'ppa:~deadsnakes/ubuntu/ppa'.
The team named '~deadsnakes' has no PPA named 'ubuntu/ppa'
Please choose from the following available PPAs:
 * 'nightly':  nightly python builds
 * 'ppa':  New Python Versions
 * 'python3.10-jammy':  python3.10-jammy
```

And when adding this ppa on a fresh ubuntu vm, omitting the `-y` option, I was prompted with:
`Press [ENTER] to continue or Ctrl-c to cancel adding it.` so I assumed that was causing this error.
##### ENVIRONMENTS AFFECTED
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
