### PR TITLE
Make AWS Backup rules deduplicate monthly/quarterly backups

### DIFF
--- a/src/commcare_cloud/terraform/modules/backup/main.tf
+++ b/src/commcare_cloud/terraform/modules/backup/main.tf
@@ -36,7 +36,7 @@ resource "aws_backup_plan" "business_continuity_plan" {
     completion_window        = 10080
     enable_continuous_backup = false
     rule_name                = "Monthly"
-    schedule                 = "cron(0 13 ? * 1#1 *)"
+    schedule                 = "cron(0 13 ? FEB,MAR,MAY,JUN,AUG,SEP,NOV,DEC 1#1 *)"
     start_window             = 60
     target_vault_name        = aws_backup_vault.business_continuity_local_vault.name
 
@@ -52,27 +52,27 @@ resource "aws_backup_plan" "business_continuity_plan" {
       delete_after = 1
     }
   }
-  dynamic "rule" {
-    for_each = toset(var.quarterly_retention != 0 ? [1] : [])
-    content {
-      completion_window        = 10080
-      enable_continuous_backup = false
-      rule_name                = "Quarterly"
-      schedule                 = "cron(0 13 ? JAN,APR,JUL,OCT 1#1 *)"
-      start_window             = 60
-      target_vault_name        = aws_backup_vault.business_continuity_local_vault.name
+  rule {
+    completion_window        = 10080
+    enable_continuous_backup = false
+    rule_name                = "Quarterly"
+    schedule                 = "cron(0 13 ? JAN,APR,JUL,OCT 1#1 *)"
+    start_window             = 60
+    target_vault_name        = aws_backup_vault.business_continuity_local_vault.name
 
-      copy_action {
-        destination_vault_arn = aws_backup_vault.business_continuity_remote_vault.arn
-
-        lifecycle {
-          delete_after = var.quarterly_retention
-        }
-      }
+    copy_action {
+      destination_vault_arn = aws_backup_vault.business_continuity_remote_vault.arn
 
       lifecycle {
-        delete_after = 1
+        // if quarterly retention is 0, or even just less than monthly retention
+        // then save these month's backups only as long as we'd save *any* month's backups
+        // i.e. the length used in the "Monthly" rule
+        delete_after = max(var.quarterly_retention, var.monthly_retention)
       }
+    }
+
+    lifecycle {
+      delete_after = 1
     }
   }
 }


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-13845

This makes it so that every month at the same time EITHER a quarterly or a monthly backup is taken, where previously every third month BOTH a quarterly and a monthly backup were taken. The difference between the two is that the quarterly backups will be kept longer. (If quarterly backups are specified have a _shorter_ retention than the monthly backups, they fall back to being kept just as long as the monthly backups, so basically it gracefully degrades to quarterly backups == monthly backups.)

This has been applied on staging, using `cchq staging terraform init && cchq staging terraform apply -target module.backup_plan`, and will likewise be applied to production once merged.

##### ENVIRONMENTS AFFECTED
staging, production
