### PR TITLE
Add hardware requirements for running CommCareHQ in docker for development

### DIFF
--- a/hosting_docs/source/prereqs/5-requirements.rst
+++ b/hosting_docs/source/prereqs/5-requirements.rst
@@ -217,3 +217,22 @@ Recommendations are the same as for a Small Cluster configuration:
 
 The level of skills, and the number of personnel, required to manage a
 Large Cluster configuration are higher than for a Small Cluster.
+
+
+
+Running CommCareHQ inside Docker
+--------------------------------
+Running CommCareHQ inside docker is currently not supported/optimized for production environments. However, it is
+the recommended way to get the CommCareHQ ecosystem up and running for development purposes.
+
+Running services inside containers requires additional resources to the base resource requirements for the
+ecosystem running inside the container(s). Some testing revealed that the minimum resource requirements to run
+the CommCareHQ ecosystem with docker is the following:
+
+* CPU: 31.133% (equavalent to 1 core)
+
+* Memory: 5GB
+
+However, it is recommended that your system have more resources than the above in order to do more than just
+"keep the lights on". The exact resource requirement is heavily dependend on your own system and you should use the
+above only as a baseline.

--- a/hosting_docs/source/prereqs/5-requirements.rst
+++ b/hosting_docs/source/prereqs/5-requirements.rst
@@ -228,7 +228,7 @@ the recommended way to get the CommCareHQ ecosystem up and running for developme
 Running services inside containers requires additional resources to the base resource requirements for the
 ecosystem running inside the container(s). The minimum resource requirements to run the CommCareHQ ecosystem with docker is the following:
 
-* CPU: 31.133% (equavalent to 1 core)
+* CPU: 31.133% (on a single core)
 
 * Memory: 5GB
 

--- a/hosting_docs/source/prereqs/5-requirements.rst
+++ b/hosting_docs/source/prereqs/5-requirements.rst
@@ -226,8 +226,7 @@ Running CommCareHQ inside docker is currently not supported/optimized for produc
 the recommended way to get the CommCareHQ ecosystem up and running for development purposes.
 
 Running services inside containers requires additional resources to the base resource requirements for the
-ecosystem running inside the container(s). Some testing revealed that the minimum resource requirements to run
-the CommCareHQ ecosystem with docker is the following:
+ecosystem running inside the container(s). The minimum resource requirements to run the CommCareHQ ecosystem with docker is the following:
 
 * CPU: 31.133% (equavalent to 1 core)
 


### PR DESCRIPTION
[Ticket](https://dimagi-dev.atlassian.net/browse/SC-2358)

Description:
This PR updates the [Hardware requirements section](https://commcare-cloud.readthedocs.io/en/latest/prereqs/5-requirements.html#hardware-requirements-and-deployment-options) in the deployment docs to state some system requirements in order to run HQ in docker locally for development purposes. Since we don't support running HQ in production using docker (yet), I'm only stating the minimum recommended requirements in order to run the containers.

##### ENVIRONMENTS AFFECTED
None
