### PR TITLE
Fix issue with changelog output during deploy

### DIFF
--- a/src/commcare_cloud/fab/diff_templates/console.txt.j2
+++ b/src/commcare_cloud/fab/diff_templates/console.txt.j2
@@ -18,11 +18,11 @@ New version details:
 
 {%- if changelogs.error -%}
 Changelogs:
-    Please review any pending changelogs from https://commcare-cloud.readthedocs.io/en/latest/ and make sure that these are applied on your environment before deploying to avoid getting your environment into a broaken state.
+    Please review any pending changelogs from https://commcare-cloud.readthedocs.io/en/latest/ and make sure that these are applied on your environment before deploying to avoid getting your environment into a broken state.
 
 {%- else -%}
 Changelogs:
-    There have been some changelogs since last deploy, you must make sure that these are applied on your environment before deploying to avoid getting your environment into a broaken state.
+    There have been some changelogs since last deploy, you must make sure that these are applied on your environment before deploying to avoid getting your environment into a broken state.
 
 {% for log in changelogs.changelogs -%}
         {{ log }}

--- a/src/commcare_cloud/fab/utils.py
+++ b/src/commcare_cloud/fab/utils.py
@@ -135,7 +135,7 @@ def get_changelogs_in_date_range(since, until, get_file_fn=None):
         CHANGELOG_INDEX = "hosting_docs/source/changelog/index.md"
         return str(repo.get_contents(CHANGELOG_INDEX).decoded_content).split("\\n")
 
-    file_content = _get_file_content() if not get_file_fn  else get_file_fn()
+    file_content = _get_file_content_as_lines() if not get_file_fn  else get_file_fn()
     search_dates = [
         (since + datetime.timedelta(day)).strftime('%Y-%m-%d')
         for day in range((until - since).days + 1)


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Fixed a typo and corrected the method rename introduced in 11b0931ce813d7f6c496ba2f70381bd924cd89d8.

```
Error getting changelogs: name '_get_file_content' is not defined. Please report this at https://forum.dimagi.com/c/developers/
```
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None
