### PR TITLE
increase max_content_length

### DIFF
--- a/src/commcare_cloud/ansible/roles/elasticsearch/templates/config/elasticsearch.yml.j2
+++ b/src/commcare_cloud/ansible/roles/elasticsearch/templates/config/elasticsearch.yml.j2
@@ -27,6 +27,7 @@ http.port: {{ elasticsearch_http_port }}
 
 http.cors.enabled: true
 http.cors.allow-origin: "null"
+http.max_content_length: 200mb
 path.data: {{ elasticsearch_data_dir }}/data
 path.logs: {{ elasticsearch_data_dir }}/logs
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
A domain in prod is submitting forms larger than 100mb (the ES doc size limit), which are piling up in the pillow errors table, and painfully slow to retry. This increases the size limit so that those forms will successfully make it into ES.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All
