### PR TITLE
Decrease submission_reprocessing_queue concurrency

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -93,7 +93,7 @@ celery_processes:
       pooling: gevent
       concurrency: 2
     submission_reprocessing_queue:
-      concurrency: 3
+      concurrency: 2
       prefetch_multiplier: 1
     sumologic_logs_queue:
       pooling: gevent


### PR DESCRIPTION
Scale back by one, from 3 to 2 (it was initially 1), and keep
prefetch_multiplier at 1 (it was initially absent).

##### Environments Affected
Production