### PR TITLE
Fix rebuild commands

### DIFF
--- a/hosting_docs/source/reference/howto/wipe_persistent_data.rst
+++ b/hosting_docs/source/reference/howto/wipe_persistent_data.rst
@@ -46,6 +46,28 @@ in the sequence given below, so you shouldn't proceed to next steps until the pr
 
 #. Wipe PostgreSQL databases
 
+   Check status & start postgres if NOT running.
+
+   .. code-block::
+
+      $ cchq <env_name> service postgresql status
+
+   Status should be "OK" for both postgresql and pgbouncer.
+
+   If not running, Start postgresql and pgbouncer through postgresql service
+
+   .. code-block::
+
+      $ cchq <env_name> service postgresql start
+
+   If that does not start both successfully, reset services by running
+
+   .. code-block::
+
+      $ cchq <env_name> ap deploy_postgres.yml
+
+   Check status & once status is "OK", Wipe postgres data
+
    .. code-block::
 
       $ cchq <env_name> ap wipe_postgres.yml

--- a/hosting_docs/source/reference/howto/wipe_persistent_data.rst
+++ b/hosting_docs/source/reference/howto/wipe_persistent_data.rst
@@ -112,8 +112,13 @@ Rebuilding environment
 
       $ cchq <env_name> ap deploy_db.yml --skip-check
 
-#. Run a code deploy to create Kafka topics, create Postgres
-   tables, and Elasticsearch indices.
+   Run initial migration
+
+   .. code-block::
+
+      $ cchq <env_name> ap migrate_on_fresh_install.yml -e CCHQ_IS_FRESH_INSTALL=1
+
+#. Run a code deploy to create Kafka topics and Elasticsearch indices.
 
    .. code-block::
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Couple of issues came up when we were following the documentation for rebuild on a test environment.
1. PG was not restarted post shut down to kill connections to execute data wipe. So that is now added
2. An initial migration is needed post wipe to setup tables before deploy. If this isn't done, deploy fails at `ensure_checkpoints_safe` task which needs `pillowtop_kafkacheckpoint` table to be present. So that is resolved by running the migrate_on_fresh_install playbook

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None
