### PR TITLE
Fix git safe-directory warning bug that prevents deploy-diff feature

### DIFF
--- a/src/commcare_cloud/commands/deploy/commcare.py
+++ b/src/commcare_cloud/commands/deploy/commcare.py
@@ -195,7 +195,7 @@ def _get_deployed_version(environment):
         AnsibleContext(None, environment),
         "django_manage",
         "shell",
-        f"cd {code_current}; git rev-parse HEAD",
+        f"sudo -iu cchq bash -c 'git --git-dir={code_current}/.git rev-parse HEAD'",
         become=False,
         run_command=ansible_json,
     )


### PR DESCRIPTION

Currently the deploy script's deploy-diff feature is failing due to a bug in `_get_deployed_version` which produces below error. This fails silently so no one complained about this.
```
fatal: detected dubious ownership in repository at '/home/cchq/www/staging/releases/2023-01-11_06.14'
To add an exception for this directory, call:

	git config --global --add safe.directory /home/cchq/www/staging/releases/2023-01-11_06.14non-zero return code
```
This is due to ansible not owning the current directory. This change fixes this by executing the command as cchq user.


##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->

##### Announce New Release
<!-- 
Review https://github.com/dimagi/commcare-cloud/tree/master/changelog#determining-whether-a-change-is-announce-worthy
to determine if a changelog entry is necessary if not already created.
-->
<!-- Delete this section if the PR does not contain any new changelog entries -->
- [ ] After merging, I will follow [these instructions](https://confluence.dimagi.com/display/saas/Announcing+changes+affecting+third+parties#Announcingchangesaffectingthirdparties-announcing)
to announce a new commcare-cloud release. 
