### PR TITLE
Fix Changelog issue related to rendering double curly braces

### DIFF
--- a/changelog/0069-configure-java-17-for-formplayer.yml
+++ b/changelog/0069-configure-java-17-for-formplayer.yml
@@ -6,16 +6,18 @@ context: |
   This change is to configure Java 17 for Formplayer. 
 
 details: |
-  This sets a specific Java version just for formplayer. It should only affect the machine that formplayer is on and it shouldn't imapct any other 
+  This sets a specific Java version just for formplayer. It should only affect the machine that formplayer is on and it shouldn't impact any other 
   Java processes running on that machine. 
 
 update_steps: |
 
   1. Update commcare-cloud to the latest version
   2. Add the following setting to the environment's `public.yml` and set its value accordingly:
-      ```
-      formplayer_java_version: {\{ java_17_bin_path }}/java
-      ```
+      +++
+      <pre style="background-color:#f8f8f8" class="code literal-block">
+      formplayer_java_version: &#123;&#123; java_17_bin_path }}/java
+      </pre>
+      +++
   3. Update Formplayer 
       ```
       commcare-cloud <env> ap deploy_formplayer.yml --limit=formplayer

--- a/hosting_docs/source/changelog/0069-configure-java-17-for-formplayer.md
+++ b/hosting_docs/source/changelog/0069-configure-java-17-for-formplayer.md
@@ -15,16 +15,18 @@ This change is not known to be dependent on any particular version of CommCare.
 This change is to configure Java 17 for Formplayer. 
 
 ## Details
-This sets a specific Java version just for formplayer. It should only affect the machine that formplayer is on and it shouldn't imapct any other 
+This sets a specific Java version just for formplayer. It should only affect the machine that formplayer is on and it shouldn't impact any other 
 Java processes running on that machine. 
 
 ## Steps to update
 
 1. Update commcare-cloud to the latest version
 2. Add the following setting to the environment's `public.yml` and set its value accordingly:
-    ```
-    formplayer_java_version: {\{ java_17_bin_path }}/java
-    ```
+    +++
+    <pre style="background-color:#f8f8f8" class="code literal-block">
+    formplayer_java_version: &#123;&#123; java_17_bin_path }}/java
+    </pre>
+    +++
 3. Update Formplayer 
     ```
     commcare-cloud <env> ap deploy_formplayer.yml --limit=formplayer


### PR DESCRIPTION
This PR is to fix an issue in the Changelog in which double curly braces, **{{**, get rendered as **{{ '{{' }}**. I couldn't find much on the web so I went for a hacky solution, I replaced the [code block](https://myst-parser.readthedocs.io/en/latest/syntax/syntax.html#code-syntax-highlighting) with a [block break](https://myst-parser.readthedocs.io/en/latest/syntax/syntax.html#block-breaks) (which can interpret HTML) and employed some inline styling to produce the same look as the code block. I will continue looking for a better option but in the meantime we can more comfortably release the instructions to 3rd parties.