### PR TITLE
Remove leftover elasticsearch_upstart reference

### DIFF
--- a/src/commcare_cloud/ansible/roles/elasticsearch/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/elasticsearch/tasks/main.yml
@@ -126,7 +126,7 @@
 - name: Restart Elasticsearch
   become: yes
   service: name=elasticsearch state=restarted
-  when: copy_elasticsearch_conf_result.changed or copy_elasticsearch_upstart_result.changed or copy_elasticsearch_logging_result.changed
+  when: copy_elasticsearch_conf_result.changed or copy_elasticsearch_logging_result.changed
   tags:
     - es_restart
 


### PR DESCRIPTION
Remove leftover copy_elasticsearch_upstart_result variable reference
from Elasticsearch restart task.