### PR TITLE
Remove sed command from makefile (was used to support python 3.6)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,11 @@ PIP_COMPILE = pip-compile --output-file ${REQUIREMENTS} setup.py
 ANSIBLE_ENV=COLUMNS=80
 src/commcare_cloud/help_cache/ansible.txt: export ANSIBLE_CONFIG=src/commcare_cloud/ansible/ansible.cfg
 src/commcare_cloud/help_cache/ansible.txt:
-	$(ANSIBLE_ENV) ansible -h | sed 's/^optional arguments:/options:/' > src/commcare_cloud/help_cache/ansible.txt
+	$(ANSIBLE_ENV) ansible -h > src/commcare_cloud/help_cache/ansible.txt
 
 src/commcare_cloud/help_cache/ansible-playbook.txt: export ANSIBLE_CONFIG=src/commcare_cloud/ansible/ansible.cfg
 src/commcare_cloud/help_cache/ansible-playbook.txt:
-	$(ANSIBLE_ENV) ansible-playbook -h | sed 's/^optional arguments:/options:/' > src/commcare_cloud/help_cache/ansible-playbook.txt
+	$(ANSIBLE_ENV) ansible-playbook -h > src/commcare_cloud/help_cache/ansible-playbook.txt
 
 hosting_docs/source/reference/1-commcare-cloud/commands.md : src/commcare_cloud/* src/commcare_cloud/*/* src/commcare_cloud/*/*/*
 	manage-commcare-cloud make-docs > hosting_docs/source/reference/1-commcare-cloud/commands.md


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
As the title explains, this was needed when supporting both 3.6 and 3.10, but since we have dropped support for 3.6, we do not need this special line in the makefile to ensure docs are formatted consistently regardless of using 3.6 or 3.10.
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None
