### PR TITLE
set autovacuum_vacuum_cost_limit

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -521,6 +521,7 @@ rds_instances:
       maintenance_work_mem: 960MB
       max_connections: "LEAST({DBInstanceClassMemory/9531392},5000)"
       vacuum_cost_limit: 2000
+      autovacuum_vacuum_cost_limit: 2000
 
   - identifier: "pgformplayer2-production"
     instance_type: "db.m5.xlarge"
@@ -536,6 +537,7 @@ rds_instances:
       maintenance_work_mem: 4172000kB
       max_wal_size: 4GB
       vacuum_cost_limit: 1000
+      autovacuum_vacuum_cost_limit: 1000
       pg_transport.work_mem: 131072
       pg_transport.timing: 1
       max_worker_processes: 40
@@ -558,6 +560,7 @@ rds_instances:
       shared_buffers: 12GB
       maintenance_work_mem: 4172000kB
       vacuum_cost_limit: 1000
+      autovacuum_vacuum_cost_limit: 1000
       pg_transport.work_mem: 262144 
       pg_transport.timing: 1
       max_worker_processes: 40


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-14317

This sets `autovacuum_vacuum_cost_limit` to the same value as `vacuum_cost_limit` , which is required as of postgres 14 in RDS, since it no longer defaults to `-1`, the setting to just use the value in `vacuum_cost_limit`.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production

