### PR TITLE
allow inline update

### DIFF
--- a/src/commcare_cloud/ansible/roles/elasticsearch/templates/config/elasticsearch.yml.j2
+++ b/src/commcare_cloud/ansible/roles/elasticsearch/templates/config/elasticsearch.yml.j2
@@ -82,6 +82,7 @@ indices.fielddata.cache.size:  {{ elasticsearch_fielddata_cache_size }}
 # somewhat of a security risk but required by pact custom reports
 script.engine.groovy.inline.aggs: true
 script.engine.groovy.inline.search: true
+script.engine.groovy.inline.update: true
 {% endif %}
 {% endif %}
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-14330

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All

The form reindex is failing because some documents contain reserved fields in their source. The cleanest way to deal with that issues is with inline reindex scripts https://www.elastic.co/guide/en/elasticsearch/reference/2.4/docs-reindex.html#_reindex_to_change_the_name_of_a_field, however we can't use those without this setting.