### PR TITLE
Fix the commands.md doc

### DIFF
--- a/hosting_docs/source/reference/1-commcare-cloud/commands.md
+++ b/hosting_docs/source/reference/1-commcare-cloud/commands.md
@@ -231,7 +231,7 @@ commcare-cloud <env> audit-environment [--use-factory-auth]
 
 State information is saved in the '~/.commcare-cloud/snapshots' directory. It is a good idea to run this before making any major changes to your environment, as it allows you to have a record of your environment's current state.
 
-##### Optional Arguments
+##### Options
 
 ###### `--use-factory-auth`
 


### PR DESCRIPTION
This PR fixes the `commands.md` doc by regenerating it. What's interesting to me is that this time the generated text is different, meaning either 1. the previously generated docs were generated incorrectly or 2. I accidentally tampered with it (more likely, but I can't remember doing so)

##### Environments Affected
N/A