### PR TITLE
xform backfill pillow

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -133,6 +133,8 @@ pillows:
       num_processes: 1
     UserGroupsDbKafkaPillow:
       num_processes: 1
+    XFormToElasticsearchPillowBackfill:
+      num_processes: 12
   pillow_b1000:
     xform-pillow:
       num_processes: 33

--- a/environments/production/elasticsearch.yml
+++ b/environments/production/elasticsearch.yml
@@ -1,3 +1,3 @@
 settings:
   case_search:
-    number_of_shards: 16
+    number_of_shards: 96

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -178,6 +178,13 @@ localsettings:
     auditcare: auditcare
   LOCAL_MIDDLEWARE:
     - 'django.middleware.security.SecurityMiddleware'
+  LOCAL_PILLOWS:
+    - name: 'XFormToElasticsearchPillowBackfill'
+        class: 'pillowtop.pillow.interface.ConstructedPillow'
+        instance: 'corehq.pillows.xform.get_xform_to_elasticsearch_pillow'
+        params:
+          index_name: 'xforms_2023-01-27'
+          index_alias: 'xforms-1'
   PILLOWTOP_MACHINE_ID: hqdb0
   ALLOW_PHONE_AS_DEFAULT_TWO_FACTOR_DEVICE: True
   RATE_LIMIT_SUBMISSIONS: yes

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -180,11 +180,11 @@ localsettings:
     - 'django.middleware.security.SecurityMiddleware'
   LOCAL_PILLOWS:
     - name: 'XFormToElasticsearchPillowBackfill'
-        class: 'pillowtop.pillow.interface.ConstructedPillow'
-        instance: 'corehq.pillows.xform.get_xform_to_elasticsearch_pillow'
-        params:
-          index_name: 'xforms_2023-01-27'
-          index_alias: 'xforms-1'
+      class: 'pillowtop.pillow.interface.ConstructedPillow'
+      instance: 'corehq.pillows.xform.get_xform_to_elasticsearch_pillow'
+      params:
+        index_name: 'xforms_2023-01-27'
+        index_alias: 'xforms-1'
   PILLOWTOP_MACHINE_ID: hqdb0
   ALLOW_PHONE_AS_DEFAULT_TWO_FACTOR_DEVICE: True
   RATE_LIMIT_SUBMISSIONS: yes


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production

This adds the XForm backfill pillow needed to process all changes that have happened since we kicked off the reindex.

I also noticed that our settings for the case search index were incorrect so updated them in a separate commit to reflect the actual state of production.