### PR TITLE
Use setup_auth for couchdb-migrate rsync

### DIFF
--- a/src/commcare_cloud/commands/migrations/couchdb.py
+++ b/src/commcare_cloud/commands/migrations/couchdb.py
@@ -417,7 +417,7 @@ def _run_migration(migration, target_context, check_mode, no_stop):
     prepare_to_sync_files(migration, file_configs, target_context)
     host_ips = ",".join(file_configs)
 
-    auth = noop_context() if check_mode else ssh_auth(migration, file_configs, target_context)
+    auth = ssh_auth(migration, file_configs, target_context)
     if no_stop:
         stop_couch_context = noop_context()
     else:

--- a/src/commcare_cloud/commands/migrations/couchdb.py
+++ b/src/commcare_cloud/commands/migrations/couchdb.py
@@ -414,7 +414,8 @@ def _run_migration(migration, target_context, check_mode, no_stop):
 
     puts(color_summary('Copy file lists to nodes:'))
     file_configs = get_migration_file_configs(migration)
-    host_ips = ",".join(prepare_to_sync_files(migration, file_configs, target_context))
+    prepare_to_sync_files(migration, file_configs, target_context)
+    host_ips = ",".join(file_configs)
 
     auth = noop_context() if check_mode else ssh_auth(migration, file_configs, target_context)
     if no_stop:
@@ -477,21 +478,19 @@ def commit_migration(migration):
 
 
 def prepare_to_sync_files(migration, file_configs, target_context):
-    rsync_files_by_host = generate_rsync_lists(migration, file_configs)
+    generate_rsync_lists(migration, file_configs)
 
-    for host_ip in rsync_files_by_host:
+    for host_ip in file_configs:
         copy_scripts_to_target_host(
             host_ip,
             migration.rsync_files_path,
             target_context
         )
-    return rsync_files_by_host
 
 
 def generate_rsync_lists(migration, file_configs):
     for target_host, files_for_node in file_configs.items():
         prepare_file_copy_scripts(target_host, files_for_node, migration.rsync_files_path)
-    return list(file_configs)
 
 
 def get_migration_file_configs(migration):

--- a/src/commcare_cloud/commands/migrations/couchdb.py
+++ b/src/commcare_cloud/commands/migrations/couchdb.py
@@ -50,10 +50,13 @@ from commcare_cloud.commands.ansible.run_module import run_ansible_module
 from commcare_cloud.commands.command_base import Argument, CommandBase
 from commcare_cloud.commands.migrations.config import CouchMigration
 from commcare_cloud.commands.migrations.copy_files import (
+    Plan,
     SourceFiles,
     copy_scripts_to_target_host,
     execute_file_copy_scripts,
     prepare_file_copy_scripts,
+    setup_auth,
+    teardown_auth,
 )
 from commcare_cloud.commands.utils import render_template
 
@@ -410,18 +413,30 @@ def _run_migration(migration, target_context, check_mode, no_stop):
     run_ansible_module(source_context, 'couchdb2', 'file', file_args)
 
     puts(color_summary('Copy file lists to nodes:'))
-    host_ips = ",".join(prepare_to_sync_files(migration, target_context))
+    file_configs = get_migration_file_configs(migration)
+    host_ips = ",".join(prepare_to_sync_files(migration, file_configs, target_context))
 
+    auth = noop_context() if check_mode else ssh_auth(migration, file_configs, target_context)
     if no_stop:
         stop_couch_context = noop_context()
     else:
         puts(color_summary('Stop couch and reallocate shards'))
         stop_couch_context = stop_couch(migration.all_environments, check_mode)
 
-    with stop_couch_context:
+    with auth, stop_couch_context:
         execute_file_copy_scripts(target_context, host_ips, check_mode)
 
     return 0
+
+
+@contextmanager
+def ssh_auth(migration, file_configs, target_context):
+    plan = Plan(migration.source_environment, file_configs)
+    setup_auth(plan, target_context, migration.working_dir)
+    try:
+        yield
+    finally:
+        teardown_auth(plan, target_context, migration.working_dir)
 
 
 @contextmanager
@@ -461,8 +476,8 @@ def commit_migration(migration):
         print(response)
 
 
-def prepare_to_sync_files(migration, target_context):
-    rsync_files_by_host = generate_rsync_lists(migration)
+def prepare_to_sync_files(migration, file_configs, target_context):
+    rsync_files_by_host = generate_rsync_lists(migration, file_configs)
 
     for host_ip in rsync_files_by_host:
         copy_scripts_to_target_host(
@@ -473,11 +488,10 @@ def prepare_to_sync_files(migration, target_context):
     return rsync_files_by_host
 
 
-def generate_rsync_lists(migration):
-    migration_file_configs = get_migration_file_configs(migration)
-    for target_host, files_for_node in migration_file_configs.items():
+def generate_rsync_lists(migration, file_configs):
+    for target_host, files_for_node in file_configs.items():
         prepare_file_copy_scripts(target_host, files_for_node, migration.rsync_files_path)
-    return list(migration_file_configs)
+    return list(file_configs)
 
 
 def get_migration_file_configs(migration):

--- a/tests/test_couch_migration.py
+++ b/tests/test_couch_migration.py
@@ -116,9 +116,8 @@ def _generate_plan_and_rsync_lists(migration, plan_name):
         generate_shard_plan(migration)
 
     with patch('couchdb_cluster_admin.file_plan.get_shard_allocation', mock_func):
-        # this also get's called in generate_rsync_lists but we want the result to test against
         migration_file_configs = get_migration_file_configs(migration)
-        generate_rsync_lists(migration)
+        generate_rsync_lists(migration, migration_file_configs)
     return migration_file_configs
 
 


### PR DESCRIPTION
Remote-to-remote authentication was broken when `PrivilegedCommand` was replaced with `run_ansible_module` in commit https://github.com/dimagi/commcare-cloud/commit/4285227c0832abd841f5dc41566086506a2fd5ee. `PrivilegedCommand` used `run_fab_task`, which used SSH agent forwarding in combination with `sudo -E` to facilitate remote-to-remote SSH connections. `setup_auth` configures SSH authentication between remote hosts.

https://dimagi-dev.atlassian.net/browse/SAAS-14368

:tropical_fish: Review commits individually.

##### Environments Affected
None.