### PR TITLE
do not run xform backfill pillow

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -133,8 +133,6 @@ pillows:
       num_processes: 1
     UserGroupsDbKafkaPillow:
       num_processes: 1
-    XFormToElasticsearchPillowBackfill:
-      num_processes: 12
   pillow_b1000:
     xform-pillow:
       num_processes: 33


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-14330

Part of the switchover to the new index, this will stop running the backfill pillow

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production