### PR TITLE
Refactor the commcare-audit role and add a filesystem healthcheck task

### DIFF
--- a/src/commcare_cloud/ansible/commcare-audit.yml
+++ b/src/commcare_cloud/ansible/commcare-audit.yml
@@ -1,4 +1,4 @@
-- name: Store stats of "/opt/data" directory
+- name: Collect audit information
   hosts: all
   gather_facts: true
   become: true

--- a/src/commcare_cloud/ansible/roles/commcare-audit/tasks/disk_usage.yml
+++ b/src/commcare_cloud/ansible/roles/commcare-audit/tasks/disk_usage.yml
@@ -1,0 +1,5 @@
+--- 
+- name: Running 'df -h' command
+  shell: "df -h | tee {{ audit_directory }}/disk_usage.txt"
+  delegate_to: localhost
+  become_user: "{{ control_user }}"

--- a/src/commcare_cloud/ansible/roles/commcare-audit/tasks/file_permissions.yml
+++ b/src/commcare_cloud/ansible/roles/commcare-audit/tasks/file_permissions.yml
@@ -1,0 +1,23 @@
+---
+- name: Check if current data directory exists
+  stat:
+    path: /opt/data
+  register: data_dir
+
+- name: Get stats of current data directory
+  stat:
+    path: /opt/data
+  register: data_stats
+  when: data_dir.stat.exists
+
+- name: Save current data directory permissions
+  template:
+    src: opt_data_file_permissions.txt.j2
+    dest: "{{ audit_directory }}/opt_data_file_permissions.txt"
+  delegate_to: localhost
+  become_user: "{{ control_user }}"
+  when: data_dir.stat.exists
+  vars:
+    mode: "{{ data_stats.stat.mode }}"
+    owner: "{{ data_stats.stat.uid }}"
+    group: "{{ data_stats.stat.gid }}"

--- a/src/commcare_cloud/ansible/roles/commcare-audit/tasks/filesystem_health.yml
+++ b/src/commcare_cloud/ansible/roles/commcare-audit/tasks/filesystem_health.yml
@@ -1,0 +1,29 @@
+---
+- name: Get lsblk output in JSON format
+  shell: "lsblk -l --json"
+  register: lsblk_output
+
+- name: Filter JSON output for non-null mountpoints
+  set_fact:
+    filtered_mountpoints: "{{ (lsblk_output.stdout | from_json).blockdevices\
+    | selectattr('mountpoint', '!=', None) | map(attribute='name') }}"
+
+- name: Get filesystem health
+  shell: "sudo tune2fs -l /dev/{{ item }}"
+  with_items: "{{ filtered_mountpoints }}"
+  register: filesystems_health
+  ignore_errors: true
+
+- name: Filter for successfull checks
+  set_fact:
+    successfull_filesystem_checks: "{{ filesystems_health.results | selectattr('rc', 'eq', 0)\
+    | map(attribute='stdout_lines') | flatten }}"
+
+- name: Save to file
+  lineinfile:
+    path: "{{ audit_directory }}/filesystems_health.txt"
+    line: "{{ item }}"
+    create: true
+  with_items: "{{ successfull_filesystem_checks }}"
+  delegate_to: localhost
+  become_user: "{{ control_user }}"

--- a/src/commcare_cloud/ansible/roles/commcare-audit/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/commcare-audit/tasks/main.yml
@@ -1,41 +1,26 @@
 ---
-- name: Check if /opt/data exists
-  stat:
-    path: /opt/data
-  register: data_dir
+- name: Set host's audit directory
+  set_fact:
+    host_audit_directory: "{{ audit_path }}/{{ ansible_hostname }}"
 
-- name: Get stats of "/opt/data" directory
-  stat:
-    path: /opt/data
-  register: data_stats
-  when: data_dir.stat.exists
-
-- name: Execute the `$df -h` command.
-  command: "df"
-  register: dfout
-
-- name: Add "/opt/data" stats folder to control machine
+- name: Create host's audit directory
   delegate_to: localhost
   become_user: "{{ control_user }}"
   file:
-    path: "{{ audit_path }}/{{ ansible_hostname }}/"
+    path: "{{ host_audit_directory }}/"
     state: directory
-  when: data_dir.stat.exists
 
-- name: Create permissions file
-  template:
-    src: opt_data_file_permissions.txt.j2
-    dest: "{{ audit_path }}/{{ ansible_hostname }}/opt_data_file_permissions.txt"
-  delegate_to: localhost
-  become_user: "{{ control_user }}"
+- name: Store disk usage stats
+  include_tasks: disk_usage.yml
   vars:
-    mode: "{{ data_stats.stat.mode }}"
-    owner: "{{ data_stats.stat.uid }}"
-    group: "{{ data_stats.stat.gid }}"
+    - audit_directory: "{{ host_audit_directory }}"
 
-- name: Create template
-  copy:
-    content: "{{ dfout.stdout }}"
-    dest: "{{ audit_path }}/{{ ansible_hostname }}/disk_usage.txt"
-  delegate_to: localhost
-  become_user: "{{ control_user }}"
+- name: Store data directory permissions
+  include_tasks: file_permissions.yml
+  vars:
+    - audit_directory: "{{ host_audit_directory }}"
+
+- name: Store filesystem stats
+  include_tasks: filesystem_health.yml
+  vars:
+    - audit_directory: "{{ host_audit_directory }}"

--- a/src/commcare_cloud/commands/ansible/ops_tool.py
+++ b/src/commcare_cloud/commands/ansible/ops_tool.py
@@ -514,7 +514,7 @@ class AuditEnvironment(_AnsiblePlaybookAlias):
         self._collect_commcare_hq_details()
         self._validate_environment_settings()
         self._collect_control_machine_os_level_info()
-        self._collect_service_folder_permissions_info()
+        self._audit_hosts()
         self._collect_service_status_info()
         
         self._write_info_file()
@@ -562,7 +562,7 @@ class AuditEnvironment(_AnsiblePlaybookAlias):
         os_data["os_distrib"] = os_distrib
         self.env_info_dict["os_data"] = os_data
         
-    def _collect_service_folder_permissions_info(self):
+    def _audit_hosts(self):
         args = self.args
         args.playbook = 'commcare-audit.yml'
         control_user = os.getlogin()


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
This PR is the same as [this one](https://github.com/dimagi/commcare-cloud/pull/5747), but with some fixes. It uses the same ticket as that PR, so please check out that PR to get the ticket. This PR basically just adds a filesystem healthcheck for all machines and saves the output in the host's folder that sits in the `~/.commcare-cloud/audits` directory. I also did a refactor of the commcare-audit ansible role.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All (Any)