### PR TITLE
Do not stop celery and pillowtop before db migrate

### DIFF
--- a/src/commcare_cloud/fab/operations/db.py
+++ b/src/commcare_cloud/fab/operations/db.py
@@ -50,24 +50,6 @@ def set_in_progress_flag(use_current_release=False):
 
 
 @roles(ROLES_DEPLOY)
-def migrations_exist():
-    """
-    Check if there exists database migrations to run
-    """
-    with cd(env.code_root):
-        result = sudo(f'{env.virtualenv_root}/bin/python manage.py showmigrations | grep "\\[ ]" | wc -l')
-        try:
-            # This command usually returns some logging and then then number of migrations
-            result = result.splitlines()
-            n_migrations = int(result[-1])
-        except Exception:
-            # If we fail on this, return True to be safe. It's most likely cause we lost connection and
-            # failed to return a value python could parse into an int
-            return True
-        return n_migrations > 0
-
-
-@roles(ROLES_DEPLOY)
 def create_kafka_topics():
     """Create kafka topics if needed.  This is pretty fast."""
     with cd(env.code_root):


### PR DESCRIPTION
All database migrations must be backward-compatible, so stopping services is unnecessary. Webworkers are not stopped, and they can do the same things that celery or pillow process do, so it does not make sense to treat pillow and celery processes specially. This should help to avoid deploy-related downtime that causes queue backups.

Service restart on error is no longer necessary since no services have been stopped at that point.

##### Environments Affected
All.