### PR TITLE
increase rabbit heartbeat

### DIFF
--- a/src/commcare_cloud/ansible/roles/rabbitmq/templates/rabbitmq.conf.j2
+++ b/src/commcare_cloud/ansible/roles/rabbitmq/templates/rabbitmq.conf.j2
@@ -3,3 +3,4 @@ log.connection.level = warning
 log.federation.level = warning
 log.mirroring.level = warning
 consumer_timeout = 86400001
+heartbeat = 600


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-14376
The recurring `repeat_record_queue` issues are strongly correlated with [heartbeat](https://www.rabbitmq.com/heartbeats.html) timeouts from rabbitmq, visible in the rabbitmq logs and as broken pipe errors in the celery logs, which appear to come from long running tasks. This PR seeks to remedy the issue by extending the heartbeat timeout, under the assumption that the celery workers failed to acknowledge the heartbeat pings because they were too busy processing those tasks and could not switch out of the greenlet in time. The new timeout was chosen to be longer than the problematic tasks, generally in the 300-400s range, but not so long as to be ineffective, since rabbitmq warns that too long a timeout can be problematic for message producers, which need to know if the connection is broken.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All
