### PR TITLE
Ansible deploy HQ: part 2 - set up virtualenv

### DIFF
--- a/src/commcare_cloud/ansible/library/setup_virtualenv.py
+++ b/src/commcare_cloud/ansible/library/setup_virtualenv.py
@@ -38,7 +38,9 @@ options:
         default: 'python_env'
         type: str
     python_version:
-        description: Python version.
+        description: Python version. Included in the virtualenv name to
+            allow multiple virtualenvs to exist when upgrading to a new
+            version of Python.
         required: true
         type: str
     requirements_file:

--- a/src/commcare_cloud/ansible/library/setup_virtualenv.py
+++ b/src/commcare_cloud/ansible/library/setup_virtualenv.py
@@ -1,0 +1,152 @@
+#! /usr/bin/env python3
+from __future__ import (absolute_import, division, print_function)
+
+from pathlib import Path
+from shlex import quote
+
+from ansible.module_utils.basic import AnsibleModule
+
+__metaclass__ = type
+
+
+DOCUMENTATION = """
+---
+module: setup_virtualenv
+
+short_description: Setup virtualenv for a software release.
+
+version_added: "1.0.0"
+
+description: Create a virtualenv for a software release. Use
+    'virtualenv-clone' to copy the virtualenv from a previous release
+    as a starting point. Then update requirements with 'pip-sync'.
+
+options:
+    src:
+        description: Directory path containing a previous release.
+        required: true
+        type: str
+    dest:
+        description: Directory path in which to create the new virtualenv.
+        required: true
+        type: str
+    env_name:
+        description: Virtualenv base name. The python version is added
+            to the virtualenv name, and a symlink is created linking the
+            base name to the virtualenv directory. Default: 'python_env'
+        required: false
+        default: 'python_env'
+        type: str
+    python_version:
+        description: Python version.
+        required: true
+        type: str
+    requirements_file:
+        description: Pip requirements file path (may be relative to dest).
+        required: true
+        type: str
+    http_proxy:
+        description: HTTP proxy address.
+        required: false
+        type: str
+
+extends_documentation_fragment:
+    - commcare_cloud.ansible
+
+author:
+    - Daniel Miller (@millerdev)
+"""
+
+EXAMPLES = """
+- name: Setup virtualenv
+  setup_virtualenv:
+    src: "/path/to/releases/previous"
+    dest: "/path/to/releases/next"
+    python_version: "3.9"
+    requirements_file: "requirements/prod-requirements.txt"
+"""
+
+RETURN = """
+changed:
+    description: Changed flag.
+    type: bool
+diff:
+    description: Dict of before and after states of the virtualenv.
+    type: dict
+    sample: {'before': {'path': ...}, 'after': {'path': ...}}
+venv:
+    description: Path of the new virtualenv.
+    type: str
+    sample: /path/to/releases/next/python_env
+"""
+
+
+def main():
+    module_args = {
+        'src': {'type': 'str', 'required': True},
+        'dest': {'type': 'str', 'required': True},
+        'env_name': {'type': 'str', 'default': 'python_env'},
+        'python_version': {'type': 'str', 'required': True},
+        'requirements_file': {'type': 'str', 'required': True},
+        'http_proxy': {'type': 'str', 'default': None},
+    }
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+    params = module.params
+    env_name = params["env_name"]
+    python_version = params["python_version"]
+    full_env_name = f"{env_name}-{python_version}"
+    src = Path(params["src"])
+    dest = Path(params["dest"])
+    # resolve() because of bug in virtualenv-clone: can't clone env from symlink
+    prev_env = src.resolve() / full_env_name
+    next_env = dest / full_env_name
+    python_env = dest / env_name
+    requirements_file = dest / params["requirements_file"]
+    proxy = params["http_proxy"]
+
+    diff = {'before': {'path': str(prev_env)}, 'after': {'path': str(next_env)}}
+    result = {'changed': False, 'venv': str(python_env), 'diff': diff}
+
+    if not python_env.exists():
+        result["changed"] = True
+        if not module.check_mode:
+            if not (next_env / "bin/python").exists():
+                if not prev_env.exists():
+                    module.fail_json(msg=f"virtualenv not found: {prev_env}")
+                    return
+                clone_virtualenv(prev_env, next_env, module)
+            pip_sync(requirements_file, next_env, module, proxy)
+            python_env.symlink_to(full_env_name)
+
+    module.exit_json(**result)
+
+
+def clone_virtualenv(prev_env, next_env, module):
+    module.run_command(["virtualenv-clone", prev_env, next_env], check_rc=True)
+
+
+def pip_sync(requirements_file, venv_path, module, proxy):
+    pip = venv_path / "bin/pip"
+    pip_args = ["--timeout=60"]
+    if proxy:
+        pip_args.append(f"--proxy={quote(proxy)}")
+    module.run_command(
+        [pip, "install", "--quiet", "--upgrade", *pip_args, "pip-tools"],
+        check_rc=True,
+    )
+    pip_sync = venv_path / "bin/pip-sync"
+    module.run_command(
+        [pip_sync, "--quiet", f"--pip-args={' '.join(pip_args)}", requirements_file],
+        check_rc=True,
+    )
+
+
+class Error(Exception):
+    pass
+
+
+if __name__ == '__main__':
+    main()

--- a/src/commcare_cloud/ansible/roles/deploy_hq/tasks/setup_release.yml
+++ b/src/commcare_cloud/ansible/roles/deploy_hq/tasks/setup_release.yml
@@ -6,3 +6,11 @@
     reference: "{{ code_releases }}/git_mirrors"
     key_file: "{{ deploy_key | default(omit, true) }}"
     previous_release: "{{ code_home }}"
+
+- name: Setup virtualenv
+  setup_virtualenv:
+    src: "{{ code_home }}"
+    dest: "{{ code_source }}"
+    python_version: "{{ python_version }}"
+    requirements_file: "requirements/prod-requirements.txt"
+    http_proxy: "{{ http_proxy | default(omit, true) }}"

--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -277,7 +277,6 @@ def _setup_release(keep_days=2, full_cluster=True):
     :param keep_days: The number of days to keep this release before it will be purged
     :param full_cluster: If False, only setup on webworkers[0] where the command will be run
     """
-    execute_with_timing(release.update_virtualenv(full_cluster))
     execute_with_timing(copy_release_files, full_cluster)
 
     if keep_days > 0:

--- a/tests/test_deploy/fake-venv-bin/pip
+++ b/tests/test_deploy/fake-venv-bin/pip
@@ -1,0 +1,2 @@
+#! /usr/bin/bash
+echo "pip installed"

--- a/tests/test_deploy/fake-venv-bin/pip
+++ b/tests/test_deploy/fake-venv-bin/pip
@@ -1,2 +1,2 @@
-#! /usr/bin/bash
+#! /usr/bin/env bash
 echo "pip installed"

--- a/tests/test_deploy/fake-venv-bin/pip-sync
+++ b/tests/test_deploy/fake-venv-bin/pip-sync
@@ -1,0 +1,2 @@
+#! /usr/bin/bash
+echo "pip synced"

--- a/tests/test_deploy/fake-venv-bin/pip-sync
+++ b/tests/test_deploy/fake-venv-bin/pip-sync
@@ -1,2 +1,2 @@
-#! /usr/bin/bash
+#! /usr/bin/env bash
 echo "pip synced"

--- a/tests/test_deploy/fake-venv-bin/virtualenv-clone
+++ b/tests/test_deploy/fake-venv-bin/virtualenv-clone
@@ -1,3 +1,3 @@
-#! /usr/bin/bash
-/usr/bin/mkdir -p $2
-/usr/bin/cp -P $1/bin $2/
+#! /usr/bin/env bash
+mkdir -p $2
+cp -P $1/bin $2/

--- a/tests/test_deploy/fake-venv-bin/virtualenv-clone
+++ b/tests/test_deploy/fake-venv-bin/virtualenv-clone
@@ -1,0 +1,3 @@
+#! /usr/bin/bash
+/usr/bin/mkdir -p $2
+/usr/bin/cp -P $1/bin $2/

--- a/tests/test_deploy/test_setup_virtualenv.py
+++ b/tests/test_deploy/test_setup_virtualenv.py
@@ -1,0 +1,140 @@
+import shutil
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import patch
+
+from testil import tempdir
+
+from .. import ansible
+from ..utils import set_log_level, test_context
+
+PYTHON_VERSION = "3.9"
+
+
+class TestSetupVirtualenv(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        test_context(cls, set_log_level("datadog"))
+        cls.tmp = tmp = Path(test_context(cls, tempdir()))
+        cls.previous_release = prev = tmp / "prev"
+        cls.requires = tmp / "requires.txt"
+        with open(cls.requires, mode="w"):
+            pass
+        fake_venv_bin = create_fake_virtualenv(prev / f"venv-{PYTHON_VERSION}")
+        test_context(cls, patch.dict('os.environ', {"PATH": str(fake_venv_bin)}))
+
+    def setUp(self):
+        self.release = self.tmp / "release"
+        self.release.mkdir()
+        (self.release / "requires.txt").symlink_to(self.requires)
+        self.addCleanup(shutil.rmtree, self.release)
+
+    def test_setup_virtualenv(self):
+        result = ansible.run("setup_virtualenv", {
+            "src": str(self.previous_release),
+            "dest": str(self.release),
+            "env_name": "venv",
+            "python_version": PYTHON_VERSION,
+            "requirements_file": "requires.txt",
+        })
+        self.assertTrue(result.get("changed"), result)
+        assert (self.release / "venv-3.9/bin").is_dir(), listdir(self.release)
+        assert (self.release / "venv/bin").is_dir(), listdir(self.release)
+        self.assertEqual(result["venv"], str(self.release / "venv"))
+
+    def test_setup_virtualenv_with_wrong_python_version(self):
+        py36_release = self.tmp / "py36"
+        create_fake_virtualenv(py36_release / f"venv-3.6")
+        with self.assertRaisesRegex(ansible.Fail, "virtualenv not found: "):
+            ansible.run("setup_virtualenv", {
+                "src": str(py36_release),
+                "dest": str(self.release),
+                "env_name": "venv",
+                "python_version": PYTHON_VERSION,
+                "requirements_file": "requires.txt",
+            })
+        assert not (self.release / "venv-3.6").is_dir()
+        assert not (self.release / "venv-3.9").is_dir()
+        assert not (self.release / "venv").is_dir()
+
+    def test_failed_virtualenv_clone(self):
+        setup_virtualenv = ansible.import_module("setup_virtualenv")
+        with patch.object(setup_virtualenv, "clone_virtualenv") as mock:
+            def clone_fail(prev_env, next_env, module):
+                next_env.mkdir()
+                raise Fail()
+            mock.side_effect = clone_fail
+            with self.assertRaises(Fail):
+                ansible.run(setup_virtualenv, {
+                    "src": str(self.previous_release),
+                    "dest": str(self.release),
+                    "env_name": "venv",
+                    "python_version": PYTHON_VERSION,
+                    "requirements_file": "requires.txt",
+                })
+        assert not (self.release / "venv-3.9/bin/python").exists()
+        assert not (self.release / "venv").exists(), listdir(self.release)
+        self.test_setup_virtualenv()
+
+    def test_failed_pip_sync(self):
+        setup_virtualenv = ansible.import_module("setup_virtualenv")
+        with patch.object(setup_virtualenv, "pip_sync") as mock:
+            def pip_fail(requirements_file, next_env, module, proxy):
+                raise Fail()
+            mock.side_effect = pip_fail
+            with self.assertRaises(Fail):
+                ansible.run(setup_virtualenv, {
+                    "src": str(self.previous_release),
+                    "dest": str(self.release),
+                    "env_name": "venv",
+                    "python_version": PYTHON_VERSION,
+                    "requirements_file": "requires.txt",
+                })
+        assert (self.release / "venv-3.9/bin/python").exists()
+        assert not (self.release / "venv").exists(), listdir(self.release)
+        with patch.object(setup_virtualenv, "clone_virtualenv") as mock:
+            mock.side_effect = Fail("unexpected: env already created")
+            self.test_setup_virtualenv()
+
+    def test_setup_virtualenv_with_default_env_name(self):
+        prev_venv = self.previous_release / f"python_env-{PYTHON_VERSION}"
+        create_fake_virtualenv(prev_venv)
+        self.addCleanup(shutil.rmtree, prev_venv)
+        result = ansible.run("setup_virtualenv", {
+            "src": str(self.previous_release),
+            "dest": str(self.release),
+            "python_version": PYTHON_VERSION,
+            "requirements_file": "requires.txt",
+        })
+        self.assertTrue(result.get("changed"), result)
+        assert (self.release / "python_env-3.9/bin").is_dir(), listdir(self.release)
+        assert (self.release / "python_env/bin").is_dir(), listdir(self.release)
+        self.assertEqual(result["venv"], str(self.release / "python_env"))
+
+    def test_check_mode(self):
+        result = ansible.run("setup_virtualenv", {
+            "src": str(self.previous_release),
+            "dest": str(self.release),
+            "env_name": "venv",
+            "python_version": PYTHON_VERSION,
+            "requirements_file": "requires.txt",
+            "_ansible_check_mode": True,
+        })
+        assert not Path(result["venv"]).exists(), result
+        assert not (self.release / f"venv-3.9").exists(), result
+
+
+def create_fake_virtualenv(path):
+    fake_venv_bin = Path(__file__).parent / "fake-venv-bin"
+    path.mkdir(parents=True)
+    (path / "bin").symlink_to(fake_venv_bin)
+    return fake_venv_bin
+
+
+def listdir(path):
+    return {p.name for p in path.iterdir()}
+
+
+class Fail(Exception):
+    pass

--- a/tests/test_deploy/test_setup_virtualenv.py
+++ b/tests/test_deploy/test_setup_virtualenv.py
@@ -46,7 +46,7 @@ class TestSetupVirtualenv(TestCase):
 
     def test_setup_virtualenv_with_wrong_python_version(self):
         py36_release = self.tmp / "py36"
-        create_fake_virtualenv(py36_release / f"venv-3.6")
+        create_fake_virtualenv(py36_release / "venv-3.6")
         with self.assertRaisesRegex(ansible.Fail, "virtualenv not found: "):
             ansible.run("setup_virtualenv", {
                 "src": str(py36_release),

--- a/tests/test_deploy/test_setup_virtualenv.py
+++ b/tests/test_deploy/test_setup_virtualenv.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 from pathlib import Path
 from unittest import TestCase
@@ -22,7 +23,7 @@ class TestSetupVirtualenv(TestCase):
         with open(cls.requires, mode="w"):
             pass
         fake_venv_bin = create_fake_virtualenv(prev / f"venv-{PYTHON_VERSION}")
-        test_context(cls, patch.dict('os.environ', {"PATH": str(fake_venv_bin)}))
+        test_context(cls, patch.dict('os.environ', {"PATH": f"{fake_venv_bin}:{os.environ['PATH']}"}))
 
     def setUp(self):
         self.release = self.tmp / "release"


### PR DESCRIPTION
Step 2 in replacing Fabric with Ansible in commcare-hq deployment automation.

:tropical_fish: review by commit.

Tested on staging.

##### Environments Affected
All.