### PR TITLE
Ansible deploy HQ: part 3 - remaining setup release tasks

### DIFF
--- a/hosting_docs/source/reference/1-commcare-cloud/commands.md
+++ b/hosting_docs/source/reference/1-commcare-cloud/commands.md
@@ -1107,8 +1107,8 @@ Use `-l` instead of a command to see the full list of commands.
     restart_webworkers
     rollback                   Rolls back the servers to the previous release...
     rollback_formplayer
-    setup_limited_release      OBSOLETE. Use deploy commcare --private --limi...
-    setup_release              OBSOLETE. Use deploy commcare --private [--kee...
+    setup_limited_release      OBSOLETE. Use deploy commcare --private [--kee...
+    setup_release              OBSOLETE. Use deploy commcare --private --limi...
     start_celery
     start_pillows
     stop_celery
@@ -1146,6 +1146,8 @@ Rather than starting a new deploy, resume a previous release.
 ###### `--private`
 
 Set up a private release for running management commands.
+This option implies --limit=django_manage. Use --limit=all
+to set up a private release on all applicable hosts.
 
 ###### `-l SUBSET, --limit SUBSET`
 

--- a/hosting_docs/source/reference/1-commcare-cloud/commands.md
+++ b/hosting_docs/source/reference/1-commcare-cloud/commands.md
@@ -1107,8 +1107,8 @@ Use `-l` instead of a command to see the full list of commands.
     restart_webworkers
     rollback                   Rolls back the servers to the previous release...
     rollback_formplayer
-    setup_limited_release      OBSOLETE. Use deploy commcare --setup-release ...
-    setup_release              OBSOLETE. Use deploy commcare --setup-release
+    setup_limited_release      OBSOLETE. Use deploy commcare --private ...
+    setup_release              OBSOLETE. Use deploy commcare --private
     start_celery
     start_pillows
     stop_celery
@@ -1125,7 +1125,7 @@ Use `-l` instead of a command to see the full list of commands.
 Deploy CommCare
 
 ```
-commcare-cloud <env> deploy [--resume RELEASE_NAME] [--setup-release] [-l SUBSET] [--keep-days KEEP_DAYS]
+commcare-cloud <env> deploy [--resume RELEASE_NAME] [--private] [-l SUBSET] [--keep-days KEEP_DAYS]
                             [--skip-record] [--commcare-rev COMMCARE_REV] [--set FAB_SETTINGS]
                             [{commcare,formplayer} ...]
 ```
@@ -1143,7 +1143,7 @@ always_deploy_formplayer is set in meta.yml, 'commcare formplayer'
 
 Rather than starting a new deploy, resume a previous release.
 
-###### `--setup-release`
+###### `--private`
 
 Set up a private release for running management commands.
 

--- a/hosting_docs/source/reference/1-commcare-cloud/commands.md
+++ b/hosting_docs/source/reference/1-commcare-cloud/commands.md
@@ -1107,8 +1107,8 @@ Use `-l` instead of a command to see the full list of commands.
     restart_webworkers
     rollback                   Rolls back the servers to the previous release...
     rollback_formplayer
-    setup_limited_release      OBSOLETE. Use deploy commcare --private ...
-    setup_release              OBSOLETE. Use deploy commcare --private
+    setup_limited_release      OBSOLETE. Use deploy commcare --private --limi...
+    setup_release              OBSOLETE. Use deploy commcare --private [--kee...
     start_celery
     start_pillows
     stop_celery
@@ -1125,8 +1125,8 @@ Use `-l` instead of a command to see the full list of commands.
 Deploy CommCare
 
 ```
-commcare-cloud <env> deploy [--resume RELEASE_NAME] [--private] [-l SUBSET] [--keep-days KEEP_DAYS]
-                            [--skip-record] [--commcare-rev COMMCARE_REV] [--set FAB_SETTINGS]
+commcare-cloud <env> deploy [--resume RELEASE_NAME] [--private] [-l SUBSET] [--keep-days KEEP_DAYS] [--skip-record]
+                            [--commcare-rev COMMCARE_REV] [--ignore-kafka-checkpoint-warning] [--set FAB_SETTINGS]
                             [{commcare,formplayer} ...]
 ```
 
@@ -1163,6 +1163,10 @@ Skip the steps involved in recording and announcing the fact of the deploy.
 
 The name of the commcare-hq git branch, tag, or SHA-1 commit hash to deploy.
 
+###### `--ignore-kafka-checkpoint-warning`
+
+Do not block deploy if Kafka checkpoints are unavailable.
+
 ###### `--set FAB_SETTINGS`
 
 fab settings in k1=v1,k2=v2 format to be passed down to fab
@@ -1172,7 +1176,7 @@ fab settings in k1=v1,k2=v2 format to be passed down to fab
 #### ``preindex-views`` Command
 
 ```
-commcare-cloud <env> preindex-views [--commcare-rev COMMCARE_REV] [--set FAB_SETTINGS]
+commcare-cloud <env> preindex-views [--commcare-rev COMMCARE_REV] [--release RELEASE_NAME]
 ```
 
 Set up a private release on the first pillowtop machine and run
@@ -1184,9 +1188,9 @@ preindex_everything with that release.
 
 The name of the commcare-hq git branch, tag, or SHA-1 commit hash to deploy.
 
-###### `--set FAB_SETTINGS`
+###### `--release RELEASE_NAME`
 
-fab settings in k1=v1,k2=v2 format to be passed down to fab
+Use/resume an existing release rather than creating a new one.
 
 ---
 

--- a/hosting_docs/source/reference/howto/tips.rst
+++ b/hosting_docs/source/reference/howto/tips.rst
@@ -25,7 +25,7 @@ Create a new release:
 
 .. code-block:: shell
 
-   commcare-cloud <env> deploy commcare --setup-release [--limit django_manage]
+   commcare-cloud <env> deploy commcare --private [--limit django_manage]
 
 Note down the release folder location: ``/home/cchq/www/<env>/releases/YYYY-MM-DD_HH.MM``
 

--- a/hosting_docs/source/reference/howto/tips.rst
+++ b/hosting_docs/source/reference/howto/tips.rst
@@ -25,7 +25,7 @@ Create a new release:
 
 .. code-block:: shell
 
-   commcare-cloud <env> deploy commcare --private [--limit django_manage]
+   commcare-cloud <env> deploy commcare --private [--limit ...]
 
 Note down the release folder location: ``/home/cchq/www/<env>/releases/YYYY-MM-DD_HH.MM``
 
@@ -42,5 +42,5 @@ This will override the default value of the ``code_home`` variable which normall
 Choosing a value for ``LIMIT``\ :
 
 
-* If you did not use ``--limit``\ , set ``LIMIT`` to ``'!formplayer'``
-* If you did use ``--limit``\ , set ``LIMIT`` to ``django_manage``
+* If you did not use ``--limit``\ , set ``LIMIT`` to ``django_manage``
+* If you did use ``--limit``\ , set ``LIMIT`` to the same value as used before.

--- a/src/commcare_cloud/ansible/deploy_hq.yml
+++ b/src/commcare_cloud/ansible/deploy_hq.yml
@@ -13,3 +13,4 @@
     - import_role: {name: deploy_hq}
       vars:
         if_not_done: setup_release
+      tags: private_release

--- a/src/commcare_cloud/ansible/deploy_hq.yml
+++ b/src/commcare_cloud/ansible/deploy_hq.yml
@@ -14,3 +14,11 @@
       vars:
         if_not_done: setup_release
       tags: private_release
+
+- name: Copy static JS
+  hosts: proxy
+  tasks:
+    - include_role: {name: deploy_hq}
+      vars:
+        if_not_done: copy_release_files
+        item: staticfiles/CACHE/js

--- a/src/commcare_cloud/ansible/roles/deploy_hq/tasks/copy_release_files.yml
+++ b/src/commcare_cloud/ansible/roles/deploy_hq/tasks/copy_release_files.yml
@@ -1,0 +1,19 @@
+- name: Check if {{ item }} directory exists in previous release
+  stat:
+    path: '{{ code_home }}/{{ item }}'
+  register: src_directory
+
+- name: Create {{ item }} directory
+  file:
+    path: "{{ code_source }}/{{ item }}"
+    state: directory
+    mode: 0755
+
+- name: Copy {{ item }} from previous release
+  copy:
+    src: "{{ code_home }}/{{ item }}/"
+    dest: "{{ code_source }}/{{ item }}/"
+    remote_src: true
+    local_follow: false
+    mode: preserve
+  when: src_directory.stat.exists

--- a/src/commcare_cloud/ansible/roles/deploy_hq/tasks/setup_release.yml
+++ b/src/commcare_cloud/ansible/roles/deploy_hq/tasks/setup_release.yml
@@ -36,3 +36,10 @@
   loop:
     - node_modules
     - bower_components
+
+- name: Mark keep until
+  file:
+    path: "{{ code_source }}/KEEP_UNTIL__{{ keep_until }}"
+    mode: 0644
+    state: touch
+  when: keep_until | default(None)

--- a/src/commcare_cloud/ansible/roles/deploy_hq/tasks/setup_release.yml
+++ b/src/commcare_cloud/ansible/roles/deploy_hq/tasks/setup_release.yml
@@ -1,3 +1,11 @@
+# Negated tag checks for "private_release" are used instead of normal
+# tags because the "private_release" tag is inherited from deploy_hq.yml
+# to all tasks in this file. Tag inheritance is required because of the
+# "include_role" task in main.yml. In other words, the tasks in this
+# file would not run if they were tagged "private_release" unless the
+# "include_role" statement that loads them was also tagged, and that is
+# not desirable because main.yml is generic.
+
 - name: Clone source code
   git_setup_release:
     repo: "{{ commcarehq_repository }}"
@@ -14,3 +22,17 @@
     python_version: "{{ python_version }}"
     requirements_file: "requirements/prod-requirements.txt"
     http_proxy: "{{ http_proxy | default(omit, true) }}"
+
+- name: Copy localsettings.py
+  copy:
+    src: "{{ code_home }}/localsettings.py"
+    dest: "{{ code_source }}/localsettings.py"
+    remote_src: true
+    mode: preserve
+
+- name: Copy release files
+  include_tasks: copy_release_files.yml
+  when: '"private_release" not in ansible_run_tags'
+  loop:
+    - node_modules
+    - bower_components

--- a/src/commcare_cloud/ansible/roles/deploy_hq/tasks/setup_release.yml
+++ b/src/commcare_cloud/ansible/roles/deploy_hq/tasks/setup_release.yml
@@ -1,11 +1,3 @@
-# Negated tag checks for "private_release" are used instead of normal
-# tags because the "private_release" tag is inherited from deploy_hq.yml
-# to all tasks in this file. Tag inheritance is required because of the
-# "include_role" task in main.yml. In other words, the tasks in this
-# file would not run if they were tagged "private_release" unless the
-# "include_role" statement that loads them was also tagged, and that is
-# not desirable because main.yml is generic.
-
 - name: Clone source code
   git_setup_release:
     repo: "{{ commcarehq_repository }}"
@@ -30,13 +22,6 @@
     remote_src: true
     mode: preserve
 
-- name: Copy release files
-  include_tasks: copy_release_files.yml
-  when: '"private_release" not in ansible_run_tags'
-  loop:
-    - node_modules
-    - bower_components
-
 - name: Mark keep until
   file:
     path: "{{ code_source }}/KEEP_UNTIL__{{ keep_until }}"
@@ -53,22 +38,38 @@
     firstmatch: true
     state: present
 
-- name: Ensure checkpoints safe
-  command:
-    cmd: >-
-      ./manage.py validate_kafka_pillow_checkpoints
-      {{ "--print-only" if ignore_kafka_checkpoint_warning | default(False) else "" }}
-    chdir: '{{ code_source }}'
-  register: checkpoints_result
-  changed_when: checkpoints_result.rc
-  failed_when: '"rc" not in checkpoints_result'
+- name: Full release tasks
   when: '"private_release" not in ansible_run_tags'
-  run_once: true
+  # Negated tag check instead of normal tags on other tasks because the
+  # "private_release" tag is inherited from deploy_hq.yml to all tasks
+  # in this file. Tag inheritance is required because of the
+  # "include_role" task in main.yml. In other words, the tasks in this
+  # file would not run if they were tagged "private_release" unless the
+  # "include_role" statement that loads them was also tagged, and that
+  # is not desirable because main.yml is generic.
+  block:
+    - name: Copy release files
+      include_tasks: copy_release_files.yml
+      when: '"private_release" not in ansible_run_tags'
+      loop:
+        - node_modules
+        - bower_components
 
-- name: Unsafe checkpoints error
-  fail:
-    msg: >-
-      Deploy failed, likely because kafka checkpoints were not available.
-      You can rerun with --ignore-kafka-checkpoint-warning to prevent this
-      error from blocking the deploy.
-  when: '"private_release" not in ansible_run_tags and checkpoints_result.rc'
+    - name: Ensure checkpoints safe
+      command:
+        cmd: >-
+          ./manage.py validate_kafka_pillow_checkpoints
+          {{ "--print-only" if ignore_kafka_checkpoint_warning | default(False) else "" }}
+        chdir: '{{ code_source }}'
+      register: checkpoints_result
+      changed_when: checkpoints_result.rc
+      failed_when: '"rc" not in checkpoints_result'
+      run_once: true
+
+    - name: Unsafe checkpoints error
+      fail:
+        msg: >-
+          Deploy failed, likely because kafka checkpoints were not available.
+          You can rerun with --ignore-kafka-checkpoint-warning to prevent this
+          error from blocking the deploy.
+      when: checkpoints_result.rc'

--- a/src/commcare_cloud/ansible/roles/deploy_hq/tasks/setup_release.yml
+++ b/src/commcare_cloud/ansible/roles/deploy_hq/tasks/setup_release.yml
@@ -52,3 +52,23 @@
     regexp: "^#!"
     firstmatch: true
     state: present
+
+- name: Ensure checkpoints safe
+  command:
+    cmd: >-
+      ./manage.py validate_kafka_pillow_checkpoints
+      {{ "--print-only" if ignore_kafka_checkpoint_warning | default(False) else "" }}
+    chdir: '{{ code_source }}'
+  register: checkpoints_result
+  changed_when: checkpoints_result.rc
+  failed_when: '"rc" not in checkpoints_result'
+  when: '"private_release" not in ansible_run_tags'
+  run_once: true
+
+- name: Unsafe checkpoints error
+  fail:
+    msg: >-
+      Deploy failed, likely because kafka checkpoints were not available.
+      You can rerun with --ignore-kafka-checkpoint-warning to prevent this
+      error from blocking the deploy.
+  when: '"private_release" not in ansible_run_tags and checkpoints_result.rc'

--- a/src/commcare_cloud/ansible/roles/deploy_hq/tasks/setup_release.yml
+++ b/src/commcare_cloud/ansible/roles/deploy_hq/tasks/setup_release.yml
@@ -43,3 +43,12 @@
     mode: 0644
     state: touch
   when: keep_until | default(None)
+
+- name: Set manage.py shebang
+  # Convenience for running management commands without activating virtualenv.
+  lineinfile:
+    path: "{{ code_source }}/manage.py"
+    line: "#! {{ code_source }}/python_env/bin/python"
+    regexp: "^#!"
+    firstmatch: true
+    state: present

--- a/src/commcare_cloud/commands/deploy/command.py
+++ b/src/commcare_cloud/commands/deploy/command.py
@@ -50,6 +50,9 @@ class Deploy(CommandBase):
         Argument('--commcare-rev', help="""
             The name of the commcare-hq git branch, tag, or SHA-1 commit hash to deploy.
         """, default=None),
+        Argument('--ignore-kafka-checkpoint-warning', action='store_true', help="""
+            Do not block deploy if Kafka checkpoints are unavailable.
+        """),
         Argument('--set', dest='fab_settings', help="""
             fab settings in k1=v1,k2=v2 format to be passed down to fab
         """, default=None),

--- a/src/commcare_cloud/commands/deploy/command.py
+++ b/src/commcare_cloud/commands/deploy/command.py
@@ -35,7 +35,7 @@ class Deploy(CommandBase):
         Argument('--resume', metavar="RELEASE_NAME", help="""
             Rather than starting a new deploy, resume a previous release.
         """),
-        Argument('--setup-release', action='store_true', help="""
+        Argument('--private', action='store_true', help="""
             Set up a private release for running management commands.
         """),
         Argument('-l', '--limit', metavar='SUBSET', help="""

--- a/src/commcare_cloud/commands/deploy/command.py
+++ b/src/commcare_cloud/commands/deploy/command.py
@@ -37,6 +37,8 @@ class Deploy(CommandBase):
         """),
         Argument('--private', action='store_true', help="""
             Set up a private release for running management commands.
+            This option implies --limit=django_manage. Use --limit=all
+            to set up a private release on all applicable hosts.
         """),
         Argument('-l', '--limit', metavar='SUBSET', help="""
             Limit selected hosts.

--- a/src/commcare_cloud/commands/deploy/commcare.py
+++ b/src/commcare_cloud/commands/deploy/commcare.py
@@ -64,6 +64,8 @@ def deploy_commcare(environment, args, unknown_args):
         if args.limit:
             exit("--limit is not allowed except with --private")
         fab_command = "deploy_commcare"
+    if args.ignore_kafka_checkpoint_warning:
+        ansible_args.extend(["-e", "ignore_kafka_checkpoint_warning=true"])
     environment.create_generated_yml()
     rc = run_ansible_playbook(
         'deploy_hq.yml',

--- a/src/commcare_cloud/commands/deploy/commcare.py
+++ b/src/commcare_cloud/commands/deploy/commcare.py
@@ -57,6 +57,8 @@ def deploy_commcare(environment, args, unknown_args):
         until = (datetime.utcnow() + timedelta(days=args.keep_days)).strftime(DATE_FMT)
         ansible_args.extend(["-e", f"keep_until={until}"])
     if args.private:
+        if not args.limit:
+            args.limit = "django_manage"
         fab_command = None
         ansible_args.append("--tags=private_release")
         ansible_args.extend(unknown_args)

--- a/src/commcare_cloud/commands/deploy/commcare.py
+++ b/src/commcare_cloud/commands/deploy/commcare.py
@@ -45,7 +45,7 @@ def deploy_commcare(environment, args, unknown_args):
         start_time=datetime.utcnow()
     )
 
-    should_record = not (args.skip_record or args.private or getattr(args, "preindex_views", False))
+    should_record = not (args.skip_record or args.private)
     if should_record:
         record_deploy_start(environment, context)
 
@@ -56,10 +56,7 @@ def deploy_commcare(environment, args, unknown_args):
     if args.keep_days:
         until = (datetime.utcnow() + timedelta(days=args.keep_days)).strftime(DATE_FMT)
         ansible_args.extend(["-e", f"keep_until={until}"])
-    if getattr(args, "preindex_views", False):
-        fab_command = "preindex_views"
-        ansible_args.append("--tags=private_release")
-    elif args.private:
+    if args.private:
         fab_command = None
         ansible_args.append("--tags=private_release")
         ansible_args.extend(unknown_args)

--- a/src/commcare_cloud/commands/deploy/commcare.py
+++ b/src/commcare_cloud/commands/deploy/commcare.py
@@ -5,7 +5,7 @@ import pytz
 
 from commcare_cloud.alias import commcare_cloud
 from commcare_cloud.cli_utils import ask
-from commcare_cloud.colors import color_notice, color_error
+from commcare_cloud.colors import color_notice, color_error, color_summary
 from commcare_cloud.commands.ansible.run_module import (
     AnsibleContext,
     BadAnsibleResult,
@@ -99,6 +99,9 @@ def deploy_commcare(environment, args, unknown_args):
 
     if should_record:
         record_successful_deploy(environment, context)
+    if args.private:
+        print(color_summary("Your private release is located here:"))
+        print(color_summary(environment.remote_conf.code_source))
 
     return 0
 

--- a/src/commcare_cloud/commands/deploy/commcare.py
+++ b/src/commcare_cloud/commands/deploy/commcare.py
@@ -60,14 +60,9 @@ def deploy_commcare(environment, args, unknown_args):
         fab_command = "preindex_views"
         ansible_args.append("--tags=private_release")
     elif args.private:
-        if args.limit:
-            if args.limit == 'django_manage':
-                fab_command = "setup_limited_release"
-            else:
-                exit("--limit only supports 'django_manage' at this time")
-        else:
-            fab_command = "setup_release"
+        fab_command = None
         ansible_args.append("--tags=private_release")
+        ansible_args.extend(unknown_args)
     else:
         if args.limit:
             exit("--limit is not allowed except with --private")
@@ -85,7 +80,7 @@ def deploy_commcare(environment, args, unknown_args):
         unknown_args=ansible_args,
     )
 
-    if rc == 0:
+    if fab_command and rc == 0:
         rc = commcare_cloud(
             environment.name, 'fab', f'{fab_command}{fab_func_args}',
             '--set', ','.join(fab_settings), branch=args.branch, *unknown_args

--- a/src/commcare_cloud/commands/deploy/commcare.py
+++ b/src/commcare_cloud/commands/deploy/commcare.py
@@ -50,7 +50,7 @@ def deploy_commcare(environment, args, unknown_args):
     ansible_args = ["-e", f"code_version={code_version}"]
     if getattr(args, "preindex_views", False):
         fab_command = "preindex_views"
-    elif args.setup_release:
+    elif args.private:
         if args.limit:
             if args.limit == 'django_manage':
                 fab_command = "setup_limited_release"
@@ -60,7 +60,7 @@ def deploy_commcare(environment, args, unknown_args):
             fab_command = "setup_release"
     else:
         if args.limit:
-            exit("--limit is not allowed except with --setup-release")
+            exit("--limit is not allowed except with --private")
         fab_command = "deploy_commcare"
     environment.create_generated_yml()
     rc = run_ansible_playbook(
@@ -93,7 +93,7 @@ def deploy_commcare(environment, args, unknown_args):
 
 
 def confirm_deploy(environment, deploy_revs, diffs, args):
-    if args.setup_release:
+    if args.private:
         return True
 
     if args.resume:

--- a/src/commcare_cloud/commands/deploy/commcare.py
+++ b/src/commcare_cloud/commands/deploy/commcare.py
@@ -52,6 +52,7 @@ def deploy_commcare(environment, args, unknown_args):
     ansible_args = ["-e", f"code_version={code_version}"]
     if getattr(args, "preindex_views", False):
         fab_command = "preindex_views"
+        ansible_args.append("--tags=private_release")
     elif args.private:
         if args.limit:
             if args.limit == 'django_manage':
@@ -60,6 +61,7 @@ def deploy_commcare(environment, args, unknown_args):
                 exit("--limit only supports 'django_manage' at this time")
         else:
             fab_command = "setup_release"
+        ansible_args.append("--tags=private_release")
     else:
         if args.limit:
             exit("--limit is not allowed except with --private")

--- a/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -294,7 +294,8 @@ class DjangoManage(CommandBase):
     def run(self, args, manage_args):
         environment = get_environment(args.env_name)
         if args.release:
-            code_dir = environment.remote_conf.release(args.release)
+            environment.release_name = args.release
+            code_dir = environment.remote_conf.code_source
         else:
             code_dir = environment.remote_conf.code_current
 

--- a/src/commcare_cloud/commands/preindex_views.py
+++ b/src/commcare_cloud/commands/preindex_views.py
@@ -1,3 +1,4 @@
+from commcare_cloud.alias import commcare_cloud
 from commcare_cloud.cli_utils import check_branch
 from commcare_cloud.commands import shared_args
 from commcare_cloud.commands.command_base import Argument, CommandBase
@@ -17,9 +18,9 @@ class PreindexViews(CommandBase):
         Argument('--commcare-rev', help="""
             The name of the commcare-hq git branch, tag, or SHA-1 commit hash to deploy.
         """, default=None),
-        Argument('--set', dest='fab_settings', help="""
-            fab settings in k1=v1,k2=v2 format to be passed down to fab
-        """, default=None),
+        Argument('--release', metavar="RELEASE_NAME", help="""
+            Use/resume an existing release rather than creating a new one.
+        """),
         shared_args.QUIET_ARG,
         shared_args.BRANCH_ARG,
     )
@@ -27,10 +28,24 @@ class PreindexViews(CommandBase):
     def run(self, args, unknown_args):
         add_default_args(Deploy, args)
         check_branch(args)
-        args.preindex_views = True
+        args.private = True
         args.limit = "pillowtop[0]"
         environment = get_environment(args.env_name)
-        return deploy_commcare(environment, args, unknown_args)
+        if args.release:
+            environment.release_name = args.resume = args.release
+        rc = deploy_commcare(environment, args, ())
+        if rc == 0:
+            rc = commcare_cloud(
+                environment.name,
+                "django-manage",
+                "preindex_everything",
+                f"--server={args.limit}",
+                f"--release={environment.release_name}",
+                "--tmux",
+                *["--mail"] if environment.fab_settings_config.email_enabled else [],
+                *unknown_args,
+            )
+        return rc
 
 
 def add_default_args(command_class, args):

--- a/src/commcare_cloud/environment/main.py
+++ b/src/commcare_cloud/environment/main.py
@@ -369,6 +369,7 @@ class Environment(object):
                 self.fab_settings_config.code_repo
                 if not self.meta_config.bare_non_cchq_environment else {}
             ),
+            'ignore_kafka_checkpoint_warning': self.fab_settings_config.ignore_kafka_checkpoint_warning,
             'ES_SETTINGS': (
                 self.elasticsearch_config.settings.to_json()
                 if not self.meta_config.bare_non_cchq_environment else {}

--- a/src/commcare_cloud/environment/remote.py
+++ b/src/commcare_cloud/environment/remote.py
@@ -15,5 +15,6 @@ class RemoteConf:
     def code_current(self):
         return f'/home/{self.cchq_user}/www/{self.deploy_env}/current'
 
-    def release(self, release_name):
-        return f'/home/{self.cchq_user}/www/{self.deploy_env}/releases/{release_name}'
+    @property
+    def code_source(self):
+        return f'/home/{self.cchq_user}/www/{self.deploy_env}/releases/{self.environment.release_name}'

--- a/src/commcare_cloud/fab/README.md
+++ b/src/commcare_cloud/fab/README.md
@@ -66,7 +66,7 @@ fab <env> rollback
 
 The case may arise where you need to setup a new release, but do not want to do a full deploy. For example, this is often used when you would want to run a new management command that was just merged. To do this run:
 ```
-cchq <env> deploy commcare --setup-release [--limit=django_manage]
+cchq <env> deploy commcare --private [--limit=django_manage]
 ```
 
 This will create a release with the most recent master code and a new virtualenv. Just cd into the directory that
@@ -75,13 +75,13 @@ is printed on the screen and run your command, or use `django-manage` with the `
 To set up a release based on a non-master branch, run:
 
 ```
-cchq <env> deploy commcare --setup-release [--limit=django_manage] --commcare-rev=<HQ BRANCH>
+cchq <env> deploy commcare --private [--limit=django_manage] --commcare-rev=<HQ BRANCH>
 ```
 
 Upon deploys, releases like these are cleaned up by the deploy process. If you know you have a long running command, you can ensure that the release does not get removed by using the `--keep-days` option:
 
 ```
-cchq <env> deploy commcare --setup-release [--limit=django_manage] --keep-days=10
+cchq <env> deploy commcare --private [--limit=django_manage] --keep-days=10
 ```
 
 This will keep your release around for at least 10 days before it gets removed by a deploy.
@@ -92,14 +92,14 @@ To get a list of possible tasks to run, use `cchq <env> fab -l`. Here is an abbr
 
 ```
 clean_releases         Cleans old and failed deploys from the ~/www/<environment>/releases/ directory
-deploy                 Preindex and deploy if it completes quickly enough, otherwise abort
+deploy                 OBSOLETE. Use 'deploy commcare ...' instead.
 force_update_static
 hotfix_deploy          deploy ONLY the code with no extra cleanup or syncing
-manage                 run a management command
+manage                 OBSOLETE. Use 'django-manage' instead.
 preindex_views         Creates a new release that runs preindex_everything. Clones code from
 restart_services
 rollback               Rolls back the servers to the previous release if it exists and is same
-setup_release          Setup a release in the releases directory with the most recent code.
+setup_release          OBSOLETE. Use deploy commcare --private
 start_pillows
 stop_pillows
 supervisorctl

--- a/src/commcare_cloud/fab/README.md
+++ b/src/commcare_cloud/fab/README.md
@@ -66,7 +66,7 @@ fab <env> rollback
 
 The case may arise where you need to setup a new release, but do not want to do a full deploy. For example, this is often used when you would want to run a new management command that was just merged. To do this run:
 ```
-cchq <env> deploy commcare --private [--limit=django_manage]
+cchq <env> deploy commcare --private
 ```
 
 This will create a release with the most recent master code and a new virtualenv. Just cd into the directory that
@@ -75,13 +75,13 @@ is printed on the screen and run your command, or use `django-manage` with the `
 To set up a release based on a non-master branch, run:
 
 ```
-cchq <env> deploy commcare --private [--limit=django_manage] --commcare-rev=<HQ BRANCH>
+cchq <env> deploy commcare --private --commcare-rev=<HQ BRANCH>
 ```
 
 Upon deploys, releases like these are cleaned up by the deploy process. If you know you have a long running command, you can ensure that the release does not get removed by using the `--keep-days` option:
 
 ```
-cchq <env> deploy commcare --private [--limit=django_manage] --keep-days=10
+cchq <env> deploy commcare --private --keep-days=10
 ```
 
 This will keep your release around for at least 10 days before it gets removed by a deploy.

--- a/src/commcare_cloud/fab/README.md
+++ b/src/commcare_cloud/fab/README.md
@@ -96,7 +96,7 @@ deploy                 OBSOLETE. Use 'deploy commcare ...' instead.
 force_update_static
 hotfix_deploy          deploy ONLY the code with no extra cleanup or syncing
 manage                 OBSOLETE. Use 'django-manage' instead.
-preindex_views         Creates a new release that runs preindex_everything. Clones code from
+preindex_views         OBSOLETE. Use 'preindex-views' instead.
 restart_services
 rollback               Rolls back the servers to the previous release if it exists and is same
 setup_release          OBSOLETE. Use deploy commcare --private

--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -276,8 +276,6 @@ def _setup_release(keep_days=2, full_cluster=True):
     :param keep_days: The number of days to keep this release before it will be purged
     :param full_cluster: If False, only setup on webworkers[0] where the command will be run
     """
-    execute_with_timing(copy_release_files, full_cluster)
-
     if keep_days > 0:
         execute_with_timing(release.mark_keep_until(full_cluster), keep_days)
 
@@ -319,11 +317,6 @@ def _deploy_without_asking(skip_record):
 @task
 def update_current(release=None):
     execute(release.update_current, release)
-
-
-def copy_release_files(full_cluster=True):
-    if full_cluster:
-        execute(release.copy_compressed_js_staticfiles)
 
 
 @task

--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -452,7 +452,6 @@ def reset_pillow(pillow):
 
 
 ONLINE_DEPLOY_COMMANDS = [
-    db.ensure_checkpoints_safe,
     staticfiles.yarn_install,
     staticfiles.version_static,     # run after any new bower code has been installed
     staticfiles.collectstatic,

--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -213,7 +213,6 @@ def pillowtop():
 @roles(ROLES_PILLOWTOP)
 def preindex_views():
     """OBSOLETE. Use 'preindex-views' instead"""
-    _setup_release()
     db.preindex_views()
 
 
@@ -245,26 +244,11 @@ def setup_limited_release():
     """OBSOLETE. Use deploy commcare --private --limit=django_manage
                                      [--keep-days=N] [--commcare-rev=HQ_BRANCH]
     """
-    _setup_release(full_cluster=False)
 
 
 @incomplete_task("deploy commcare --private ...")
 def setup_release():
     """OBSOLETE. Use deploy commcare --private [--keep-days=N] [--commcare-rev=HQ_BRANCH]
-    """
-    _setup_release(full_cluster=True)
-
-
-def _setup_release(full_cluster=True):
-    """
-    Setup a release in the releases directory with the most recent code.
-    Useful for running management commands. These releases will automatically
-    be cleaned up at the finish of each deploy.
-
-    More options at
-    https://github.com/dimagi/commcare-cloud/blob/master/src/commcare_cloud/fab/README.md#private-releases
-
-    :param full_cluster: If False, only setup on webworkers[0] where the command will be run
     """
 
 
@@ -470,7 +454,6 @@ def reset_pillow(pillow):
 
 
 ONLINE_DEPLOY_COMMANDS = [
-    _setup_release,
     db.ensure_checkpoints_safe,
     staticfiles.yarn_install,
     staticfiles.version_static,     # run after any new bower code has been installed

--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -266,8 +266,6 @@ def _setup_release(full_cluster=True):
 
     :param full_cluster: If False, only setup on webworkers[0] where the command will be run
     """
-    print(blue("Your private release is located here: "))
-    print(blue(env.code_root))
 
 
 def deploy_checkpoint(command_index, command_name, fn, *args, **kwargs):

--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -322,10 +322,7 @@ def update_current(release=None):
 
 
 def copy_release_files(full_cluster=True):
-    execute(release.copy_localsettings(full_cluster))
     if full_cluster:
-        execute(release.copy_components)
-        execute(release.copy_node_modules)
         execute(release.copy_compressed_js_staticfiles)
 
 

--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -248,18 +248,17 @@ def parse_int_or_exit(val):
         exit()
 
 
-@incomplete_task("deploy commcare --setup-release --limit=django_manage ...")
+@incomplete_task("deploy commcare --private --limit=django_manage ...")
 def setup_limited_release(keep_days=1):
-    """OBSOLETE. Use deploy commcare --setup-release --limit=django_manage
+    """OBSOLETE. Use deploy commcare --private --limit=django_manage
                                      [--keep-days=N] [--commcare-rev=HQ_BRANCH]
     """
     _setup_release(parse_int_or_exit(keep_days), full_cluster=False)
 
 
-@incomplete_task("deploy commcare --setup-release ...")
+@incomplete_task("deploy commcare --private ...")
 def setup_release(keep_days=0):
-    """OBSOLETE. Use deploy commcare --setup-release
-                                     [--keep-days=N] [--commcare-rev=HQ_BRANCH]
+    """OBSOLETE. Use deploy commcare --private [--keep-days=N] [--commcare-rev=HQ_BRANCH]
     """
     _setup_release(parse_int_or_exit(keep_days), full_cluster=True)
 

--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -54,6 +54,7 @@ from .utils import (
     clear_cached_deploy,
     execute_with_timing,
     incomplete_task,
+    obsolete_task,
     retrieve_cached_deploy_checkpoint,
     retrieve_cached_deploy_env,
     traceback_string,
@@ -209,11 +210,10 @@ def pillowtop():
     env.supervisor_roles = ROLES_PILLOWTOP
 
 
-@task
+@obsolete_task
 @roles(ROLES_PILLOWTOP)
 def preindex_views():
     """OBSOLETE. Use 'preindex-views' instead"""
-    print(preindex_views.__doc__)
 
 
 @roles(ROLES_DEPLOY)
@@ -227,10 +227,9 @@ def send_email(subject, message, use_current_release=False):
         )
 
 
-@task
+@obsolete_task
 def kill_stale_celery_workers():
     """OBSOLETE use 'kill-stale-celery-workers' instead"""
-    print(kill_stale_celery_workers.__doc__)
 
 
 @task
@@ -239,14 +238,14 @@ def rollback_formplayer():
     print("cchq {} ansible-playbook rollback_formplayer.yml --tags=rollback".format(env.deploy_env))
 
 
-@incomplete_task("deploy commcare --private --limit=django_manage ...")
+@obsolete_task
 def setup_limited_release():
     """OBSOLETE. Use deploy commcare --private --limit=django_manage
                                      [--keep-days=N] [--commcare-rev=HQ_BRANCH]
     """
 
 
-@incomplete_task("deploy commcare --private ...")
+@obsolete_task
 def setup_release():
     """OBSOLETE. Use deploy commcare --private [--keep-days=N] [--commcare-rev=HQ_BRANCH]
     """
@@ -337,11 +336,10 @@ def clean_releases(keep=3):
     execute(release.clean_releases, keep)
 
 
-@task
+@obsolete_task
 @roles(['deploy'])
 def manage(cmd=None):
     """OBSOLETE use 'django-manage' instead"""
-    exit(manage.__doc__)
 
 
 @incomplete_task("deploy commcare ...")
@@ -468,7 +466,7 @@ ONLINE_DEPLOY_COMMANDS = [
 ]
 
 
-@task
+@obsolete_task
 def check_status():
     """OBSOLETE replaced by
 
@@ -476,13 +474,11 @@ def check_status():
     commcare-cloud <env> service postgresql status
     commcare-cloud <env> service elasticsearch status
     """
-    exit(check_status.__doc__)
 
 
-@task
+@obsolete_task
 def perform_system_checks():
     """OBSOLETE use 'perform-system-checks' instead"""
-    exit(perform_system_checks.__doc__)
 
 
 def make_tasks_for_envs(available_envs):

--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -240,45 +240,32 @@ def rollback_formplayer():
     print("cchq {} ansible-playbook rollback_formplayer.yml --tags=rollback".format(env.deploy_env))
 
 
-def parse_int_or_exit(val):
-    try:
-        return int(val)
-    except (ValueError, TypeError):
-        print(red("Unable to parse '{}' into an integer".format(val)))
-        exit()
-
-
 @incomplete_task("deploy commcare --private --limit=django_manage ...")
-def setup_limited_release(keep_days=1):
+def setup_limited_release():
     """OBSOLETE. Use deploy commcare --private --limit=django_manage
                                      [--keep-days=N] [--commcare-rev=HQ_BRANCH]
     """
-    _setup_release(parse_int_or_exit(keep_days), full_cluster=False)
+    _setup_release(full_cluster=False)
 
 
 @incomplete_task("deploy commcare --private ...")
-def setup_release(keep_days=0):
+def setup_release():
     """OBSOLETE. Use deploy commcare --private [--keep-days=N] [--commcare-rev=HQ_BRANCH]
     """
-    _setup_release(parse_int_or_exit(keep_days), full_cluster=True)
+    _setup_release(full_cluster=True)
 
 
-def _setup_release(keep_days=2, full_cluster=True):
+def _setup_release(full_cluster=True):
     """
     Setup a release in the releases directory with the most recent code.
     Useful for running management commands. These releases will automatically
-    be cleaned up at the finish of each deploy. To ensure that a release will
-    last past a deploy use the `keep_days` param.
+    be cleaned up at the finish of each deploy.
 
     More options at
     https://github.com/dimagi/commcare-cloud/blob/master/src/commcare_cloud/fab/README.md#private-releases
 
-    :param keep_days: The number of days to keep this release before it will be purged
     :param full_cluster: If False, only setup on webworkers[0] where the command will be run
     """
-    if keep_days > 0:
-        execute_with_timing(release.mark_keep_until(full_cluster), keep_days)
-
     print(blue("Your private release is located here: "))
     print(blue(env.code_root))
 

--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -209,11 +209,11 @@ def pillowtop():
     env.supervisor_roles = ROLES_PILLOWTOP
 
 
-@incomplete_task("preindex-views")
+@task
 @roles(ROLES_PILLOWTOP)
 def preindex_views():
     """OBSOLETE. Use 'preindex-views' instead"""
-    db.preindex_views()
+    print(preindex_views.__doc__)
 
 
 @roles(ROLES_DEPLOY)

--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -40,11 +40,9 @@ from fabric.colors import blue, magenta, red
 from fabric.context_managers import cd
 from fabric.contrib import console
 from fabric.operations import require
-from github import GithubException
 
 from commcare_cloud.environment.main import get_environment
 from commcare_cloud.environment.paths import get_available_envs
-from commcare_cloud.github import github_repo
 from .checks import check_servers
 from .const import ROLES_ALL_SERVICES, ROLES_DEPLOY, ROLES_DJANGO, ROLES_PILLOWTOP
 from .operations import db

--- a/src/commcare_cloud/fab/fabfile.py
+++ b/src/commcare_cloud/fab/fabfile.py
@@ -238,14 +238,13 @@ def rollback_formplayer():
 
 @obsolete_task
 def setup_limited_release():
-    """OBSOLETE. Use deploy commcare --private --limit=django_manage
-                                     [--keep-days=N] [--commcare-rev=HQ_BRANCH]
+    """OBSOLETE. Use deploy commcare --private [--keep-days=N] [--commcare-rev=HQ_BRANCH]
     """
 
 
 @obsolete_task
 def setup_release():
-    """OBSOLETE. Use deploy commcare --private [--keep-days=N] [--commcare-rev=HQ_BRANCH]
+    """OBSOLETE. Use deploy commcare --private --limit=all [--keep-days=N] [--commcare-rev=HQ_BRANCH]
     """
 
 

--- a/src/commcare_cloud/fab/operations/db.py
+++ b/src/commcare_cloud/fab/operations/db.py
@@ -8,24 +8,6 @@ from ..const import ROLES_DEPLOY
 
 
 @roles(ROLES_DEPLOY)
-def ensure_checkpoints_safe():
-    extras = '--print-only' if env.ignore_kafka_checkpoint_warning else ''
-    with cd(env.code_root):
-        try:
-            sudo(f'{env.virtualenv_root}/bin/python manage.py validate_kafka_pillow_checkpoints {extras}')
-        except Exception:
-            if env.ignore_kafka_checkpoint_warning:
-                # if we were forcing and still got an error this is likely a bug so we should raise it
-                raise
-            raise Exception(
-                "Deploy failed, likely because kafka checkpoints weren't available.\n"
-                "Scroll up for more detailed information.\n"
-                "You can rerun with --set ignore_kafka_checkpoint_warning=true "
-                "to prevent this error from blocking the deploy."
-            )
-
-
-@roles(ROLES_DEPLOY)
 def migrate():
     """run migrations on remote environment"""
     with cd(env.code_root):

--- a/src/commcare_cloud/fab/operations/db.py
+++ b/src/commcare_cloud/fab/operations/db.py
@@ -1,20 +1,10 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from fabric.context_managers import cd, settings, hide
+from fabric.context_managers import cd
 from fabric.api import roles, sudo, env
-from fabric.decorators import runs_once
 
-from ..const import ROLES_PILLOWTOP, ROLES_DEPLOY
-
-
-@roles(ROLES_PILLOWTOP)
-@runs_once
-def preindex_views():
-    with cd(env.code_root):
-        command = f'{env.virtualenv_root}/bin/python {env.code_root}/manage.py preindex_everything 8 {env.user}'
-        mail_flag = '--mail' if env.email_enabled else ''
-        sudo(f'echo "{command}" {mail_flag} | at -t `date -d "5 seconds" +%m%d%H%M.%S`')
+from ..const import ROLES_DEPLOY
 
 
 @roles(ROLES_DEPLOY)

--- a/src/commcare_cloud/fab/operations/release.py
+++ b/src/commcare_cloud/fab/operations/release.py
@@ -104,35 +104,6 @@ def clean_releases(keep=3):
     git_gc_current()
 
 
-def copy_localsettings(full_cluster=True):
-    roles_to_use = _get_roles(full_cluster)
-
-    @parallel
-    @roles(roles_to_use)
-    def copy():
-        sudo('cp {}/localsettings.py {}/localsettings.py'.format(env.code_current, env.code_root))
-
-    return copy
-
-
-@parallel
-@roles(ROLES_ALL_SRC)
-def copy_components():
-    if files.exists('{}/bower_components'.format(env.code_current), use_sudo=True):
-        sudo('cp -r {}/bower_components {}/bower_components'.format(env.code_current, env.code_root))
-    else:
-        sudo('mkdir {}/bower_components'.format(env.code_root))
-
-
-@parallel
-@roles(ROLES_ALL_SRC)
-def copy_node_modules():
-    if files.exists('{}/node_modules'.format(env.code_current), use_sudo=True):
-        sudo('cp -r {}/node_modules {}/node_modules'.format(env.code_current, env.code_root))
-    else:
-        sudo('mkdir {}/node_modules'.format(env.code_root))
-
-
 @parallel
 @roles(ROLES_STATIC)
 def copy_compressed_js_staticfiles():
@@ -173,7 +144,3 @@ def mark_keep_until(full_cluster=True):
             sudo('touch {}{}'.format(KEEP_UNTIL_PREFIX, until_date))
 
     return mark
-
-
-def _get_roles(full_cluster):
-    return ROLES_ALL_SRC if full_cluster else ROLES_MANAGE

--- a/src/commcare_cloud/fab/operations/release.py
+++ b/src/commcare_cloud/fab/operations/release.py
@@ -15,7 +15,6 @@ from ..const import (
     RELEASE_RECORD,
     ROLES_ALL_SRC,
     ROLES_MANAGE,
-    ROLES_STATIC,
 )
 
 
@@ -102,14 +101,6 @@ def clean_releases(keep=3):
 
     # as part of the clean up step, run gc in the 'current' directory
     git_gc_current()
-
-
-@parallel
-@roles(ROLES_STATIC)
-def copy_compressed_js_staticfiles():
-    if files.exists('{}/staticfiles/CACHE/js'.format(env.code_current), use_sudo=True):
-        sudo('mkdir -p {}/staticfiles/CACHE'.format(env.code_root))
-        sudo('cp -r {}/staticfiles/CACHE/js {}/staticfiles/CACHE/js'.format(env.code_current, env.code_root))
 
 
 @roles(ROLES_ALL_SRC)

--- a/src/commcare_cloud/fab/operations/release.py
+++ b/src/commcare_cloud/fab/operations/release.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 import os
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from fabric import utils
 from fabric.api import env, parallel, roles, sudo
@@ -122,16 +122,3 @@ def get_number_of_releases():
 @parallel
 def ensure_release_exists(release):
     return files.exists(release, use_sudo=True)
-
-
-def mark_keep_until(full_cluster=True):
-    roles_to_use = _get_roles(full_cluster)
-
-    @roles(roles_to_use)
-    @parallel
-    def mark(keep_days):
-        until_date = (datetime.utcnow() + timedelta(days=keep_days)).strftime(DATE_FMT)
-        with cd(env.code_root):
-            sudo('touch {}{}'.format(KEEP_UNTIL_PREFIX, until_date))
-
-    return mark

--- a/src/commcare_cloud/fab/utils.py
+++ b/src/commcare_cloud/fab/utils.py
@@ -29,6 +29,15 @@ def execute_with_timing(fn, *args, **kwargs):
             timing_log.write('{}: {}\n'.format(fn.__name__, duration.seconds))
 
 
+def obsolete_task(fn):
+    assert callable(fn), f"expected a function, got {fn!r}"
+    @task
+    @wraps(fn)
+    def obsolete(*args, **kw):
+        sys.exit(fn.__doc__)
+    return obsolete
+
+
 def incomplete_task(replacement_command):
     assert isinstance(replacement_command, str), \
         f"@incomplete_task(...) expected a string, got {replacement_command}"

--- a/tests/test_deploy/test_command.py
+++ b/tests/test_deploy/test_command.py
@@ -104,7 +104,7 @@ def test_deploy_limited_release():
         datetime=fakedatetime,
         run_ansible_playbook=run_playbook,
     ):
-        _deploy_commcare("--private", "--limit=django_manage")
+        _deploy_commcare("--private")
 
     eq(log, ["deploy_hq.yml"])
 
@@ -132,7 +132,7 @@ def test_deploy_limited_release_to_webworker():
     eq(log, ["deploy_hq.yml"])
 
 
-def test_deploy_private():
+def test_deploy_private_release_to_all_applicable_hosts():
     def run_playbook(playbook, context, *args, unknown_args=None, **kw):
         eq(unknown_args, [
             "-e", "code_version=def456",
@@ -140,7 +140,7 @@ def test_deploy_private():
             "--tags=private_release",
         ])
         eq(context.environment.release_name, "GHOST")
-        eq(kw.get("limit"), None)
+        eq(kw.get("limit"), "all")
         log.append(playbook)
         return 0
 
@@ -152,7 +152,7 @@ def test_deploy_private():
         datetime=fakedatetime,
         run_ansible_playbook=run_playbook,
     ):
-        _deploy_commcare("--private")
+        _deploy_commcare("--private", "--limit=all")
 
     eq(log, ["deploy_hq.yml"])
     eq(summary, [
@@ -179,7 +179,7 @@ def test_deploy_limited_release_with_keep_days():
         datetime=fakedatetime,
         run_ansible_playbook=run_playbook,
     ):
-        _deploy_commcare("--private", "--limit=django_manage", "--keep-days=10")
+        _deploy_commcare("--private", "--keep-days=10")
 
     eq(log, ["deploy_hq.yml"])
 

--- a/tests/test_deploy/test_command.py
+++ b/tests/test_deploy/test_command.py
@@ -87,7 +87,7 @@ def test_resume_deploy_without_release_name_raises():
 
 def test_deploy_limited_release():
     def run_playbook(playbook, context, *args, unknown_args=None, **kw):
-        eq(unknown_args, ["-e", "code_version=def456"])
+        eq(unknown_args, ["-e", "code_version=def456", "--tags=private_release"])
         eq(context.environment.release_name, "GHOST")
         eq(kw.get("limit"), "django_manage")
         log.append(playbook)
@@ -112,7 +112,7 @@ def test_deploy_limited_release():
 
 def test_deploy_private():
     def run_playbook(playbook, context, *args, unknown_args=None, **kw):
-        eq(unknown_args, ["-e", "code_version=def456"])
+        eq(unknown_args, ["-e", "code_version=def456", "--tags=private_release"])
         eq(context.environment.release_name, "GHOST")
         eq(kw.get("limit"), None)
         log.append(playbook)
@@ -137,7 +137,7 @@ def test_deploy_private():
 
 def test_deploy_limited_release_with_keep_days():
     def run_playbook(playbook, context, *args, unknown_args=None, **kw):
-        eq(unknown_args, ["-e", "code_version=def456"])
+        eq(unknown_args, ["-e", "code_version=def456", "--tags=private_release"])
         eq(context.environment.release_name, "GHOST")
         eq(kw.get("limit"), "django_manage")
         log.append(playbook)
@@ -162,7 +162,7 @@ def test_deploy_limited_release_with_keep_days():
 
 def test_preindex_views():
     def run_playbook(playbook, context, *args, unknown_args=None, **kw):
-        eq(unknown_args, ["-e", "code_version=def456"])
+        eq(unknown_args, ["-e", "code_version=def456", "--tags=private_release"])
         eq(context.environment.release_name, "GHOST")
         eq(kw.get("limit"), "pillowtop[0]")
         log.append(playbook)

--- a/tests/test_deploy/test_command.py
+++ b/tests/test_deploy/test_command.py
@@ -94,7 +94,7 @@ def test_deploy_limited_release():
         patch.object(commcare, "run_ansible_playbook", run_playbook),
         patch.object(commcare, "commcare_cloud", run_fab),
     ):
-        _deploy_commcare("--setup-release", "--limit=django_manage")
+        _deploy_commcare("--private", "--limit=django_manage")
 
     eq(log, [
         "deploy_hq.yml",
@@ -102,7 +102,7 @@ def test_deploy_limited_release():
     ])
 
 
-def test_deploy_setup_release():
+def test_deploy_private():
     def run_playbook(playbook, context, *args, unknown_args=None, **kw):
         eq(unknown_args, ["-e", "code_version=def456"])
         eq(context.environment.release_name, "GHOST")
@@ -119,7 +119,7 @@ def test_deploy_setup_release():
         patch.object(commcare, "run_ansible_playbook", run_playbook),
         patch.object(commcare, "commcare_cloud", run_fab),
     ):
-        _deploy_commcare("--setup-release")
+        _deploy_commcare("--private")
 
     eq(log, [
         "deploy_hq.yml",
@@ -144,7 +144,7 @@ def test_deploy_limited_release_with_keep_days():
         patch.object(commcare, "run_ansible_playbook", run_playbook),
         patch.object(commcare, "commcare_cloud", run_fab),
     ):
-        _deploy_commcare("--setup-release", "--limit=django_manage", "--keep-days=10")
+        _deploy_commcare("--private", "--limit=django_manage", "--keep-days=10")
 
     eq(log, [
         "deploy_hq.yml",

--- a/tests/test_deploy/test_command.py
+++ b/tests/test_deploy/test_command.py
@@ -229,7 +229,10 @@ def _deploy_commcare(*argv, cmd=("deploy", "commcare")):
         patch.object(Environment, "release_name", "GHOST"),
     ):
         argv = ("cchq", "small_cluster") + cmd + argv
-        return call_commcare_cloud(argv)
+        try:
+            call_commcare_cloud(argv)
+        finally:
+            get_environment.reset_cache()
 
 
 class fakedatetime:

--- a/tests/test_deploy/test_command.py
+++ b/tests/test_deploy/test_command.py
@@ -2,7 +2,7 @@
 # Way too many things are mocked here.
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from testil import assert_raises, eq
 
@@ -25,9 +25,13 @@ def test_deploy_commcare_happy_path():
         return 0
 
     log = []
-    with (
-        patch.object(commcare, "run_ansible_playbook", run_playbook),
-        patch.object(commcare, "commcare_cloud", run_fab),
+    with patch.multiple(
+        commcare,
+        commcare_cloud=run_fab,
+        record_deploy_failed=Mock(),
+        record_deploy_start=Mock(),
+        record_successful_deploy=Mock(),
+        run_ansible_playbook=run_playbook,
     ):
         _deploy_commcare()
 
@@ -49,9 +53,13 @@ def test_resume_deploy_with_release_name():
         return 0
 
     log = []
-    with (
-        patch.object(commcare, "run_ansible_playbook", run_playbook),
-        patch.object(commcare, "commcare_cloud", run_fab),
+    with patch.multiple(
+        commcare,
+        commcare_cloud=run_fab,
+        record_deploy_failed=Mock(),
+        record_deploy_start=Mock(),
+        record_successful_deploy=Mock(),
+        run_ansible_playbook=run_playbook,
     ):
         _deploy_commcare("--resume=FRANK")
 
@@ -185,9 +193,6 @@ def _deploy_commcare(*argv, cmd=("deploy", "commcare")):
     with (
         patch("commcare_cloud.environment.paths.ENVIRONMENTS_DIR", envs),
         patch.object(command, "check_branch"),
-        patch.object(commcare, "record_deploy_start"),
-        patch.object(commcare, "record_deploy_failed"),
-        patch.object(commcare, "record_successful_deploy"),
         patch.object(commcare, "confirm_deploy", lambda *a: True),
         patch.object(commcare, "DEPLOY_DIFF", diff),
         patch.object(Environment, "create_generated_yml", lambda self:None),

--- a/tests/test_deploy/test_command.py
+++ b/tests/test_deploy/test_command.py
@@ -134,8 +134,10 @@ def test_deploy_private():
         return 0
 
     log = []
+    summary = []
     with patch.multiple(
         commcare,
+        color_summary=summary.append,
         commcare_cloud=run_fab,
         datetime=fakedatetime,
         run_ansible_playbook=run_playbook,
@@ -145,6 +147,10 @@ def test_deploy_private():
     eq(log, [
         "deploy_hq.yml",
         "fab setup_release:run_incomplete=yes --set release_name=GHOST",
+    ])
+    eq(summary, [
+        "Your private release is located here:",
+        "/home/cchq/www/small_cluster/releases/GHOST",
     ])
 
 


### PR DESCRIPTION
The `deploy` command argument `--setup-release` has been renamed to `--private`. Private releases are intended for running management commands, and therefore do not include static JavaScript files.

`preindex-views` now runs the management command in a tmux session rather than kicking it off in the background and returning immediately.

Tested locally in containers and with automated tests. Also tested on staging:
- private release (in which `./manage.py check_services` was run)
- `preindex-views`
- a full deploy.

:blowfish: Review by commit.

##### Environments Affected
All.