### PR TITLE
Set DATA_UPLOAD_MAX_NUMBER_FILES

### DIFF
--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -599,6 +599,8 @@ ALLOW_PHONE_AS_DEFAULT_TWO_FACTOR_DEVICE = {{ localsettings.ALLOW_PHONE_AS_DEFAU
 
 RATE_LIMIT_SUBMISSIONS = {{ localsettings.RATE_LIMIT_SUBMISSIONS | default(False) }}
 
+DATA_UPLOAD_MAX_NUMBER_FILES = {{ localsettings.DATA_UPLOAD_MAX_NUMBER_FILES | default('None') }}
+
 {% if 'SAVED_EXPORT_ACCESS_CUTOFF' in localsettings %}
 SAVED_EXPORT_ACCESS_CUTOFF = {{ localsettings.SAVED_EXPORT_ACCESS_CUTOFF }}
 {% endif %}


### PR DESCRIPTION
Django 3.2.18 introduced a new setting, DATA_UPLOAD_MAX_NUMBER_FILES,
which defaults to 100.

Restore the previous behavior by setting it to None, leaving the
option for different per environment values.

https://dimagi-dev.atlassian.net/browse/SAAS-14469

##### Environments Affected
All