### PR TITLE
reduce ram for es heap

### DIFF
--- a/src/commcare_cloud/ansible/roles/elasticsearch/defaults/main.yml
+++ b/src/commcare_cloud/ansible/roles/elasticsearch/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 elasticsearch_version: 2.4.6
 # https://www.elastic.co/guide/en/elasticsearch/guide/current/heap-sizing.html#_give_half_your_memory_to_lucene
-# Either half the machines RAM or 30 GB. Never want to go over 30 GB
-elasticsearch_memory: "{{ [ansible_memory_mb.real.total // 2, 30000] | min }}m"
+# Either half the machines RAM or 24 GB. If changing in the future, never want to go over 30 GB
+elasticsearch_memory: "{{ [ansible_memory_mb.real.total // 2, 24576] | min }}m"
 elasticsearch_download_sha256: 5f7e4bb792917bb7ffc2a5f612dfec87416d54563f795d6a70637befef4cfc6f.
 elasticsearch_home: "/opt/elasticsearch-{{ elasticsearch_version }}"
 elasticsearch_conf_dir: "/etc/elasticsearch-{{ elasticsearch_version }}"


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-14151

ES timeouts are linked to large and slow GC events. While the long term plan to reshard the case index still seems like the best way to prevent these memory spikes, ES [recommends](https://www.elastic.co/blog/a-heap-of-trouble) reducing heap size as a way to help keep GC events smaller, and heap usage on prod nodes never exceeds 24GB. Switching to G1GC may also help but ES does not recommend that until a higher version of the JDK than we currently run ES on, so it may be something to look into after the upgrade.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production (could be all, but that is the only one with machines large enough to be affected)
