### PR TITLE
Generate localsettings.py from template on each deploy

### DIFF
--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -129,6 +129,8 @@ AMQP_HOST: "{{ groups.rabbitmq.0 }}"
 AMQP_NAME: commcarehq
 OLD_AMQP_HOST: null
 OLD_AMQP_NAME: commcarehq
+BROKER_URL: 'amqp://{{ AMQP_USER }}:{{ AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
+OLD_BROKER_URL: "{{ ('amqp://' + OLD_AMQP_USER + ':' + OLD_AMQP_PASSWORD + '@' + OLD_AMQP_HOST + ':5672/' + OLD_AMQP_NAME) if OLD_AMQP_HOST else None }}"
 DROPBOX_APP_NAME: 'CommCareHQFiles'
 ELASTICSEARCH_PORT: 9200
 JAR_KEY_ALIAS: javarosakey

--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -49,9 +49,6 @@ couchdb_version: 2.3.1
 couchdb2_port: 15984
 couchdb2_local_port: "{{ 15986 if couchdb_version is version('3.0.0', '<') else couchdb2_port }}"
 couchdb2_proxy_port: "{{ 35984 if couchdb_use_haproxy else 25984 }}"
-couchdb_admins: "{
-  '{{ COUCH_USERNAME }}': '{{ COUCH_PASSWORD }}',
-}"
 
 is_redis_cluster: '{{ "redis_cluster_master" in groups and groups["redis_cluster_master"]|length > 1 }}'
 redis_bind: 0.0.0.0

--- a/src/commcare_cloud/ansible/roles/commcarehq/vars/main.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/vars/main.yml
@@ -2,8 +2,6 @@ code_releases: "{{ www_home }}/releases"
 code_source: "{{ code_releases }}/{{ ansible_date_time.date }}_{{ ansible_date_time.hour }}.{{ ansible_date_time.minute }}"
 python_name: python{{ python_version }}
 virtualenv_source: "{{ code_source }}/python_env-{{ python_version }}"
-BROKER_URL: 'amqp://{{ AMQP_USER }}:{{ AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
-OLD_BROKER_URL: "{{ ('amqp://' + OLD_AMQP_USER + ':' + OLD_AMQP_PASSWORD + '@' + OLD_AMQP_HOST + ':5672/' + OLD_AMQP_NAME) if OLD_AMQP_HOST else None }}"
 
 django_bash_runner_path: "{{ service_home }}/{{ deploy_env }}_django_bash_runner.sh"
 django_bash_runner: "/bin/bash {{ django_bash_runner_path }}"

--- a/src/commcare_cloud/ansible/roles/deploy_hq/tasks/setup_release.yml
+++ b/src/commcare_cloud/ansible/roles/deploy_hq/tasks/setup_release.yml
@@ -15,12 +15,14 @@
     requirements_file: "requirements/prod-requirements.txt"
     http_proxy: "{{ http_proxy | default(omit, true) }}"
 
-- name: Copy localsettings.py
-  copy:
-    src: "{{ code_home }}/localsettings.py"
+- name: Generate localsettings.py
+  template:
+    src: roles/commcarehq/templates/localsettings.py.j2
     dest: "{{ code_source }}/localsettings.py"
-    remote_src: true
-    mode: preserve
+    owner: "{{ cchq_user }}"
+    group: "{{ cchq_user }}"
+    mode: 0600
+  no_log: true
 
 - name: Mark keep until
   file:


### PR DESCRIPTION
As suggested in PR feedback https://github.com/dimagi/commcare-cloud/pull/5820#discussion_r1132165786

- `update-config` is no longer required to update `localsettings.py`. However, the existing `update-config` workflow can still be used to preview and check the validity of changes to `localsettings.py` if desired.
- As implemented with [`no_log: true`](https://github.com/dimagi/commcare-cloud/blob/595cb85504d60b3a527a405d192784c4f9023bdf/src/commcare_cloud/ansible/roles/deploy_hq/tasks/setup_release.yml#L25), `localsettings.py` content is not printed on the console, reducing the risk of copy/paste exposing sensitive information.

##### Environments Affected
All.