### PR TITLE
Use become on "Formplayer Supervisor Config" due to order in which tasks are run

### DIFF
--- a/src/commcare_cloud/ansible/deploy_commcarehq.yml
+++ b/src/commcare_cloud/ansible/deploy_commcarehq.yml
@@ -62,6 +62,9 @@
 
 - name: Formplayer Supervisor Config
   hosts: formplayer
+  # become is necessary to run the supervisor role (a dependency of the commcarehq role)
+  # which by this point hasn't been run yet on formplayer (but has on other machines)
+  become: true
   tasks:
     - import_role:
         name: commcarehq


### PR DESCRIPTION
Fixes issue first introduced in https://github.com/dimagi/commcare-cloud/pull/5723

##### Environments Affected
all (fixes an issue that would have happened upon new formplayer machine setup on any env, but doesn't need to be applied to any working formplayer machine)
