### PR TITLE
Make "Set DIR_MODE for adduser" run on first time setup before users are created

### DIFF
--- a/src/commcare_cloud/ansible/roles/bootstrap-machine/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/bootstrap-machine/tasks/main.yml
@@ -26,6 +26,9 @@
     path: /etc/adduser.conf
     regexp: '^DIR_MODE=0750'
     replace: 'DIR_MODE=0755'
+  tags:
+    - users
+    - bootstrap-users
 
 - name: reset ssh connection to allow umask changes to take affect
   meta: reset_connection


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-13767

Improves upon a general Ubuntu 22.04 improvement first attempted in https://github.com/dimagi/commcare-cloud/pull/5828.

##### Environments Affected
Ubuntu 22.04
