### PR TITLE
Move DIR_MODE to proper role and add HOME_MODE

### DIFF
--- a/src/commcare_cloud/ansible/roles/bootstrap-machine/meta/main.yml
+++ b/src/commcare_cloud/ansible/roles/bootstrap-machine/meta/main.yml
@@ -4,5 +4,7 @@ dependencies:
     tags:
       - users
       - bootstrap-users
-  - {role: ssh, tags: ssh}
-  - {role: swap, tags: swap}
+  - role: ssh
+    tags: ssh
+  - role: swap
+    tags: swap

--- a/src/commcare_cloud/ansible/roles/bootstrap-machine/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/bootstrap-machine/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - name: Install packages we would want on any machine ever
   apt:
     name:
@@ -5,32 +6,3 @@
     state: present
   become: yes
 
-- name: Set proper umask
-  lineinfile:
-    dest: /etc/login.defs
-    state: present
-    regexp: "^UMASK"
-    line: "UMASK\t\t022"
-  tags:
-    - umask
-
-- name: Set proper umask for this session
-  shell: umask 022
-  tags:
-    - umask
-
-# To account for the default of 0750 on Jammy
-# which is too strict for us
-- name: Set DIR_MODE for adduser
-  replace:
-    path: /etc/adduser.conf
-    regexp: '^DIR_MODE=0750'
-    replace: 'DIR_MODE=0755'
-  tags:
-    - users
-    - bootstrap-users
-
-- name: reset ssh connection to allow umask changes to take affect
-  meta: reset_connection
-
-- meta: flush_handlers

--- a/src/commcare_cloud/ansible/roles/bootstrap-users/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/bootstrap-users/tasks/main.yml
@@ -15,6 +15,20 @@
     line: "PS1={{ bash_PS1 }}"
     state: present
 
+# To account for the default of 0750 on Jammy
+# which is too strict for us
+- name: Set DIR_MODE for adduser
+  replace:
+    path: /etc/adduser.conf
+    regexp: '^DIR_MODE=0750'
+    replace: 'DIR_MODE=0755'
+
+- name: Set HOME_MODE for useradd
+  replace:
+    path: /etc/login.defs
+    regexp: '^HOME_MODE\t0750'
+    replace: 'HOME_MODE\t0755'
+
 - name: Add ansible group
   become: yes
   group:


### PR DESCRIPTION
Ansible uses 'useradd', which relies on HOME_MODE in login.defs, if
defined (and on UMASK otherwise).

##### Environments Affected
All