### PR TITLE
Remove redundant python2 installs that won't install on Jammy

### DIFF
--- a/src/commcare_cloud/ansible/roles/postgresql_base/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/postgresql_base/tasks/main.yml
@@ -24,11 +24,8 @@
       - "postgresql-{{ postgresql_version }}-plproxy"
       - "postgresql-contrib-{{ postgresql_version }}"
       - "postgresql-server-dev-{{ postgresql_version }}"
-      - python-docutils  # required for building pghashlib
       - libpq-dev
-      - python-psycopg2
       - unzip
-      - libreadline-dev 
 
 - name: Install PostgreSQL & dependencies
   apt:


### PR DESCRIPTION
This code cleanup shouldn't affect Bionic, but makes it work on Jammy. The `python-*` installs are python 2 versions of things we now install using `python3-*`, and the `libreadline-dev` is already installed in the task right below it.

##### Environments Affected
all (but it shouldn't have any affect)
