### PR TITLE
Fix recent aws backup changes

### DIFF
--- a/src/commcare_cloud/terraform/modules/backup/main.tf
+++ b/src/commcare_cloud/terraform/modules/backup/main.tf
@@ -16,7 +16,7 @@ resource "aws_backup_plan" "business_continuity_plan" {
     completion_window        = 10080
     enable_continuous_backup = false
     rule_name                = "Daily"
-    schedule                 = "cron(0 13 ? * 2,3,4,5,6 *)"
+    schedule                 = "cron(0 13 ? * 2,3,4,5,6,7 *)"
     start_window             = 60
     target_vault_name        = aws_backup_vault.business_continuity_local_vault.name
 

--- a/src/commcare_cloud/terraform/modules/backup/main.tf
+++ b/src/commcare_cloud/terraform/modules/backup/main.tf
@@ -69,7 +69,10 @@ resource "aws_backup_plan" "business_continuity_plan" {
     }
 
     lifecycle {
-      delete_after = 1
+      // The schedule overlaps with Weekly.
+      // When there's an overlap, AWS Backup picks the one with longer (local) retention.
+      // Setting this higher than Weekly's is a hack to make it always pick this one when they overlap.
+      delete_after = 2
     }
   }
   rule {
@@ -89,7 +92,10 @@ resource "aws_backup_plan" "business_continuity_plan" {
     }
 
     lifecycle {
-      delete_after = 1
+      // The schedule overlaps with Weekly.
+      // When there's an overlap, AWS Backup picks the one with longer (local) retention.
+      // Setting this higher than Weekly's is a hack to make it always pick this one when they overlap.
+      delete_after = 2
     }
   }
 }


### PR DESCRIPTION
This fixes a couple bugs in https://github.com/dimagi/commcare-cloud/pull/5791:
- Saturday cross region backups were being inadvertently excluded (this may be causing us to actually get charged **more** on Sundays because of a lack of a very-recent backup to piggyback off of, but that is just a hypothesis based on something I noticed in our cost data)
- On the first Sunday of the month, it wasn't deterministic whether it would do a Weekly backup or a Monthly/Quarterly backup.

##### Environments Affected
staging, production
