### PR TITLE
Hide git mirrors directory

### DIFF
--- a/src/commcare_cloud/ansible/library/clean_releases.py
+++ b/src/commcare_cloud/ansible/library/clean_releases.py
@@ -60,7 +60,6 @@ EXAMPLES = """
   clean_releases:
     path: "/path/to/releases"
     exclude:
-      - git_mirrors
       - 2023-03-07_13.16
 """
 
@@ -97,7 +96,7 @@ def main():
         exclude.add(current_release.name)
         keep -= 1
 
-    before = {p.name for p in releases_path.iterdir() if p.is_dir()}
+    before = {p.name for p in releases_path.iterdir() if p.is_dir() and not p.name.startswith('.')}
     before_list = sorted(before)
     diff = {'before': {'releases': before_list}, 'after': {'releases': before_list}}
     result = {'changed': False, 'diff': diff}

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/git_repository.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/git_repository.yml
@@ -19,7 +19,7 @@
       repo: "{{ item.url }}"
       dest: "{{ repo_dest }}"
       version: "{{ item.version }}"
-      reference: "{{ code_releases }}/git_mirrors"
+      reference: "{{ code_releases }}/.git_mirrors"
       key_file: "{{ deploy_key|default(omit, true) }}"
     tags:
       - git

--- a/src/commcare_cloud/ansible/roles/deploy_hq/tasks/clean_releases.yml
+++ b/src/commcare_cloud/ansible/roles/deploy_hq/tasks/clean_releases.yml
@@ -9,5 +9,4 @@
   clean_releases:
     path: '{{ www_home }}/releases'
     exclude:
-      - git_mirrors
       - '{{ release_name }}'

--- a/src/commcare_cloud/ansible/roles/deploy_hq/tasks/setup_release_common.yml
+++ b/src/commcare_cloud/ansible/roles/deploy_hq/tasks/setup_release_common.yml
@@ -3,7 +3,7 @@
     repo: "{{ commcarehq_repository }}"
     dest: "{{ code_source }}"
     version: "{{ code_version }}"
-    reference: "{{ code_releases }}/git_mirrors"
+    reference: "{{ code_releases }}/.git_mirrors"
     key_file: "{{ deploy_key | default(omit, true) }}"
     previous_release: "{{ code_home }}"
 

--- a/src/commcare_cloud/commands/ansible/run_module.py
+++ b/src/commcare_cloud/commands/ansible/run_module.py
@@ -320,7 +320,7 @@ class ListReleases(CommandBase):
                 'echo ---;'
                 'ls {{ www_home }}/releases/*/.build-complete;'
                 'echo ---;'
-                'ls {{ www_home }}/releases | grep -v git_mirrors;'
+                'ls {{ www_home }}/releases;'
             ),
             become=True,
             become_user='cchq',

--- a/src/commcare_cloud/commands/clean_releases.py
+++ b/src/commcare_cloud/commands/clean_releases.py
@@ -29,11 +29,9 @@ class CleanReleases(CommandBase):
         context = AnsibleContext(args)
         environment = context.environment
         extra_args = (f"--playbook-dir={environment.paths.ansible_path}",) + tuple(unknown_args)
-        module_args = [
-            "path={{www_home}}/releases",
-            f"keep={args.keep}",
-            "exclude={{%s}}" % json.dumps(["git_mirrors"] + args.exclude),
-        ]
+        module_args = ["path={{www_home}}/releases", f"keep={args.keep}"]
+        if args.exclude:
+            module_args.append("exclude={{%s}}" % json.dumps(args.exclude))
         shared_dir = environment.fab_settings_config.shared_dir_for_staticfiles
         if shared_dir:
             module_args.append(f"shared_dir_for_staticfiles={shared_dir}")

--- a/tests/test_deploy/test_clean_releases.py
+++ b/tests/test_deploy/test_clean_releases.py
@@ -159,6 +159,16 @@ class TestCleanReleases(TestCase):
         self.assertEqual(listdir(self.releases), {"r2", "r3"})
         self.assertEqual(listdir(shared_dir), {SHARED_VERSION, shares["r3"], "other"})
 
+    def test_clean_releases_does_not_delete_hidden_directories(self):
+        hidden_dir = self.releases / ".git_mirrors"
+        hidden_dir.mkdir()
+        result = ansible.run("clean_releases", {"path": str(self.releases)})
+        self.assertTrue(result.get("changed"), result)
+        self.assertNotIn(".git_mirrors", result["diff"]["before"]["releases"])
+        self.assertNotIn(".git_mirrors", result["diff"]["after"]["releases"])
+        self.assertEqual(listdir(self.releases), {"r2", "r3", ".git_mirrors"})
+        self.assertTrue(hidden_dir.is_dir())
+
     def make_release(self, name, keep_until=None):
         (self.releases / name).mkdir()
         (self.releases / name / ".build-complete").touch()


### PR DESCRIPTION
Reduce the number of places that need to know about the "git mirrors" directory:
- `clean_releases` and `list-releases` ignore hidden directories.
- People looking in the releases directory will be less likely to be confused because `.git_mirrors` is hidden from commands like `ls` by default.

This will have the side effect of breaking the git repositories in existing releases when `clean_releases` is run the first time after this is merged (it will delete the old `git_mirrors` directory). The only instance where this would likely matter is in a private release where someone was using git to update the release to a new version of the code. Probably the easiest  workaround there is to create a new private release and discard the old one. However, the following command can be used if a release gets broken that way and it becomes necessary to (temporarily, until the next `clean_releases` run) rehabilitate its git repo:

    sudo -u cchq ln -s .git_mirrors /home/cchq/www/<env>/releases/git_mirrors

##### Environments Affected
All.