### PR TITLE
remove ubuntu 18.04 from github runner tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: ["ubuntu-18.04", "ubuntu-22.04"]
+        os: ["ubuntu-22.04"]
         python-version: ["3.10"]
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/6002
Ubuntu 18.04 action runner image is deprecated from github

##### Environments Affected
All