### PR TITLE
post message to slack with diff

### DIFF
--- a/src/commcare_cloud/commands/deploy/deploy_diff.py
+++ b/src/commcare_cloud/commands/deploy/deploy_diff.py
@@ -181,6 +181,9 @@ class DeployDiff:
     def get_email_diff(self):
         return self.render_diff("email.html.j2")
 
+    def get_slack_diff(self):
+        return self.render_diff("slack.md.j2")
+
     def render_diff(self, template_name):
         template = self.j2.get_template(template_name)
         return template.render(

--- a/src/commcare_cloud/commands/deploy/diff_templates/slack.md.j2
+++ b/src/commcare_cloud/commands/deploy/diff_templates/slack.md.j2
@@ -1,0 +1,28 @@
+{% macro render_pr(info) -%}
+    - <{{ info.url }}|{{ info.title }}> (`{{ info.labels|map(attribute='name')|join("`, `") }}`)
+{%- endmacro %}
+
+{%- if new_version_details -%}
+New version details:
+{%- for key, val in new_version_details.items() %}
+    {{ "%-20s"|format(key) }}: {{ val }}
+{%- endfor %}
+{% endif %}
+
+{% for msg in errors -%}
+- [ERR] {{ msg }}
+{%- endfor %}
+{% for msg in warnings -%}
+- [WARN] {{ mgs }}
+{%- endfor %}
+
+{%- if pr_infos -%}
+List of PRs since last deploy:
+{% for info in pr_infos -%}
+{{ render_pr(info) }}
+{% endfor %}
+{%- endif %}
+
+{% if compare_url -%}
+Here's the complete diff on github: {{ compare_url }}
+{%- endif %}

--- a/src/commcare_cloud/commands/deploy/slack.py
+++ b/src/commcare_cloud/commands/deploy/slack.py
@@ -65,6 +65,12 @@ class SlackClient:
         blocks = self._get_message_blocks("*Deploy Started*", context)
         response = self._post_message(message, blocks)
         context.set_meta_value('slack_thread_ts', response["ts"])
+        if self.environment.fab_settings_config.generate_deploy_diffs:
+            diff_blocks = [{
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": context.diff.get_slack_diff()}
+            }]
+            self._post_message("Deploy diff", diff_blocks, thread_ts=response["ts"])
 
     def send_deploy_end_message(self, context, is_success):
         thread_ts = context.get_meta_value('slack_thread_ts')


### PR DESCRIPTION
Add a slack message that includes the deploy diff.

This will save having to copy the diff output from the console into Slack. It also allows us to do better formatting for the slack message.


##### Environments Affected
prod, india