### PR TITLE
Add default release_name to formplayer role

### DIFF
--- a/src/commcare_cloud/ansible/roles/formplayer/defaults/main.yml
+++ b/src/commcare_cloud/ansible/roles/formplayer/defaults/main.yml
@@ -11,3 +11,7 @@ formplayer_purge_time_spec: '2d'
 _should_update_formplayer_in_place: no
 formplayer_data_dir: "{{ encrypted_root }}/formplayer"
 use_monit_for_formplayer: false
+# Default release name for cases like deploy-stack where it is not
+# explicitly set. This is overridden by environment.release_name (from
+# Python via .generated.yml) on formplayer deploy.
+release_name: "{{ ansible_date_time.date }}_{{ ansible_date_time.hour }}.{{ ansible_date_time.minute }}"


### PR DESCRIPTION
Introduced by https://github.com/dimagi/commcare-cloud/pull/5862/commits/54c291cd175f522d130c6ba399d134b0b9041967 of https://github.com/dimagi/commcare-cloud/pull/5862 

The scope where `release_name` is needed includes the `formplayer` role anywhere `formplayer_release_dir` or `_formplayer_target_dir` are referenced, which is currently only done by the main tasks file. This fix seems better than reverting the commit that introduce the issue since it maintains a more limited scope where `release_name` is set.

Fixes error on `cchq <env> deploy-stack`:
```
TASK [formplayer: Formplayer build dir] ***********
task path: .../commcare-cloud/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml:98
fatal: [...]: FAILED! => {
    "msg": "{{ formplayer_build_dir }}/releases/{{ release_name}}: 'release_name' is undefined"
}
```

##### Environments Affected
All.