### PR TITLE
Add option to update localsettings.py on deploy

### DIFF
--- a/hosting_docs/source/reference/1-commcare-cloud/commands.md
+++ b/hosting_docs/source/reference/1-commcare-cloud/commands.md
@@ -1095,7 +1095,7 @@ Deploy CommCare
 
 ```
 commcare-cloud <env> deploy [--resume RELEASE_NAME] [--private] [-l SUBSET] [--keep-days KEEP_DAYS] [--skip-record]
-                            [--commcare-rev COMMCARE_REV] [--ignore-kafka-checkpoint-warning]
+                            [--commcare-rev COMMCARE_REV] [--ignore-kafka-checkpoint-warning] [--update-config]
                             [{commcare,formplayer} ...]
 ```
 
@@ -1139,6 +1139,11 @@ The name of the commcare-hq git branch, tag, or SHA-1 commit hash to deploy.
 ###### `--ignore-kafka-checkpoint-warning`
 
 Do not block deploy if Kafka checkpoints are unavailable.
+
+###### `--update-config`
+
+Generate new localsettings.py rather than copying from the previous
+release.
 
 ---
 

--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -135,6 +135,8 @@ AMQP_HOST: "{{ groups.rabbitmq.0 }}"
 AMQP_NAME: commcarehq
 OLD_AMQP_HOST: null
 OLD_AMQP_NAME: commcarehq
+BROKER_URL: 'amqp://{{ AMQP_USER }}:{{ AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
+OLD_BROKER_URL: "{{ ('amqp://' + OLD_AMQP_USER + ':' + OLD_AMQP_PASSWORD + '@' + OLD_AMQP_HOST + ':5672/' + OLD_AMQP_NAME) if OLD_AMQP_HOST else None }}"
 DROPBOX_APP_NAME: 'CommCareHQFiles'
 ELASTICSEARCH_PORT: 9200
 JAR_KEY_ALIAS: javarosakey

--- a/src/commcare_cloud/ansible/roles/commcarehq/vars/main.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/vars/main.yml
@@ -2,8 +2,6 @@ code_releases: "{{ www_home }}/releases"
 code_source: "{{ code_releases }}/{{ ansible_date_time.date }}_{{ ansible_date_time.hour }}.{{ ansible_date_time.minute }}"
 python_name: python{{ python_version }}
 virtualenv_source: "{{ code_source }}/python_env-{{ python_version }}"
-BROKER_URL: 'amqp://{{ AMQP_USER }}:{{ AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
-OLD_BROKER_URL: "{{ ('amqp://' + OLD_AMQP_USER + ':' + OLD_AMQP_PASSWORD + '@' + OLD_AMQP_HOST + ':5672/' + OLD_AMQP_NAME) if OLD_AMQP_HOST else None }}"
 
 django_bash_runner_path: "{{ service_home }}/{{ deploy_env }}_django_bash_runner.sh"
 django_bash_runner: "/bin/bash {{ django_bash_runner_path }}"

--- a/src/commcare_cloud/ansible/roles/deploy_hq/tasks/setup_release_common.yml
+++ b/src/commcare_cloud/ansible/roles/deploy_hq/tasks/setup_release_common.yml
@@ -22,6 +22,15 @@
     remote_src: true
     mode: preserve
 
+- name: Update localsettings.py
+  template:
+    src: roles/commcarehq/templates/localsettings.py.j2
+    dest: "{{ code_source }}/localsettings.py"
+    owner: "{{ cchq_user }}"
+    group: "{{ cchq_user }}"
+    mode: 0600
+  when: update_config | default(False)
+
 - name: Mark keep until
   file:
     path: "{{ code_source }}/KEEP_UNTIL__{{ keep_until }}"

--- a/src/commcare_cloud/commands/deploy/command.py
+++ b/src/commcare_cloud/commands/deploy/command.py
@@ -58,6 +58,10 @@ class Deploy(CommandBase):
         Argument('--ignore-kafka-checkpoint-warning', action='store_true', help="""
             Do not block deploy if Kafka checkpoints are unavailable.
         """),
+        Argument('--update-config', action='store_true', help="""
+            Generate new localsettings.py rather than copying from the previous
+            release.
+        """),
         shared_args.QUIET_ARG,
         shared_args.BRANCH_ARG,
     )
@@ -97,6 +101,7 @@ def _warn_about_non_formplayer_args(args):
         '--skip-record',
         '--commcare-rev',
         '--ignore-kafka-checkpoint-warning',
+        '--update-config',
     ]:
         dest = arg.lstrip("-").replace("-", "_")
         if getattr(args, dest) not in [None, False]:

--- a/src/commcare_cloud/commands/deploy/commcare.py
+++ b/src/commcare_cloud/commands/deploy/commcare.py
@@ -62,6 +62,8 @@ def deploy_commcare(environment, args, unknown_args):
             exit("--limit is not allowed except with --private")
     if args.ignore_kafka_checkpoint_warning:
         ansible_args.extend(["-e", "ignore_kafka_checkpoint_warning=true"])
+    if args.update_config:
+        ansible_args.extend(["-e", "update_config=true"])
     ansible_args.extend(unknown_args)
     rc = run_ansible_playbook(
         'deploy_hq.yml',


### PR DESCRIPTION
Usually `localsettings.py` is copied directly from the previous release. Deploying with the new option will cause localsettings to be generated from the template. This is mainly intended to be used in private releases in conjunction with `--branch` for testing not-yet-deployed localsettings changes.

I am planning to use this while rolling out a new repeaters database.

Use with care on non-private releases. If an unexpected change is deployed it can be reverted with `cchq <env> deploy --resume=<previous-release>`.

This is an iteration on https://github.com/dimagi/commcare-cloud/pull/5824. Advantages of this approach:
- It's optional instead of the default.
- It updates localsettings after copying from the previous release, making the diff output meaningful.

Tested on staging.

##### Environments Affected
All.