### PR TITLE
staging repeaters database

### DIFF
--- a/environments/staging/postgresql.yml
+++ b/environments/staging/postgresql.yml
@@ -47,6 +47,9 @@ dbs:
   auditcare:
     pgbouncer_host: pgproxy5
     pgbouncer_reserve_pool_size: 2
+  repeaters:
+    pgbouncer_host: pgproxy5
+    pgbouncer_reserve_pool_size: 2
   form_processing:
     proxy:
       host: pgproxy5

--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -160,6 +160,7 @@ localsettings:
     - {name: 'ddtrace.contrib.django', host: webworkers}
   LOCAL_CUSTOM_DB_ROUTING:
     auditcare: auditcare
+    repeaters: repeaters
   LOCAL_MIDDLEWARE:
     - 'django.middleware.security.SecurityMiddleware'
   PILLOWTOP_MACHINE_ID: staging-hqdb0-ubuntu

--- a/src/commcare_cloud/environment/constants.py
+++ b/src/commcare_cloud/environment/constants.py
@@ -9,6 +9,7 @@ class _Constants(jsonobject.JsonObject):
     ucr_db_name = jsonobject.StringProperty(default='commcarehq_ucr')
     synclogs_db_name = jsonobject.StringProperty(default='commcarehq_synclogs')
     auditcare_db_name = jsonobject.StringProperty(default='commcarehq_auditcare')
+    repeaters_db_name = jsonobject.StringProperty(default='commcarehq_repeaters')
     form_processing_proxy_db_name = jsonobject.StringProperty(default='commcarehq_proxy')
     form_processing_proxy_standby_db_name = jsonobject.StringProperty(default='commcarehq_proxy_standby')
 

--- a/src/commcare_cloud/environment/schemas/postgresql.py
+++ b/src/commcare_cloud/environment/schemas/postgresql.py
@@ -236,6 +236,7 @@ class PostgresqlConfig(jsonobject.JsonObject):
             self.dbs.ucr,
             self.dbs.formplayer,
             self.dbs.auditcare,
+            self.dbs.repeaters,
         ] + self.dbs.custom + self.dbs.standby if _f]
 
     def _check_reporting_databases(self):
@@ -299,6 +300,7 @@ class SmartDBConfig(jsonobject.JsonObject):
     synclogs = jsonobject.ObjectProperty(lambda: SynclogsDBOptions, required=False)
     form_processing = jsonobject.ObjectProperty(lambda: FormProcessingConfig, required=False)
     auditcare = jsonobject.ObjectProperty(lambda: AuditcareDBOptions, required=False, default=None)
+    repeaters = jsonobject.ObjectProperty(lambda: RepeatersDBOptions, required=False, default=None)
 
     custom = jsonobject.ListProperty(lambda: CustomDBOptions)
     standby = jsonobject.ListProperty(lambda: StandbyDBOptions)
@@ -367,6 +369,11 @@ class SynclogsDBOptions(DBOptions):
 class AuditcareDBOptions(DBOptions):
     name = constants.auditcare_db_name
     django_alias = 'auditcare'
+
+
+class RepeatersDBOptions(DBOptions):
+    name = constants.repeaters_db_name
+    django_alias = 'repeaters'
 
 
 class FormProcessingConfig(jsonobject.JsonObject):


### PR DESCRIPTION
Add support for a separate repeaters database and add staging configuration for the same.

The database will need to be created prior to merging this branch. On staging it can be created on the same postgres (RDS) instance as the main db since load is not a concern.

Rollout procedure:
```sh
cchq staging django-manage dbshell
```
```sql
CREATE DATABASE commcarehq_repeaters CHARACTER SET utf8;
```
```sh
git checkout dm/staging-repeaters-db
git rebase master
git push -f

cchq staging deploy --private --branch=dm/staging-repeaters-db --commcare-rev=dm/repeaters-db-split --update-config
cchq staging ssh django_manage
sudo -iu cchq
cd /path/to/private/release
./manage.py migrate --database=repeaters
./manage.py migrate
```

Merge `dm/staging-repeaters-db` on commcare-cloud
Merge `dm/repeaters-db-split` on commcare-hq

```sh
cchq staging deploy
cchq staging update-config
```


##### Environments Affected
Staging.
