### PR TITLE
Remove UCR_COMPARISONS variable

### DIFF
--- a/environments/india/public.yml
+++ b/environments/india/public.yml
@@ -173,11 +173,6 @@ localsettings:
 #  STATIC_ROOT:
   WS4REDIS_CONNECTION_HOST: "redis.india.commcare.local"
   USER_REPORTING_METADATA_BATCH_ENABLED: True
-  UCR_COMPARISONS:
-    static-mpr_1_person_cases:
-    static-mpr_2a_3_child_delivery_forms:
-    static-mpr_2ci_child_birth_list:
-    static-asr_2_pregnancies:
   STATIC_TOGGLE_STATES:
     ucr_sum_when_templates:
       always_enabled:

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -975,18 +975,6 @@ TRANSIFEX_DETAILS = {
 }
 {% endif %}
 
-{% if localsettings.UCR_COMPARISONS is defined %}
-UCR_COMPARISONS = {
-{% for old_config, new_config in localsettings.UCR_COMPARISONS.items() %}
-    {% if new_config %}
-     '{{ old_config }}': '{{ new_config }}',
-    {% else %}
-    '{{ old_config }}': None,
-    {% endif %}
-{% endfor %}
-}
-{% endif %}
-
 {% if localsettings.KAFKA_API_VERSION is defined or kafka_version is defined %}
 KAFKA_API_VERSION = tuple({{ localsettings.KAFKA_API_VERSION|default(kafka_version.split('.')|map('int')|list) }})
 {% endif %}


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Relates to https://github.com/dimagi/commcare-hq/pull/32969

This feature is no longer used and can be removed. The static UCRs that are removed in this PR no longer exist in commcare-hq which is why it is safe to remove.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->

