### PR TITLE
reverse order of requirejs build so that all the summary build.js files default to bootstrap 3 settings

### DIFF
--- a/src/commcare_cloud/ansible/roles/deploy_hq/tasks/staticfiles_collect.yml
+++ b/src/commcare_cloud/ansible/roles/deploy_hq/tasks/staticfiles_collect.yml
@@ -27,5 +27,5 @@
     - collectstatic --noinput -v 0
     - fix_less_imports_collectstatic
     - compilejsi18n
-    - build_requirejs
     - build_requirejs --bootstrap_version bootstrap5
+    - build_requirejs


### PR DESCRIPTION
I believe this will fix the symptoms in https://dimagi-dev.atlassian.net/browse/SAAS-14605 while I dig deeper into `build_requirejs` for a more longterm fix for the bootstrap5 version of the build

##### Environments Affected
all
