### PR TITLE
Enable intelligent tiering on log buckets

### DIFF
--- a/src/commcare_cloud/terraform/modules/logshipping/main.tf
+++ b/src/commcare_cloud/terraform/modules/logshipping/main.tf
@@ -27,6 +27,25 @@ resource "aws_s3_bucket_acl" "log_bucket" {
   acl    = "private"
 }
 
+resource "aws_s3_bucket_lifecycle_configuration" "log_bucket" {
+  bucket = aws_s3_bucket.log_bucket.id
+
+  rule {
+    id     = "Intelligent-Tiering"
+    status = "Enabled"
+
+    noncurrent_version_transition {
+      noncurrent_days = 0
+      storage_class   = "INTELLIGENT_TIERING"
+    }
+
+    transition {
+      days          = 0
+      storage_class = "INTELLIGENT_TIERING"
+    }
+  }
+}
+
 module "formplayer_request_response_logs_firehose_stream" {
   source = "./firehose_stream"
   environment = var.environment


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-14607

We've applied this to other buckets in the past. No user-facing effect at all, just more cost effective.

##### Environments Affected
staging, india, production
