### PR TITLE
Only grab from first djangomanage machine

### DIFF
--- a/src/commcare_cloud/commands/deploy/commcare.py
+++ b/src/commcare_cloud/commands/deploy/commcare.py
@@ -246,7 +246,7 @@ def get_deployed_version(environment, from_source=False):
         hosts = "webworkers,celery,proxy,pillowtop,django_manage"
     else:
         release = environment.remote_conf.code_current
-        hosts = "django_manage"
+        hosts = "django_manage[0]"
     code_current = shlex.quote(release)
     res = run_ansible_module(
         AnsibleContext(None, environment),


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi.slack.com/archives/C0B44C0Q2/p1685566977608219

By grabbing the latest release from one django machine, we avoid the issue of a newly deploy machine with a different rev conflicting with the most recent deploy rev. My only hesitation is the potential for the newly deployed machine to be equivalent to django_manage[0] in certain scenarios, which would result in an incorrect diff.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->