### PR TITLE
Adds FCM creds to secrets

### DIFF
--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -1100,3 +1100,7 @@ ABDM_CLIENT_ID = {{ ABDM_CLIENT_ID }}
 {% if ABDM_CLIENT_SECRET %}
 ABDM_CLIENT_SECRET = {{ ABDM_CLIENT_SECRET }}
 {% endif %}
+
+{% if FCM_CREDS %}
+FCM_CREDS = json.loads('{{ FCM_CREDS|to_json }}')
+{% endif %}

--- a/src/commcare_cloud/environment/secrets/backends/ansible_vault/tests/expected-generated-variables.yml
+++ b/src/commcare_cloud/environment/secrets/backends/ansible_vault/tests/expected-generated-variables.yml
@@ -68,3 +68,4 @@ deploy_event_token: "{{ deploy_event_token | default(None) }}"
 slack_token: "{{ slack_token | default(None) }}"
 ABDM_CLIENT_ID: '{{ secrets.ABDM_CLIENT_ID | default(None) }}'
 ABDM_CLIENT_SECRET: '{{ secrets.ABDM_CLIENT_SECRET | default(None) }}'
+FCM_CREDS: '{{ secrets.FCM_CREDS | default(None) }}'

--- a/src/commcare_cloud/environment/secrets/backends/aws_secrets/tests/expected-generated-variables.yml
+++ b/src/commcare_cloud/environment/secrets/backends/aws_secrets/tests/expected-generated-variables.yml
@@ -69,3 +69,4 @@ deploy_event_token: "{{ lookup('cchq_aws_secret', 'commcare-staging/deploy_event
 slack_token: "{{ lookup('cchq_aws_secret', 'commcare-staging/slack_token', errors='ignore') | default(None) }}"
 ABDM_CLIENT_ID: '{{ lookup(''cchq_aws_secret'', ''commcare-staging/ABDM_CLIENT_ID'', errors=''ignore'') | default(None) }}'
 ABDM_CLIENT_SECRET: '{{ lookup(''cchq_aws_secret'', ''commcare-staging/ABDM_CLIENT_SECRET'', errors=''ignore'') | default(None) }}'
+FCM_CREDS: '{{ lookup(''cchq_aws_secret'', ''commcare-staging/FCM_CREDS'', errors=''ignore'') | default(None) }}'

--- a/src/commcare_cloud/environment/secrets/secrets.yml
+++ b/src/commcare_cloud/environment/secrets/secrets.yml
@@ -177,3 +177,5 @@
   legacy_namespace: secrets
 - name: ABDM_CLIENT_SECRET
   legacy_namespace: secrets
+- name: FCM_CREDS
+  legacy_namespace: secrets


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
This is for adding credentials file(JSON) of FCM to enable the capability of sending FCM Push Notifcations through HQ.

Jira Ticket : [INDIV-125](https://dimagi-dev.atlassian.net/browse/INDIV-125)
Design Document: [Link](https://docs.google.com/document/d/1m-atLS7gcPRKWWdPd_pW62JLfrW122hAxCkIVurWeyQ/edit#)

PR for the said feature:
https://github.com/dimagi/commcare-hq/pull/33047

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All




[INDIV-125]: https://dimagi-dev.atlassian.net/browse/INDIV-125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ