### PR TITLE
fcm creds load directly from json string

### DIFF
--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -1102,5 +1102,5 @@ ABDM_CLIENT_SECRET = {{ ABDM_CLIENT_SECRET }}
 {% endif %}
 
 {% if FCM_CREDS %}
-FCM_CREDS = json.loads('{{ FCM_CREDS|to_json }}')
+FCM_CREDS = json.loads({{ FCM_CREDS }})
 {% endif %}


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
This is a follow up to this [PR](https://github.com/dimagi/commcare-cloud/pull/5982).
This is a minor change it to use json string directly instead of filter `to_json`.The required json contains `\n` characters and the said filter does not encodes it as `json.dumps` would do. This is turn causes an error.

Any other reccomendations are welcome.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All