### PR TITLE
Create user for postgres_fdw connections

### DIFF
--- a/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer.users.j2
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer.users.j2
@@ -1,6 +1,9 @@
 {% for group in postgres_users.values() %}
 "{{ group.username }}" "{{ group.password }}"
 {% endfor %}
+{% if postgresql_dbs.repeaters and inventory_hostname in postgresql_dbs.repeaters.pgbouncer_hosts %}
+"repeaters_fdw_user" "{{ postgres_users.commcare.password }}"
+{% endif %}
 {% if inventory_hostname in groups['citusdb_worker']|default([]) %}
 "postgres" ""
 {% endif %}

--- a/src/commcare_cloud/ansible/roles/postgresql_base/tasks/set_up_dbs.yml
+++ b/src/commcare_cloud/ansible/roles/postgresql_base/tasks/set_up_dbs.yml
@@ -121,7 +121,7 @@
 - name: Enable postgres_fdw extension in the main db
   become: yes
   become_user: "{{ db_is_remote and 'ansible' or 'postgres' }}"
-  community.postgresql.postgresql_query:
+  postgresql_query:
     db: '{{ postgresql_dbs.main.name }}'
     port: "{{ postgresql_port }}"
     login_host: "{{ db_is_remote and postgresql_host or omit }}"
@@ -130,4 +130,25 @@
     query: |
       CREATE EXTENSION IF NOT EXISTS postgres_fdw;
       GRANT USAGE ON FOREIGN DATA WRAPPER postgres_fdw TO {{ postgres_users.commcare.username }};
-  when: postgresql_host == postgresql_dbs.main.host
+  when: postgresql_dbs.repeaters and postgresql_host == postgresql_dbs.main.host
+
+- name: Create repeaters_fdw_user in repeaters database
+  # for postgres_fdw because it changes session settings like
+  # search_path that interfere with other pgbouncer clients
+  become: yes
+  become_user: "{{ db_is_remote and 'ansible' or 'postgres' }}"
+  postgresql_query:
+    db: '{{ postgresql_dbs.main.name }}'
+    port: "{{ postgresql_port }}"
+    login_host: "{{ db_is_remote and postgresql_host or omit }}"
+    login_user: "{{ db_is_remote and postgres_users.root.username or omit }}"
+    login_password: "{{ db_is_remote and postgres_users.root.password or omit }}"
+    query: |
+      DO $$ BEGIN
+        IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = 'repeaters_fdw_user') THEN
+          CREATE USER repeaters_fdw_user
+            WITH PASSWORD '{{ postgres_users.commcare.password }}'
+            IN ROLE "{{ postgres_users.commcare.username }}";
+        END IF;
+      END $$;
+  when: postgresql_dbs.repeaters and postgresql_host == postgresql_dbs.repeaters.host


### PR DESCRIPTION
Resolves an [issue](https://dimagi-dev.atlassian.net/browse/QA-5146) that occurred while rolling out https://github.com/dimagi/commcare-cloud/pull/5927

An alternate method of creating the user and assigning to the commcare role using `postgresql_user` and `postgresql_membership` Ansible commands was also implemented, but it was more verbose and had no obvious advantages over the more succinct `postgresql_query` task in this PR.

Tested with the following process:
### Revert to repeaters tables in the main db (with downtime)
```sh
cchq staging deploy --private --commcare-rev=dm/repeaters-db-split --branch=dm/repeaters-fdw-user
cchq staging downtime start
cchq staging ssh django_manage
sudo -iu cchq
cd /path/to/private/release
./manage.py migrate repeaters 0001_adjust_auth_field_format_squashed_0015_drop_connection_settings_fk
./manage.py migrate repeaters zero --database=repeaters
# repeaters tables are now in the main db

cchq staging update-config --branch=dm/revert-staging-repeaters-db  # temporary branch to remove repeaters db from localsettings
cchq staging downtime end
```

### Move tables to the repeaters database without downtime
```sh
cchq staging ansible-playbook deploy_postgres.yml --tags=remote_postgresql,pgbouncer --branch=dm/repeaters-fdw-user

# execute commands in the private release created above
./manage.py migrate repeaters --database=repeaters
./manage.py migrate repeaters
# check https://staging.commcarehq.org/a/caseexpression/settings/project/couch_repeat_record_report/?repeater=
# verify no sentry errors

cchq staging update-config
cchq service commcare restart
# check https://staging.commcarehq.org/a/caseexpression/settings/project/couch_repeat_record_report/?repeater=
# verify no sentry errors

```

##### Environments Affected
staging