### PR TITLE
Make rsyslog and related logs rotate by size and check hourly

### DIFF
--- a/src/commcare_cloud/ansible/roles/common/tasks/audit.yml
+++ b/src/commcare_cloud/ansible/roles/common/tasks/audit.yml
@@ -21,4 +21,3 @@
     insertafter: '^/var/log/messages'
     line: '/var/log/commands.log'
     state: present
-

--- a/src/commcare_cloud/ansible/roles/common/tasks/logging.yml
+++ b/src/commcare_cloud/ansible/roles/common/tasks/logging.yml
@@ -18,3 +18,19 @@
   include_role:
     name: ansible-logrotate
   when: "logrotate_scripts | length > 0"
+
+- name: Configure logrotate size limit in rsyslog (replacing weekly)
+  lineinfile:
+    path: /etc/logrotate.d/rsyslog
+    regexp: '^	weekly'
+    insertbefore: 'missingok'
+    line: '	size 750M'
+    state: present
+
+- name: Configure logrotate timer (hourly instead of daily)
+  lineinfile:
+    path: /etc/systemd/system/timers.target.wants/logrotate.timer
+    regexp: '^OnCalendar='
+    line: 'OnCalendar=hourly'
+    insertafter: '^\[Timer\]'
+    state: present


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-14661

This affects all machine types and change the default rsyslog configuration to rotate based on file size (instead of flat weekly) and check for rotation hourly (instead of daily).

The diff looks something like this (I removed repetition and names of machines)
```
TASK [common : Configure logrotate size limit in rsyslog (replacing weekly)] *********************************************************************************************************************************************************************************************************************************************************************************************
--- before: /etc/logrotate.d/rsyslog (content)
+++ after: /etc/logrotate.d/rsyslog (content)
@@ -14,7 +14,7 @@
 /var/log/commands.log
 {
 	rotate 4
-	weekly
+	size 750M
 	missingok
 	notifempty
 	compress

TASK [common : Configure logrotate timer (hourly instead of daily)] ******************************************************************************************************************************************************************************************************************************************************************************************************
--- before: /etc/systemd/system/timers.target.wants/logrotate.timer (content)
+++ after: /etc/systemd/system/timers.target.wants/logrotate.timer (content)
@@ -3,7 +3,7 @@
 Documentation=man:logrotate(8) man:logrotate.conf(5)

 [Timer]
-OnCalendar=daily
+OnCalendar=hourly
 AccuracySec=1h
 Persistent=true
```

##### Environments Affected
all
