### PR TITLE
Create repeaters database on India env

### DIFF
--- a/environments/india/postgresql.yml
+++ b/environments/india/postgresql.yml
@@ -49,6 +49,11 @@ dbs:
     pgbouncer_hosts:
       - pgbouncer5
       - pgbouncer6
+  repeaters:
+    pgbouncer_endpoint: pgmain_nlb
+    pgbouncer_hosts:
+      - pgbouncer5
+      - pgbouncer6
   form_processing:
     proxy:
       host: pgbouncer7

--- a/environments/india/public.yml
+++ b/environments/india/public.yml
@@ -154,6 +154,7 @@ localsettings:
   J2ME_ADDRESS: "{{ J2ME_SITE_HOST }}"
   LOCAL_CUSTOM_DB_ROUTING:
     auditcare: auditcare
+    repeaters: repeaters
   LOCAL_MIDDLEWARE:
     - 'django.middleware.security.SecurityMiddleware'
   PILLOWTOP_MACHINE_ID: indiacloud


### PR DESCRIPTION
This is preparation for the first and second steps outlined in https://github.com/dimagi/commcare-hq/pull/33108

Apply with the following command:
```sh
cchq india ansible-playbook deploy_postgres.yml --tags=configure,remote_postgresql,pgbouncer --branch=dm/repeaters-db-india
```

To create the private release, use this command:
```sh
cchq india deploy --private --update-config --branch=dm/repeaters-db-india
```

This PR will be merged prior to running `update-config` to apply the new repeaters database routing to HQ services.

##### Environments Affected
India