### PR TITLE
Create repeaters database on production env

### DIFF
--- a/environments/production/postgresql.yml
+++ b/environments/production/postgresql.yml
@@ -101,6 +101,19 @@ dbs:
       - pgbouncer_c1
       - pgbouncer13
       - pgbouncer14
+  repeaters:
+    host: rds_pgmain1
+    pgbouncer_endpoint: pgmain_nlb
+    pgbouncer_pool_size: 6
+    pgbouncer_reserve_pool_size: 0
+    pgbouncer_hosts:
+      - pgbouncer_a4
+      - pgbouncer_a5
+      - pgbouncer_b2
+      - pgbouncer_b3
+      - pgbouncer_c1
+      - pgbouncer13
+      - pgbouncer14
   form_processing:
     proxy:
       host: pgbouncer_a6

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -179,6 +179,7 @@ localsettings:
   J2ME_ADDRESS: "{{ J2ME_SITE_HOST }}"
   LOCAL_CUSTOM_DB_ROUTING:
     auditcare: auditcare
+    repeaters: repeaters
   LOCAL_MIDDLEWARE:
     - 'django.middleware.security.SecurityMiddleware'
   PILLOWTOP_MACHINE_ID: hqdb0


### PR DESCRIPTION
This is preparation for the first and second steps outlined in https://github.com/dimagi/commcare-hq/pull/33108

Apply with the following command:
```sh
cchq production ansible-playbook deploy_postgres.yml --tags=remote_postgresql,pgbouncer --branch=dm/repeaters-db-production
```

To create the private release, use this command:
```sh
cchq production deploy --private --update-config --branch=dm/repeaters-db-production
```

This PR will be merged prior to running `update-config` to apply the new repeaters database routing to HQ services.

##### Environments Affected
Production