### PR TITLE
Set india case pillow to not process cases in chunks

### DIFF
--- a/environments/india/app-processes.yml
+++ b/environments/india/app-processes.yml
@@ -64,6 +64,7 @@ pillows:
     case-pillow:
       num_processes: 2
       dedicated_migration_process: True
+      processor_chunk_size: 0
     xform-pillow:
       num_processes: 2
       dedicated_migration_process: True


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://github.com/dimagi/commcare-hq/pull/33047

Recently ID added a feature that relies on case pillow to process cases at an acceptable speed. Currently, India has a [pillow lag](https://app.datadoghq.com/dashboard/ewu-jyr-udt/change-feeds-pillows?fullscreen_end_ts=1687869307269&fullscreen_paused=false&fullscreen_section=overview&fullscreen_start_ts=1687696507269&fullscreen_widget=3845479150817126&tpl_var_env%5B0%5D=india&from_ts=1687868402253&to_ts=1687869302253&live=true) of order of minutes & at times an hour+. This is suspected to be due to low load on India.
The change here makes case pillow process cases right away instead of in chunks, which [waits](https://github.com/dimagi/commcare-hq/blob/20b1f6539d62a361a9f40fddd26a245a7b3a0404/corehq/ex-submodules/pillowtop/pillow/interface.py#L171) for at least 10 cases (which is the [default number](https://github.com/dimagi/commcare-hq/blob/786cc52e1ed70dc0b27a24826d1572707b48e545/corehq/pillows/case.py#L73)). The change here makes chunk size to 0, which leads [this](https://github.com/dimagi/commcare-hq/blob/20b1f6539d62a361a9f40fddd26a245a7b3a0404/corehq/ex-submodules/pillowtop/pillow/interface.py#L167) be False and go for immediate processing.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
India

##### Announce New Release
Not needed
