### PR TITLE
Use maxmemory-policy=allkeys-lru on india redis and downsize

### DIFF
--- a/environments/india/terraform.yml
+++ b/environments/india/terraform.yml
@@ -372,6 +372,8 @@ elasticache_cluster:
   cache_node_type: "cache.t4g.medium"
   cache_engine_version: "7.0"
   cache_prameter_group: "default.redis7"
+  params:
+    maxmemory-policy: 'allkeys-lru'
   automatic_failover: true
   transit_encryption: false
   at_rest_encryption: true

--- a/environments/india/terraform.yml
+++ b/environments/india/terraform.yml
@@ -369,7 +369,7 @@ internal_albs:
 
 elasticache_cluster:
   create: yes
-  cache_node_type: "cache.t4g.medium"
+  cache_node_type: "cache.t4g.small"
   cache_engine_version: "7.0"
   cache_prameter_group: "default.redis7"
   params:


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-14659

Having already rolled out https://github.com/dimagi/commcare-cloud/pull/6009 on staging, this PR does the same to india.

I'm choosing to downsize at the same time, because right now the memory usage such that there will not be evictions for a long time, whereas the point of this change is to change the eviction strategy to a preferable one. Since downsizing it is necessary for this change to have any immediate effect and since doing these together allows us to have only one (potentially lightly disruptive) restart instead of two, I decided to bundle them into one changeset to be applied together.

##### Environments Affected
india
