### PR TITLE
Downsize staging webworkers

### DIFF
--- a/environments/staging/terraform.yml
+++ b/environments/staging/terraform.yml
@@ -35,7 +35,7 @@ servers:
     os: jammy 
 
   - server_name: "web13-staging"
-    server_instance_type: "t3a.xlarge"
+    server_instance_type: "t3a.large"
     network_tier: "app-private"
     az: "a"
     volume_size: 80
@@ -46,7 +46,7 @@ servers:
     server_auto_recovery: true
 
   - server_name: "web14-staging"
-    server_instance_type: "t3a.xlarge"
+    server_instance_type: "t3a.large"
     network_tier: "app-private"
     az: "b"
     volume_size: 80


### PR DESCRIPTION
t3a.xlarge => t3a.large
There's no big story behind this; I just came across it and noticed these machines were larger than they needed to be.

##### Environments Affected
staging
