### PR TITLE
Revert & Correct "Set india case pillow to not process cases in chunks"

### DIFF
--- a/environments/india/app-processes.yml
+++ b/environments/india/app-processes.yml
@@ -64,6 +64,7 @@ pillows:
     case-pillow:
       num_processes: 2
       dedicated_migration_process: True
+      processor_chunk_size: 1
     xform-pillow:
       num_processes: 2
       dedicated_migration_process: True

--- a/environments/india/app-processes.yml
+++ b/environments/india/app-processes.yml
@@ -64,7 +64,6 @@ pillows:
     case-pillow:
       num_processes: 2
       dedicated_migration_process: True
-      processor_chunk_size: 0
     xform-pillow:
       num_processes: 2
       dedicated_migration_process: True


### PR DESCRIPTION
Reverts dimagi/commcare-cloud#6011

Using 0 resulted for `processor-chunk-size` resulted in the param to be ignored due to if condition [here](https://github.com/dimagi/commcare-cloud/blob/a6ee9daf0d05009c75872da1e4e9897425153bc8/src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_pillowtop.conf.j2#L12).
So 1 should be used instead