### PR TITLE
Put all production case-pillow processes on one machine

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -101,11 +101,8 @@ celery_processes:
 
 pillows:
   pillow_a2000:
-    # case-sql partitions: 96
-    case-pillow:
-      num_processes: 25
-      total_processes: 49
-      start_process: 0
+    xform-pillow:
+      num_processes: 33
       dedicated_migration_process: True
     user-pillow:
       num_processes: 1
@@ -134,11 +131,8 @@ pillows:
     UserGroupsDbKafkaPillow:
       num_processes: 1
   pillow_b2000:
-    xform-pillow:
-      num_processes: 33
-      dedicated_migration_process: True
+  # case-sql partitions: 96
     case-pillow:
-      num_processes: 24
+      num_processes: 49
       total_processes: 49
-      start_process: 25
       dedicated_migration_process: True


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-14708

Put all production case-pillow processes on one machine, and move xform-pillow onto the other machine.

This is meant to simplify the configuration and to eliminate observed lag discrepancies between kafka case-sql topic partitions being processed on one machine versus the other.

I took a look at the history, and the way it ended up the way it is looks more _ad hoc_ than intentional, as the original split was followed by a number of reorganizations and changes in `num_processes`.

- Original split: https://github.com/dimagi/commcare-cloud/pull/5131
- Further split over three machines: https://github.com/dimagi/commcare-cloud/pull/5138
- Reduce `num_processes` and partially consolidate: https://github.com/dimagi/commcare-cloud/pull/5141

##### Environments Affected
production