### PR TITLE
set FLOWER_UNAUTHENTICATED_API to true

### DIFF
--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_celery_flower.conf.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_celery_flower.conf.j2
@@ -1,5 +1,6 @@
 #jinja2: trim_blocks: True, lstrip_blocks: True
 [program:{{ project }}-{{ deploy_env }}-celery_flower]
+environment=FLOWER_UNAUTHENTICATED_API="true"
 command={{ virtualenv_home }}/bin/celery
     -A corehq flower
     --address=0.0.0.0


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
This is a recent change in flower which does not allows the unauthenticated API requests. Since we use flower inside VPC so it makes sense for us to not care about the change and continue using the way we were using Flower APIs before.

setting `FLOWER_UNAUTHENTICATED_API` to true will bypass the recent authentication added to the APIs.

I have put the changes on staging and flower metrics are back on datadog.
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
ALL
