### PR TITLE
Downsize production elasticache cluster (again) to cache.r6g.large

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -602,7 +602,7 @@ internal_albs:
 
 elasticache_cluster:
   create: yes
-  cache_node_type: "cache.r6g.xlarge"
+  cache_node_type: "cache.r6g.large"
   cache_engine_version: "7.x"
   params:
     maxmemory-policy: 'allkeys-lru'


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-14659

This is along the same lines as the similar commit in https://github.com/dimagi/commcare-cloud/pull/6022, but one size smaller.

##### Environments Affected
production
