### PR TITLE
Update case index shards to 32

### DIFF
--- a/environments/production/elasticsearch.yml
+++ b/environments/production/elasticsearch.yml
@@ -3,3 +3,5 @@ settings:
     number_of_shards: 96
   xforms:
     number_of_shards: 64
+  hqcases:
+    number_of_shards: 32


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-12152
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production

I will be running this after this is applied to recreate secondary index with the shards info.

```
from corehq.apps.es.client import manager
from corehq.apps.es import case_adapter as adapter
from corehq.apps.es.migration_operations import CreateIndex


manager.index_delete(adapter.secondary.index_name)
CreateIndex(
    adapter.secondary.index_name,
    adapter.type,
    adapter.mapping,
    adapter.analysis,
    adapter.settings_key,
).run()
```