### PR TITLE
Switch to disabling APM on staging formplayer

### DIFF
--- a/environments/staging/app-processes.yml
+++ b/environments/staging/app-processes.yml
@@ -1,4 +1,6 @@
-formplayer_command_args: '-javaagent:/home/cchq/dd-java-agent.jar -Dsrc.main.java.org.javarosa.enableOpenTracing=true'
+formplayer_command_args: ''
+# Use the following to enable datadog tracing
+# formplayer_command_args: '-javaagent:/home/cchq/dd-java-agent.jar -Dsrc.main.java.org.javarosa.enableOpenTracing=true'
 management_commands:
   celery_a1:
     handle_survey_actions:


### PR DESCRIPTION
leaving instructions for how to re-enable when temporarily needed for something.

The motivation here is to clean up datadog features we don't use so we don't get charged for them.

##### Environments Affected
staging
