### PR TITLE
Bump pyyaml from 5.4.1 to 6.0.1 (to fix the build)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -111,7 +111,7 @@ python-dateutil==2.8.2
     # via botocore
 pytz==2022.1
     # via commcare-cloud (setup.py)
-pyyaml==5.4.1
+pyyaml==6.0.1
     # via
     #   ansible-core
     #   couchdb-cluster-admin


### PR DESCRIPTION
The commcare-cloud build has been failing for about 4 days. This was a shot in the dark, but it looks like it worked to fix the build.

The idea came from this section in the ongoing commcare-cloud build failure:

```
Collecting pyyaml==5.4.1 (from -r /tmp/tmp_2plar3l (line 45))
  Downloading PyYAML-5.4.1.tar.gz (175 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 175.1/175.1 kB 46.3 MB/s eta 0:00:00
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'error'
  error: subprocess-exited-with-error
```

It wasn't obvious to me just from the text that pyyaml was the cause of the error that followed (as opposed to just being coincidentally close to when it happened), but from the fact that this fixed the build, I do believe it turned out to be the cause. I don't know what made pyyaml 5.4.1 stop being able to be installed, but this does seem to fix it.