### PR TITLE
Remove unused ICDS metric

### DIFF
--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -1070,10 +1070,6 @@ USE_KAFKA_SHORTEST_BACKLOG_PARTITIONER = {{ localsettings.USE_KAFKA_SHORTEST_BAC
 MESSAGING_RULE_CASE_CHUNK_SIZE = {{ localsettings.MESSAGING_RULE_CASE_CHUNK_SIZE }}
 {% endif %}
 
-{% if localsettings.TRACK_ES_REPORT_LOAD is defined %}
-TRACK_ES_REPORT_LOAD = {{ localsettings.TRACK_ES_REPORT_LOAD }}
-{% endif %}
-
 {% if localsettings.ASYNC_INDICATOR_CHUNK_SIZE is defined %}
 ASYNC_INDICATOR_CHUNK_SIZE = {{ localsettings.ASYNC_INDICATOR_CHUNK_SIZE }}
 {% endif %}


### PR DESCRIPTION
I came across this when looking for datadog metrics in elasticsearch code. Looks like it was built for ICDS, and it's not enabled for any Dimagi envs or documented anywhere that I could find, so it feels pretty safe to remove.

See also https://github.com/dimagi/commcare-hq/pull/33281

##### Environments Affected

None that I'm aware of, though it's possible third party environments have turned this on if they grepped through the codebase. 
