### PR TITLE
Add domain to alternate hosts in production public.yml

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -26,6 +26,7 @@ new_domain_email: inquiries@dimagi.com
 ALTERNATE_HOSTS:
   - rec-mobile.sante.gov.bf
   - onse-iss.commcarehq.org
+  - sic.snis-sante.mg
 show_maintenance_updates_on_deploy: False
 
 DATADOG_ENABLED: True


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-2995).

A project is in the process of moving from producton to a self-hosted instance of CommCare. A step in this process involves adding their domain to the old environment's `public.yml` file (production in this case).

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production