### PR TITLE
add connectid url

### DIFF
--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -195,6 +195,7 @@ localsettings:
   ES_GROUPS_INDEX_SWAPPED: True
   ES_SMS_INDEX_SWAPPED: True
   ES_USERS_INDEX_SWAPPED: True
+  CONNECTID_URL: 'https://connectid.dimagi.com/o/userinfo'
 
 
 # comment these two lines out to make a new rackspace machine

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -1159,3 +1159,7 @@ ABDM_CLIENT_SECRET = {{ ABDM_CLIENT_SECRET }}
 {% if FCM_CREDS %}
 FCM_CREDS = json.loads({{ FCM_CREDS }})
 {% endif %}
+
+{% if CONNECTID_URL is defined %}
+CONNECTID_USERINFO_URL = {{ localsettings.CONNECTID_URL }}
+{% endif %}

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -1160,6 +1160,6 @@ ABDM_CLIENT_SECRET = {{ ABDM_CLIENT_SECRET }}
 FCM_CREDS = json.loads({{ FCM_CREDS }})
 {% endif %}
 
-{% if CONNECTID_URL is defined %}
-CONNECTID_USERINFO_URL = {{ localsettings.CONNECTID_URL }}
+{% if localsettings.CONNECTID_URL is defined %}
+CONNECTID_USERINFO_URL = "{{ localsettings.CONNECTID_URL }}"
 {% endif %}


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
This allows setting a URL for ConnectID in HQ's localsettings, but only sets it for staging. It will be used for single sign on workflows, to verify tokens from ConnectID


##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Staging
