### PR TITLE
change celery instance-type from r5 to r6a

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -209,7 +209,7 @@ servers:
     os: jammy
 
   - server_name: "celery_b2{i}-production"
-    server_instance_type: r5.2xlarge
+    server_instance_type: r6a.2xlarge
     network_tier: "app-private"
     az: "b"
     volume_size: 80
@@ -219,7 +219,7 @@ servers:
     count: 4
 
   - server_name: "celery_c2{i}-production"
-    server_instance_type: r5.2xlarge
+    server_instance_type: r6a.2xlarge
     network_tier: "app-private"
     az: "c"
     volume_size: 83


### PR DESCRIPTION
**Ticket:** https://dimagi-dev.atlassian.net/browse/SAAS-14783

**Environments Affected:** Production