### PR TITLE
add connectid url

### DIFF
--- a/environments/india/public.yml
+++ b/environments/india/public.yml
@@ -124,6 +124,7 @@ localsettings:
   BANK_SWIFT_CODE: 'CTZIUS33'
 #  COUCH_CACHE_DOCS:
 #  COUCH_CACHE_VIEWS:
+  CONNECTID_URL: 'https://connectid.dimagi.com/o/userinfo'
   COUCH_USERNAME: "{{ COUCH_USERNAME }}"
   COUCH_PASSWORD: "{{ COUCH_PASSWORD }}"
   DEPLOY_MACHINE_NAME: "{{ inventory_hostname }}"

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -228,6 +228,7 @@ localsettings:
         - 'ils-gateway-train'
   USER_REPORTING_METADATA_BATCH_ENABLED: True
   WS4REDIS_CONNECTION_HOST: "redis.production.commcare.local"
+  CONNECTID_URL: 'https://connectid.dimagi.com/o/userinfo'
 
 # comment these two lines out to make a new rackspace machine
 commcare_cloud_root_user: ubuntu


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
This adds the necessary settings for https://github.com/dimagi/commcare-hq/pull/33300 to work in production and India, which will allow users who have been distributed the connect APKs to use SSO for authentication with commcare.
 
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production
India
