### PR TITLE
Fix python version specification in linter action

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-python@v1
         if: ${{ steps.changed-files.outputs.all_changed_files }}
         with:
-          python-version: 3.10
+          python-version: '3.10'
 
       - name: Install Python dependencies
         if: ${{ steps.changed-files.outputs.all_changed_files }}


### PR DESCRIPTION
3.10 was being interpreted as a number, 3.1, instead of a string "3.10"

Noticed this error on https://github.com/dimagi/commcare-cloud/pull/6092. Not sure why this wouldn't have been pervasive on all PRs in the last two weeks.

##### Environments Affected
None
