### PR TITLE
Updates to avoid big last batch

### DIFF
--- a/src/commcare_cloud/ansible/restart_webworker_services.yml
+++ b/src/commcare_cloud/ansible/restart_webworker_services.yml
@@ -1,6 +1,6 @@
 - name: Rolling restart webworker services
   hosts: webworkers
-  serial: ["10%", "40%", "75%", "100%"]
+  serial: ["10%", "30%", "50%", "100%"]
   become: true
   any_errors_fatal: true
   pre_tasks:

--- a/src/commcare_cloud/ansible/restart_webworker_services.yml
+++ b/src/commcare_cloud/ansible/restart_webworker_services.yml
@@ -1,6 +1,6 @@
 - name: Rolling restart webworker services
   hosts: webworkers
-  serial: ["10%", "40%", "100%"]
+  serial: ["10%", "40%", "75%", "100%"]
   become: true
   any_errors_fatal: true
   pre_tasks:


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Current HQ deploy fails due to rolling restart trying a restart on the full set of webworkers under `production_commcare_submissions` block.
This change would help with a smaller blocks
This would just cause a slightly longer deploy (~1 minute)

Using https://github.com/dimagi/commcare-cloud/pull/5852/files/f66001d7386ea30437e99a2093415f2a31d6702b#diff-3d7593c6d6f4d6c05a0a5c9a194301e3eaec3cc436f730dfa64b233fa5102054R3 as the guide to ensure that the change should be safe

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All
