### PR TITLE
Make couch bind not just to localhost

### DIFF
--- a/src/commcare_cloud/ansible/roles/couchdb2/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/couchdb2/tasks/main.yml
@@ -66,6 +66,13 @@
   notify: restart couchdb2
   when: couchdb_version is version('3.0.0', '>=')
 
+- name: Bind not just to localhost
+  lineinfile:
+    dest: "/etc/default/couchdb"
+    line: "ERL_EPMD_ADDRESS=127.0.0.1"
+    state: absent
+  notify: restart couchdb2
+
 - name: Start couchdb2
   shell: /bin/true
   notify: start couchdb2


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-13767

Beginning in recent versions of couch, the new default configuration file has couch bind only to localhost. This change removes that default so that it binds all (previous default) for external access within the network as well.

This change was initially incorporated as a manual step in the procedure; this PR automates that manual step.

##### Environments Affected
All
