### PR TITLE
Fix supervisor service file management

### DIFF
--- a/src/commcare_cloud/ansible/deploy_commcarehq.yml
+++ b/src/commcare_cloud/ansible/deploy_commcarehq.yml
@@ -104,15 +104,7 @@
     - webworkers
   tasks:
     - set_fact:
-        supervisor_files:
-          - "{{ celery_managed_files|default([]) }}"
-          - "{{ pillowtop_managed_files|default([]) }}"
-          - "{{ proxy_managed_files|default([]) }}"
-          - "{{ webworker_managed_files|default([]) }}"
-          - "{{ formplayer_managed_files|default([]) }}"
-          - "{{ mgmt_cmd_managed_files|default([]) }}"
-          - "{{ prometheus_managed_files|default([]) }}"
-          - "{{ prometheus_django_runner_managed_files|default([]) }}"
+        supervisor_files: "{{ supervisor_service_files.values()|selectattr('should_exist')|map(attribute='file_path') }}"
     - name: "Find supervisor config files"
       become: true
       shell: find {{ service_home|quote }} -type f
@@ -125,7 +117,7 @@
         path: "{{ item }}"
         state: absent
       with_items: "{{ contents.stdout_lines }}"
-      when: item not in supervisor_files|sum(start=[])
+      when: item not in supervisor_files
   tags: services
 
 - name: Celery tasks cleanup Cron job

--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -212,3 +212,7 @@ supervisor_service_files:
     file_path: "{{ service_home }}/{{ deploy_env }}_supervisor_management_commands.conf"
     template: ../templates/supervisor_management_commands.conf.j2
     should_exist: "{{ app_processes_config.management_commands.get(inventory_hostname, {}) }}"
+  pillowtop:
+    file_path: "{{ service_home }}/{{ deploy_env }}_supervisor_pillowtop.conf"
+    template: ../templates/supervisor_pillowtop.conf.j2
+    should_exist: "{{ inventory_hostname in groups['pillowtop'] }}"

--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -186,3 +186,7 @@ supervisor_service_files:
     file_path: "{{ service_home }}/{{ deploy_env }}_supervisor_django.conf"
     template: ../templates/supervisor_django.conf.j2
     should_exist: "{{ inventory_hostname in groups['webworkers'] }}"
+  celery_beat:
+    file_path: "{{ service_home }}/{{ deploy_env }}_supervisor_celery_beat.conf"
+    template: ../templates/supervisor_celery_beat.conf.j2
+    should_exist: "{{ app_processes_config.celery_processes.get(inventory_hostname).beat is defined }}"

--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -182,7 +182,7 @@ java_17_bin_path: /usr/lib/jvm/java-1.17.0-openjdk-amd64/bin
 #  ./src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_management_commands.conf.j2
 #  ./src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_celery_flower.conf.j2
 #
-# The only one not matching this pattern is celery_bash_runner
+# The only ones not matching this pattern is celery_bash_runner and django_bash_runner
 supervisor_service_files:
   django:
     file_path: "{{ service_home }}/{{ deploy_env }}_supervisor_django.conf"
@@ -223,4 +223,9 @@ supervisor_service_files:
   prometheus:
     file_path: "{{ service_home }}/{{ deploy_env }}_supervisor_prometheus.conf"
     template: ../templates/supervisor_prometheus.conf.j2
+    should_exist: "{{ prometheus_monitoring_enabled|default(False) }}"
+  # only used with prometheus
+  django_bash_runner:
+    file_path: "{{ service_home }}/{{ deploy_env }}_django_bash_runner.sh"
+    template: ../templates/django_bash_runner.sh.j2
     should_exist: "{{ prometheus_monitoring_enabled|default(False) }}"

--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -190,3 +190,7 @@ supervisor_service_files:
     file_path: "{{ service_home }}/{{ deploy_env }}_supervisor_celery_beat.conf"
     template: ../templates/supervisor_celery_beat.conf.j2
     should_exist: "{{ app_processes_config.celery_processes.get(inventory_hostname).beat is defined }}"
+  celery_flower:
+    file_path: "{{ service_home }}/{{ deploy_env }}_supervisor_celery_flower.conf"
+    template: ../templates/supervisor_celery_flower.conf.j2
+    should_exist: "{{ app_processes_config.celery_processes.get(inventory_hostname).flower is defined }}"

--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -216,3 +216,7 @@ supervisor_service_files:
     file_path: "{{ service_home }}/{{ deploy_env }}_supervisor_pillowtop.conf"
     template: ../templates/supervisor_pillowtop.conf.j2
     should_exist: "{{ inventory_hostname in groups['pillowtop'] }}"
+  websockets:
+    file_path: "{{ service_home }}/{{ deploy_env }}_supervisor_websockets.conf"
+    template: ../templates/supervisor_websockets.conf
+    should_exist: "{{ inventory_hostname in groups['proxy'] and run_websockets_wsgi }}"

--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -182,3 +182,7 @@ java_17_bin_path: /usr/lib/jvm/java-1.17.0-openjdk-amd64/bin
 #  ./src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_management_commands.conf.j2
 #  ./src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_celery_flower.conf.j2
 supervisor_service_files:
+  django:
+    file_path: "{{ service_home }}/{{ deploy_env }}_supervisor_django.conf"
+    template: ../templates/supervisor_django.conf.j2
+    should_exist: "{{ inventory_hostname in groups['webworkers'] }}"

--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -220,3 +220,7 @@ supervisor_service_files:
     file_path: "{{ service_home }}/{{ deploy_env }}_supervisor_websockets.conf"
     template: ../templates/supervisor_websockets.conf
     should_exist: "{{ inventory_hostname in groups['proxy'] and run_websockets_wsgi }}"
+  prometheus:
+    file_path: "{{ service_home }}/{{ deploy_env }}_supervisor_prometheus.conf"
+    template: ../templates/supervisor_prometheus.conf.j2
+    should_exist: "{{ prometheus_monitoring_enabled|default(False) }}"

--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -181,6 +181,8 @@ java_17_bin_path: /usr/lib/jvm/java-1.17.0-openjdk-amd64/bin
 #  ./src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_formplayer_spring.conf.j2
 #  ./src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_management_commands.conf.j2
 #  ./src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_celery_flower.conf.j2
+#
+# The only one not matching this pattern is celery_bash_runner
 supervisor_service_files:
   django:
     file_path: "{{ service_home }}/{{ deploy_env }}_supervisor_django.conf"
@@ -197,4 +199,8 @@ supervisor_service_files:
   celery_workers:
     file_path: "{{ service_home }}/{{ deploy_env }}_supervisor_celery_workers.conf"
     template: ../templates/supervisor_celery_workers.conf.j2
+    should_exist: "{{ app_processes_config.celery_processes.get(inventory_hostname) is defined }}"
+  celery_bash_runner:
+    file_path: "{{ service_home }}/{{ deploy_env }}_celery_bash_runner.sh"
+    template: ../templates/celery_bash_runner.sh.j2
     should_exist: "{{ app_processes_config.celery_processes.get(inventory_hostname) is defined }}"

--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -194,3 +194,7 @@ supervisor_service_files:
     file_path: "{{ service_home }}/{{ deploy_env }}_supervisor_celery_flower.conf"
     template: ../templates/supervisor_celery_flower.conf.j2
     should_exist: "{{ app_processes_config.celery_processes.get(inventory_hostname).flower is defined }}"
+  celery_workers:
+    file_path: "{{ service_home }}/{{ deploy_env }}_supervisor_celery_workers.conf"
+    template: ../templates/supervisor_celery_workers.conf.j2
+    should_exist: "{{ app_processes_config.celery_processes.get(inventory_hostname) is defined }}"

--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -182,7 +182,7 @@ java_17_bin_path: /usr/lib/jvm/java-1.17.0-openjdk-amd64/bin
 #  ./src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_management_commands.conf.j2
 #  ./src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_celery_flower.conf.j2
 #
-# The only ones not matching this pattern is celery_bash_runner and django_bash_runner
+# The only ones not matching this pattern are celery_bash_runner and django_bash_runner
 supervisor_service_files:
   django:
     file_path: "{{ service_home }}/{{ deploy_env }}_supervisor_django.conf"

--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -169,3 +169,16 @@ ansible_become_password: "{{ ansible_sudo_pass }}"
 
 # Java version for Formplayer
 java_17_bin_path: /usr/lib/jvm/java-1.17.0-openjdk-amd64/bin
+
+#  To find this complete list, you can run:
+#  $ find . -type f | grep templates/supervisor_
+#  ./src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_django.conf.j2
+#  ./src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_celery_beat.conf.j2
+#  ./src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_prometheus.conf.j2
+#  ./src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_pillowtop.conf.j2
+#  ./src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_celery_workers.conf.j2
+#  ./src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_websockets.conf
+#  ./src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_formplayer_spring.conf.j2
+#  ./src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_management_commands.conf.j2
+#  ./src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_celery_flower.conf.j2
+supervisor_service_files:

--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -208,3 +208,7 @@ supervisor_service_files:
     file_path: "{{ service_home }}/{{ deploy_env }}_supervisor_formplayer_spring.conf"
     template: ../templates/supervisor_formplayer_spring.conf.j2
     should_exist: "{{ inventory_hostname in groups['formplayer'] }}"
+  management_commands:
+    file_path: "{{ service_home }}/{{ deploy_env }}_supervisor_management_commands.conf"
+    template: ../templates/supervisor_management_commands.conf.j2
+    should_exist: "{{ app_processes_config.management_commands.get(inventory_hostname, {}) }}"

--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -204,3 +204,7 @@ supervisor_service_files:
     file_path: "{{ service_home }}/{{ deploy_env }}_celery_bash_runner.sh"
     template: ../templates/celery_bash_runner.sh.j2
     should_exist: "{{ app_processes_config.celery_processes.get(inventory_hostname) is defined }}"
+  formplayer_spring:
+    file_path: "{{ service_home }}/{{ deploy_env }}_supervisor_formplayer_spring.conf"
+    template: ../templates/supervisor_formplayer_spring.conf.j2
+    should_exist: "{{ inventory_hostname in groups['formplayer'] }}"

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/celery.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/celery.yml
@@ -1,13 +1,6 @@
 # Note: Make sure to add queues with associated tasks to the solo_queues list in
 # validate_app_processes_config(), in app_processes.py, so they don't share a process with another queue.
 
-- set_fact:
-    celery_managed_files:
-      - "{{ supervisor_service_files.celery_bash_runner.file_path }}"
-      - "{{ supervisor_service_files.celery_flower.file_path }}"
-      - "{{ supervisor_service_files.celery_beat.file_path }}"
-      - "{{ supervisor_service_files.celery_workers.file_path }}"
-
 - name: Add celery_bash_runner files
   template:
     src: "{{ supervisor_service_files.celery_bash_runner.template }}"

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/celery.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/celery.yml
@@ -3,14 +3,13 @@
 - set_fact:
     celery_bash_runner: "{{ service_home }}/{{ deploy_env }}_celery_bash_runner.sh"
     supervisor_celery_flower: "{{ service_home }}/{{ deploy_env }}_supervisor_celery_flower.conf"
-    supervisor_celery_beat: "{{ service_home }}/{{ deploy_env }}_supervisor_celery_beat.conf"
     supervisor_celery_workers: "{{ service_home }}/{{ deploy_env }}_supervisor_celery_workers.conf"
 
 - set_fact:
     celery_managed_files:
       - "{{celery_bash_runner}}"
       - "{{supervisor_celery_flower}}"
-      - "{{supervisor_celery_beat}}"
+      - "{{ supervisor_service_files.celery_beat.file_path }}"
       - "{{supervisor_celery_workers}}"
 
 - name: Add celery_bash_runner files
@@ -26,18 +25,16 @@
 - name: define special celery services
   template:
     src: "{{ item.template }}"
-    dest: "{{ item.file_name }}"
+    dest: "{{ item.file_path }}"
     owner: "{{ cchq_user }}"
     group: "{{ cchq_user }}"
     mode: 0600
-  when: item.should_apply
+  when: item.should_exist
   with_items:
     - template: ../templates/supervisor_celery_flower.conf.j2
-      file_name: "{{supervisor_celery_flower}}"
-      should_apply: "{{ app_processes_config.celery_processes.get(inventory_hostname).flower is defined }}"
-    - template: ../templates/supervisor_celery_beat.conf.j2
-      file_name: "{{supervisor_celery_beat}}"
-      should_apply: "{{ app_processes_config.celery_processes.get(inventory_hostname).beat is defined }}"
+      file_path: "{{supervisor_celery_flower}}"
+      should_exist: "{{ app_processes_config.celery_processes.get(inventory_hostname).flower is defined }}"
+    - "{{ supervisor_service_files.celery_beat }}"
 
 - name: define celery workers
   template:

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/celery.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/celery.yml
@@ -2,14 +2,13 @@
 # validate_app_processes_config(), in app_processes.py, so they don't share a process with another queue.
 - set_fact:
     celery_bash_runner: "{{ service_home }}/{{ deploy_env }}_celery_bash_runner.sh"
-    supervisor_celery_workers: "{{ service_home }}/{{ deploy_env }}_supervisor_celery_workers.conf"
 
 - set_fact:
     celery_managed_files:
       - "{{celery_bash_runner}}"
       - "{{ supervisor_service_files.celery_flower.file_path }}"
       - "{{ supervisor_service_files.celery_beat.file_path }}"
-      - "{{supervisor_celery_workers}}"
+      - "{{ supervisor_service_files.celery_workers.file_path }}"
 
 - name: Add celery_bash_runner files
   template:
@@ -35,12 +34,12 @@
 
 - name: define celery workers
   template:
-    src: "../templates/supervisor_celery_workers.conf.j2"
-    dest: "{{ supervisor_celery_workers }}"
+    src: "{{ supervisor_service_files.celery_workers.template }}"
+    dest: "{{ supervisor_service_files.celery_workers.file_path }}"
     owner: "{{ cchq_user }}"
     group: "{{ cchq_user }}"
     mode: 0644
-  when: app_processes_config.celery_processes.get(inventory_hostname) is defined
+  when: supervisor_service_files.celery_workers.should_exist
   with_items:
     - env_vars:
         http_proxy: "{% if http_proxy_address is defined %}http://{{ http_proxy_address }}:{{ http_proxy_port }}{% endif %}"

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/celery.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/celery.yml
@@ -2,13 +2,12 @@
 # validate_app_processes_config(), in app_processes.py, so they don't share a process with another queue.
 - set_fact:
     celery_bash_runner: "{{ service_home }}/{{ deploy_env }}_celery_bash_runner.sh"
-    supervisor_celery_flower: "{{ service_home }}/{{ deploy_env }}_supervisor_celery_flower.conf"
     supervisor_celery_workers: "{{ service_home }}/{{ deploy_env }}_supervisor_celery_workers.conf"
 
 - set_fact:
     celery_managed_files:
       - "{{celery_bash_runner}}"
-      - "{{supervisor_celery_flower}}"
+      - "{{ supervisor_service_files.celery_flower.file_path }}"
       - "{{ supervisor_service_files.celery_beat.file_path }}"
       - "{{supervisor_celery_workers}}"
 
@@ -31,9 +30,7 @@
     mode: 0600
   when: item.should_exist
   with_items:
-    - template: ../templates/supervisor_celery_flower.conf.j2
-      file_path: "{{supervisor_celery_flower}}"
-      should_exist: "{{ app_processes_config.celery_processes.get(inventory_hostname).flower is defined }}"
+    - "{{ supervisor_service_files.celery_flower }}"
     - "{{ supervisor_service_files.celery_beat }}"
 
 - name: define celery workers

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/celery.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/celery.yml
@@ -1,24 +1,21 @@
 # Note: Make sure to add queues with associated tasks to the solo_queues list in
 # validate_app_processes_config(), in app_processes.py, so they don't share a process with another queue.
-- set_fact:
-    celery_bash_runner: "{{ service_home }}/{{ deploy_env }}_celery_bash_runner.sh"
 
 - set_fact:
     celery_managed_files:
-      - "{{celery_bash_runner}}"
+      - "{{ supervisor_service_files.celery_bash_runner.file_path }}"
       - "{{ supervisor_service_files.celery_flower.file_path }}"
       - "{{ supervisor_service_files.celery_beat.file_path }}"
       - "{{ supervisor_service_files.celery_workers.file_path }}"
 
 - name: Add celery_bash_runner files
   template:
-    src: "../templates/celery_bash_runner.sh.j2"
-    dest: "{{ item.file_name }}"
+    src: "{{ supervisor_service_files.celery_bash_runner.template }}"
+    dest: "{{ supervisor_service_files.celery_bash_runner.file_path }}"
     owner: "{{ cchq_user }}"
     group: "{{ cchq_user }}"
     mode: 0644
-  with_items:
-    - file_name: "{{ celery_bash_runner }}"
+  when: supervisor_service_files.celery_bash_runner.should_exist
 
 - name: define special celery services
   template:

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/formplayer.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/formplayer.yml
@@ -1,11 +1,6 @@
 - set_fact:
-    supervisor_formplayer_spring: "{{ service_home }}/{{ deploy_env }}_supervisor_formplayer_spring.conf"
-  tags:
-    - formplayer_deploy
-
-- set_fact:
     formplayer_managed_files:
-      - "{{ supervisor_formplayer_spring }}"
+      - "{{ supervisor_service_files.formplayer_spring.file_path }}"
   tags:
     - formplayer_deploy
 
@@ -23,11 +18,12 @@
 - name: define formplayer spring services
   become: yes
   template:
-    src: "../templates/supervisor_formplayer_spring.conf.j2"
-    dest: "{{ supervisor_formplayer_spring }}"
+    src: "{{ supervisor_service_files.formplayer_spring.template }}"
+    dest: "{{ supervisor_service_files.formplayer_spring.file_path }}"
     owner: "{{ cchq_user }}"
     group: "{{ cchq_user }}"
     mode: 0644
+  when: supervisor_service_files.formplayer_spring.should_exist
   with_items:
     - env_vars:
         http_proxy: "{% if http_proxy_address is defined %}http://{{ http_proxy_address }}:{{ http_proxy_port }}{% endif %}"

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/formplayer.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/formplayer.yml
@@ -1,9 +1,3 @@
-- set_fact:
-    formplayer_managed_files:
-      - "{{ supervisor_service_files.formplayer_spring.file_path }}"
-  tags:
-    - formplayer_deploy
-
 - name: create services home
   become: yes
   file:

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/management_commands.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/management_commands.yml
@@ -1,19 +1,16 @@
 - set_fact:
-    supervisor_management_commands: "{{ service_home }}/{{ deploy_env }}_supervisor_management_commands.conf"
-
-- set_fact:
     mgmt_cmd_managed_files:
-      - "{{ supervisor_management_commands }}"
+      - "{{ supervisor_service_files.management_commands.file_path }}"
 
 - name: define management command services
   become: yes
   template:
-    src: "../templates/supervisor_management_commands.conf.j2"
-    dest: "{{ supervisor_management_commands }}"
+    src: "{{ supervisor_service_files.management_commands.template }}"
+    dest: "{{ supervisor_service_files.management_commands.file_path }}"
     owner: "{{ cchq_user }}"
     group: "{{ cchq_user }}"
     mode: 0644
-  when: app_processes_config.management_commands.get(inventory_hostname, {})
+  when: supervisor_service_files.management_commands.should_exist
   with_items:
     - env_vars:
         TMPDIR: '{{ encrypted_tmp }}'

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/management_commands.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/management_commands.yml
@@ -1,7 +1,3 @@
-- set_fact:
-    mgmt_cmd_managed_files:
-      - "{{ supervisor_service_files.management_commands.file_path }}"
-
 - name: define management command services
   become: yes
   template:

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/pillowtop.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/pillowtop.yml
@@ -1,7 +1,3 @@
-- set_fact:
-    pillowtop_managed_files:
-      - "{{ supervisor_service_files.pillowtop.file_path }}"
-
 - name: define pillowtop services
   become: yes
   template:

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/pillowtop.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/pillowtop.yml
@@ -1,18 +1,16 @@
 - set_fact:
-    supervisor_pillowtop: "{{ service_home }}/{{ deploy_env }}_supervisor_pillowtop.conf"
-
-- set_fact:
     pillowtop_managed_files:
-      - "{{ supervisor_pillowtop }}"
+      - "{{ supervisor_service_files.pillowtop.file_path }}"
 
 - name: define pillowtop services
   become: yes
   template:
-    src: "../templates/supervisor_pillowtop.conf.j2"
-    dest: "{{ supervisor_pillowtop }}"
+    src: "{{ supervisor_service_files.pillowtop.template }}"
+    dest: "{{ supervisor_service_files.pillowtop.file_path }}"
     owner: "{{ cchq_user }}"
     group: "{{ cchq_user }}"
     mode: 0644
+  when: supervisor_service_files.pillowtop.should_exist
   with_items:
     - env_vars:
         TMPDIR: '{{ encrypted_tmp }}'

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/prometheus.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/prometheus.yml
@@ -1,9 +1,6 @@
 - set_fact:
-    supervisor_prometheus: "{{ service_home }}/{{ deploy_env }}_supervisor_prometheus.conf"
-
-- set_fact:
     prometheus_managed_files:
-      - "{{ supervisor_prometheus }}"
+      - "{{ supervisor_service_files.prometheus.file_path }}"
 
 - name: Creates Prometheus Metrics directory
   become: yes
@@ -17,9 +14,9 @@
 - name: define prometheus service
   become: yes
   template:
-    src: "../templates/supervisor_prometheus.conf.j2"
-    dest: "{{ supervisor_prometheus }}"
+    src: "{{ supervisor_service_files.prometheus.template }}"
+    dest: "{{ supervisor_service_files.prometheus.file_path }}"
     owner: "{{ cchq_user }}"
     group: "{{ cchq_user }}"
     mode: 0644
-  when: prometheus_monitoring_enabled|default(False)
+  when: supervisor_service_files.prometheus.should_exist

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/prometheus.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/prometheus.yml
@@ -1,7 +1,3 @@
-- set_fact:
-    prometheus_managed_files:
-      - "{{ supervisor_service_files.prometheus.file_path }}"
-
 - name: Creates Prometheus Metrics directory
   become: yes
   file:

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/prometheus_django_runner.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/prometheus_django_runner.yml
@@ -1,7 +1,3 @@
-- set_fact:
-    prometheus_django_runner_managed_files:
-      - "{{ supervisor_service_files.django_bash_runner.file_path }}"
-
 - name: Add django_bash_runner
   become: yes
   template:

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/prometheus_django_runner.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/prometheus_django_runner.yml
@@ -1,13 +1,13 @@
 - set_fact:
     prometheus_django_runner_managed_files:
-      - "{{ django_bash_runner_path }}"
+      - "{{ supervisor_service_files.django_bash_runner.file_path }}"
 
 - name: Add django_bash_runner
   become: yes
   template:
-    src: "../templates/django_bash_runner.sh.j2"
-    dest: "{{ django_bash_runner_path }}"
+    src: "{{ supervisor_service_files.django_bash_runner.template }}"
+    dest: "{{ supervisor_service_files.django_bash_runner.file_path }}"
     owner: "{{ cchq_user }}"
     group: "{{ cchq_user }}"
     mode: 0644
-  when: prometheus_monitoring_enabled|default(False)
+  when: supervisor_service_files.django_bash_runner.should_exist

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/proxy_websockets.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/proxy_websockets.yml
@@ -1,7 +1,3 @@
-- set_fact:
-    proxy_managed_files:
-      - "{{ supervisor_service_files.websockets.file_path }}"
-
 - name: define websockets services
   become: yes
   template:

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/proxy_websockets.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/proxy_websockets.yml
@@ -1,15 +1,13 @@
 - set_fact:
-    supervisor_websockets: "{{ service_home }}/{{ deploy_env }}_supervisor_websockets.conf"
-
-- set_fact:
     proxy_managed_files:
-      - "{{ supervisor_websockets }}"
+      - "{{ supervisor_service_files.websockets.file_path }}"
 
 - name: define websockets services
   become: yes
   template:
-    src: "../templates/supervisor_websockets.conf"
-    dest: "{{ supervisor_websockets }}"
+    src: "{{ supervisor_service_files.websockets.template }}"
+    dest: "{{ supervisor_service_files.websockets.file_path }}"
     owner: "{{ cchq_user }}"
     group: "{{ cchq_user }}"
     mode: 0644
+  when: supervisor_service_files.websockets.should_exist

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/webworkers.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/webworkers.yml
@@ -1,18 +1,16 @@
 - set_fact:
-    supervisor_django: "{{ service_home }}/{{ deploy_env }}_supervisor_django.conf"
-
-- set_fact:
     webworker_managed_files:
-      - "{{ supervisor_django }}"
+      - "{{ supervisor_service_files.django.file_path }}"
 
 - name: define django worker service
   become: yes
   template:
-    src: "../templates/supervisor_django.conf.j2"
-    dest: "{{ supervisor_django }}"
+    src: "{{ supervisor_service_files.django.template }}"
+    dest: "{{ supervisor_service_files.django.file_path }}"
     owner: "{{ cchq_user }}"
     group: "{{ cchq_user }}"
     mode: 0644
+  when: supervisor_service_files.django.should_exist
   with_items:
     - env_vars:
         http_proxy: "{% if http_proxy_address is defined %}http://{{ http_proxy_address }}:{{ http_proxy_port }}{% endif %}"

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/webworkers.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/webworkers.yml
@@ -1,7 +1,3 @@
-- set_fact:
-    webworker_managed_files:
-      - "{{ supervisor_service_files.django.file_path }}"
-
 - name: define django worker service
   become: yes
   template:

--- a/src/commcare_cloud/ansible/roles/commcarehq/vars/main.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/vars/main.yml
@@ -3,8 +3,7 @@ code_source: "{{ code_releases }}/{{ ansible_date_time.date }}_{{ ansible_date_t
 python_name: python{{ python_version }}
 virtualenv_source: "{{ code_source }}/python_env-{{ python_version }}"
 
-django_bash_runner_path: "{{ service_home }}/{{ deploy_env }}_django_bash_runner.sh"
-django_bash_runner: "/bin/bash {{ django_bash_runner_path }}"
+django_bash_runner: "/bin/bash {{ supervisor_service_files.django_bash_runner.file_path }}"
 django_direct_runner: "{{ virtualenv_home }}/bin/python {{ code_home }}/manage.py"
 
 formplayer_java: "{{ formplayer_java_version | default('java') }}"

--- a/src/commcare_cloud/ansible/roles/supervisor/templates/supervisor_task.conf.j2
+++ b/src/commcare_cloud/ansible/roles/supervisor/templates/supervisor_task.conf.j2
@@ -1,7 +1,0 @@
-;
-; {{ ansible_managed }}
-;
-[program:{{ item.name }}]
-{% for key, val in item.config.items() %}
-{{ key }}={{ val }}
-{% endfor %}


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-14853?focusedCommentId=284526

This change prevents an issue that can happen when moving certain processes between machines; types of processes affected by this issue include: celery beat, celery flower, and the management commands, at least. The issue was that on the machine that is no longer supposed to have the process, the corresponding supervisor service file is simply _abandoned_, rather than deleted, which means it ends up running in both the old and new locations.

To fix this, this PR takes logic that was strewn through multiple files and centralizes it. Critically, it centralizes the logic dictating whether each individual service file is supposed to exist on a given machine or not. This allows the process that sweeps the service file directory at the end for unexpected files to have a complete understanding of what files are supposed to be there. Previously, the logic available to this task presumed, basically, that if the machine was a celery machine then any celery beat service file (for example) was supposed to be there. This PR updates that logic so that it's exactly the same logic as the task uses to decide whether to create that file on a given machine or not in the first place.

This issue was first introduced in https://github.com/dimagi/commcare-cloud/pull/3796/commits/58004f054720ae399c921ba9dbcaad12ff3d1363 in mid 2020 (though from the look of that PR https://github.com/dimagi/commcare-cloud/pull/3796, that change itself was introduced to fix a different problem).

##### Safety Story
This PR is backwards compatible, in the sense that any environment already set up correctly won't experience a diff when `update-supervisor-confs` is next applied. Of course, if it has stray service files that weren't previously detected, those will be deleted in the diff after this update. I have confirmed this (in check mode of course) on staging, india, and production.

I have also confirmed that it is still true to the previous behavior of applying changes made to `inventory.ini` and `app-processes.yml` through some ad hoc spot testing. Given that the changes were all very mechanical and had a limited impact on the overall logic, I think this is sufficient to allay concerns that these changes broke the fundamental logic in some important way.

##### Environments Affected
all (no environment files changed, though)
