### PR TITLE
Always install latest patch version of python

### DIFF
--- a/src/commcare_cloud/ansible/roles/common_installs/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/common_installs/tasks/main.yml
@@ -30,7 +30,7 @@
   become: yes
   apt:
     name:
-      - python{{ python_version }}
+      - python{{ python_version }}={{ python_version }}.*
       - python{{ python_version }}-dev
   tags:
     - python


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-14864

I have tested out the changes on django-manage machine and ran `cchq --control staging deploy-stack --limit=web13 --tags=python --branch=ap/update-python-to-latest-patch`.

The command ran fine without any errors and changes were applied without any issues. 

After that I verified on django-manage machine that we got the latest patched python version

```
(staging) aphulera@web13-staging:~$ python3.9 --version
Python 3.9.18
```

However we have 3.9.16 on other machines, for eg - in Web14

```
(staging) aphulera@web14-staging:~$ python3.9 --version
Python 3.9.16
```


##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All
##### Announce New Release
<!-- 
Review https://github.com/dimagi/commcare-cloud/tree/master/changelog#determining-whether-a-change-is-announce-worthy
to determine if a changelog entry is necessary if not already created.
-->
<!-- Delete this section if the PR does not contain any new changelog entries -->
- [x] After merging, I will follow [these instructions](https://confluence.dimagi.com/display/saas/Announcing+changes+affecting+third+parties#Announcingchangesaffectingthirdparties-announcing)
to announce a new commcare-cloud release. 
