### PR TITLE
Add jvm option path

### DIFF
--- a/src/commcare_cloud/ansible/roles/elasticsearch/templates/systemd/elasticsearch.service.j2
+++ b/src/commcare_cloud/ansible/roles/elasticsearch/templates/systemd/elasticsearch.service.j2
@@ -9,6 +9,9 @@ Type=simple
 Environment=ES_HOME={{ elasticsearch_home }}
 Environment=CONF_DIR={{ elasticsearch_conf_dir}}
 Environment=ES_PATH_CONF={{ elasticsearch_conf_dir}}
+{% if elasticsearch_version == '5.6.16'%}
+Environment=ES_JVM_OPTIONS={{ elasticsearch_conf_dir}}
+{% endif %}
 {% if elasticsearch_version == '2.4.6'%}
 Environment=ES_HEAP_SIZE={{ elasticsearch_memory }}
 {% endif %}

--- a/src/commcare_cloud/ansible/roles/elasticsearch/templates/systemd/elasticsearch.service.j2
+++ b/src/commcare_cloud/ansible/roles/elasticsearch/templates/systemd/elasticsearch.service.j2
@@ -10,7 +10,7 @@ Environment=ES_HOME={{ elasticsearch_home }}
 Environment=CONF_DIR={{ elasticsearch_conf_dir}}
 Environment=ES_PATH_CONF={{ elasticsearch_conf_dir}}
 {% if elasticsearch_version == '5.6.16'%}
-Environment=ES_JVM_OPTIONS={{ elasticsearch_conf_dir}}
+Environment=ES_JVM_OPTIONS={{ elasticsearch_conf_dir}}/jvm.options
 {% endif %}
 {% if elasticsearch_version == '2.4.6'%}
 Environment=ES_HEAP_SIZE={{ elasticsearch_memory }}


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
The ES 5 was not respecting the config path and jvm options need to be specifically defined using Environment variable ES_JVM_OPTIONS
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All
