### PR TITLE
Make es_conf include elasticsearch service reload-daemon logic

### DIFF
--- a/src/commcare_cloud/ansible/roles/elasticsearch/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/elasticsearch/tasks/main.yml
@@ -108,6 +108,8 @@
     daemon-reload: yes
     name: elasticsearch
   when: copy_elasticsearch_systemd_result.changed
+  tags:
+    - es_conf
 
 - debug: msg="If you're just updating the ES conf then you sill need to restart the cluster. Use  the 'es_rolling_restart' playbook."
   when: copy_elasticsearch_conf_result.changed


### PR DESCRIPTION
Noticed as part of recent maintenance that when run with `--tags=es_conf`, a change to elasticsearch's .service file made by the previous task does not cause a service reload like it should.

##### Environments Affected
none in particular
