### PR TITLE
disable inline script updates in elasticsearch

### DIFF
--- a/src/commcare_cloud/ansible/roles/elasticsearch/templates/config/elasticsearch.yml.j2
+++ b/src/commcare_cloud/ansible/roles/elasticsearch/templates/config/elasticsearch.yml.j2
@@ -87,7 +87,6 @@ indices.fielddata.cache.size:  {{ elasticsearch_fielddata_cache_size }}
 # somewhat of a security risk but required by pact custom reports
 script.engine.groovy.inline.aggs: true
 script.engine.groovy.inline.search: true
-script.engine.groovy.inline.update: true
 {% endif %}
 {% endif %}
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Since we have reindexed all the environments, now we don't need to enable inline script updates on our cluster
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All

Will run deploy-stack on all environments to disable the it.

