### PR TITLE
Use subprocess.run instead of check_output

### DIFF
--- a/src/commcare_cloud/commands/terraform/aws.py
+++ b/src/commcare_cloud/commands/terraform/aws.py
@@ -40,6 +40,19 @@ def check_output(cmd_parts, env, silent=False):
     return subprocess.check_output(cmd_parts, env=env_vars)
 
 
+def run(cmd_parts, env, silent=False):
+
+    env_vars = os.environ.copy()
+    env_vars.update(env)
+    if not silent:
+        cmd = ' '.join(shlex_quote(arg) for arg in cmd_parts)
+        print_command('{} {}'.format(
+            ' '.join('{}={}'.format(key, value) for key, value in env.items()),
+            cmd,
+        ))
+    return subprocess.run(cmd_parts, env=env_vars)
+
+
 def aws_cli(environment, cmd_parts):
 
     return json.loads(
@@ -627,7 +640,7 @@ def _has_valid_session_credentials_for_sso():
 
 
 def _refresh_sso_credentials(aws_session_profile):
-    check_output(['aws', 'sso', 'login'], env={'AWS_PROFILE': aws_session_profile})
+    run(['aws', 'sso', 'login'], env={'AWS_PROFILE': aws_session_profile})
 
 
 def _has_valid_v1_session_credentials(aws_profile):

--- a/src/commcare_cloud/commands/terraform/aws.py
+++ b/src/commcare_cloud/commands/terraform/aws.py
@@ -50,7 +50,8 @@ def run(cmd_parts, env, silent=False):
             ' '.join('{}={}'.format(key, value) for key, value in env.items()),
             cmd,
         ))
-    return subprocess.run(cmd_parts, env=env_vars)
+    # check=True to raise error if results in non-zero exit status
+    return subprocess.run(cmd_parts, env=env_vars, check=True)
 
 
 def aws_cli(environment, cmd_parts):

--- a/src/commcare_cloud/commands/terraform/aws.py
+++ b/src/commcare_cloud/commands/terraform/aws.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import, print_function, unicode_literals
 import json
 import os
 import subprocess
-import textwrap
 from datetime import datetime
 from dateutil import parser
 import pytz
@@ -103,7 +102,6 @@ def get_aws_resources(environment):
         "--output", "json",
         "--region", config.region,
     ])]
-
 
     nlb_endpoints = aws_cli(environment, [
         'aws', 'elbv2', 'describe-load-balancers',
@@ -428,7 +426,10 @@ def _aws_sign_in_with_sso(environment):
     aws_session_profile = '{}:session'.format(environment.terraform_config.aws_profile)
     # todo: add `... or if _date_modified(AWS_CONFIG_PATH) > _date_modified(AWS_CREDENTIALS_PATH)`
     if not _has_profile_for_sso(aws_session_profile):
-        puts(color_notice("Configuring SSO. To further customize, run `aws configure sso --profile {}`".format(aws_session_profile)))
+        puts(color_notice(
+            "Configuring SSO. To further customize, run `aws configure sso "
+            "--profile {}`".format(
+                aws_session_profile)))
         _write_profile_for_sso(
             aws_session_profile,
             sso_start_url=environment.aws_config.sso_config.sso_start_url,


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-14935

AWS sso login recently changed to include a verification code to ensure the device that requested the login is the same as the one you are allowing authentication for. We used `check_output` to call `aws sso login`, which swallows the output and does not wait for the command to finish, meaning users could not verify the matching code. By switching to `subprocess.run`, we are able to see the command output as if running it directly, and therefore can verify the code.
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None
