### PR TITLE
Re-enable compressing formplayer DBs on production

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -67,6 +67,7 @@ filebeat_inputs:
     tags: nginx-error
 
 formplayer_java_version: "{{ java_17_bin_path }}/java"
+formplayer_archive_time_spec: '3d'
 formplayer_purge_time_spec: '10d'
 formplayer_sensitive_data_logging: true
 formplayer_forward_ip_proxy: true


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-14929

During COVID times, we [disabled formplayer DB compression](https://github.com/dimagi/commcare-cloud/pull/3997) as a tradeoff to increase performance (decompressing the database takes time). We now find ourselves in a steadier state, but disk usage across formplayer machines is nearing its limit. There are quite a few very large user DBs, so the hope is that by reintroducing this compression, we will free up enough disk space to make a meaningful difference.

We chose 3 days as the inactive threshold to ensure a more random distribution of decompressing DBs. We wanted to avoid "stampede effects", where users log on at the same time every morning and have to wait for their DB to be decompressed, or similarly log on Monday morning after the weekend. 3 days is hopefully large enough to avoid this, but small enough to actually have an impact.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production
