### PR TITLE
Set default ansible-galaxy url to legacy format endpoint

### DIFF
--- a/src/commcare_cloud/ansible/ansible.cfg
+++ b/src/commcare_cloud/ansible/ansible.cfg
@@ -24,3 +24,6 @@ pipelining = True
 
 [inventory]
 enable_plugins = ini, csv
+
+[galaxy]
+server = https://old-galaxy.ansible.com/


### PR DESCRIPTION
as recommended in https://github.com/ansible/awx/issues/14496. Fixes an incompatability with a change from today

Discovered from the broken build in https://github.com/dimagi/commcare-cloud/pull/6117.

##### Environments Affected
None
