### PR TITLE
revert target nodes in couch target groups in load balancer

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -615,8 +615,8 @@ internal_albs:
     health_check_interval: 30
     targets:
       - couch11-production
+      - couch12-production
       - couch_a0-production
-      - couch_a1-production
 
 elasticache_cluster:
   create: yes


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Reverts one change done in https://github.com/dimagi/commcare-cloud/pull/6117, adds back `couch12` to target groups to match the state of production.
More details in https://dimagi-dev.atlassian.net/browse/SAAS-14844?focusedCommentId=290024
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production
