### PR TITLE
Downsizing django_manage from m6a.xlarge_to_r6a.large in production

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -36,7 +36,7 @@ servers:
     os: jammy 
 
   - server_name: "djangomanage_a1-production"
-    server_instance_type: m6a.xlarge
+    server_instance_type: r6a.large
     network_tier: "app-private"
     az: "a"
     volume_size: 60


### PR DESCRIPTION
**Ticket :** https://dimagi-dev.atlassian.net/browse/SAAS-15020 

**Environments Affected :** production