### PR TITLE
Fix readthedocs - Add python version

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,6 +3,9 @@
 version: 2
 build:
   os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
 sphinx:
   configuration: docs/source/conf.py
 formats: all


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
I thought tools might not be required in https://github.com/dimagi/commcare-cloud/pull/6158, but it seems it is required in the doc config.

