### PR TITLE
Add nosearch directive for incomplete scaling docs

### DIFF
--- a/docs/source/scaling/2-webworkers.rst
+++ b/docs/source/scaling/2-webworkers.rst
@@ -1,3 +1,5 @@
+:nosearch:
+
 Webworkers
 ==========
 

--- a/docs/source/scaling/3-postgres.rst
+++ b/docs/source/scaling/3-postgres.rst
@@ -1,3 +1,5 @@
+:nosearch:
+
 PostgreSQL
 ==========
 

--- a/docs/source/scaling/4-redis.rst
+++ b/docs/source/scaling/4-redis.rst
@@ -1,3 +1,5 @@
+:nosearch:
+
 Redis
 =====
 

--- a/docs/source/scaling/5-elasticsearch.rst
+++ b/docs/source/scaling/5-elasticsearch.rst
@@ -1,3 +1,5 @@
+:nosearch:
+
 Elasticsearch
 =============
 

--- a/docs/source/scaling/6-sizing-buckets.rst
+++ b/docs/source/scaling/6-sizing-buckets.rst
@@ -1,3 +1,5 @@
+:nosearch:
+
 .. _sizing-buckets:
 
 Sizing Buckets


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
I noticed these docs appeared when searching for "elasticsearch" in commcare-cloud docs. Given these docs are incomplete, we should prevent them from appearing in the search results. Adding the `:nosearch:` directive seems to do the trick. See https://www.sphinx-doc.org/en/master/usage/restructuredtext/field-lists.html for more info on this directive.

Before:
![Screenshot from 2023-11-06 11-58-44](https://github.com/dimagi/commcare-cloud/assets/15785053/8b70d825-09a7-4f3d-869e-f6b07257ebb5)

After:
![Screenshot from 2023-11-06 12-01-15](https://github.com/dimagi/commcare-cloud/assets/15785053/0ca01056-1c55-4326-9b23-0c1c9368ca1e)

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None
