### PR TITLE
Fixed Improper Method Call: Replaced `mktemp`

### DIFF
--- a/src/commcare_cloud/commands/terraform/terraform_migrate_state.py
+++ b/src/commcare_cloud/commands/terraform/terraform_migrate_state.py
@@ -123,7 +123,8 @@ class RemoteMigrationStateManager(object):
         wrapped as as a RemoteMigrationState object.
         """
 
-        temp_filename = tempfile.mktemp()
+        temp_fd, temp_filename = tempfile.mkstemp()
+        os.close(temp_fd)
         try:
 
             try:
@@ -151,7 +152,8 @@ class RemoteMigrationStateManager(object):
         AWS_PROFILE={aws_profile} aws s3 cp {tempfile} s3://{state_bucket}/migration-state/{environment}.json
         after dumping the object to tempfile
         """
-        temp_filename = tempfile.mktemp()
+        temp_fd, temp_filename = tempfile.mkstemp()
+        os.close(temp_fd)
         try:
             with open(temp_filename, 'w', encoding='utf-8') as f:
                 json.dump(remote_migration_state.to_json(), f)


### PR DESCRIPTION
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->

##### Announce New Release
<!-- 
Review https://github.com/dimagi/commcare-cloud/tree/master/changelog#determining-whether-a-change-is-announce-worthy
to determine if a changelog entry is necessary if not already created.
-->
<!-- Delete this section if the PR does not contain any new changelog entries -->
- [ ] After merging, I will follow [these instructions](https://confluence.dimagi.com/display/saas/Announcing+changes+affecting+third+parties#Announcingchangesaffectingthirdparties-announcing)
to announce a new commcare-cloud release. 

## Details
While triaging your project, our bug fixing tool generated the following message(s)-

> In file: [terraform_migrate_state.py](https://github.com/dimagi/commcare-cloud/blob/master/src/commcare_cloud/commands/terraform/terraform_migrate_state.py#L126), there is a method that creates a temporary file using an unsafe API `mktemp`. The use of this method is discouraged in the [Python documentation](https://docs.python.org/3/library/tempfile.html#tempfile.mktemp). iCR suggested that a temporary file should be created using `mkstemp` which is a [safe API](https://docs.python.org/3/library/tempfile.html#tempfile.mkstemp). iCR replaced the usage of mktemp with `mkstemp`.


## Changes
Replaced `mktemp()` method with a `mkstemp()` and closed the file-descriptors associated with it.


## Testing
I ran `nosetests` after creating a virtualenv and running `pip install -e .[test]`. I got `AttributeError: __enter__` in all of the FAILED tests.


## Previously Found & Fixed
- https://www.github.com/invesalius/invesalius3/pull/679
- https://www.github.com/Azure/azure-linux-extensions/pull/1816
- https://www.github.com/celery/billiard/pull/394


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
\- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.

