### PR TITLE
Add MAX_MOBILE_UCR_LIMIT of 2 to staging settings

### DIFF
--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -161,6 +161,7 @@ localsettings:
     repeaters: repeaters
   LOCAL_MIDDLEWARE:
     - 'django.middleware.security.SecurityMiddleware'
+  MAX_MOBILE_UCR_LIMIT: 2
   PILLOWTOP_MACHINE_ID: staging-hqdb0-ubuntu
   ALLOW_PHONE_AS_DEFAULT_TWO_FACTOR_DEVICE: True
   RATE_LIMIT_SUBMISSIONS: yes


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/QA-5808

The use of this setting hasn't been deployed to any environments yet, but I want to set it to 2 for staging to test the change with QA. See the ticket above for more context.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Staging