### PR TITLE
Downsizing pgshard1-production from db.m5.2xlarge to db.m5.xlarge

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -437,7 +437,7 @@ rds_instances:
       max_connections: "LEAST({DBInstanceClassMemory/9531392},5000)"
 
   - identifier: "pgshard1-production"
-    instance_type: "db.m5.2xlarge"
+    instance_type: "db.m5.xlarge"
     storage: 750
     max_storage: 2500
     storage_type: gp3


### PR DESCRIPTION
**Ticket:** https://dimagi-dev.atlassian.net/browse/SAAS-15129

**Environments Affected:** Production