### PR TITLE
Allow terraform destroy for backup-production enviroment

### DIFF
--- a/src/commcare_cloud/commands/terraform/terraform.py
+++ b/src/commcare_cloud/commands/terraform/terraform.py
@@ -53,12 +53,12 @@ class Terraform(CommandBase):
     )
 
     def run(self, args, unknown_args):
-        if 'destroy' in unknown_args:
+        environment = get_environment(args.env_name)
+        if 'destroy' in unknown_args and environment.name != 'backup-production':
             puts(color_error("Refusing to run a terraform command containing the argument 'destroy'."))
             puts(color_error("It's simply not worth the risk."))
             exit(-1)
 
-        environment = get_environment(args.env_name)
         run_dir = environment.paths.get_env_file_path('.generated-terraform')
         modules_dir = os.path.join(TERRAFORM_DIR, 'modules')
         modules_dest = os.path.join(run_dir, 'modules')


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
We generally don't allow `destroy` in any of the environments. This came out during destroying `backup-production` environment, destroying backup env with terraform is much cleaner as compared to deleting stuff manually from AWS console. So this PR attempts to allow destroy with  only `backup-production` enviroment.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
`backup-production`
