### PR TITLE
Add defaults for route table

### DIFF
--- a/src/commcare_cloud/terraform/modules/network/main.tf
+++ b/src/commcare_cloud/terraform/modules/network/main.tf
@@ -98,7 +98,16 @@ resource "aws_route_table" "private" {
   vpc_id = aws_vpc.main.id
 
   dynamic "route" {
-    for_each = var.external_routes
+    for_each = concat(
+      tolist([
+        tomap({
+          cidr_block = "0.0.0.0/0",
+          nat_gateway_id = aws_nat_gateway.main.id,
+        }),
+      ]),
+      var.external_routes,
+    )
+
     content {
       # TF-UPGRADE-TODO: The automatic upgrade tool can't predict
       # which keys might be set in maps assigned here, so it has
@@ -129,7 +138,15 @@ resource "aws_route_table" "public" {
   vpc_id = aws_vpc.main.id
 
   dynamic "route" {
-    for_each = var.external_routes
+    for_each = concat(
+      tolist([
+        tomap({
+          cidr_block = "0.0.0.0/0",
+          "gateway_id" = aws_internet_gateway.main.id,
+        }),
+      ]),
+      var.external_routes,
+    )
     content {
       # TF-UPGRADE-TODO: The automatic upgrade tool can't predict
       # which keys might be set in maps assigned here, so it has


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-14154
During the terraform upgrade to 0.12, the defaults were accidently removed, this PR attempts to fix that.

See the comment - https://github.com/dimagi/commcare-cloud/pull/4849/files#r1023369662

The changes have been tested out while setting up backup-production environment recently.
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All
