### PR TITLE
Add WAF rules for Rich Text Emails

### DIFF
--- a/src/commcare_cloud/commands/terraform/constants.py
+++ b/src/commcare_cloud/commands/terraform/constants.py
@@ -28,6 +28,9 @@ COMMCAREHQ_XML_POST_URLS_REGEX = r"""
 ^/a/([\w\.:-]+)/fixtures/fixapi/
 ^/a/([\w\.:-]+)/importer/excel/bulk_upload_api/$
 ^/a/([\w\.:-]+)/importer/excel/config/$
+^/a/([\w\.:-]+)/messaging/broadcasts/add/$
+^/a/([\w\.:-]+)/messaging/conditional/add/$
+^/a/([\w\.:-]+)/messaging/conditional/edit/([\w-]+)/$
 ^/a/([\w\.:-]+)/receiver/$
 ^/a/([\w\.:-]+)/receiver/([\w-]+)/$
 ^/a/([\w\.:-]+)/receiver/api/$

--- a/src/commcare_cloud/commands/terraform/constants.py
+++ b/src/commcare_cloud/commands/terraform/constants.py
@@ -48,6 +48,7 @@ COMMCAREHQ_XML_POST_URLS_REGEX = r"""
 ^/formplayer/validate_form$
 ^/gvi/api/sms/$
 ^/jserror/$
+^/log_email_event/([\w]+)/([\w\.:-]+)/?$
 ^/log_email_event/([\w]+)/?$
 ^/telerivet/in/?$
 ^/telerivet/status/([\w\-]+)/$


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://github.com/dimagi/commcare-hq/pull/33798
https://docs.google.com/document/d/1TXplH3kNAONMWRmOWoObApzBtyniIehsxX6Ehc_jGho/edit

This adds WAF rules for Rich Text emails which save HTML from the frontend. 

It also adds an extra WAF rule that seems to not have been taken into account before. 

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production



