### PR TITLE
Revert to larger pgshard nodes using m6g where cost-optimal

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -479,7 +479,7 @@ rds_instances:
       max_connections: "LEAST({DBInstanceClassMemory/9531392},5000)"
 
   - identifier: "pgshard1-production"
-    instance_type: "db.m6g.xlarge"
+    instance_type: "db.m6g.2xlarge"
     storage: 750
     max_storage: 2500
     storage_type: gp3
@@ -494,7 +494,7 @@ rds_instances:
       max_connections: "LEAST({DBInstanceClassMemory/9531392},5000)"
 
   - identifier: "pgshard2-production"
-    instance_type: "db.m5.xlarge"
+    instance_type: "db.m6g.2xlarge"
     storage: 750
     max_storage: 2500
     storage_type: gp3
@@ -509,7 +509,7 @@ rds_instances:
       max_connections: "LEAST({DBInstanceClassMemory/9531392},5000)"
 
   - identifier: "pgshard3-production"
-    instance_type: "db.m5.xlarge"
+    instance_type: "db.m5.2xlarge"
     storage: 750
     max_storage: 2500
     storage_type: gp3


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-15129

We're unhappy with the performance of the smaller configuration (`db.m*.xlarge`) so we're going to revert to the original larger one (`db.m*.2xlarge`). The use of m6g for some machines but not others is intentionally chosen to optimize our RI usage.

##### Environments Affected
production
