### PR TITLE
Reuse maintenance window check for formplayer deploys

### DIFF
--- a/src/commcare_cloud/commands/deploy/commcare.py
+++ b/src/commcare_cloud/commands/deploy/commcare.py
@@ -1,8 +1,6 @@
 import shlex
 from datetime import datetime, timedelta
 
-import pytz
-
 from commcare_cloud.alias import commcare_cloud
 from commcare_cloud.cli_utils import ask
 from commcare_cloud.colors import color_error, color_notice, color_summary
@@ -19,7 +17,7 @@ from commcare_cloud.commands.deploy.utils import (
     record_deploy_start,
     announce_deploy_success,
     create_release_tag,
-    within_maintenance_window,
+    confirm_environment_time,
     DeployContext,
     record_deploy_failed,
 )
@@ -115,7 +113,7 @@ def confirm_deploy(environment, deploy_revs, rev_diffs, args):
 
     if not (
         _confirm_translated(environment, quiet=args.quiet)
-        and _confirm_environment_time(environment, quiet=args.quiet)
+        and confirm_environment_time(environment, quiet=args.quiet)
     ):
         return False
 
@@ -176,19 +174,6 @@ def _confirm_translated(environment, quiet=False):
         'and review and merge the latest automated "Update Translations" pull request.\n',
         quiet=quiet
     )
-
-
-def _confirm_environment_time(environment, quiet=False):
-    if within_maintenance_window(environment):
-        return True
-    window = environment.fab_settings_config.acceptable_maintenance_window
-    d = datetime.now(pytz.timezone(window['timezone']))
-    message = (
-        "Whoa there bud! You're deploying '%s' outside the configured maintenance window. "
-        "The current local time is %s.\n"
-        "ARE YOU DOING SOMETHING EXCEPTIONAL THAT WARRANTS THIS?"
-    ) % (environment.name, d.strftime("%-I:%M%p on %h. %d %Z"))
-    return ask(message, quiet=quiet)
 
 
 def _print_same_code_warning(code_branch):

--- a/src/commcare_cloud/commands/deploy/formplayer.py
+++ b/src/commcare_cloud/commands/deploy/formplayer.py
@@ -13,8 +13,14 @@ from commcare_cloud.commands.ansible import ansible_playbook
 from commcare_cloud.commands.ansible.helpers import AnsibleContext
 from commcare_cloud.commands.deploy.deploy_diff import DeployDiff
 from commcare_cloud.commands.deploy.sentry import update_sentry_post_deploy
-from commcare_cloud.commands.deploy.utils import record_deploy_start, record_deploy_failed, \
-    announce_deploy_success, create_release_tag, DeployContext
+from commcare_cloud.commands.deploy.utils import (
+    announce_deploy_success,
+    confirm_environment_time,
+    create_release_tag,
+    record_deploy_start,
+    record_deploy_failed,
+    DeployContext
+)
 from commcare_cloud.user_utils import get_default_username
 from commcare_cloud.commands.utils import timeago
 from commcare_cloud.events import publish_deploy_event
@@ -47,6 +53,10 @@ class VersionInfo(namedtuple("VersionInfo", "commit, message, time, build_time")
 
 
 def deploy_formplayer(environment, args):
+    if not confirm_environment_time(environment, quiet=args.quiet):
+        print(color_notice("Aborted by user"))
+        return 1
+
     print(color_notice("\nPreparing to deploy Formplayer to: "), end="")
     print(f"{environment.name}\n")
 

--- a/src/commcare_cloud/commands/deploy/utils.py
+++ b/src/commcare_cloud/commands/deploy/utils.py
@@ -56,8 +56,8 @@ def record_deploy_start(environment, context):
 def send_deploy_start_email(environment, context):
     is_nonstandard_deploy_time = not within_maintenance_window(environment)
     is_non_default_branch = (
-        context.revision != environment.fab_settings_config.default_branch and
-        context.revision is not None
+        context.revision != environment.fab_settings_config.default_branch
+        and context.revision is not None
     )
     env_name = environment.meta_config.deploy_env
     subject = f"{context.user} has initiated a {context.service_name} deploy to {env_name}"

--- a/src/commcare_cloud/commands/deploy/utils.py
+++ b/src/commcare_cloud/commands/deploy/utils.py
@@ -6,6 +6,7 @@ import pytz
 from memoized import memoized
 
 from commcare_cloud.alias import commcare_cloud
+from commcare_cloud.cli_utils import ask
 from commcare_cloud.colors import color_summary, color_error
 from commcare_cloud.commands.deploy.slack import notify_slack_deploy_start, notify_slack_deploy_end
 from commcare_cloud.user_utils import get_default_username
@@ -125,6 +126,20 @@ def send_email(environment, subject, message='', to_admins=True, recipients=None
             *args,
             show_command=False
         )
+
+
+def confirm_environment_time(environment, quiet=False):
+    if within_maintenance_window(environment):
+        return True
+    window = environment.fab_settings_config.acceptable_maintenance_window
+    d = datetime.now(pytz.timezone(window['timezone']))
+    message = (
+        "Whoa there bud! You're deploying '%s' outside the configured maintenance window. "
+        "The current local time is %s.\n"
+        "ARE YOU DOING SOMETHING EXCEPTIONAL THAT WARRANTS THIS?"
+    ) % (environment.name, d.strftime("%-I:%M%p on %h. %d %Z"))
+    return ask(message, quiet=quiet)
+
 
 def within_maintenance_window(environment):
     window = environment.fab_settings_config.acceptable_maintenance_window


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
I deployed formplayer at a non ideal time, and realized the existing maintenance window check we have for commcare deploys is not used for formplayer. This PR reuses that code for formplayer deploys as well.

Tested on production:
![image](https://github.com/dimagi/commcare-cloud/assets/15785053/332a3f49-10e0-4704-ab3e-ae6ce64ed34e)


##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None
