### PR TITLE
Update quick_monolith_install script with settings for Ubuntu 22.04

### DIFF
--- a/quick_monolith_install/sample-environment/postgresql.yml
+++ b/quick_monolith_install/sample-environment/postgresql.yml
@@ -11,10 +11,7 @@ postgres_override:
   postgresql_max_stack_depth: 4MB
   postgresql_shared_buffers: 1GB
 
+SEPARATE_FORM_PROCESSING_DBS: False
+
 dbs:
-  form_processing:
-    partitions:
-      p1:
-        shards: [0, 511]
-      p2:
-        shards: [512, 1023]
+  form_processing: null

--- a/quick_monolith_install/sample-environment/public.yml.j2
+++ b/quick_monolith_install/sample-environment/public.yml.j2
@@ -5,6 +5,9 @@ elasticsearch_cluster_name: '{{env_name}}-es'
 elasticsearch_version: 2.4.6
 elasticsearch_download_sha256: 5f7e4bb792917bb7ffc2a5f612dfec87416d54563f795d6a70637befef4cfc6f.
 
+formplayer_java_version: {% raw %}"{{ java_17_bin_path }}/java"
+{% endraw %}
+
 backup_blobdb: True
 backup_postgres: 'plain'
 backup_es_s3: False

--- a/quick_monolith_install/sample-environment/public.yml.j2
+++ b/quick_monolith_install/sample-environment/public.yml.j2
@@ -27,6 +27,7 @@ couchdb_cluster_settings:
   n: 1
 
 couchdb_use_haproxy: True
+haproxy_version: 2.4
 couch_dbs:
   default:
     host: 127.0.0.1


### PR DESCRIPTION
This change only affects the quick_monolith_install script. It follows on from #6201

It updates the environment settings for running a monolith on Ubuntu 22.04, and aligns with corresponding updates to the sample environment config [here](https://github.com/dimagi/sample-environment/pull/16) and [here](https://github.com/dimagi/sample-environment/pull/18).

##### Environments Affected
None
