### PR TITLE
Fix Sphinx version error

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx==4.3.2
-sphinx-rtd-theme==1.0.0
-myst_parser==0.17.2
+Sphinx==7.2.6
+sphinx-rtd-theme==2.0.0
+myst-parser==2.0.0


### PR DESCRIPTION
Updates to ReadTheDocs are failing because
```
Sphinx version error:
The sphinxcontrib.applehelp extension used by this project needs at least Sphinx v5.0; it therefore cannot be built with this version.
```

More context: https://readthedocs.org/projects/commcare-cloud/builds/23167204/

##### Environments Affected

None. Affects docs only.
