### PR TITLE
Register different variable names depending on kafka version (wipe_kafka.yml)

### DIFF
--- a/src/commcare_cloud/ansible/wipe_kafka.yml
+++ b/src/commcare_cloud/ansible/wipe_kafka.yml
@@ -23,31 +23,35 @@
     - name: Get PostgreSQL defaults
       include_vars: roles/kafka/defaults/main.yml
 
+    - name: Get Kafka topics (version <= 0.9)
+      command: "/opt/kafka/bin/kafka-topics.sh --list --zookeeper localhost:{{ zookeeper_client_port }}"
+      register: topics_result_0_9
+      check_mode: no
+      when: kafka_version is version('0.9', '<=')
+
     - name: Get Kafka topics (version > 0.9 and < 3.x)
       command: "/opt/kafka/bin/kafka-topics.sh --list --exclude-internal --zookeeper localhost:{{ zookeeper_client_port }}"
-      register: topics_result
+      register: topics_result_1_to_3
       check_mode: no
       when: (kafka_version is version('0.9', '>')) and (kafka_version is version('3.0', '<'))
 
     - name: Get Kafka topics (version >= 3.0)
       command: "/opt/kafka/bin/kafka-topics.sh --list --exclude-internal -bootstrap-server localhost:9092"
-      register: topics_result
+      register: topics_result_3_0
       check_mode: no
       when: kafka_version is version('3.0', '>=')
 
-    - name: Get Kafka topics (version <= 0.9)
-      command: "/opt/kafka/bin/kafka-topics.sh --list --zookeeper localhost:{{ zookeeper_client_port }}"
-      register: topics_result
-      check_mode: no
+    - set_fact:
+        topics_for_delete: "{{ topics_result_0_9.stdout_lines | difference(kafka_internal_topics) }}"
       when: kafka_version is version('0.9', '<=')
 
     - set_fact:
-        topics_for_delete: "{{ topics_result.stdout_lines }}"
-      when: kafka_version is version('0.9', '>')
+        topics_for_delete: "{{ topics_result_1_to_3.stdout_lines }}"
+      when: (kafka_version is version('0.9', '>')) and (kafka_version is version('3.0', '<'))
 
     - set_fact:
-        topics_for_delete: "{{ topics_result.stdout_lines | difference(kafka_internal_topics) }}"
-      when: kafka_version is version('0.9', '<=')
+        topics_for_delete: "{{ topics_result_3_0.stdout_lines }}"
+      when: kafka_version is version('3.0', '>=')
 
     - name: Allow Kafka server to delete topics
       lineinfile:


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Even when a task is skipped, information is still registered to the specified variable, which means this previously only worked for versions of kafka <= 0.9, since that was the last task to update `kafka_output`.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None