### PR TITLE
Sync couch views happens as part of migrate_multi now

### DIFF
--- a/src/commcare_cloud/ansible/migrate_on_fresh_install.yml
+++ b/src/commcare_cloud/ansible/migrate_on_fresh_install.yml
@@ -2,14 +2,6 @@
   hosts: "{{ groups.webworkers.0 }}"
   become: true
   tasks:
-    - name: Sync couch views
-      become: yes
-      become_user: "{{ cchq_user }}"
-      django_manage:
-        command: 'sync_couch_views'
-        app_path: "{{ code_home }}"
-        virtualenv: "{{ virtualenv_home }}"
-      when: CCHQ_IS_FRESH_INSTALL is defined and CCHQ_IS_FRESH_INSTALL
     - name: Migrate DB
       become: yes
       become_user: "{{ cchq_user }}"


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
We have a RequestReindex command that is used in a migration to specify that couch views should be reindexed. On fresh install, this will run because of [this migration](https://github.com/dimagi/commcare-hq/blob/master/corehq/preindex/migrations/0001_initial.py).

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None