### PR TITLE
Remove obsolete command `ptop_es_manage`

### DIFF
--- a/docs/source/installation/migration/1-migrating-project.rst
+++ b/docs/source/installation/migration/1-migrating-project.rst
@@ -157,7 +157,6 @@ before importing data from the old environment.
 
   * Rebuild the indices with the new data
     ``./manage.py ptop_preindex``
-    ``./manage.py ptop_es_manage --flip_all_aliases``
 
 * Print the database numbers and compare them to the values obtained previously
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
A small doc fix that removes the command that do not exist anymore and is not required.
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All