### PR TITLE
Add removing kafka data for debugging kafka issues

### DIFF
--- a/docs/source/reference/howto/wipe_persistent_data.rst
+++ b/docs/source/reference/howto/wipe_persistent_data.rst
@@ -134,4 +134,5 @@ Issues with check_services
     
      $ cchq monolith service kafka stop
      $ rm -rf /var/lib/zookeeper/*
+     $ rm -rf /opt/data/kafka/data/*
      $ cchq monolith service kafka restart


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
This line is also necessary when "resetting" kafka once it has gotten into a broken state. I don't love that I hard code the paths here since theoretically a self hoster could setup a different path, but hopefully they would be aware of that and able to make the necessary change for their own system.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None
