### PR TITLE
Decrease to 1 to see if rabbit still closes connection

### DIFF
--- a/environments/india/app-processes.yml
+++ b/environments/india/app-processes.yml
@@ -15,7 +15,7 @@ celery_processes:
   celery8,celery9:
     reminder_queue:
       pooling: gevent
-      concurrency: 20
+      concurrency: 1
     submission_reprocessing_queue:
       concurrency: 1
     sms_queue:


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi.atlassian.net/browse/SAAS-15294

Attempting to see if decreasing concurrency will change the behavior currently observed.

Planning to run `cchq --control india update-supervisor-confs --branch=gh/celery/increase-reminder-queue-concurrency-again --limit=celery`
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
