### PR TITLE
Update COMMCARE_ANALYTICS_HOST for staging to point to the staging host

### DIFF
--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -127,7 +127,7 @@ localsettings:
   BANK_NAME: "RBS Citizens N.A."
   BANK_SWIFT_CODE: 'CTZIUS33'
   CELERY_PERIODIC_QUEUE: 'celery_null'
-  COMMCARE_ANALYTICS_HOST: "http://commcare-analytics-demo.dimagi.com"
+  COMMCARE_ANALYTICS_HOST: "https://commcare-analytics-staging.dimagi.com"
   COUCH_CACHE_DOCS: True
   COUCH_CACHE_VIEWS: True
   COUCH_PASSWORD: "{{ COUCH_PASSWORD }}"


### PR DESCRIPTION
No ticket, I just noticed that the link to the analytics server is broken. We have a staging instance, but staging doesn't point to that. This update should fix this.

##### Environments Affected
Staging

##### Announce New Release
No announcement needed, since this is staging
