### PR TITLE
[India] Set broker heartbeat to match timeout specified in rabbitmq.conf

### DIFF
--- a/environments/india/public.yml
+++ b/environments/india/public.yml
@@ -122,7 +122,7 @@ localsettings:
   BANK_ADDRESS: { 'first_line': "1 Citizens Drive", 'city': "Riverside", 'region': "RI", 'postal_code': "02915" }
   BANK_NAME: "RBS Citizens N.A."
   BANK_SWIFT_CODE: 'CTZIUS33'
-  BROKER_HEARTBEAT: 600
+  CELERY_BROKER_HEARTBEAT: 600
 #  COUCH_CACHE_DOCS:
 #  COUCH_CACHE_VIEWS:
   CONNECTID_URL: 'https://connectid.dimagi.com/o/userinfo'

--- a/environments/india/public.yml
+++ b/environments/india/public.yml
@@ -122,6 +122,7 @@ localsettings:
   BANK_ADDRESS: { 'first_line': "1 Citizens Drive", 'city': "Riverside", 'region': "RI", 'postal_code': "02915" }
   BANK_NAME: "RBS Citizens N.A."
   BANK_SWIFT_CODE: 'CTZIUS33'
+  BROKER_HEARTBEAT: 600
 #  COUCH_CACHE_DOCS:
 #  COUCH_CACHE_VIEWS:
   CONNECTID_URL: 'https://connectid.dimagi.com/o/userinfo'

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -396,6 +396,9 @@ CELERY_BROKER_WRITE_URL = BROKER_WRITE_URL = '{{ BROKER_URL }}'
 {% else %}
 CELERY_BROKER_URL = BROKER_URL = '{{ BROKER_URL }}'
 {% endif %}
+{% if 'BROKER_HEARTBEAT' in localsettings and localsettings.BROKER_HEARTBEAT %}
+BROKER_HEARTBEAT = '{{ localsettings.BROKER_HEARTBEAT }}'
+{% endif %}
 CELERY_HEARTBEAT_THRESHOLDS = {
 {% for queue, threshold in CELERY_HEARTBEAT_THRESHOLDS.items() | sort %}
     {{ queue | to_json }}: {% if threshold == None %}None{% else %}{{ threshold | to_json }}{% endif %},

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -396,8 +396,8 @@ CELERY_BROKER_WRITE_URL = BROKER_WRITE_URL = '{{ BROKER_URL }}'
 {% else %}
 CELERY_BROKER_URL = BROKER_URL = '{{ BROKER_URL }}'
 {% endif %}
-{% if 'BROKER_HEARTBEAT' in localsettings and localsettings.BROKER_HEARTBEAT %}
-BROKER_HEARTBEAT = '{{ localsettings.BROKER_HEARTBEAT }}'
+{% if 'CELERY_BROKER_HEARTBEAT' in localsettings and localsettings.CELERY_BROKER_HEARTBEAT %}
+CELERY_BROKER_HEARTBEAT = '{{ localsettings.CELERY_BROKER_HEARTBEAT }}'
 {% endif %}
 CELERY_HEARTBEAT_THRESHOLDS = {
 {% for queue, threshold in CELERY_HEARTBEAT_THRESHOLDS.items() | sort %}


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi.atlassian.net/browse/SAAS-15294

We've been seeing timeout issues on the India environment, likely due to some long running tasks on the `reminder_queue`. My understanding is that [this code](https://github.com/dimagi/commcare-cloud/blob/3c579e8885e72346cfb91062fbd0e8436db470ae/src/commcare_cloud/ansible/roles/rabbitmq/templates/rabbitmq.conf.j2#L6-L6) sets the timeout on the server side (from rabbitmq's perspective), but the client (celery) also specifies a timeout value, and rabbit and celery agree to use the lower of the two values (docs [here](https://www.rabbitmq.com/heartbeats.html#heartbeats-timeout)).

So this PR's aim to specify the [broker_heartbeat](https://docs.celeryq.dev/en/v5.2.7/userguide/configuration.html#broker-heartbeat) value from celery's side so that rabbit and celery agree on a value of 600 seconds.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
India