### PR TITLE
Increase Indicator Queue Count Variable

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -232,6 +232,7 @@ localsettings:
   USER_REPORTING_METADATA_BATCH_ENABLED: True
   WS4REDIS_CONNECTION_HOST: "redis.production.commcare.local"
   CONNECTID_URL: 'https://connectid.dimagi.com/o/userinfo'
+  ASYNC_INDICATORS_TO_QUEUE: 20000
 
 # comment these two lines out to make a new rackspace machine
 commcare_cloud_root_user: ubuntu
@@ -256,5 +257,3 @@ shared_dir_gid: 1500
 # for better time syncronization on aws servers
 # replace ntp with chrony.
 use_chrony: True
-
-ASYNC_INDICATORS_TO_QUEUE: 20000

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -256,3 +256,5 @@ shared_dir_gid: 1500
 # for better time syncronization on aws servers
 # replace ntp with chrony.
 use_chrony: True
+
+ASYNC_INDICATORS_TO_QUEUE: 20000


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-3498).

This change is part of an urgent request to rebuild a UCR datasource. To help speed up the process, we are increasing the amount of indicators that can be queued to 20k (default is 10k).

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
production