### PR TITLE
Various documentation updates for data migration

### DIFF
--- a/docs/source/installation/migration/1-migrating-project.rst
+++ b/docs/source/installation/migration/1-migrating-project.rst
@@ -152,6 +152,8 @@ will be unable to submit forms or sync with the server.
 * Proceed to step 4.
 
 
+.. _import-data-into-environment:
+
 4. Import the data to the new environment
 -----------------------------------------
 

--- a/docs/source/installation/migration/2-migrating-instance.rst
+++ b/docs/source/installation/migration/2-migrating-instance.rst
@@ -5,7 +5,7 @@ Migrating an entire CommCare HQ instance
 
 This document describes high level steps to migrate an entire CommCare HQ instance from one set of servers
 to another set of servers.  If you are looking to migrate just a single project to a new environment
-please see :ref:`migrate-instance`. You can also use that method if you care about
+please see :ref:`migrate-project`. You can also use that method if you care about
 only a single project in your environment and don't need other projects.
 
 There are database and application services in a CommCare HQ instance. Only the data for database services need to be

--- a/docs/source/reference/howto/wipe_persistent_data.rst
+++ b/docs/source/reference/howto/wipe_persistent_data.rst
@@ -113,7 +113,7 @@ Start new environment
 
 .. note::
 
-   The following steps should only be run if you are not planning to migrate a project from an existing environment.
+   The following steps should only be run if you are **not** planning to migrate a project from an existing environment.
 
 
 #. End downtime (you will encounter a prompt that says no record of downtime was found, continue anyway as this starts services up).

--- a/docs/source/reference/howto/wipe_persistent_data.rst
+++ b/docs/source/reference/howto/wipe_persistent_data.rst
@@ -101,17 +101,21 @@ Rebuilding environment
 
       $ cchq <env_name> django-manage create_kafka_topics
 
-    .. note::
+.. warning::
 
-        If you are migrating a project to a new environment, you can return to the steps outlined in
-        `Import the data to the new environment <installation/migration/1-migrating-project.html#import-the-data-to-the-new-environment>`_.
-        Otherwise, you can continue with the following steps.
+    If you are migrating a project to a new environment, return to the steps outlined in
+    :ref:`import-data-into-environment`. Do not start services back up until you have finished loading
+    data into your new environment.
 
-#. Run a code deploy to start CommCare back up.
+
+Start services back up
+----------------------
+
+#. End downtime (you will encounter a prompt that says no record of downtime was found, continue anyway as this starts services up).
 
    .. code-block::
 
-      $ cchq <env_name> deploy
+      $ cchq <env_name> downtime end
 
 
 #. Recreate a superuser (where you substitute your address in place of

--- a/docs/source/reference/howto/wipe_persistent_data.rst
+++ b/docs/source/reference/howto/wipe_persistent_data.rst
@@ -108,8 +108,13 @@ Rebuilding environment
     data into your new environment.
 
 
-Start services back up
-----------------------
+Start new environment
+---------------------
+
+.. note::
+
+   The following steps should only be run if you are not planning to migrate a project from an existing environment.
+
 
 #. End downtime (you will encounter a prompt that says no record of downtime was found, continue anyway as this starts services up).
 
@@ -119,8 +124,7 @@ Start services back up
 
 
 #. Recreate a superuser (where you substitute your address in place of
-   "you@your.domain"). This is optional and should not be performed if
-   you are planning to migrate domain from other environment.
+   "you@your.domain").
 
    .. code-block::
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
I forgot I had https://github.com/dimagi/commcare-cloud/pull/6216 open which has some overlapping changes. I'm going to move forward with this one first, and then resolve the conflicts on that PR separately.

There were a couple of defective links that I resolved as well as making it more clear to readers that services should not be started back up until after loading data into the new environment. I also replaced the deploy step with a simple downtime end call because a deploy step is now included when starting the steps for rebuilding an environment.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None