### PR TITLE
Removed second run of build_requirejs from staticfiles_collect.yml

### DIFF
--- a/src/commcare_cloud/ansible/roles/deploy_hq/tasks/staticfiles_collect.yml
+++ b/src/commcare_cloud/ansible/roles/deploy_hq/tasks/staticfiles_collect.yml
@@ -27,5 +27,4 @@
     - collectstatic --noinput -v 0
     - fix_less_imports_collectstatic
     - compilejsi18n
-    - build_requirejs --bootstrap_version bootstrap5
     - build_requirejs


### PR DESCRIPTION
See https://github.com/dimagi/commcare-hq/pull/34346 - once that PR is merged, this can be merged.

Once this is merged, https://github.com/dimagi/commcare-hq/pull/34349 will drop the param from the script.

##### Environments Affected
None, this is a change to the deploy process

##### Announce New Release
This does not need to be announced