### PR TITLE
add custom properties to fomplayer config for DB connection pool

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -75,6 +75,9 @@ formplayer_forward_ip_proxy: true
 formplayer_detailed_tags:
   - form_name
   - module_name
+formplayer_custom_properties:
+  spring.datasource.hikari.maximum-pool-size: 20
+  spring.datasource.hikari.minimum-idle: 5
 
 KSPLICE_ACTIVE: yes
 

--- a/src/commcare_cloud/ansible/roles/formplayer/templates/application.properties.j2
+++ b/src/commcare_cloud/ansible/roles/formplayer/templates/application.properties.j2
@@ -65,3 +65,9 @@ server.forward-headers-strategy=NATIVE
 {% if formplayer_detailed_tags is defined %}
 detailed_tagging.tag_names={{ formplayer_detailed_tags|join(',') }}
 {% endif %}
+
+# Per-environment custom properties
+{% for key, value in formplayer_custom_properties.items() %}
+{{ key }}={{ value }}
+{% endfor %}
+```

--- a/src/commcare_cloud/ansible/roles/formplayer/vars/main.yml
+++ b/src/commcare_cloud/ansible/roles/formplayer/vars/main.yml
@@ -23,3 +23,7 @@ formplayer_release_name: '{{ release_name }}-{{ env_monitoring_id }}'
 # Instructs Spring Boot to process X-FORWARDED-FOR headers. Should be set if behind a 
 # trusted load balancer which forwards the original IP in headers.
 formplayer_forward_ip_proxy: false
+
+# Mapping to define custom properties to be set in the formplayer application.properties file
+# Override this in your environment file to set custom properties
+formplayer_custom_properties: {}


### PR DESCRIPTION
Change request: https://dimagi.atlassian.net/browse/SAAS-15447

Update DB connection pool configuration on production:

- maximum-pool-size
  - Change from the default of 10 to 20 to better handle peak usage
- minimum-idle
  - Change from the default of 10 to 5 to reduce off peak DB connections and connections from instances receiving less requests

Config options docs: https://github.com/brettwooldridge/HikariCP?tab=readme-ov-file#gear-configuration-knobs-baby

##### Environments Affected
Production