### PR TITLE
Enable datadog APM on production mobile_webworkers

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -1,5 +1,5 @@
 datadog_pythonagent: True
-django_command_prefix: ''
+django_command_prefix: '{{ virtualenv_home }}/bin/ddtrace-run '
 celery_command_prefix: ''
 gunicorn_workers_static_factor: 0
 gunicorn_workers_factor: 4

--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -1,5 +1,5 @@
 datadog_pythonagent: True
-django_command_prefix: '{{ virtualenv_home }}/bin/ddtrace-run '
+django_command_prefix: '{% if inventory_hostname in groups["mobile_webworkers"] %}{{ virtualenv_home }}/bin/ddtrace-run {% endif %}'
 celery_command_prefix: ''
 gunicorn_workers_static_factor: 0
 gunicorn_workers_factor: 4

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/webworkers.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/webworkers.yml
@@ -18,4 +18,5 @@
         DATADOG_ENV: "{% if app_processes_config.datadog_pythonagent %}{{ env_monitoring_id }}{% endif %}"
         DD_REQUESTS_SERVICE_NAME: "{% if app_processes_config.datadog_pythonagent %}requests{% endif %}"
         DD_REQUESTS_SPLIT_BY_DOMAIN: "{% if app_processes_config.datadog_pythonagent %}True{% endif %}"
+        DD_ENV: "{% if app_processes_config.datadog_pythonagent %}{{ env_monitoring_id }}{% endif %}"
       gunicorn_workers: "{{ app_processes_config.gunicorn_workers_static_factor + (ansible_processor_vcpus * app_processes_config.gunicorn_workers_factor)|int }}"

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/webworkers.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/webworkers.yml
@@ -18,5 +18,5 @@
         DATADOG_ENV: "{% if app_processes_config.datadog_pythonagent %}{{ env_monitoring_id }}{% endif %}"
         DD_REQUESTS_SERVICE_NAME: "{% if app_processes_config.datadog_pythonagent %}requests{% endif %}"
         DD_REQUESTS_SPLIT_BY_DOMAIN: "{% if app_processes_config.datadog_pythonagent %}True{% endif %}"
-        DD_ENV: "{% if app_processes_config.datadog_pythonagent %}{{ env_monitoring_id }}{% endif %}"
+        DD_ENV: "{% if app_processes_config.datadog_pythonagent and app_processes_config.django_command_prefix %}{{ env_monitoring_id }}{% endif %}"
       gunicorn_workers: "{{ app_processes_config.gunicorn_workers_static_factor + (ansible_processor_vcpus * app_processes_config.gunicorn_workers_factor)|int }}"


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/SAAS-15465
This will only affect `mobile_webworkers` on production. I have tested that running update-supervisor-confs with this code (in check mode) does not result in any changes to any other supervisor conf files.

Here's what the change to each mobile_webworkers supervisor conf file looks like:

```
--- before: /home/cchq/www/production/services/production_supervisor_django.conf
+++ after: /home/droberts/.ansible/tmp/ansible-local-3337219uxey0k3z/tmpittijtka/supervisor_django.conf.j2
@@ -1,8 +1,8 @@
 [program:commcare-hq-production-django]
 directory=/home/cchq/www/production/current/
 ; gunicorn
-environment=TMPDIR="/opt/tmp",DATADOG_PATCH_MODULES="requests:true,gevent:true,psycopg:true,redis:true,sqlalchemy:true,elasticsearch:true",DATADOG_ENV="production",DD_REQUESTS_SERVICE_NAME="requests",DD_REQUESTS_SPLIT_BY_DOMAIN="True",
-command=/home/cchq/www/production/current/python_env/bin/gunicorn
+environment=TMPDIR="/opt/tmp",DATADOG_PATCH_MODULES="requests:true,gevent:true,psycopg:true,redis:true,sqlalchemy:true,elasticsearch:true",DATADOG_ENV="production",DD_REQUESTS_SERVICE_NAME="requests",DD_REQUESTS_SPLIT_BY_DOMAIN="True",DD_ENV="production",
+command=/home/cchq/www/production/current/python_env/bin/ddtrace-run /home/cchq/www/production/current/python_env/bin/gunicorn
     deployment.gunicorn.commcarehq_wsgi:application
     -c deployment/gunicorn/gunicorn_conf.py
     -k gevent

changed: [10.202.10.73] => (item={'env_vars': {'http_proxy': '', 'https_proxy': '', 'no_proxy': '', 'TMPDIR': '/opt/tmp', 'DATADOG_PATCH_MODULES': 'requests:true,gevent:true,psycopg:true,redis:true,sqlalchemy:true,elasticsearch:true', 'PROMETHEUS_MULTIPROC_DIR': '', 'DATADOG_ENV': 'production', 'DD_REQUESTS_SERVICE_NAME': 'requests', 'DD_REQUESTS_SPLIT_BY_DOMAIN': True, 'DD_ENV': 'production'}, 'gunicorn_workers': '32'})
```

##### Environments Affected
production