### PR TITLE
Increase production formplayer database connection pool size from 20 to 40

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -76,7 +76,7 @@ formplayer_detailed_tags:
   - form_name
   - module_name
 formplayer_custom_properties:
-  spring.datasource.hikari.maximum-pool-size: 20
+  spring.datasource.hikari.maximum-pool-size: 40
   spring.datasource.hikari.minimum-idle: 5
 
 KSPLICE_ACTIVE: yes


### PR DESCRIPTION
Follow up to https://github.com/dimagi/commcare-cloud/pull/6256.
At high enough load, these formplayer db connections are the clear bottleneck, with some machines using all 20, creating a pileup of requests waiting for connections. Likely harmless to go higher than 40, as pgbouncer is gatekeeping the actual connections to postgresql, but starting here to be safe.

##### Environments Affected
production
