### PR TITLE
Temporarily disable production formplayer APM

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -5,7 +5,7 @@ gunicorn_workers_static_factor: 0
 gunicorn_workers_factor: 4
 formplayer_memory: "31g"
 formplayer_g1heapregionsize: "16m"
-formplayer_command_args: '-javaagent:/home/cchq/dd-java-agent.jar -Dsrc.main.java.org.javarosa.enableOpenTracing=true -Ddd.profiling.enabled=true -XX:FlightRecorderOptions=stackdepth=256 -Ddd.service=formplayer -Ddd.env=production -Ddd.trace.sample.rate=0.1'
+# formplayer_command_args: '-javaagent:/home/cchq/dd-java-agent.jar -Dsrc.main.java.org.javarosa.enableOpenTracing=true -Ddd.profiling.enabled=true -XX:FlightRecorderOptions=stackdepth=256 -Ddd.service=formplayer -Ddd.env=production -Ddd.trace.sample.rate=0.1'
 management_commands:
   celerybeat_a0:
     run_submission_reprocessing_queue:


### PR DESCRIPTION
To apply, run `cchq production update-supervisor-confs --limit formplayer` (say 'y' to reload).

##### Environments Affected
production
