### PR TITLE
Disable Formplayer APM Traces for Memory Testing on Prod

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -5,7 +5,8 @@ gunicorn_workers_static_factor: 0
 gunicorn_workers_factor: 4
 formplayer_memory: "31g"
 formplayer_g1heapregionsize: "16m"
-formplayer_command_args: '-javaagent:/home/cchq/dd-java-agent.jar -Dsrc.main.java.org.javarosa.enableOpenTracing=true -Ddd.profiling.enabled=true -XX:FlightRecorderOptions=stackdepth=256 -Ddd.service=formplayer -Ddd.env=production -Ddd.trace.sample.rate=0.1'
+#Disable formplayer APM Trace Agent to evaluate memory imapct
+#formplayer_command_args: '-javaagent:/home/cchq/dd-java-agent.jar -Dsrc.main.java.org.javarosa.enableOpenTracing=true -Ddd.profiling.enabled=true -XX:FlightRecorderOptions=stackdepth=256 -Ddd.service=formplayer -Ddd.env=production -Ddd.trace.sample.rate=0.1'
 management_commands:
   celerybeat_a0:
     run_submission_reprocessing_queue:


### PR DESCRIPTION
Since enabling APM in February we've seen a change to the memory pattern on the formplayer workers
![image](https://github.com/dimagi/commcare-cloud/assets/155066/2cc9c4cf-e39f-4484-8ef5-2a44556a0c0d)

Temporarily disables this deep APM Tracing and Profiling  so we can evaluate load tests to see if this pattern reverts.

##### Environments Affected
Production