### PR TITLE
Add playbook to cleanup pg_repack on pgbouncer_a6

### DIFF
--- a/src/commcare_cloud/ansible/cleanup_pg_repack.yml
+++ b/src/commcare_cloud/ansible/cleanup_pg_repack.yml
@@ -1,0 +1,30 @@
+- name: Cleanup pg_repack configuration
+  hosts: pgbouncer_a6
+  tasks:
+    - include_vars:
+        file: roles/postgresql_base/defaults/main.yml
+
+    - name: Check if pg_repack is installed
+      stat:
+        path: "{{ postgres_install_dir }}/bin/pg_repack"
+      register: pg_repack_stat
+
+    - name: Display if pg_repack is installed
+      debug:
+        msg: "pg_repack is installed"
+      when: pg_repack_stat.stat.exists == True
+
+    - name: Check if pg_repack cron exists
+      stat:
+        path: "/etc/cron.d/pg_repack_commcarehq_synclogs"
+      register: pg_repack_cron
+
+    - name: Display if pg_repack cron exists
+      debug:
+        msg: "pg_repack cron is configured"
+      when: pg_repack_cron.stat.exists == True
+
+    - name: Remove pg_repack cron file
+      file:
+        path: "/etc/cron.d/pg_repack_commcarehq_synclogs"
+        state: absent

--- a/src/commcare_cloud/ansible/cleanup_pg_repack.yml
+++ b/src/commcare_cloud/ansible/cleanup_pg_repack.yml
@@ -18,3 +18,4 @@
       file:
         path: "/etc/cron.d/pg_repack_commcarehq_synclogs"
         state: absent
+      when: pg_repack_cron.stat.exists == True

--- a/src/commcare_cloud/ansible/cleanup_pg_repack.yml
+++ b/src/commcare_cloud/ansible/cleanup_pg_repack.yml
@@ -9,20 +9,10 @@
         path: "{{ postgres_install_dir }}/bin/pg_repack"
       register: pg_repack_stat
 
-    - name: Display if pg_repack is installed
-      debug:
-        msg: "pg_repack is installed"
-      when: pg_repack_stat.stat.exists == True
-
     - name: Check if pg_repack cron exists
       stat:
         path: "/etc/cron.d/pg_repack_commcarehq_synclogs"
       register: pg_repack_cron
-
-    - name: Display if pg_repack cron exists
-      debug:
-        msg: "pg_repack cron is configured"
-      when: pg_repack_cron.stat.exists == True
 
     - name: Remove pg_repack cron file
       file:


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi.atlassian.net/browse/SAAS-15320

I don't have plans to merge this PR, but wanted to get it reviewed before running. As Danny noted [here](https://dimagi.atlassian.net/browse/SAAS-15320?focusedCommentId=313527), we don't actually need to have pg_repack running on this database anymore since the entire point of partitioning this db is to make it easy to drop tables. The current working theory is that pg_repack runs are changing the table ownership to root, and making it impossible for our periodic celery task to drop these tables. After running this to disable pg_repack, we should be able to change the table ownership manually and have the celery task successfully drop tables again.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production