### PR TITLE
move formplayer sqlite temp DBs to the data directory

### DIFF
--- a/src/commcare_cloud/ansible/roles/formplayer/templates/application.properties.j2
+++ b/src/commcare_cloud/ansible/roles/formplayer/templates/application.properties.j2
@@ -70,4 +70,3 @@ detailed_tagging.tag_names={{ formplayer_detailed_tags|join(',') }}
 {% for key, value in formplayer_custom_properties.items() %}
 {{ key }}={{ value }}
 {% endfor %}
-```

--- a/src/commcare_cloud/ansible/roles/formplayer/templates/application.properties.j2
+++ b/src/commcare_cloud/ansible/roles/formplayer/templates/application.properties.j2
@@ -5,6 +5,7 @@ server.port={{ formplayer_port }}
 user.suffix=commcarehq.org
 logging.config=logback-spring.xml
 sqlite.dataDir={{ formplayer_data_dir }}/
+sqlite.tmpDataDir={{ formplayer_data_dir }}/tmp_dbs/
 
 // Takes the format of https://<key>@sentry.io/<project>
 // More info on the DSN can be found here: https://docs.sentry.io/quickstart/#configure-the-dsn


### PR DESCRIPTION
This updates the formplayer configuration settings:

```diff
- sqlite.tmpDataDir=tmp_dbs/
+ sqlite.tmpDataDir=/opt/data/formplayer/tmp_dbs/
```

The impact of this is that formplayer will no longer store the temporary sqlite database relative to the release folder but will store them in the data directory. These DBs are used to store case search result data.

This is beneficial for two reasons:
1. Keep all user data together and on the drive with encryption and sized for user data
2. Persist tmp DBs across deploys (currently they are relative to the current release)
 
##### Environments Affected
ALL

Post deploy steps (optional):
* Remove tmp_dbs from the current releases
