### PR TITLE
Added webpack to the HQ deploy process

### DIFF
--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -238,3 +238,5 @@ formplayer_java_version: "{{ java_17_bin_path }}/java"
 maintenance_start_time: "06:00"
 
 maintenance_end_time: "08:00"
+
+use_webpack: true

--- a/src/commcare_cloud/ansible/deploy_hq.yml
+++ b/src/commcare_cloud/ansible/deploy_hq.yml
@@ -48,10 +48,10 @@
   hosts: [webworkers, proxy]
   any_errors_fatal: true
   tasks:
-    - import_role: {name: deploy_hq}
+    - include_role: {name: deploy_hq}
       vars:
         if_not_done: run_webpack
-      when: use_webpack is defined and use_webpack
+      when: use_webpack | default(false)
   
 
 - name: Collect static files

--- a/src/commcare_cloud/ansible/deploy_hq.yml
+++ b/src/commcare_cloud/ansible/deploy_hq.yml
@@ -45,7 +45,7 @@
         if_not_done: yarn_install
 
 - name: Run webpack
-  hosts: [proxy]
+  hosts: [webworkers, proxy]
   any_errors_fatal: true
   tasks:
     - import_role: {name: deploy_hq}

--- a/src/commcare_cloud/ansible/deploy_hq.yml
+++ b/src/commcare_cloud/ansible/deploy_hq.yml
@@ -45,7 +45,7 @@
         if_not_done: yarn_install
 
 - name: Run webpack
-  hosts: [webworkers]
+  hosts: [proxy]
   any_errors_fatal: true
   tasks:
     - import_role: {name: deploy_hq}

--- a/src/commcare_cloud/ansible/deploy_hq.yml
+++ b/src/commcare_cloud/ansible/deploy_hq.yml
@@ -44,6 +44,14 @@
       vars:
         if_not_done: yarn_install
 
+- name: Run webpack
+  hosts: [webworkers]
+  any_errors_fatal: true
+  tasks:
+    - import_role: {name: deploy_hq}
+      vars:
+        if_not_done: run_webpack
+
 - name: Collect static files
   hosts: [webworkers, proxy]
   any_errors_fatal: true

--- a/src/commcare_cloud/ansible/deploy_hq.yml
+++ b/src/commcare_cloud/ansible/deploy_hq.yml
@@ -51,6 +51,8 @@
     - import_role: {name: deploy_hq}
       vars:
         if_not_done: run_webpack
+      when: use_webpack is defined and use_webpack
+  
 
 - name: Collect static files
   hosts: [webworkers, proxy]

--- a/src/commcare_cloud/ansible/roles/deploy_hq/tasks/run_webpack.yml
+++ b/src/commcare_cloud/ansible/roles/deploy_hq/tasks/run_webpack.yml
@@ -1,0 +1,10 @@
+- name: Check for webpack configuration
+  stat:
+    path: "{{ code_source }}/webpack.config.js"
+  register: config_file 
+
+- name: Run webpack
+  command:
+    cmd: yarn run build:react
+    chdir: '{{ code_source }}'
+  when: config_file.stat.exists


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Associated ticket: https://dimagi.atlassian.net/browse/SAAS-15485

Adds support for running webpack while deploying HQ, if a webpack configuration file is found. This is not currently required by any live code, but allows us to test react and vue (and other javascript features) in the future

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->

##### Announce New Release
<!-- 
Review https://github.com/dimagi/commcare-cloud/tree/master/changelog#determining-whether-a-change-is-announce-worthy
to determine if a changelog entry is necessary if not already created.
-->
<!-- Delete this section if the PR does not contain any new changelog entries -->
- [ ] After merging, I will follow [these instructions](https://confluence.dimagi.com/display/saas/Announcing+changes+affecting+third+parties#Announcingchangesaffectingthirdparties-announcing)
to announce a new commcare-cloud release. 
