### PR TITLE
Increase ES data nodes to 2800 GB

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -119,7 +119,7 @@ servers:
     volume_size: 30
     volume_encrypted: yes
     block_device:
-      volume_size: 2100
+      volume_size: 2800
       enable_cross_region_backup: yes
     group: "elasticsearch"
     os: jammy 
@@ -132,7 +132,7 @@ servers:
     volume_size: 30
     volume_encrypted: yes
     block_device:
-      volume_size: 2100
+      volume_size: 2800
     group: "elasticsearch"
     os: jammy 
     count: 4
@@ -144,7 +144,7 @@ servers:
     volume_size: 30
     volume_encrypted: yes
     block_device:
-      volume_size: 1300
+      volume_size: 2800
       enable_cross_region_backup: yes
     group: "elasticsearch"
     os: jammy
@@ -159,7 +159,7 @@ servers:
     volume_size: 30
     volume_encrypted: yes
     block_device:
-      volume_size: 1300
+      volume_size: 2800
     group: "elasticsearch"
     os: jammy
     count: 2


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
We want to have enough disk space for reindexing the case search index. This also makes all data nodes a consistent size.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production