### PR TITLE
Changed webpack command to be more generic

### DIFF
--- a/src/commcare_cloud/ansible/roles/deploy_hq/tasks/run_webpack.yml
+++ b/src/commcare_cloud/ansible/roles/deploy_hq/tasks/run_webpack.yml
@@ -5,6 +5,6 @@
 
 - name: Run webpack
   command:
-    cmd: yarn run build:react
+    cmd: yarn run build:webpack
     chdir: '{{ code_source }}'
   when: config_file.stat.exists


### PR DESCRIPTION
##### Environments Affected
Staging (only if webpack is being used)

Changed the webpack command from `yarn build:react` to `yarn build:webpack` to be more accommodating if we use some framework other than React.
