### PR TITLE
Remove pg_repack from pgbouncer_a6

### DIFF
--- a/environments/production/postgresql.yml
+++ b/environments/production/postgresql.yml
@@ -15,15 +15,6 @@ pgbouncer_override:
   pgbouncer_pool_timeout: 1
   pgbouncer_reserve_pool: 5
 
-pg_repack:
-  pgbouncer_a6:
-    - database: commcarehq_synclogs
-      host: "{{ DEFAULT_POSTGRESQL_HOST }}"
-      username: "{{ postgres_users.root.username }}"
-      password: "{{ postgres_users.root.password }}"
-      port: 5432
-      skip_superuser_check: True
-
 # We're temporarily disabling read replicas
 # and will revisit after migration to RDS
 #LOAD_BALANCED_APPS:


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi.atlassian.net/browse/SAAS-15320

We don't need to run pg_repack on this machine anymore since we use partitioned tables that we periodically drop (so pg_repack isn't useful).

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production
