### PR TITLE
Add deploy_event_url for India

### DIFF
--- a/environments/india/fab-settings.yml
+++ b/environments/india/fab-settings.yml
@@ -1,3 +1,4 @@
 tag_deploy_commits: True
 use_shared_dir_for_staticfiles: True
 shared_dir_for_staticfiles: /mnt/shared_india/temp
+deploy_event_url: https://api.github.com/repos/dimagi/dimagi-qa/dispatches


### PR DESCRIPTION
Enables publication of india deploy events to the dimagi-qa repo, which will cause QA tests to run.

In addition to this PR, a new _dimagi-qa-india-deploy-event_ token was created on the @dimagi/qa account, and the [confluence page](https://confluence.dimagi.com/display/saas/SaaS+Env+Secrets+and+Accounts) was updated. The value of that token was set on the india `deploy_event_token` secret.

<!--- Provide a link to the ticket or document which prompted this change -->

##### ENVIRONMENTS AFFECTED
india