### PR TITLE
Starting syncing writes to sub-index of case-search on staging

### DIFF
--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -197,6 +197,12 @@ localsettings:
   ES_GROUPS_INDEX_SWAPPED: False
   ES_SMS_INDEX_SWAPPED: False
   ES_USERS_INDEX_SWAPPED: False
+  CASE_SEARCH_SUB_INDICES: {
+      'co-carecoordination-test': {
+          'index_cname': 'case_search_bha',
+          'multiplex_writes': True,
+      }
+  }
   CONNECTID_URL: 'https://connectid.dimagi.com/o/userinfo'
 
 

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -1007,6 +1007,11 @@ ES_XFORM_INDEX_NAME = '{{ localsettings.ES_XFORM_INDEX_NAME }}'
 ES_CASE_SEARCH_INDEX_NAME = '{{ localsettings.ES_CASE_SEARCH_INDEX_NAME }}'
 {% endif %}
 
+
+{% if localsettings.CASE_SEARCH_SUB_INDICES is defined %}
+CASE_SEARCH_SUB_INDICES = json.loads('{{ localsettings.CASE_SEARCH_SUB_INDICES|to_json }}')
+{% endif %}
+
 {# Flag to toggle the multiplexing settings defined below #}
 {% if localsettings.ES_MULTIPLEX_TO_VERSION is defined %}
 ES_MULTIPLEX_TO_VERSION = '{{ localsettings.ES_MULTIPLEX_TO_VERSION }}'


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Adding this PR to test a separate index for `co-carecoordination-test` on staging env.
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
staging

