### PR TITLE
Config to start multiplexing writes to case-search sub-index in Prod

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -188,6 +188,12 @@ localsettings:
   ES_SMS_INDEX_SWAPPED: False
   ES_USERS_INDEX_SWAPPED: False
   # Index settings end
+  CASE_SEARCH_SUB_INDICES: {
+    'co-carecoordination': {
+        'index_cname': 'case_search_bha',
+        'multiplex_writes': True,
+    }
+  }
   IS_DIMAGI_ENVIRONMENT: True
   HQ_INSTANCE: 'www'
   INACTIVITY_TIMEOUT: 20160


### PR DESCRIPTION
Enables multiplexer for `care-coordination` domain so that writes happen to both case_search and case_search_bha index 
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production

