### PR TITLE
Add co-carecoordination-perf domain to case_search_bha

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -192,6 +192,10 @@ localsettings:
     'co-carecoordination': {
         'index_cname': 'case_search_bha',
         'multiplex_writes': True,
+    },
+    'co-carecoordination-perf': {
+        'index_cname': 'case_search_bha',
+        'multiplex_writes': True,
     }
   }
   IS_DIMAGI_ENVIRONMENT: True


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Update production settings to start multiplexing case search writes to the dedicated bha index for co-carecoordination-perf.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production
