### PR TITLE
Ensure that SMTP message body is not empty

### DIFF
--- a/src/commcare_cloud/commands/deploy/utils.py
+++ b/src/commcare_cloud/commands/deploy/utils.py
@@ -99,16 +99,19 @@ def announce_deploy_success(environment, context):
     )
 
 
-def send_email(environment, subject, message='', to_admins=True, recipients=None):
+def send_email(environment, subject, message, to_admins=True, recipients=None):
     """
     Call a Django management command to send an email.
 
-    :param environment: The Environement object
+    :param environment: The Environment object
     :param subject: Email subject
-    :param message: Email message
+    :param message: Email message body
     :param to_admins: True if mail should be sent to Django admins
     :param recipients: List of additional addresses to send mail to
     """
+    if not message:
+        raise ValueError('Some cloud hosting providers require a message body')
+
     if environment.fab_settings_config.email_enabled:
         print(color_summary(f">> Sending email: {subject}"))
         args = [

--- a/src/commcare_cloud/commands/deploy/utils.py
+++ b/src/commcare_cloud/commands/deploy/utils.py
@@ -100,7 +100,7 @@ def send_email(environment, subject, message='', to_admins=True, recipients=None
     """
     Call a Django management command to send an email.
 
-    :param environment: The Environment object
+    :param environment: The Environement object
     :param subject: Email subject
     :param message: Email message
     :param to_admins: True if mail should be sent to Django admins
@@ -108,11 +108,6 @@ def send_email(environment, subject, message='', to_admins=True, recipients=None
     """
     if environment.fab_settings_config.email_enabled:
         print(color_summary(f">> Sending email: {subject}"))
-
-        if not message:
-            # Azure Communication Services require a message body
-            message = subject
-
         args = [
             message,
             '--subject', subject,

--- a/src/commcare_cloud/commands/deploy/utils.py
+++ b/src/commcare_cloud/commands/deploy/utils.py
@@ -60,27 +60,30 @@ def send_deploy_start_email(environment, context):
         and context.revision is not None
     )
     env_name = environment.meta_config.deploy_env
-    subject = f"{context.user} has initiated a {context.service_name} deploy to {env_name}"
+    message = f"{context.user} has initiated a {context.service_name} deploy to {env_name}"
     prefix = ""
     if is_nonstandard_deploy_time:
-        subject += " outside maintenance window"
+        message += " outside maintenance window"
         prefix = "ATTENTION: "
     if is_non_default_branch:
-        subject += f" with non-default branch '{context.revision}'"
+        message += f" with non-default branch '{context.revision}'"
         prefix = "ATTENTION: "
-    subject = f"{prefix}{subject}"
+    message = f"{prefix}{message}"
 
     send_email(
         environment,
-        subject=subject,
+        subject=message,
+        message=message,
     )
 
 
 def record_deploy_failed(environment, context):
     notify_slack_deploy_end(environment, context, is_success=False)
+    message = f"{context.service_name} deploy to {environment.name} failed"
     send_email(
         environment,
-        subject=f"{context.service_name} deploy to {environment.name} failed",
+        subject=message,
+        message=message,
     )
 
 

--- a/src/commcare_cloud/commands/deploy/utils.py
+++ b/src/commcare_cloud/commands/deploy/utils.py
@@ -100,7 +100,7 @@ def send_email(environment, subject, message='', to_admins=True, recipients=None
     """
     Call a Django management command to send an email.
 
-    :param environment: The Environement object
+    :param environment: The Environment object
     :param subject: Email subject
     :param message: Email message
     :param to_admins: True if mail should be sent to Django admins
@@ -108,6 +108,11 @@ def send_email(environment, subject, message='', to_admins=True, recipients=None
     """
     if environment.fab_settings_config.email_enabled:
         print(color_summary(f">> Sending email: {subject}"))
+
+        if not message:
+            # Azure Communication Services require a message body
+            message = subject
+
         args = [
             message,
             '--subject', subject,


### PR DESCRIPTION
Context: [Forum](https://forum.dimagi.com/t/email-error-when-deploying/10812)

Email notifications of both the start of a deploy, and of a failed deploy, have empty message bodies. Azure Communication Services rejects emails with empty message bodies with the following exception:

> smtplib.SMTPDataError: (501, b'5.6.0 Request body validation error. Need either non-empty Html or PlainText body to be present.')

##### Environments Affected

Only affects environments that use Azure Communication Services for SMTP. No Dimagi environments are affected.
