### PR TITLE
change python runtime to 3.12 for check_file lambda

### DIFF
--- a/src/commcare_cloud/terraform/modules/logshipping/main.tf
+++ b/src/commcare_cloud/terraform/modules/logshipping/main.tf
@@ -121,7 +121,7 @@ resource "aws_lambda_function" "check_file_lambda" {
     function_name = "check_file_lambda"
     role = aws_iam_role.check_file_lambda.arn
     handler = "check_file_lambda.handler"
-    runtime = "python3.8"
+    runtime = "python3.12"
     timeout = 30
     source_code_hash = data.archive_file.lambda_zip.output_base64sha256
 


### PR DESCRIPTION
We have already updated the lambda function to use python 3.12 instead of 3.8 which will soon be EOL. This terraform change maps to that change.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All Dimagi Envs

