### PR TITLE
Remove additional pillow processes from pillow_a2000

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -102,11 +102,6 @@ celery_processes:
 
 pillows:
   pillow_a2000:
-    case-pillow:
-      num_processes: 4
-      total_processes: 17
-      start_process: 13
-      dedicated_migration_process: True
     xform-pillow:
       num_processes: 33
       dedicated_migration_process: True
@@ -140,6 +135,5 @@ pillows:
   # case-sql partitions: 96
     case-pillow:
       num_processes: 13
-      total_processes: 17
-      start_process: 0
+      total_processes: 13
       dedicated_migration_process: True


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Case pillows were put onto their own machine to prevent other pillows from disrupting case updates. I added 4 processes back to pillow_a2000 yesterday in hopes of adding some additional processing power, but it didn't realistically make enough of a difference to warrant permanently keeping that change.

Additionally, we've [already observed pillow lag](https://app.datadoghq.com/dashboard/ewu-jyr-udt/change-feeds-pillows?fromUser=true&fullscreen_end_ts=1718200654624&fullscreen_paused=true&fullscreen_refresh_mode=paused&fullscreen_section=overview&fullscreen_start_ts=1718194256413&fullscreen_widget=210889790&refresh_mode=paused&view=spans&from_ts=1718194256413&to_ts=1718200654624&live=false) isolated to 6 specific partitions (which correlates with 1 process being behind since 1 process is responsible for 6 partitions in the current configuration), so it seems best to remove these for now.

There is active work being done to improve our rate limiting to prevent pillow lag, and as a fallback, we are prepared to upsize pillow_b2000 and double the number of case pillow processes on that machine if needed, which should be far more effective if we encounter significant lag again.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production
