### PR TITLE
Double case pillows

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -134,6 +134,6 @@ pillows:
   pillow_b2000:
   # case-sql partitions: 96
     case-pillow:
-      num_processes: 13
-      total_processes: 13
+      num_processes: 25
+      total_processes: 25
       dedicated_migration_process: True

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -310,7 +310,7 @@ servers:
     count: 1
 
   - server_name: "pillow_b2{i}-production"
-    server_instance_type: r6a.4xlarge
+    server_instance_type: r6a.8xlarge
     network_tier: "app-private"
     az: "b"
     volume_size: 50


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
**Creating in case this is needed. Right now it is not.**

Efforts to improve rate limiting and reduce the risk of unreasonable pillow lag are actively in progress, but in the meantime we remain susceptible to spikes in pillow lag. Apart from waiting out the increased load causing the backlog in pillows, our only other short term option is to increase the size of the pillow machine that handles processing case pillows so that we can increase the number of case pillow processes (we are currently memory bound on the r6a.4xlarge machine size).

This PR is only here in case it is absolutely needed.

### Steps to rollout
1. Merge this PR
2. Follow [instructions](https://dimagi.atlassian.net/wiki/spaces/saas/pages/2146636174/How+to+modify+instance+type+on+AWS) to update the instance type to `r6a.8xlarge` in AWS for pillow_b2000
3. Run `cchq --control production after-reboot pillow_b2000`
4. Run `cchq --control production update-supervisor-confs --limit=pillowtop`


##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production
