### PR TITLE
Route /hq/admin/phone/restore requests to mobile webworkers

### DIFF
--- a/src/commcare_cloud/ansible/roles/nginx/vars/cchq_ssl.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/cchq_ssl.yml
@@ -67,7 +67,15 @@ nginx_sites:
       proxy_buffers: 8 64k
       proxy_buffer_size: 64k
       client_body_buffer_size: 512k
-    - name: '~ /a/[^/]+/(receiver|phone|admin/phone)/'
+    - name: '~ /a/[^/]+/(receiver|phone)/'
+      balancer: "{{ deploy_env }}_commcare_submissions"
+      proxy_redirect: "http://{{ SITE_HOST }} https://{{ SITE_HOST }}"
+      proxy_next_upstream_tries: 1
+      proxy_read_timeout: 900s
+      proxy_buffers: 8 64k
+      proxy_buffer_size: 64k
+      client_body_buffer_size: 512k
+    - name: '~ /hq/admin/phone/restore/'
       balancer: "{{ deploy_env }}_commcare_submissions"
       proxy_redirect: "http://{{ SITE_HOST }} https://{{ SITE_HOST }}"
       proxy_next_upstream_tries: 1

--- a/src/commcare_cloud/ansible/roles/nginx/vars/cchq_ssl.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/cchq_ssl.yml
@@ -67,15 +67,7 @@ nginx_sites:
       proxy_buffers: 8 64k
       proxy_buffer_size: 64k
       client_body_buffer_size: 512k
-    - name: '~ /a/[^/]+/(receiver|phone)/'
-      balancer: "{{ deploy_env }}_commcare_submissions"
-      proxy_redirect: "http://{{ SITE_HOST }} https://{{ SITE_HOST }}"
-      proxy_next_upstream_tries: 1
-      proxy_read_timeout: 900s
-      proxy_buffers: 8 64k
-      proxy_buffer_size: 64k
-      client_body_buffer_size: 512k
-    - name: '~ /hq/admin/phone/restore/'
+    - name: '~ (/a/[^/]+/(receiver|phone)/|/hq/admin/phone/restore/)'
       balancer: "{{ deploy_env }}_commcare_submissions"
       proxy_redirect: "http://{{ SITE_HOST }} https://{{ SITE_HOST }}"
       proxy_next_upstream_tries: 1

--- a/src/commcare_cloud/ansible/roles/nginx/vars/cchq_ssl.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/cchq_ssl.yml
@@ -67,7 +67,7 @@ nginx_sites:
       proxy_buffers: 8 64k
       proxy_buffer_size: 64k
       client_body_buffer_size: 512k
-    - name: '~ /a/[^/]+/(receiver|phone)/'
+    - name: '~ /a/[^/]+/(receiver|phone|admin/phone)/'
       balancer: "{{ deploy_env }}_commcare_submissions"
       proxy_redirect: "http://{{ SITE_HOST }} https://{{ SITE_HOST }}"
       proxy_next_upstream_tries: 1


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi.atlassian.net/browse/SAAS-15627

This may not be as targeted as we want. We want to route all admin/phone/restore requests to mobile webworkers. Currently, the only admin/phone/ requests defined in admin/urls.py are the two restore requests (app aware and not).
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
