### PR TITLE
Double repeat_record_queue concurrency

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -54,7 +54,7 @@ celery_processes:
       concurrency: 1
     repeat_record_queue:
       pooling: gevent
-      concurrency: 6
+      concurrency: 12
       prefetch_multiplier: 1
     saved_exports_queue:
       concurrency: 3


### PR DESCRIPTION
This is intended to deal with spikes in the repeat_record_queue better.

Context:
* [Slack](https://dimagi.slack.com/archives/C0B44C0Q2/p1719412357335229)
* https://github.com/dimagi/commcare-cloud/pull/4651

##### Environments Affected

production
