### PR TITLE
Add New Celery Queue for Custom Script (Temporary)

### DIFF
--- a/commcare-cloud-bootstrap/environment/app-processes.yml.j2
+++ b/commcare-cloud-bootstrap/environment/app-processes.yml.j2
@@ -5,7 +5,7 @@ celery_processes:
     flower: {}
     background_queue,case_rule_queue,celery,analytics_queue,case_import_queue:
       concurrency: 1
-    email_queue,reminder_case_update_queue,export_download_queue,linked_domain_queue,malt_generation_queue:
+    email_queue,reminder_case_update_queue,export_download_queue,linked_domain_queue,malt_generation_queue, soltech_custom_script_queue:
       concurrency: 1
     reminder_rule_queue,repeat_record_queue,saved_exports_queue:
       concurrency: 1

--- a/commcare-cloud-bootstrap/environment/app-processes.yml.j2
+++ b/commcare-cloud-bootstrap/environment/app-processes.yml.j2
@@ -5,7 +5,7 @@ celery_processes:
     flower: {}
     background_queue,case_rule_queue,celery,analytics_queue,case_import_queue:
       concurrency: 1
-    email_queue,reminder_case_update_queue,export_download_queue,linked_domain_queue,malt_generation_queue, soltech_custom_script_queue:
+    email_queue,reminder_case_update_queue,export_download_queue,linked_domain_queue,malt_generation_queue:
       concurrency: 1
     reminder_rule_queue,repeat_record_queue,saved_exports_queue:
       concurrency: 1

--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -72,6 +72,8 @@ celery_processes:
       prefetch_multiplier: 1
     ush_background_tasks:
       concurrency: 8
+    soltech_custom_script_queue:  # TODO: Remove after executing script
+    concurrency: 4
 
   celerybeat_a0:
     # not really queues

--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -73,7 +73,7 @@ celery_processes:
     ush_background_tasks:
       concurrency: 8
     soltech_custom_script_queue:  # TODO: Remove after executing script
-    concurrency: 4
+      concurrency: 4
 
   celerybeat_a0:
     # not really queues

--- a/src/commcare_cloud/environment/schemas/app_processes.py
+++ b/src/commcare_cloud/environment/schemas/app_processes.py
@@ -136,7 +136,8 @@ CELERY_PROCESSES = [
     CeleryProcess("ucr_indicator_queue", required=False, blockage_threshold=60 * 60),
     CeleryProcess("ucr_queue", required=False, blockage_threshold=60 * 60),
     CeleryProcess("user_import_queue", required=False, blockage_threshold=60 * 60),
-    CeleryProcess("ush_background_tasks", required=False, blockage_threshold=3 * 60 * 60)
+    CeleryProcess("ush_background_tasks", required=False, blockage_threshold=3 * 60 * 60),
+    CeleryProcess("soltech_custom_script_queue", required=False)  # TODO: Remove after executing script
 ]
 
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
We are planning on running [this](https://github.com/dimagi/commcare-hq/pull/34588) custom script for a domain to move cases and mobile workers to different locations. A new queue will be used so as to not clog up existing queues due to the high number of cases that we expect to move (~1.6m). This queue will only be added temporarily and will be removed again once the script has finished executing successfully for all cases.

For additional context, please refer to [this](https://dimagi.atlassian.net/browse/SAAS-15527?focusedCommentId=335643) support ticket.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
This new queue will only be available to the production environment, where we plan to run the script.
