### PR TITLE
change instance type from t3a.medium to t3a.xlarge

### DIFF
--- a/environments/staging/terraform.yml
+++ b/environments/staging/terraform.yml
@@ -314,7 +314,7 @@ servers:
 
 proxy_servers:
   - server_name: "proxy6-staging"
-    server_instance_type: "t3a.medium"
+    server_instance_type: "t3a.xlarge"
     network_tier: "app-private"
     az: "b"
     volume_size: 80
@@ -324,7 +324,7 @@ proxy_servers:
     os: jammy
 
   - server_name: "proxy8-staging"
-    server_instance_type: "t3a.medium"
+    server_instance_type: "t3a.xlarge"
     network_tier: "app-private"
     az: "a"
     volume_size: 80


### PR DESCRIPTION
We started seeing staging deploy failure due to CPU constraints, the machine would become unresponsive during the deploy. So we are scaling the machines which get CPU starved on deploy.

[Context](https://dimagi.slack.com/archives/C0WLJ3HRP/p1719494057721179)

This is already applied on staging.

<!--- Provide a link to the ticket or document which prompted this change -->

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Staging

