### PR TITLE
Remove celery7 from inventory file

### DIFF
--- a/environments/india/aws-resources.yml
+++ b/environments/india/aws-resources.yml
@@ -2,8 +2,6 @@ celery14-india: 10.203.10.24
 celery14-india.instance_id: i-0a74f0479d21fd422
 celery15-india: 10.203.11.161
 celery15-india.instance_id: i-010474080b0895d92
-celery7-india: 10.203.10.192
-celery7-india.instance_id: i-067835e8065640f0c
 celerybeat_a2-india: 10.203.10.244
 celerybeat_a2-india.instance_id: i-0440283034514a9f3
 control2-india: 10.203.10.243

--- a/environments/india/inventory.ini
+++ b/environments/india/inventory.ini
@@ -6,8 +6,6 @@
 10.203.10.149 hostname=web6-india ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-08ab1806acb89e010 root_encryption_mode=aws
 [web7]
 10.203.11.54 hostname=web7-india ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-0a8979344e89c50c7 root_encryption_mode=aws
-[celery7]
-10.203.10.192 hostname=celery7-india ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-067835e8065640f0c swap_size=4G
 [celerybeat_a2]
 10.203.10.244 hostname=celerybeat-a2-india ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-0440283034514a9f3 root_encryption_mode=aws swap_size=4G
 [celery14]

--- a/environments/india/inventory.ini.j2
+++ b/environments/india/inventory.ini.j2
@@ -2,7 +2,6 @@
 {{ __djangomanage3__ }}
 {{ __web6__ }}
 {{ __web7__ }}
-{{ __celery7__ }} swap_size=4G
 {{ __celerybeat_a2__ }} swap_size=4G
 {{ __celery14__ }} swap_size=4G
 {{ __celery15__ }} swap_size=4G

--- a/environments/india/terraform.yml
+++ b/environments/india/terraform.yml
@@ -65,16 +65,6 @@ servers:
     os: jammy
     server_auto_recovery: true
 
-  - server_name: "celery7-india"
-    server_instance_type: "t3a.xlarge"
-    network_tier: "app-private"
-    az: "a"
-    volume_size: 60
-    volume_encrypted: no
-    volume_type: "gp3"
-    group: celery
-    os: jammy
-
   - server_name: "celerybeat_a2-india"
     server_instance_type: "t3a.xlarge"
     network_tier: "app-private"


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
India

Celery7 is removed in https://github.com/dimagi/commcare-cloud/pull/6334, but still exist in inventory file.
This PR is to remove it from the inventory so we don't try to connect to it when deploy.
