### PR TITLE
Add Celery Queue Env Var to Production Localsettings (Temporary)

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -248,6 +248,8 @@ localsettings:
   WS4REDIS_CONNECTION_HOST: "redis.production.commcare.local"
   CONNECTID_URL: 'https://connectid.dimagi.com/o/userinfo'
   ASYNC_INDICATORS_TO_QUEUE: 20000
+  # TODO: Remove after script has finished executing
+  SOLTECH_CUSTOM_SCRIPT_CELERY_QUEUE: 'soltech_custom_script_queue'
 
 # comment these two lines out to make a new rackspace machine
 commcare_cloud_root_user: ubuntu

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -1193,3 +1193,7 @@ CONNECTID_USERINFO_URL = "{{ localsettings.CONNECTID_URL }}"
 {% if localsettings.MAX_MOBILE_UCR_LIMIT is defined %}
 MAX_MOBILE_UCR_LIMIT = {{ localsettings.MAX_MOBILE_UCR_LIMIT }}
 {% endif %}
+
+{% if localsettings.SOLTECH_CUSTOM_SCRIPT_CELERY_QUEUE is defined %}
+SOLTECH_CUSTOM_SCRIPT_CELERY_QUEUE = {{ localsettings.SOLTECH_CUSTOM_SCRIPT_CELERY_QUEUE}}
+{% endif %}


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-3638).

This PR adds in a new env var to production so that we can define which Celery queue to run a custom script for. We plan on using a custom `soltech_custom_script_queue` Celery queue when running the script, but if needed we might switch to an existing Celery queue for testing purposes.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production
