### PR TITLE
Add slowlog thresholds to elasticsearch.yml template

### DIFF
--- a/src/commcare_cloud/ansible/roles/elasticsearch/templates/config/elasticsearch.yml.j2
+++ b/src/commcare_cloud/ansible/roles/elasticsearch/templates/config/elasticsearch.yml.j2
@@ -26,6 +26,15 @@ http.max_content_length: 200mb
 path.data: {{ elasticsearch_data_dir }}/data
 path.logs: {{ elasticsearch_data_dir }}/logs
 
+# configure slow logs
+index.search.slowlog.threshold.query.warn: 10s
+index.search.slowlog.threshold.fetch.warn: 1s
+index.search.slowlog.level: warn
+
+index.indexing.slowlog.threshold.query.warn: 10s
+index.indexing.slowlog.threshold.fetch.warn: 1s
+index.indexing.slowlog.level: warn
+
 {% if elasticsearch_version is version('5.6.16', '<=') %}
 # discovery.zen.minimum_master_nodes is the minimum number of
 # MASTER ELIGIBLE nodes that must be reachable before a master may be elected


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
I noticed that slowlogs for elasticsearch haven't been written to since September 8th, which is when we upgraded from 2 to 5.

Looking closer at slowlogs documentation for [2](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/index-modules-slowlog.html) and [5](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/index-modules-slowlog.html), I'm not seeing an obvious difference in how slowlogs are configured.

However when talking about the various log level thresholds, it is the case that the docs say
> By default, none are enabled (set to -1)
which to me implies that if none of those thresholds are set for any log level, we won't ever write slowlogs.

I don't see any references in commcare-cloud that would imply we are currently setting this value, and when querying a specific index's settings, I don't see any log related settings either. The only thing I can find that _might_ relate to how slowlogs worked on v2 of ES are [these lines](https://github.com/dimagi/commcare-cloud/blob/62f738fb858e3bfd9ef48007523d7a618d943ae1/src/commcare_cloud/ansible/roles/elasticsearch/templates/config/logging.yml.j2#L18-L19) in the logging.yml template, but I'm not sure if that is actually relevant.

@AmitPhulera I figure you might have a better idea of what changed here, but wanted to get something up so that we can resolve this.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None