### PR TITLE
Decrease repeat_record_queue worker concurrency from 36 to 12

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -54,7 +54,7 @@ celery_processes:
       concurrency: 1
     repeat_record_queue:
       pooling: gevent
-      concurrency: 36
+      concurrency: 12
       prefetch_multiplier: 1
     saved_exports_queue:
       concurrency: 3


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi.atlassian.net/browse/SAAS-15765

Having too much concurrency disrupts our ability to effectively rate limit repeat records, since the more concurrency you have, the more likely it is for a batch of slow tasks to be executed simultaneously when usage is allowed. It isn't until enough of those slow tasks return and report the request durations that rate limits will start to apply to repeat record attempts.

This is decreasing the concurrency back to what it was a few weeks ago https://github.com/dimagi/commcare-cloud/pull/6341 before we had rate limiting implemented. At that point, it made sense to increase concurrency to free up worker CPU to actually process responses while waiting for slower tasks, but now that rate limited is implemented, we shouldn't need that much concurrency.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production
