### PR TITLE
Comment couch nodes that are currently stopped form inventory

### DIFF
--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -431,20 +431,10 @@ elasticsearch_data=false
 [couch_a0]
 10.202.40.200 hostname=couch-a0-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-0451df80fe9da4eef datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws
 
-; Temporarily stopped as we arn't using these couch instances
-; But they would be used when we upgrade couch.
-
-; [couch_a1]
-; 10.202.40.179 hostname=couch-a1-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-04b77afb7b43ddf16 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws
-; [couch_b0]
-; 10.202.41.204 hostname=couch-b0-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-03f70dc45f928a0a7 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws
-
 [couchdb2:children]
 couch11
 couch12
 couch_a0
-;  couch_a1
-;  couch_b0
 
 [couchdb2:vars]
 swap_size=2G

--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -430,17 +430,21 @@ elasticsearch_data=false
 
 [couch_a0]
 10.202.40.200 hostname=couch-a0-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-0451df80fe9da4eef datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws
-[couch_a1]
-10.202.40.179 hostname=couch-a1-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-04b77afb7b43ddf16 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws
-[couch_b0]
-10.202.41.204 hostname=couch-b0-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-03f70dc45f928a0a7 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws
+
+; Temporarily stopped as we arn't using these couch instances
+; But they would be used when we upgrade couch.
+
+; [couch_a1]
+; 10.202.40.179 hostname=couch-a1-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-04b77afb7b43ddf16 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws
+; [couch_b0]
+; 10.202.41.204 hostname=couch-b0-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-03f70dc45f928a0a7 datavol_device=/dev/sdf datavol_device1=/dev/sdf is_datavol_ebsnvme=yes root_encryption_mode=aws
 
 [couchdb2:children]
 couch11
 couch12
 couch_a0
-couch_a1
-couch_b0
+;  couch_a1
+;  couch_b0
 
 [couchdb2:vars]
 swap_size=2G

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -247,15 +247,11 @@ elasticsearch_data=false
 {{ __couch12__ }}
 
 {{ __couch_a0__ }}
-{{ __couch_a1__ }}
-{{ __couch_b0__ }}
 
 [couchdb2:children]
 couch11
 couch12
 couch_a0
-couch_a1
-couch_b0
 
 [couchdb2:vars]
 swap_size=2G


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
I realised after stopping the node that we would also need to remove/comment the machines from inventory otherwise every ansible command that gather facts will raise the issue of unreachable hosts.

@dannyroberts  Not sure if better way would be completely removing the nodes or commenting is fine?

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production