### PR TITLE
Remove deleted DNS records from nginx config

### DIFF
--- a/src/commcare_cloud/ansible/cleanup_deleted_dns_records_nginx.yml
+++ b/src/commcare_cloud/ansible/cleanup_deleted_dns_records_nginx.yml
@@ -1,0 +1,20 @@
+- name: Remove deleted DNS records from nginx config
+  hosts: 
+    - proxy_a3
+    - proxy_b3
+  become: true
+  tasks:
+    - include_role:
+        name: nginx
+        tasks_from: set_site_present
+      vars:
+        site_present: False
+      with_items:
+        - {name: motech, vars_file: motech}
+        - {name: motech, vars_file: motech_http}
+        - {name: motech2, vars_file: motech2}
+        - {name: motech2, vars_file: motech2_http}
+        - {name: cas_sentry, vars_file: cas_sentry}
+        - {name: cas_grafana, vars_file: cas_grafana}
+      loop_control:
+        loop_var: site_config

--- a/src/commcare_cloud/ansible/cleanup_deleted_dns_records_nginx.yml
+++ b/src/commcare_cloud/ansible/cleanup_deleted_dns_records_nginx.yml
@@ -10,11 +10,9 @@
       vars:
         site_present: False
       with_items:
-        - {name: motech, vars_file: motech}
-        - {name: motech, vars_file: motech_http}
-        - {name: motech2, vars_file: motech2}
-        - {name: motech2, vars_file: motech2_http}
-        - {name: cas_sentry, vars_file: cas_sentry}
-        - {name: cas_grafana, vars_file: cas_grafana}
+        - motech
+        - motech_http
+        - motech2
+        - motech2_http
       loop_control:
-        loop_var: site_config
+        loop_var: file_name


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Followup to https://github.com/dimagi/commcare-cloud/pull/6357 and https://github.com/dimagi/commcare-cloud/pull/6358. We need to actually remove the URLs that are no longer resolvable from the nginx config in order to prevent the nginx config check from failing during actions like deploys.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production
