### PR TITLE
Remove remaining motech references

### DIFF
--- a/environments/backup-production/proxy.yml
+++ b/environments/backup-production/proxy.yml
@@ -21,5 +21,3 @@ special_sites:
   - tableau
   - wiki
   - wiki_http
-  - motech
-  - motech2

--- a/environments/motech/inventory.ini
+++ b/environments/motech/inventory.ini
@@ -1,2 +1,0 @@
-[motech]
-motech.internal.commcarehq.org

--- a/environments/production/proxy.yml
+++ b/environments/production/proxy.yml
@@ -24,5 +24,3 @@ special_sites:
   - tableau
   - wiki
   - wiki_http
-  - motech
-  - motech2


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
The first commit just removes motech and motech2 from the `special_sites` var in prod and backup prod, which is used when deciding which sites to install in the nginx config (no longer relevant for these urls).

The second commit, which I'm less sure of, just removes the motech environment. It sounds like we no longer support that env based on the url it points to, but best to get confirmation from @dannyroberts or @AmitPhulera.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production, backup production, motech