### PR TITLE
Give repeat_record_queue a dedicated worker

### DIFF
--- a/environments/staging/app-processes.yml
+++ b/environments/staging/app-processes.yml
@@ -40,9 +40,12 @@ celery_processes:
     malt_generation_queue:
       pooling: gevent
       concurrency: 1
-    reminder_case_update_queue,reminder_queue,repeat_record_queue:
+    reminder_case_update_queue,reminder_queue:
       pooling: gevent
-      concurrency: 4
+      concurrency: 2 
+    repeat_record_queue:
+      pooling: gevent
+      concurrency: 2
     reminder_case_update_bulk_queue,reminder_rule_queue:
       concurrency: 1
     send_report_throttled:


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Selfishly am testing something on staging with repeat records, and would benefit from a dedicated worker. There is plenty of memory and CPU on the celery mcahine so not too worried about capacity issues.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Staging
