### PR TITLE
Increase compute on es coordinator nodes

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -168,7 +168,7 @@ servers:
       BillTo: USH
 
   - server_name: "escoordinator_a1-production"
-    server_instance_type: r6a.2xlarge
+    server_instance_type: m6a.4xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 30
@@ -176,7 +176,7 @@ servers:
     os: jammy 
 
   - server_name: "escoordinator_b1-production"
-    server_instance_type: r6a.2xlarge
+    server_instance_type: m6a.4xlarge
     network_tier: "db-private"
     az: "b"
     volume_size: 30


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi.atlassian.net/browse/SAAS-15776

Increase from r6a.2xlarge to m6a.4xlarge, specifically to double CPU but keep memory the same.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production