### PR TITLE
Update min and max delays for repeater rate limiting

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -219,6 +219,8 @@ localsettings:
     repeaters: repeaters
   LOCAL_MIDDLEWARE:
     - 'django.middleware.security.SecurityMiddleware'
+  MIN_REPEATER_RATE_LIMIT_DELAY: 10
+  MAX_REPEATER_RATE_LIMIT_DELAY: 30
   PILLOWTOP_MACHINE_ID: hqdb0
   ALLOW_PHONE_AS_DEFAULT_TWO_FACTOR_DEVICE: True
   RATE_LIMIT_SUBMISSIONS: yes

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -1193,3 +1193,11 @@ CONNECTID_USERINFO_URL = "{{ localsettings.CONNECTID_URL }}"
 {% if localsettings.MAX_MOBILE_UCR_LIMIT is defined %}
 MAX_MOBILE_UCR_LIMIT = {{ localsettings.MAX_MOBILE_UCR_LIMIT }}
 {% endif %}
+
+{% if localsettings.MIN_REPEATER_RATE_LIMIT_DELAY is defined %}
+MIN_REPEATER_RATE_LIMIT_DELAY = {{ localsettings.MIN_REPEATER_RATE_LIMIT_DELAY }}
+{% endif %}
+
+{% if localsettings.MAX_REPEATER_RATE_LIMIT_DELAY is defined %}
+MAX_REPEATER_RATE_LIMIT_DELAY = {{ localsettings.MAX_REPEATER_RATE_LIMIT_DELAY }}
+{% endif %}


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
We currently delay between 0 and 15 minutes when a repeat record is rate limited. Increasing these values a bit seems reasonable to prevent records from immediately being queued again (in the case that a record is delayed by 0 to 5 minutes). I tested this change on staging as well.

Once merged, I'll need to run `cchq --control production update-config` and then `cchq --control production service commcare restart`

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production
