### PR TITLE
Bump up data source queue concurrency

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -58,7 +58,7 @@ celery_processes:
       prefetch_multiplier: 1
     repeat_record_datasource_queue:
       pooling: gevent
-      concurrency: 1
+      concurrency: 4
       prefetch_multiplier: 1
     saved_exports_queue:
       concurrency: 3


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Following up on the work done in https://github.com/dimagi/commcare-cloud/pull/6377, to now bump up the queue's concurrency step by step to asses its impact and adapt for load on CommCare Analytics, which is the receiving end for the requests sent via this queue.
There are 4 celery servers, so with concurrency of 1, there were 4 requests being sent in parallel.
Bumping that to 4 for each server, so at max 16 requests will be sent at once.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production
