### PR TITLE
Lower the concurrency on data source queue

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -58,7 +58,7 @@ celery_processes:
       prefetch_multiplier: 1
     repeat_record_datasource_queue:
       pooling: gevent
-      concurrency: 4
+      concurrency: 2
       prefetch_multiplier: 1
     saved_exports_queue:
       concurrency: 3


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://github.com/dimagi/commcare-cloud/pull/6378 proved a very big change for CommCare Analytics, so increasing that to double instead of 4 times the original concurrency.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production