### PR TITLE
Add email as environment variable

### DIFF
--- a/environments/backup-production/public.yml
+++ b/environments/backup-production/public.yml
@@ -23,6 +23,7 @@ eula_change_email: eula-notifications@dimagi.com
 contact_email: info@dimagi.com
 soft_assert_email: commcarehq-ops+soft_asserts@dimagi.com
 new_domain_email: inquiries@dimagi.com
+solutions_aes_email: solutions-tech-app-engineers@dimagi.com
 
 DATADOG_ENABLED: False
 

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -23,6 +23,7 @@ eula_change_email: eula-notifications@dimagi.com
 contact_email: info@dimagi.com
 soft_assert_email: commcarehq-ops+soft_asserts@dimagi.com
 new_domain_email: inquiries@dimagi.com
+solutions_aes_email: solutions-tech-app-engineers@dimagi.com
 ALTERNATE_HOSTS:
   - rec-mobile.sante.gov.bf
   - onse-iss.commcarehq.org

--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -81,6 +81,7 @@ eula_change_email: eula-notifications@dimagi.com
 contact_email: info@dimagi.com
 soft_assert_email: commcarehq-ops+soft_asserts@dimagi.com
 new_domain_email: inquiries@dimagi.com
+solutions_aes_email: solutions-tech-app-engineers@dimagi.com
 show_maintenance_updates_on_deploy: False
 
 couch_dbs:

--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -128,6 +128,7 @@ daily_deploy_email: null
 check_s3_backups_email: null
 return_path_email: null
 new_domain_email: inquiries@example.com
+solutions_aes_email: null
 show_maintenance_updates_on_deploy: true
 
 ALTERNATE_HOSTS: []

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -966,6 +966,7 @@ CONTACT_EMAIL = '{{ contact_email }}'
 FEEDBACK_EMAIL = '{{ feedback_email }}'
 SOFT_ASSERT_EMAIL = '{{ soft_assert_email }}'
 DAILY_DEPLOY_EMAIL = '{{ daily_deploy_email }}'
+SOLUTIONS_AES_EMAIL = '{{ solutions_aes_email }}'
 {% if TRANSIFEX_API_TOKEN %}
 TRANSIFEX_DETAILS = {
     'organization': 'dimagi',


### PR DESCRIPTION
[Ticket](https://dimagi.atlassian.net/browse/SC-3844)

This PR simply adds an environment variable containing an email address that is used in HQ. This is needed so that local hosting projects' statistics don't end up spamming the inbox of this email address. See related [HQ PR here](https://github.com/dimagi/commcare-hq/pull/35073).

##### Environments Affected
Staging/Production

No announcements needed. 
