### PR TITLE
Bump up data source queue concurrency to 9

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -58,7 +58,7 @@ celery_processes:
       prefetch_multiplier: 1
     repeat_record_datasource_queue:
       pooling: gevent
-      concurrency: 6
+      concurrency: 9
       prefetch_multiplier: 1
     saved_exports_queue:
       concurrency: 3


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
A follow up to https://github.com/dimagi/commcare-cloud/pull/6380 to push more concurrency after the deploy of https://github.com/dimagi/commcare-hq/pull/35080 which should reduce the load on CCA to process each request.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production