### PR TITLE
Add UAT domain to dedicated index

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -198,6 +198,10 @@ localsettings:
     'co-carecoordination-perf': {
         'index_cname': 'case_search_bha',
         'multiplex_writes': True,
+    },
+    'co-carecoordination-uat': {
+        'index_cname': 'case_search_bha',
+        'multiplex_writes': True,
     }
   }
   IS_DIMAGI_ENVIRONMENT: True


### PR DESCRIPTION
Add third BHA domain to the dedicated case search index, in the same vein as https://github.com/dimagi/commcare-cloud/pull/6308

<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi.atlassian.net/browse/USH-4878

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production

