### PR TITLE
 Drop data source queue concurrency to 8

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -58,7 +58,7 @@ celery_processes:
       prefetch_multiplier: 1
     repeat_record_datasource_queue:
       pooling: gevent
-      concurrency: 12
+      concurrency: 8
       prefetch_multiplier: 1
     saved_exports_queue:
       concurrency: 3


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Final PR in the series of updates, following up on last PR, https://github.com/dimagi/commcare-cloud/pull/6389

Dropping concurrency to a level such that it does not hamper performance on HQ while keeping satisfactory level of updates on Analytics.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production
