### PR TITLE
Reference accurate default backup values in docs

### DIFF
--- a/docs/source/backups_dr/2-backups-guide.rst
+++ b/docs/source/backups_dr/2-backups-guide.rst
@@ -77,8 +77,8 @@ PostgreSQL backups are made daily and weekly by default and can be made hourly o
   * ``plain`` - uses the `pg_basebackup <https://www.postgresql.org/docs/9.6/app-pgbasebackup.html>`_ command to write a backup to the ``postgresql_backup_dir``. 
   * ``dump`` - uses the `pg_dumpall <https://www.postgresql.org/docs/9.6/app-pg-dumpall.html>`_ command to write a dump of the database to the ``postgresql_backup_dir``.
 
-* `postgresql_backup_days`: The number of days to keep daily backups (Default: 1)
-* `postgresql_backup_weeks`: The number of weeks to keep weekly backups (Default: 1)
+* `postgresql_backup_days`: The number of days to keep daily backups (Default: 2)
+* `postgresql_backup_weeks`: The number of weeks to keep weekly backups (Default: 2)
 * `postgres_backup_hourly`: Boolean value to enable or disable hourly backups. (Default: false)
 * `postgresql_backup_hours`: The number of hours to keep hourly backups (Default: 1).
 
@@ -223,9 +223,9 @@ CouchDB backups are made daily and weekly and optionally hourly. Old backups are
 
 * ``backup_couch: True`` to enable couchdb backups (Default: ``False``\ )
 * ``couch_s3: True`` to enable sending couchdb backups to your S3 provider (Default: ``False``\ )
-* `couch_backup_dir`: the directory to save backups in (Default: ``/opt/data/backups/couchdb2``\ )
-* `couchdb_backup_days`: The number of days to keep daily backups (Default: 1)
-* `couchdb_backup_weeks`: The number of weeks to keep weekly backups (Default: 1)
+* `couch_backup_dir`: The directory to save backups in (Default: ``/opt/data/backups/couchdb2``\ )
+* `couchdb_backup_days`: The number of days to keep daily backups (Default: 2)
+* `couchdb_backup_weeks`: The number of weeks to keep weekly backups (Default: 2)
 * `couch_backup_hourly`: Boolean value to enable or disable hourly backups. (Default: false)
 * `couchdb_backup_hours`: The number of hours to keep hourly backups (Default: 1).
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Based on [couch default values](https://github.com/dimagi/commcare-cloud/blob/eec24250cd139bae29b38b389ad7f7028ed019f5/src/commcare_cloud/ansible/roles/couchdb2/defaults/main.yml#L9-L10) and [postgres default values](https://github.com/dimagi/commcare-cloud/blob/eec24250cd139bae29b38b389ad7f7028ed019f5/src/commcare_cloud/ansible/roles/pg_backup/defaults/main.yml#L9-L10), the default values in docs should be updated. [Blob backup values](https://github.com/dimagi/commcare-cloud/blob/eec24250cd139bae29b38b389ad7f7028ed019f5/src/commcare_cloud/ansible/roles/backups/defaults/main.yml#L5-L6) are correct in [docs](https://github.com/dimagi/commcare-cloud/blob/gh%2Fdocs%2Fupdate-backup-defaults/docs/source/backups_dr/2-backups-guide.rst#blobdb-backups).

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
