### PR TITLE
Don't update sentry release in formplayer application.properties during `update-config`

### DIFF
--- a/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
@@ -166,6 +166,14 @@
     - formplayer_deploy
   when: not _should_update_formplayer_in_place and current_stat.stat.exists
 
+- name: Get current formplayer release
+  shell: "basename $(readlink {{ formplayer_current_dir }})-{{ env_monitoring_id }}"
+  check_mode: no
+  register: current_release_result
+  tags:
+    - localsettings
+    - formplayer_deploy
+
 - name: Update formplayer config files
   become: yes
   template:
@@ -179,6 +187,8 @@
       filename: application.properties
     - template: logback-spring.xml.j2
       filename: logback-spring.xml
+  vars:
+    formplayer_current_release_name: "{{ current_release_result.stdout }}"
   tags:
     - localsettings
     - formplayer_deploy

--- a/src/commcare_cloud/ansible/roles/formplayer/templates/application.properties.j2
+++ b/src/commcare_cloud/ansible/roles/formplayer/templates/application.properties.j2
@@ -16,7 +16,7 @@ sentry.dsn={{ formplayer_sentry_dsn }}
 {% endif %}
 sentry.environment={{ env_monitoring_id }}
 sentry.tags.HQHost={{ host }}
-sentry.release={{ formplayer_release_name }}
+sentry.release={{ formplayer_current_release_name if _should_update_formplayer_in_place else formplayer_release_name }}
 
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.datasource.url=jdbc:postgresql://{{ postgresql_dbs.formplayer.pgbouncer_endpoint }}:{{ postgresql_dbs.formplayer.port


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi.atlassian.net/browse/SAAS-15882

When running `update-config`, we pass in `"_should_update_formplayer_in_place": true` [here](https://github.com/dimagi/commcare-cloud/blob/cc8e9cf49fb6e0623e14af23d868c5473c799c69/src/commcare_cloud/commands/ansible/ansible_playbook.py#L282-L282). This variable is taken into consideration when setting [_formplayer_target_dir](https://github.com/dimagi/commcare-cloud/blob/cc8e9cf49fb6e0623e14af23d868c5473c799c69/src/commcare_cloud/ansible/roles/formplayer/vars/main.yml#L14-L18), but not when setting [sentry.release](https://github.com/dimagi/commcare-cloud/blob/8e375bdcdfd27eab93d2f38e93ce50c3bfb84d7c/src/commcare_cloud/ansible/roles/formplayer/templates/application.properties.j2#L19-L19).

This PR makes the change for `sentry.release` to depend on that variable, and set it to the current release if doing an update in place to avoid unnecessary changes to this setting.

sentry.release is still properly updated during formplayer deploy
![image](https://github.com/user-attachments/assets/864b75de-e109-4570-abd4-9b68aa2bf0b7)
 
#### Concerns
The logic to obtain the current formplayer release feels like I'm redoing work that has already been done, which makes this logic fragile to future changes to how we format how [formplayer releases](https://github.com/dimagi/commcare-cloud/blob/cc8e9cf49fb6e0623e14af23d868c5473c799c69/src/commcare_cloud/ansible/roles/formplayer/vars/main.yml#L21-L21).

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
