### PR TITLE
Add settings that are not present in backup prod from prod

### DIFF
--- a/environments/backup-production/public.yml
+++ b/environments/backup-production/public.yml
@@ -69,6 +69,9 @@ formplayer_forward_ip_proxy: true
 formplayer_detailed_tags:
   - form_name
   - module_name
+formplayer_custom_properties:
+  spring.datasource.hikari.maximum-pool-size: 40
+  spring.datasource.hikari.minimum-idle: 5
 
 KSPLICE_ACTIVE: no # Don't know what this does, this is set to yes in prod
 
@@ -156,6 +159,7 @@ localsettings:
   ELASTICSEARCH_MAJOR_VERSION: 5
   ES_CASE_SEARCH_INDEX_NAME: "case_search_2022-10-04"
   ES_XFORM_INDEX_NAME: "xforms_2023-01-27"
+  ES_MULTIPLEX_TO_VERSION: '6'
   # Index Multiplexer Settings  
   ES_APPS_INDEX_MULTIPLEXED: False # swap completed
   ES_CASE_SEARCH_INDEX_MULTIPLEXED: False # swap completed 
@@ -175,6 +179,20 @@ localsettings:
   ES_SMS_INDEX_SWAPPED: False
   ES_USERS_INDEX_SWAPPED: False
   # Index settings end
+  CASE_SEARCH_SUB_INDICES: {
+    'co-carecoordination': {
+        'index_cname': 'case_search_bha',
+        'multiplex_writes': True,
+    },
+    'co-carecoordination-perf': {
+        'index_cname': 'case_search_bha',
+        'multiplex_writes': True,
+    },
+    'co-carecoordination-uat': {
+        'index_cname': 'case_search_bha',
+        'multiplex_writes': True,
+    }
+  }
   IS_DIMAGI_ENVIRONMENT: True
   HQ_INSTANCE: 'backup.www'
   INACTIVITY_TIMEOUT: 20160
@@ -223,6 +241,7 @@ localsettings:
         - 'ils-gateway-train'
   USER_REPORTING_METADATA_BATCH_ENABLED: True
   WS4REDIS_CONNECTION_HOST: "redis.bk-production.commcare.local"
+  CONNECTID_URL: 'https://connectid.dimagi.com/o/userinfo'
 
 # comment these two lines out to make a new rackspace machine
 commcare_cloud_root_user: ubuntu


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi.atlassian.net/browse/SAAS-16012

There are some settings that are added between last BCP test and now which should be same on both the envs. 
Especially the elasticsearch index duplication settings for BHA indices.
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Backup Production

