### PR TITLE
Only set current release if symlink is set

### DIFF
--- a/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
@@ -166,10 +166,12 @@
     - formplayer_deploy
   when: not _should_update_formplayer_in_place and current_stat.stat.exists
 
-- name: Get current formplayer release
-  shell: "basename $(readlink {{ formplayer_current_dir }})-{{ env_monitoring_id }}"
+- name: Register current formplayer release
+  shell: "readlink {{ formplayer_current_dir }}"
   check_mode: no
   register: current_release_result
+  changed_when: no
+  failed_when: no
   tags:
     - localsettings
     - formplayer_deploy
@@ -188,7 +190,12 @@
     - template: logback-spring.xml.j2
       filename: logback-spring.xml
   vars:
-    formplayer_current_release_name: "{{ current_release_result.stdout }}"
+    current_formplayer_release: >-
+      {{
+      (("%s-%s" % (current_release_result.stdout, env_monitoring_id)) | basename)
+      if current_release_result.stdout and _should_update_formplayer_in_place
+      else formplayer_release_name
+      }}
   tags:
     - localsettings
     - formplayer_deploy

--- a/src/commcare_cloud/ansible/roles/formplayer/templates/application.properties.j2
+++ b/src/commcare_cloud/ansible/roles/formplayer/templates/application.properties.j2
@@ -16,7 +16,7 @@ sentry.dsn={{ formplayer_sentry_dsn }}
 {% endif %}
 sentry.environment={{ env_monitoring_id }}
 sentry.tags.HQHost={{ host }}
-sentry.release={{ formplayer_current_release_name if _should_update_formplayer_in_place else formplayer_release_name }}
+sentry.release={{ current_formplayer_release }}
 
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.datasource.url=jdbc:postgresql://{{ postgresql_dbs.formplayer.pgbouncer_endpoint }}:{{ postgresql_dbs.formplayer.port


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://github.com/dimagi/commcare-cloud/issues/6401

Followup to https://github.com/dimagi/commcare-cloud/pull/6395

The previous solution didn't take into consideration a fresh install where the symlink for the current release has not been setup yet. This registers the output of `readlink {{ formplayer_current_dir }}` to a variable and sets the current release name based on if that variable is an empty string or not, in addition to the `_should_update_formplayer_in_place` flag.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None