### PR TITLE
Fix undefined User_Alias HIPAA_ACTOR in sudoers

### DIFF
--- a/src/commcare_cloud/ansible/roles/bootstrap-users/templates/sudoers.j2
+++ b/src/commcare_cloud/ansible/roles/bootstrap-users/templates/sudoers.j2
@@ -6,6 +6,8 @@ User_Alias HIPAA_USERS = ansible, {% for user in dev_users.present -%}
 {{ user }}
 {%- if not loop.last %}, {% endif %}
 {%- endfor %}, {{ cchq_user }}
+User_Alias HIPAA_ACTOR = {{ cchq_user }}
+
 Runas_Alias HIPAA_ACTOR = {{ cchq_user }}
 
 Cmnd_Alias NGINX = /usr/sbin/nginx
@@ -38,6 +40,6 @@ root    ALL=(ALL:ALL) ALL
 # https://help.ubuntu.com/community/EnvironmentVariables#sudo_caveat
 Defaults env_keep += "http_proxy https_proxy HTTP_PROXY HTTPS_PROXY no_proxy NO_PROXY"
 
-{{ cchq_user }}    ALL = (ALL) NOPASSWD: HQCOMMANDS
+HIPAA_ACTOR ALL = (ALL) NOPASSWD: HQCOMMANDS
 HIPAA_USERS ALL = (HIPAA_ACTOR) NOPASSWD: ALL
 HIPAA_USERS ALL = (root) NOPASSWD: HQCOMMANDS


### PR DESCRIPTION
This adds the missing User_Alias HIPAA_ACTOR to `/etc/sudoers.d/cchq`. Visudo warns about this:

    $ sudo visudo /etc/sudoers.d/cchq # and save the file without changes
    Warning: /etc/sudoers.d/cchq:24:28: User_Alias "HIPAA_ACTOR" referenced but not defined

The refers to line 23:

    HIPAA_ACTOR ALL = (ALL) ALL

Which implies that a `User_alias HIPAA_ACTOR` has been defined, however there is none such and so this line has no effect.[^1]

There is little practical impact because `{{ cchq_user }}`, the intended `HIPAA_ACTOR`, is a member of `HIPAA_USERS`, who have nearly the same privileges, and additionally there is this line: 

    {{ cchq_user }} ALL = (ALL) NOPASSWD: HQCOMMANDS

Which I assume was put there as a workaround when `HIPAA_ACTOR` failed not grant the desired privileges - precisely because it was not defined.

So, this patch does two things: 
 - Define the User_Alias `HIPAA_ACTOR` as the intended `{{ cchq_user }}`
 - Replace the literal `{{ cchq_user }}` by the intended `HIPAA_ACTOR` alias 

[^1]: The `Runas_Alias` by the same name is in a separate "namespace", and can't be mistaken for a User_Alias: it only occurs between parentheses, whereas User_Alias is the leftmost token of a rule. Even so, `sudoers(5)` advises against using the same name (to avoid confusion) though in this case it makes sense, as the intention clearly is that the Runas and User aliases have the same member(s).