### PR TITLE
Remove duplicate shared_dir_group key

### DIFF
--- a/src/commcare_cloud/ansible/roles/aws-fsx/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/aws-fsx/tasks/main.yml
@@ -12,7 +12,6 @@
     shared_mount_dir: "{{ fsx_mount_dir }}"
     shared_dir_user: "root"
     shared_dir_group: "root"
-    shared_dir_group: "root"
     shared_dir_mode: 0777
     shared_mount_address: "{{ formplayer_fsx_dns }}"
     shared_mount_opts: "{{ fsx_shared_mount_options }}"


### PR DESCRIPTION
This fixes the (minor) "[WARNING]: While constructing a mapping from [...] src/commcare_cloud/ansible/roles/aws-fsx/tasks/main.yml, line 11, column 5, found a duplicate dict key (shared_dir_group). Using last defined value only."
