### PR TITLE
Remove duplicate 'when' in Create shared mount dir

### DIFF
--- a/src/commcare_cloud/ansible/roles/shared_dir/tasks/setup_client.yml
+++ b/src/commcare_cloud/ansible/roles/shared_dir/tasks/setup_client.yml
@@ -15,12 +15,6 @@
   tags:
     - nfs
 
-- name: Check if /opt/data is already mounted
-  debug: msg="The mount point exists"
-  with_items: "{{ ansible_mounts }}"
-  when: item.mount == "/opt/data"
-  register: check_mount
-
 - name: Create shared mount dir
   become: yes
   when: shared_drive_enabled|bool
@@ -31,7 +25,6 @@
     mode: "{{ shared_dir_mode|default(0775) }}"
     state: directory
   run_once: yes
-  when: not check_mount
   tags:
     - nfs
 


### PR DESCRIPTION
 - Remove duplicate when that overrides the proper condition (shared_drive_enabled)
 - Remove spurious check for /opt/data being mounted, is unrelated to the task
 - FTR, this undoes changes introduced in commit 6fbac06754
