### PR TITLE
Add cast to bool when checking shared_drive_enabled

### DIFF
--- a/src/commcare_cloud/ansible/roles/ecryptfs/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/ecryptfs/tasks/main.yml
@@ -84,7 +84,7 @@
 
     - name: "Create {{ encrypted_root }}/blobdb directory for setups that do not use NFS"
       become: yes
-      when: not shared_drive_enabled
+      when: not shared_drive_enabled|bool
       file: path="{{ encrypted_root }}/blobdb" owner=nobody group="{{ shared_dir_gid }}" mode=0775 state=directory
       tags:
         - ecryptfs-blobdb
@@ -97,13 +97,13 @@
         group: "{{ shared_dir_gid }}"
         mode: "u=rwx,g=rwx,o=rx"
         state: directory
-      when: not shared_drive_enabled
+      when: not shared_drive_enabled|bool
       tags:
         - ecryptfs-blobdb
 
     - name: Create blob DB symlink (cchq looks for it in the shared drive)
       become: yes
-      when: not shared_drive_enabled
+      when: not shared_drive_enabled|bool
       file: src="{{ encrypted_root }}/blobdb" dest="{{ shared_data_dir }}/blobdb" state=link
       tags:
         - ecryptfs-blobdb


### PR DESCRIPTION
 - This fixes failure to create shared_data_dir when not shared_drive_enabled
 - Note that all other tasks that perform this test already have the cast to bool