### PR TITLE
Add monit, ansible, cchq to /etc/aliases

### DIFF
--- a/src/commcare_cloud/ansible/roles/common/templates/etc_aliases.j2
+++ b/src/commcare_cloud/ansible/roles/common/templates/etc_aliases.j2
@@ -19,6 +19,11 @@ couchdb: root
 rabbitmq: root
 kafka: root
 zookeeper: root
+monit: root
+ansible: root
+{% if cchq_user is defined %}
+{{ cchq_user }}: root
+{% endif %}
 {% if root_email is defined %}
 root: {{ root_email }}
 {% endif %}


### PR DESCRIPTION
This patch adds the monit, ansible, and cchq users to `/etc/aliases`, forwarding them (as all other system accounts) to root.

Without these aliases, postfix delivery to these local accounts either fails to deliver, or gets appended to `/var/mail/...`, where it most likely goes unseen.