### PR TITLE
Fix formplayer cron prune job

### DIFF
--- a/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
@@ -40,8 +40,8 @@
     # delete any empty directories so they don't just build up (to literally 100,000+)
     # but leaving any that have been modified in the last 20m
     # (to avoid a race condition on newly created dirs)
-    # Also never delete {{ formplayer_access_log_dir }} or {{ formplayer_data_dir }}
-    job: 'find {{ formplayer_data_dir }} -mindepth 1 -not -path {{ formplayer_access_log_dir }} -empty -type d -mmin +20 -delete'
+    # and skip {{ formplayer_access_log_dir }} and its contents
+    job: "find {{ formplayer_data_dir }} -mindepth 1 -not -path {{ formplayer_access_log_dir }} -not -path '{{ formplayer_access_log_dir }}/*' -empty -type d -mmin +20 -delete"
     user: '{{ cchq_user }}'
     state: present
   tags:

--- a/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
@@ -41,7 +41,7 @@
     # but leaving any that have been modified in the last 20m
     # (to avoid a race condition on newly created dirs)
     # Also never delete {{ formplayer_access_log_dir }}
-    job: 'find {{ formplayer_data_dir }} -path {{ formplayer_access_log_dir }} -prune -o -empty -type d -mmin +20 -delete'
+    job: 'find {{ formplayer_data_dir }} -not -path {{ formplayer_access_log_dir }} -empty -type d -mmin +20 -delete'
     user: '{{ cchq_user }}'
     state: present
   tags:

--- a/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/formplayer/tasks/main.yml
@@ -40,8 +40,8 @@
     # delete any empty directories so they don't just build up (to literally 100,000+)
     # but leaving any that have been modified in the last 20m
     # (to avoid a race condition on newly created dirs)
-    # Also never delete {{ formplayer_access_log_dir }}
-    job: 'find {{ formplayer_data_dir }} -not -path {{ formplayer_access_log_dir }} -empty -type d -mmin +20 -delete'
+    # Also never delete {{ formplayer_access_log_dir }} or {{ formplayer_data_dir }}
+    job: 'find {{ formplayer_data_dir }} -mindepth 1 -not -path {{ formplayer_access_log_dir }} -empty -type d -mmin +20 -delete'
     user: '{{ cchq_user }}'
     state: present
   tags:


### PR DESCRIPTION
This fixes the formplayer cron job "delete empty sqlite db dirs"

The previous job produced this diagnostic (emailed daily to `cchq`): `find: The -delete action automatically turns on -depth, but -prune does nothing when -depth is in effect.  If you want to carry on anyway, just explicitly use the -depth option.`