### PR TITLE
Switch to c6a (non burstable) for rabbit machines

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -254,7 +254,7 @@ servers:
     os: jammy
 
   - server_name: "rabbit14-production"
-    server_instance_type: t3a.2xlarge
+    server_instance_type: c6a.2xlarge
     network_tier: "db-private"
     az: "b"
     volume_size: 30
@@ -263,7 +263,7 @@ servers:
     os: jammy
 
   - server_name: "rabbit15-production"
-    server_instance_type: t3a.2xlarge
+    server_instance_type: c6a.2xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 30


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi.atlassian.net/browse/SAAS-16072

The load characteristics on rabbit are not very bursty, and therefore it makes more sense to use a machine type that is suitable for general usage. This is because on a t3a.2xlarge, the baseline usage is 40% per CPU. Once that is exceeded, the machine uses burst credits. Load on rabbit14 is consistently above 40% so we are always eating into our CPU credits.

Memory isn't an issue at all on these machines, so we can downsize from 32 to 16 GB, which makes the cost difference ~$25 of on demand per machine a month.
![image](https://github.com/user-attachments/assets/741b802d-fb30-4603-ba49-fcd558626432)


##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production