### PR TITLE
Specify `pid` in the gunicorn config

### DIFF
--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_django.conf.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_django.conf.j2
@@ -12,7 +12,7 @@ command={{ app_processes_config.django_command_prefix }}{{ virtualenv_home }}/bi
     --log-file {{ log_home }}/{{ project }}.gunicorn.log
     --log-level debug
     --statsd-host localhost:8125
-    --pid /var/run/gunicorn.pid
+    --pid /tmp/gunicorn.pid
 user={{ cchq_user }}
 autostart=true
 autorestart=true

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_django.conf.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_django.conf.j2
@@ -12,6 +12,7 @@ command={{ app_processes_config.django_command_prefix }}{{ virtualenv_home }}/bi
     --log-file {{ log_home }}/{{ project }}.gunicorn.log
     --log-level debug
     --statsd-host localhost:8125
+    --pid /var/run/gunicorn.pid
 user={{ cchq_user }}
 autostart=true
 autorestart=true


### PR DESCRIPTION
it would be easier to refer to gunicorn process. As of now we would be using it to pass -USR1 flag to the gunicorn process after we rotate the logs. This tells gunicorn to reload log files.
I will probably run `update-supervior-conf` on staging before merging.

<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi.atlassian.net/browse/SAAS-15962

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All
