### PR TITLE
Disable termination protection on backup prod env

### DIFF
--- a/src/commcare_cloud/terraform/modules/pgbouncer_nlb/main.tf
+++ b/src/commcare_cloud/terraform/modules/pgbouncer_nlb/main.tf
@@ -4,7 +4,7 @@ resource "aws_lb" "this" {
   load_balancer_type = "network"
   subnets = var.subnets
 
-  enable_deletion_protection = true
+  enable_deletion_protection = var.environment == "bk-production" ? false : true
 
   tags = {
     Environment = var.environment

--- a/src/commcare_cloud/terraform/modules/postgresql/main.tf
+++ b/src/commcare_cloud/terraform/modules/postgresql/main.tf
@@ -36,7 +36,7 @@ module "postgresql" {
   password = var.rds_instance["password"]
   port     = var.rds_instance["port"]
 
-  deletion_protection = true
+  deletion_protection = var.environment == "bk-production" ? false : true
 
   multi_az = var.rds_instance["multi_az"]
 

--- a/src/commcare_cloud/terraform/modules/server/main.tf
+++ b/src/commcare_cloud/terraform/modules/server/main.tf
@@ -9,7 +9,7 @@ resource aws_instance "server" {
   source_dest_check       = false
   iam_instance_profile    = var.iam_instance_profile
 
-  disable_api_termination = true
+  disable_api_termination = var.environment == "bk-production" ? false : true
   ebs_optimized = true
   root_block_device {
     volume_size           = var.volume_size


### PR DESCRIPTION
we destroy it with terraform destroy after bcp is done and have to manually disable termination protection from aws console. So its better not to have it while we are creating the machines

<!--- Provide a link to the ticket or document which prompted this change -->

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Backup Production

