### PR TITLE
Backup Prod control machine instance type to be t3a.medium

### DIFF
--- a/environments/backup-production/terraform.yml
+++ b/environments/backup-production/terraform.yml
@@ -17,7 +17,7 @@ ec2_metadata_tokens_required: yes
 
 servers:
   - server_name: "control_a0-bk-production"
-    server_instance_type: t3a.small
+    server_instance_type: t3a.medium
     network_tier: "app-private"
     az: "c"
     volume_size: 20


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
The current machine was hanging while running `deploy-stack` continuously. So I have change the instance type to be t3a.medium which has better specs.
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Backup Production
