### PR TITLE
Pass directory permissions as string

### DIFF
--- a/src/commcare_cloud/ansible/roles/shared_dir/tasks/setup_client.yml
+++ b/src/commcare_cloud/ansible/roles/shared_dir/tasks/setup_client.yml
@@ -22,7 +22,7 @@
     path: "{{ shared_mount_dir }}"
     owner: "{{ shared_dir_user }}"
     group: "{{ shared_dir_group }}"
-    mode: "{{ shared_dir_mode|default(0775) }}"
+    mode: "{{ shared_dir_mode|default('0775') }}"
     state: directory
   run_once: yes
   tags:


### PR DESCRIPTION
While running 
`cchq backup-proudction ap deploy_efs_mount_shared_dir.yml`,  I encountered following error . The reason is that jinja is interpreting the permission starting with 0 as octal number? changing it to string fixes the issue.

See - https://github.com/ansible/ansible/issues/56047#issuecomment-492293723

<!--- Provide a link to the ticket or document which prompted this change -->

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All ? 

