### PR TITLE
Update pid path from tmp to services dir

### DIFF
--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_django.conf.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_django.conf.j2
@@ -12,7 +12,7 @@ command={{ app_processes_config.django_command_prefix }}{{ virtualenv_home }}/bi
     --log-file {{ log_home }}/{{ project }}.gunicorn.log
     --log-level debug
     --statsd-host localhost:8125
-    --pid /tmp/gunicorn.pid
+    --pid {{ service_home }}/gunicorn.pid
 user={{ cchq_user }}
 autostart=true
 autorestart=true


### PR DESCRIPTION
Main concern was if pid file is deleted by some automated process then it would affect the log rotation until gunicorn is restarted. So adding it to a more permanent place

<!--- Provide a link to the ticket or document which prompted this change -->

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All
