### PR TITLE
Handle static files and translations in parallel

### DIFF
--- a/src/commcare_cloud/ansible/deploy_hq.yml
+++ b/src/commcare_cloud/ansible/deploy_hq.yml
@@ -46,6 +46,7 @@
 
 - name: Collect static files
   hosts: [webworkers, proxy]
+  strategy: free
   any_errors_fatal: true
   tasks:
     - import_role: {name: deploy_hq}
@@ -54,6 +55,7 @@
 
 - name: Compress static files
   hosts: proxy[0]
+  strategy: free
   any_errors_fatal: true
   tasks:
     - import_role: {name: deploy_hq}
@@ -67,6 +69,7 @@
     - pillowtop
     - proxy
     - django_manage
+  strategy: free
   any_errors_fatal: true
   tasks:
     - import_role: {name: deploy_hq}


### PR DESCRIPTION
Adds wool dryer balls to the deploy:

Uses "strategy: free" to run "Collect static files", "Compress static files" and "Update translations" across hosts in parallel.

See [Ansible docs](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/free_strategy.html#free-strategy) for details.

**Labeling "Do not merge" because I have not tested this.**

##### Environments Affected

No environment files changed.
