### PR TITLE
Reduce Kafka logging

### DIFF
--- a/src/commcare_cloud/ansible/roles/kafka/files/log4j_2.X.X.properties
+++ b/src/commcare_cloud/ansible/roles/kafka/files/log4j_2.X.X.properties
@@ -1,4 +1,4 @@
-log4j.rootLogger=INFO, stdout, kafkaAppender
+log4j.rootLogger=INFO, kafkaAppender
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout

--- a/src/commcare_cloud/ansible/roles/kafka/files/log4j_2.X.X.properties
+++ b/src/commcare_cloud/ansible/roles/kafka/files/log4j_2.X.X.properties
@@ -71,13 +71,18 @@ log4j.additivity.kafka.request.logger=false
 log4j.logger.kafka.network.RequestChannel$=WARN, requestAppender
 log4j.additivity.kafka.network.RequestChannel$=false
 
-log4j.logger.kafka.controller=TRACE, controllerAppender
+# Change the line below to adjust KRaft mode controller logging
+log4j.logger.org.apache.kafka.controller=INFO, controllerAppender
+log4j.additivity.org.apache.kafka.controller=false
+
+# Change the line below to adjust ZK mode controller logging
+log4j.logger.kafka.controller=INFO, controllerAppender
 log4j.additivity.kafka.controller=false
 
 log4j.logger.kafka.log.LogCleaner=INFO, cleanerAppender
 log4j.additivity.kafka.log.LogCleaner=false
 
-log4j.logger.state.change.logger=TRACE, stateChangeAppender
+log4j.logger.state.change.logger=INFO, stateChangeAppender
 log4j.additivity.state.change.logger=false
 
 # Access denials are logged at INFO level, change to DEBUG to also log allowed accesses


### PR DESCRIPTION
PR for added parsimony:

 - 24ec2008b653 bumps log4j thresholds from `TRACE` to `INFO` for Zookeeper and Kafka. Rationale: `DEBUG` and lower shouldn't be on in production, and anyway we wouldn't be debugging that code (it's Zookeeper and Kafka's)
 - 7eb112295af7 removes `stdout` from the root logger, as this merely duplicates what is written to the log files (by the `KafkaAppender`) in systemd's journal. (Try `journalctl -u kafka-server`.)
