### PR TITLE
Stop ES from redundantly logging to journald 

### DIFF
--- a/src/commcare_cloud/ansible/roles/elasticsearch/files/log4j2.properties
+++ b/src/commcare_cloud/ansible/roles/elasticsearch/files/log4j2.properties
@@ -4,10 +4,10 @@ status = error
 logger.action.name = org.elasticsearch.action
 logger.action.level = debug
 
-appender.console.type = Console
-appender.console.name = console
-appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]%marker %m%n
+#appender.console.type = Console
+#appender.console.name = console
+#appender.console.layout.type = PatternLayout
+#appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]%marker %m%n
 
 ######## Server JSON ############################
 appender.rolling.type = RollingFile
@@ -57,7 +57,7 @@ appender.rolling_old.strategy.action.condition.nested_condition.exceeds = 2GB
 ################################################
 
 rootLogger.level = info
-rootLogger.appenderRef.console.ref = console
+#rootLogger.appenderRef.console.ref = console
 rootLogger.appenderRef.rolling.ref = rolling
 rootLogger.appenderRef.rolling_old.ref = rolling_old
 


### PR DESCRIPTION
This PR (like #6428 for Kafka) removes the console appender from the Elasticsearch root logger, so as to not duplicate in `journald` the logging that already goes to log files.

The second commit fixes the issue that `cchq ap deploy_db.yml --tags=es_conf` doesn't include `misc_v{5,7}.yml` thus  missing most of the ES configuration.