### PR TITLE
Add Geospatial Celery Queue

### DIFF
--- a/docs/source/reference/1-commcare-cloud/2-configuration.rst
+++ b/docs/source/reference/1-commcare-cloud/2-configuration.rst
@@ -190,7 +190,8 @@ Each ``<queue-name>`` must be one of the following values:
 ``linked_domain_queue``, ``reminder_case_update_queue``, ``reminder_queue``,
 ``reminder_rule_queue``, ``repeat_record_queue``, ``saved_exports_queue``,
 ``sumologic_logs_queue``, ``send_report_throttled``, ``sms_queue``,
-``submission_reprocessing_queue``, ``ucr_indicator_queue``, ``ucr_queue``.
+``submission_reprocessing_queue``, ``ucr_indicator_queue``, ``ucr_queue``,
+``geospatial_queue``.
 For all features to work, each of these queues must
 appear at least once, and up to once per host.
 

--- a/environments/development/app-processes.yml
+++ b/environments/development/app-processes.yml
@@ -9,7 +9,7 @@ celery_processes:
       concurrency: 1
     email_queue,reminder_case_update_queue:
       concurrency: 1
-    linked_domain_queue,reminder_rule_queue,repeat_record_queue,saved_exports_queue:
+    linked_domain_queue,reminder_rule_queue,repeat_record_queue,saved_exports_queue,geospatial_queue:
       concurrency: 1
     ucr_indicator_queue,ucr_queue:
       concurrency: 1

--- a/environments/echis/app-processes.yml
+++ b/environments/echis/app-processes.yml
@@ -79,6 +79,8 @@ celery_processes:
       prefetch_multiplier: 1
     logistics_reminder_queue:
       concurrency: 2
+    geospatial_queue:
+      concurrency: 1
   echis_server5:
     ucr_indicator_queue:
       concurrency: 15

--- a/environments/india/app-processes.yml
+++ b/environments/india/app-processes.yml
@@ -36,6 +36,8 @@ celery_processes:
       concurrency: 1
     background_queue,dashboard_comparison_queue:
       concurrency: 2
+    geospatial_queue:
+      concurrency: 1
 pillows:
   pillow5:
     AppDbChangeFeedPillow:

--- a/environments/pna/app-processes.yml
+++ b/environments/pna/app-processes.yml
@@ -11,7 +11,7 @@ celery_processes:
       concurrency: 2
     background_queue,export_download_queue,saved_exports_queue,analytics_queue:
       concurrency: 4
-    linked_domain_queue,ucr_queue,async_restore_queue,email_queue,case_rule_queue, geospatial_queue:
+    linked_domain_queue,ucr_queue,async_restore_queue,email_queue,case_rule_queue,geospatial_queue:
       concurrency: 1
     beat: {}
     celery_periodic:

--- a/environments/pna/app-processes.yml
+++ b/environments/pna/app-processes.yml
@@ -11,7 +11,7 @@ celery_processes:
       concurrency: 2
     background_queue,export_download_queue,saved_exports_queue,analytics_queue:
       concurrency: 4
-    linked_domain_queue,ucr_queue,async_restore_queue,email_queue,case_rule_queue:
+    linked_domain_queue,ucr_queue,async_restore_queue,email_queue,case_rule_queue, geospatial_queue:
       concurrency: 1
     beat: {}
     celery_periodic:

--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -76,6 +76,8 @@ celery_processes:
       prefetch_multiplier: 1
     ush_background_tasks:
       concurrency: 8
+    geospatial_queue:
+      concurrency: 1
 
   celerybeat_a0:
     # not really queues

--- a/environments/staging/app-processes.yml
+++ b/environments/staging/app-processes.yml
@@ -62,6 +62,8 @@ celery_processes:
       prefetch_multiplier: 1
     ush_background_tasks:
       concurrency: 2
+    geospatial_queue:
+      concurrency: 1
     beat: {}
     flower: {}
 pillows:

--- a/environments/swiss/app-processes.yml
+++ b/environments/swiss/app-processes.yml
@@ -10,7 +10,7 @@ celery_processes:
       concurrency: 1  
     export_download_queue:
       concurrency: 1
-    case_import_queue,reminder_case_update_queue,linked_domain_queue:
+    case_import_queue,reminder_case_update_queue,linked_domain_queue, geospatial_queue:
       concurrency: 1
     background_queue,case_rule_queue:
       concurrency: 1

--- a/environments/swiss/app-processes.yml
+++ b/environments/swiss/app-processes.yml
@@ -10,7 +10,7 @@ celery_processes:
       concurrency: 1  
     export_download_queue:
       concurrency: 1
-    case_import_queue,reminder_case_update_queue,linked_domain_queue, geospatial_queue:
+    case_import_queue,reminder_case_update_queue,linked_domain_queue,geospatial_queue:
       concurrency: 1
     background_queue,case_rule_queue:
       concurrency: 1

--- a/src/commcare_cloud/environment/schemas/app_processes.py
+++ b/src/commcare_cloud/environment/schemas/app_processes.py
@@ -137,7 +137,8 @@ CELERY_PROCESSES = [
     CeleryProcess("ucr_indicator_queue", required=False, blockage_threshold=60 * 60),
     CeleryProcess("ucr_queue", required=False, blockage_threshold=60 * 60),
     CeleryProcess("user_import_queue", required=False, blockage_threshold=60 * 60),
-    CeleryProcess("ush_background_tasks", required=False, blockage_threshold=3 * 60 * 60)
+    CeleryProcess("ush_background_tasks", required=False, blockage_threshold=3 * 60 * 60),
+    CeleryProcess("geospatial_queue", required=False, blockage_threshold=3 * 60 * 60)
 ]
 
 

--- a/src/commcare_cloud/environment/schemas/app_processes.py
+++ b/src/commcare_cloud/environment/schemas/app_processes.py
@@ -138,7 +138,7 @@ CELERY_PROCESSES = [
     CeleryProcess("ucr_queue", required=False, blockage_threshold=60 * 60),
     CeleryProcess("user_import_queue", required=False, blockage_threshold=60 * 60),
     CeleryProcess("ush_background_tasks", required=False, blockage_threshold=3 * 60 * 60),
-    CeleryProcess("geospatial_queue", required=False, blockage_threshold=3 * 60 * 60)
+    CeleryProcess("geospatial_queue", required=False, blockage_threshold=6 * 60 * 60)
 ]
 
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Jira ticket [here](https://dimagi.atlassian.net/browse/SC-3864).

A new Celery queue for the Geospatial feature has been added. Currently, there is only one task planned to be run on this queue, which is related to [this](https://github.com/dimagi/commcare-hq/pull/35126) PR. This task was originally set to run as a serial task on the `background_queue`, however it takes very long to process a lot of cases. Given how long it takes, and that it is a serial task, any domains that are queued up for the task are highly likely to fail from getting locked out of the task for too long.

Adding a new Celery queue will resolve the issue mentioned above by allowing the Geospatial Celery task to be run in parallel without the risk of blocking up something like the `background_queue`. A concurrency of 1 has been chosen since we do not expect more than a few of the Celery tasks to be fired off at any given time. Additionally, this is a task that we expect to be run quite infrequently since it is only run when the Geospatial feature is enabled for a domain.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
This touches all environments.
