### PR TITLE
Update gunicorn.pid path in logrotate config

### DIFF
--- a/src/commcare_cloud/ansible/deploy_webworker.yml
+++ b/src/commcare_cloud/ansible/deploy_webworker.yml
@@ -35,7 +35,7 @@
             - notifempty
             - sharedscripts
           scripts:
-            postrotate: "[ -s /tmp/gunicorn.pid ] && kill -USR1 `cat /tmp/gunicorn.pid`"
+            postrotate: "[ -s {{ service_home }}/gunicorn.pid ] && kill -USR1 `cat {{ service_home }}/gunicorn.pid`"
 
 # There used to be some code here for updating workers one by one
 # but it's not functionally useful until we're off fab deploy and makes things


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
The path to the gunicorn.pid file was not updated in the actual ansible task after updating [here](https://github.com/dimagi/commcare-cloud/pull/6423). This means that after rotating the logs, the gunicorn process will not actually be reloaded.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All