### PR TITLE
temporarily disable form metadata processing

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -237,6 +237,7 @@ localsettings:
   REDIS_PORT: '6379'
   REMINDERS_QUEUE_ENABLED: True
   REQUIRE_TWO_FACTOR_FOR_SUPERUSERS: True
+  RUN_FORM_META_PILLOW: False  # temporarily disable form submission metadata processing due to P1 (2024-12-06)
   STALE_EXPORT_THRESHOLD: 1800  # 30 minutes
   SMS_GATEWAY_URL: 'http://gw1.promessaging.com/sms.php'
   SMS_QUEUE_ENABLED: True


### PR DESCRIPTION
Multiple devices using the same user account is causing a locking issue with the DB queries caused in the `users_userreportingmetadatastaging` table.

Disabling this processor will unblock normal processing of xforms at the cost of stale device metadata in the user models.

See https://github.com/dimagi/commcare-hq/blob/master/corehq/pillows/xform.py#L150

### Rollout

```
cchq prod update-config
cchq prod service pillowtop restart --only xform-pillow
```

##### Environments Affected
prod