### PR TITLE
Revert "temporarily disable form metadata processing"

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -237,7 +237,6 @@ localsettings:
   REDIS_PORT: '6379'
   REMINDERS_QUEUE_ENABLED: True
   REQUIRE_TWO_FACTOR_FOR_SUPERUSERS: True
-  RUN_FORM_META_PILLOW: False  # temporarily disable form submission metadata processing due to P1 (2024-12-06)
   STALE_EXPORT_THRESHOLD: 1800  # 30 minutes
   SMS_GATEWAY_URL: 'http://gw1.promessaging.com/sms.php'
   SMS_QUEUE_ENABLED: True


### PR DESCRIPTION
Reverts dimagi/commcare-cloud#6445. This is safe to undo because of the changes made in https://github.com/dimagi/commcare-hq/pull/35485 which are currently being deployed.

Similar to before, steps to rollout will be:

```
cchq prod update-config
cchq prod service pillowtop restart --only xform-pillow
```

### Environments Affected
prod