### PR TITLE
Double block storage on kafka machines

### DIFF
--- a/environments/staging/terraform.yml
+++ b/environments/staging/terraform.yml
@@ -253,7 +253,7 @@ servers:
     volume_encrypted: yes
     volume_type: "gp3"
     block_device:
-      volume_size: 5
+      volume_size: 10
       encrypted: true
       volume_type: "gp3"
     group: "kafka"
@@ -267,7 +267,7 @@ servers:
     volume_encrypted: yes
     volume_type: "gp3"
     block_device:
-      volume_size: 5
+      volume_size: 10
       encrypted: true
       volume_type: "gp3"
     group: "kafka"
@@ -281,7 +281,7 @@ servers:
     volume_encrypted: yes
     volume_type: "gp3"
     block_device:
-      volume_size: 5
+      volume_size: 10
       encrypted: true
       volume_type: "gp3"
     group: "kafka"


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
There was an increase in case load on staging due to some testing, and the kafka machines do not have enough disk to handle it. I think this small increase should be enough to handle the additional load (trying to be conservative since it is annoying to downsize).

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Staging