### PR TITLE
Remove ipv6 cidr blocks from all the security groups in network module

### DIFF
--- a/src/commcare_cloud/terraform/modules/network/main.tf
+++ b/src/commcare_cloud/terraform/modules/network/main.tf
@@ -284,7 +284,6 @@ resource "aws_security_group" "alb-sg" {
     to_port          = "80"
     protocol         = "tcp"
     cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
   }
 
   ingress {
@@ -292,7 +291,6 @@ resource "aws_security_group" "alb-sg" {
     to_port          = "443"
     from_port        = "443"
     cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
   }
 
   ingress {
@@ -504,7 +502,6 @@ resource "aws_security_group" "rds" {
     to_port          = "5432"
     protocol         = "tcp"
     cidr_blocks      = flatten([aws_subnet.subnet-app-private.*.cidr_block, aws_subnet.subnet-db-private.*.cidr_block])
-    ipv6_cidr_blocks = ["::/0"]
   }
 
   dynamic "egress" {
@@ -547,7 +544,6 @@ resource "aws_security_group" "elasticache" {
     to_port          = "6379"
     protocol         = "tcp"
     cidr_blocks      = flatten([aws_subnet.subnet-app-private.*.cidr_block, aws_subnet.subnet-public.*.cidr_block])
-    ipv6_cidr_blocks = ["::/0"]
   }
 
   dynamic "egress" {


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Removing the cidr blocks for ipv6 entries as part of cleanup of the network module.

Ran `cchq staging terraform plan`, got 

```
 # module.network.aws_security_group.alb-sg will be updated in-place
  ~ resource "aws_security_group" "alb-sg" {
        id                     = "sg-0e7192eb2cb7907e5"
      ~ ingress                = [
          - {
              - cidr_blocks      = [
                  - "0.0.0.0/0",
                ]
              - description      = ""
              - from_port        = 443
              - ipv6_cidr_blocks = [
                  - "::/0",
                ]
              - prefix_list_ids  = []
              - protocol         = "tcp"
              - security_groups  = []
              - self             = false
              - to_port          = 443
            },
          - {
              - cidr_blocks      = [
                  - "0.0.0.0/0",
                ]
              - description      = ""
              - from_port        = 80
              - ipv6_cidr_blocks = [
                  - "::/0",
                ]
              - prefix_list_ids  = []
              - protocol         = "tcp"
              - security_groups  = []
              - self             = false
              - to_port          = 80
            },
          - {
              - cidr_blocks      = [
                  - "10.201.0.0/16",
                ]
              - description      = ""
              - from_port        = 0
              - ipv6_cidr_blocks = []
              - prefix_list_ids  = []
              - protocol         = "-1"
              - security_groups  = []
              - self             = false
              - to_port          = 0
            },
          + {
              + cidr_blocks      = [
                  + "0.0.0.0/0",
                ]
              + description      = ""
              + from_port        = 443
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "tcp"
              + security_groups  = []
              + self             = false
              + to_port          = 443
            },
          + {
              + cidr_blocks      = [
                  + "0.0.0.0/0",
                ]
              + description      = ""
              + from_port        = 80
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "tcp"
              + security_groups  = []
              + self             = false
              + to_port          = 80
            },
          + {
              + cidr_blocks      = [
                  + "10.201.0.0/16",
                ]
              + from_port        = 0
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "-1"
              + security_groups  = []
              + self             = false
              + to_port          = 0
            },
        ]
        name                   = "alb-sg-staging"
        tags                   = {
            "Name" = "alb-sg-staging"
        }
        # (7 unchanged attributes hidden)

      - timeouts {}
    }

  # module.network.aws_security_group.elasticache will be updated in-place
  ~ resource "aws_security_group" "elasticache" {
        id                     = "sg-05981a4acb5d5d0fd"
      ~ ingress                = [
          - {
              - cidr_blocks      = [
                  - "10.201.10.0/24",
                  - "10.201.11.0/24",
                  - "10.201.12.0/24",
                  - "10.201.20.0/24",
                  - "10.201.21.0/24",
                  - "10.201.22.0/24",
                ]
              - description      = ""
              - from_port        = 6379
              - ipv6_cidr_blocks = [
                  - "::/0",
                ]
              - prefix_list_ids  = []
              - protocol         = "tcp"
              - security_groups  = []
              - self             = false
              - to_port          = 6379
            },
          + {
              + cidr_blocks      = [
                  + "10.201.10.0/24",
                  + "10.201.11.0/24",
                  + "10.201.12.0/24",
                  + "10.201.20.0/24",
                  + "10.201.21.0/24",
                  + "10.201.22.0/24",
                ]
              + description      = ""
              + from_port        = 6379
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "tcp"
              + security_groups  = []
              + self             = false
              + to_port          = 6379
            },
        ]
        name                   = "elasticache-staging"
        tags                   = {
            "Name" = "elasticache-staging"
        }
        # (7 unchanged attributes hidden)

      - timeouts {}
    }

  # module.network.aws_security_group.rds will be updated in-place
  ~ resource "aws_security_group" "rds" {
        id                     = "sg-0b811c0b4425b9ab7"
      ~ ingress                = [
          - {
              - cidr_blocks      = [
                  - "10.201.10.0/24",
                  - "10.201.11.0/24",
                  - "10.201.12.0/24",
                  - "10.201.40.0/24",
                  - "10.201.41.0/24",
                  - "10.201.42.0/24",
                ]
              - description      = ""
              - from_port        = 5432
              - ipv6_cidr_blocks = [
                  - "::/0",
                ]
              - prefix_list_ids  = []
              - protocol         = "tcp"
              - security_groups  = []
              - self             = false
              - to_port          = 5432
            },
          + {
              + cidr_blocks      = [
                  + "10.201.10.0/24",
                  + "10.201.11.0/24",
                  + "10.201.12.0/24",
                  + "10.201.40.0/24",
                  + "10.201.41.0/24",
                  + "10.201.42.0/24",
                ]
              + description      = ""
              + from_port        = 5432
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "tcp"
              + security_groups  = []
              + self             = false
              + to_port          = 5432
            },
        ]
        name                   = "rds-staging"
        tags                   = {
            "Name" = "rds-staging"
        }
        # (7 unchanged attributes hidden)

      - timeouts {}
    }

```

Will apply the changes by `cchq terraform apply -target=module.network.aws_security_group.rds  -target=module.network.aws_security_group.elasticache -target=module.network.aws_security_group.alb-sg`

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Staging, India, Prod
