### PR TITLE
Update commcare cloud setup instructions

### DIFF
--- a/docs/source/installation/2-manual-install.rst
+++ b/docs/source/installation/2-manual-install.rst
@@ -456,13 +456,7 @@ Install and Configure CommCare Cloud
 
     ::
 
-        $ nano ~/.profile
-
-    Paste the following before the line that sources the init-ansible script.
-
-    ::
-
-        source ~/.commcare-cloud/load_config.sh
+       $ echo "source ~/.commcare-cloud/load_config.sh" >> ~/.profile
 
     Load the commcare-cloud config so it takes effect immediately:
 

--- a/docs/source/installation/2-manual-install.rst
+++ b/docs/source/installation/2-manual-install.rst
@@ -514,19 +514,31 @@ will tell you more about how we use this vault file.
 Deploy CommCare HQ services
 ---------------------------
 
-When you run the “commcare-cloud deploy-stack”, you will be prompted for
-the vault password from earlier. You will also be prompted for an SSH
-password. This is the root user’s password. After this step, the root
-user will not be able to log in via SSH.
+The first step is to setup the expected user configuration. You will be prompted for
+the vault password from earlier and the SSH password, which is the root user's password.
+After this step, the root user will not be able to log in via SSH.
 
 ::
 
-   $ commcare-cloud cluster deploy-stack --first-time -e 'CCHQ_IS_FRESH_INSTALL=1'
+    $ commcare-cloud cluster bootstrap-users
 
-   This command will apply without running the check first. Continue? [y/N]y
-   ansible-playbook /home/jbloggs/commcare-cloud/src/commcare_cloud/ansible/deploy_stack.yml -i /home/jbloggs/environments/cluster/inventory.ini -e @/home/jbloggs/environments/cluster/vault.yml -e @/home/jbloggs/environments/cluster/public.yml -e @/home/jbloggs/environments/cluster/.generated.yml --diff --tags=bootstrap-users -u root --ask-pass --vault-password-file=/home/jbloggs/commcare-cloud/src/commcare_cloud/ansible/echo_vault_password.sh --ask-pass --ssh-common-args -o=UserKnownHostsFile=/home/jbloggs/environments/cluster/known_hosts
-   Vault Password for 'cluster': <ansible_sudo_pass>
-   SSH password: <root user's password>
+
+Once this completes successfully, you will now be able to ssh into this machine from your previously created user (e.g., jbloggs).
+You should exit your current ssh session, and ssh back into the machine using the "-A" option to enable agent forwarding.
+This is necessary to escalate privileges when running commcare-cloud commands, as well as for executing commands on other machines if
+you are setting up a cluster.
+
+::
+
+    $ exit  # exit until no longer connected to the machine
+    $ ssh -A jbloggs@control1
+
+
+You are now ready to deploy CommCare HQ services.
+
+::
+
+   $ commcare-cloud cluster deploy-stack -e 'CCHQ_IS_FRESH_INSTALL=1'
 
 This will run a series of Ansible commands that will take quite a long
 time to run.

--- a/docs/source/installation/2-manual-install.rst
+++ b/docs/source/installation/2-manual-install.rst
@@ -514,13 +514,6 @@ will tell you more about how we use this vault file.
 Deploy CommCare HQ services
 ---------------------------
 
-You will need the SSH agent to have your SSH key for Ansible.
-
-::
-
-   $ eval `ssh-agent`
-   $ ssh-add ~/.ssh/id_rsa
-
 When you run the “commcare-cloud deploy-stack”, you will be prompted for
 the vault password from earlier. You will also be prompted for an SSH
 password. This is the root user’s password. After this step, the root

--- a/docs/source/installation/2-manual-install.rst
+++ b/docs/source/installation/2-manual-install.rst
@@ -70,7 +70,7 @@ cluster’s proxy server.
 
 Prepare all machines for automated deploy
 -----------------------------------------
-Do the following on the monolith, or on each machine in the cluster.
+Do the following on the monolith or on each machine in the cluster.
 
 Enable root login via SSH
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -126,46 +126,14 @@ To be used in the installation process.
     $ sudo touch /var/log/ansible.log
     $ sudo chmod 666 /var/log/ansible.log
 
-Install system dependencies
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-This only needs to be done on the control machine. In the case of a monolith,
+Prepare control machine for automated deploy
+--------------------------------------------
+The following steps only need to be done on the control machine. In the case of a monolith,
 there is only one machine to manage so that is also the control machine. In
 our example cluster, the control machine is named “control1”.
 
-
-1.  SSH into control1 as the “ansible” user, or the user you created during installation. You can skip this step if you are installing a monolith:
-
-    ::
-
-        $ ssh ansible@control1
-
-    This instruction assumes that the control machine’s name resolves to its IP address.
-    Replace the name with the IP address if necessary.
-
-2.  On the control machine, or the monolith, install required packages:
-
-    ::
-
-        $ sudo apt update
-        $ sudo apt install python3-pip python3-dev python3-distutils python3-venv libffi-dev sshpass net-tools
-
-3.  Check your default Python version for Python 3.x:
-
-    ::
-
-        $ python --version
-
-    If your default version is not 3.x or if the “python” command was
-    not found, make python3 your default by running the command below,
-    otherwise skip it.
-
-    ::
-
-        $ sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 10
-
-
 Create a user for yourself
---------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In general, CommCare environments are managed by a team. Each member of
 the team has their own user account.
@@ -180,22 +148,44 @@ add them to the “sudo” user group. For example, if your username were
    ...
    $ sudo usermod -a -G sudo jbloggs
 
+Switch to this user for the remainder of these setup steps:
 
-Install CommCare Cloud
-----------------------
+::
 
-1.  On the control machine or the monolith, install and configure Git:
+    $ sudo -iu jbloggs
+
+
+Install system dependencies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+1.  Install the required packages:
 
     ::
 
-        $ sudo apt install git
+        $ sudo apt update
+        $ sudo apt install python3-pip python3-dev python3-distutils python3-venv libffi-dev sshpass net-tools git
+
+2.  Configure Git:
+
+    ::
+
         $ git config --global user.name "Jay Bloggs"
         $ git config --global user.email "jbloggs@example.com"
 
     (Of course, substitute “Jay Bloggs” with your name, and
     “jbloggs@example.com” with your email address.)
 
-2.  Clone and initialize CommCare Cloud:
+3.  Make python3 default for python command:
+
+    ::
+
+        $ sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 10
+
+
+Install and Configure CommCare Cloud
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+1.  Clone and initialize CommCare Cloud:
 
     ::
 
@@ -211,7 +201,15 @@ Install CommCare Cloud
         Do you want to have the CommCare Cloud environment setup on login?
         (y/n): y
 
-3.  Clone the sample CommCare Cloud “environments” folder into your home
+    If the input times out before entering 'y', you can follow the prompt instructions
+    to setup CommCare Coud on login:
+
+    ::
+
+        $ echo '[ -t 1 ] && source ~/init-ansible' >> ~/.profile
+
+
+2.  Clone the sample CommCare Cloud “environments” folder into your home
     directory.
 
     ::
@@ -219,7 +217,7 @@ Install CommCare Cloud
         $ cd ~
         $ git clone https://github.com/dimagi/sample-environment.git environments
 
-4.  Rename your environment. You could name it after your organization
+3.  Rename your environment. You could name it after your organization
     or your project. If you are installing a monolith you could leave
     its name as “monolith”. For this example we will name it “cluster”.
 
@@ -229,14 +227,14 @@ Install CommCare Cloud
         $ git mv monolith cluster
         $ git commit -m "Renamed environment"
 
-5.  Remove the “origin” Git remote. (You will not be pushing your
+4.  Remove the “origin” Git remote. (You will not be pushing your
     changes back to the Dimagi “sample-environment” repository.)
 
     ::
 
         $ git remote remove origin
 
-6.  (Optional) You are encouraged to add a remote for your own Git
+5.  (Optional) You are encouraged to add a remote for your own Git
     repository, so that you can share and track changes to your
     environment’s configuration. For example:
 
@@ -244,21 +242,21 @@ Install CommCare Cloud
 
         $ git remote add origin git@github.com:your-organization/commcare-environment.git
 
-7.  Configure your CommCare environment.
+6.  Configure your CommCare environment.
 
     See :ref:`configure-env` for more information.
 
-8.  Add your username to the ``present`` section of
+7.  Add your username to the ``present`` section of
     ``~/environments/_users/admins.yml``.
 
     ::
 
        $ nano ~/environments/_users/admins.yml
 
-9.  Copy your **public** key to ``~/environments/_authorized_keys/``.
+8.  Copy your **public** key to ``~/environments/_authorized_keys/``.
     The filename must correspond to your username.
 
-10. Change “monolith.commcarehq.test” to your real domain name,
+9. Change “monolith.commcarehq.test” to your real domain name,
 
     ::
 
@@ -281,8 +279,7 @@ Install CommCare Cloud
        -  ``ALLOWED_HOSTS``
 
 
-
-11. Change default emails
+10. Change default emails
 
     ::
 
@@ -291,7 +288,7 @@ Install CommCare Cloud
     You should find references in ``public.yml``
 
 
-12. Configure ``inventory.ini``
+11. Configure ``inventory.ini``
 
     .. rubric:: For a monolith
        :name: for-a-monolith
@@ -429,7 +426,7 @@ Install CommCare Cloud
        db1
        db2
 
-13. Configure the ``commcare-cloud`` command.
+12. Configure the ``commcare-cloud`` command.
 
     ::
 
@@ -467,13 +464,13 @@ Install CommCare Cloud
 
        $ cp ~/commcare-cloud/src/commcare_cloud/config.example.py ~/commcare-cloud/src/commcare_cloud/config.py
 
-    Update the known hosts file
+    Update the known hosts file (substituting your environment name if necessary)
 
     ::
 
        $ commcare-cloud cluster update-local-known-hosts
 
-14. Generate secured passwords for the vault
+13. Generate secured passwords for the vault
 
     In this step, we’ll generate passwords in the ``vault.yml`` file.
     This file will store all the passwords used in this CommCare
@@ -494,7 +491,7 @@ Install CommCare Cloud
     Find the value of “ansible_sudo_pass” and record it in your password
     manager. We will need this to deploy CommCare HQ.
 
-15. Encrypt the provided vault file, using that “ansible_sudo_pass”. (As
+14. Encrypt the provided vault file, using that “ansible_sudo_pass”. (As
     usual, substitute “cluster” with the name of your environment.)
 
     ::

--- a/docs/source/installation/2-manual-install.rst
+++ b/docs/source/installation/2-manual-install.rst
@@ -158,7 +158,7 @@ Switch to this user for the remainder of these setup steps:
 
 ::
 
-    $ sudo -iu jbloggs
+    $ su - jbloggs
 
 
 Install system dependencies

--- a/docs/source/installation/2-manual-install.rst
+++ b/docs/source/installation/2-manual-install.rst
@@ -450,7 +450,13 @@ Install and Configure CommCare Cloud
 
     ::
 
-       $ echo "source ~/.commcare-cloud/load_config.sh" >> ~/.profile
+        $ nano ~/.profile
+
+    Paste the following before the line that sources the init-ansible script.
+
+    ::
+
+        source ~/.commcare-cloud/load_config.sh
 
     Load the commcare-cloud config so it takes effect immediately:
 

--- a/docs/source/installation/2-manual-install.rst
+++ b/docs/source/installation/2-manual-install.rst
@@ -208,7 +208,7 @@ Install and Configure CommCare Cloud
         (y/n): y
 
     If the input times out before entering 'y', you can follow the prompt instructions
-    to setup CommCare Coud on login:
+    to setup CommCare Cloud on login:
 
     ::
 

--- a/docs/source/installation/2-manual-install.rst
+++ b/docs/source/installation/2-manual-install.rst
@@ -491,7 +491,7 @@ Install and Configure CommCare Cloud
     Find the value of “ansible_sudo_pass” and record it in your password
     manager. We will need this to deploy CommCare HQ.
 
-14. Encrypt the provided vault file, using that “ansible_sudo_pass”. (As
+14. Encrypt the provided vault file using a newly generated password. (As
     usual, substitute “cluster” with the name of your environment.)
 
     ::

--- a/docs/source/installation/2-manual-install.rst
+++ b/docs/source/installation/2-manual-install.rst
@@ -111,6 +111,12 @@ reference.
 
         PasswordAuthentication yes
 
+    To allow keyboard interactive authentication, ensure
+
+    ::
+
+        KbdInteractiveAuthentication yes
+
 4.  Restart SSH:
 
     ::


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
I've run into various issues while setting up monoliths and am attempting to clarify those instructions in this PR.

This also notably updates documentation to be aligned with our removal of the suggestion to copy a private key to the server, and instead use `ssh -A` when/where appropriate.

Review by commit.
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None