### PR TITLE
Bump Jinja2 to 3.1.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -68,7 +68,7 @@ idna==3.7
     # via requests
 importlib-metadata==3.1.0
     # via commcare-cloud (setup.py)
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   ansible-core
     #   jinja2-cli


### PR DESCRIPTION
From the [Jinja2 release notes](https://github.com/pallets/jinja/releases/tag/3.1.5)

> This is the Jinja 3.1.5 security fix release, which fixes security issues and bugs but does not otherwise change behavior and should not result in breaking changes compared to the latest feature release.

https://dimagi.atlassian.net/browse/SAAS-16432

##### Environments Affected

None/all.