### PR TITLE
Switch to newer generation of RDS machines

### DIFF
--- a/environments/india/terraform.yml
+++ b/environments/india/terraform.yml
@@ -330,7 +330,7 @@ proxy_servers:
 
 rds_instances:
   - identifier: "pgmain0-india"
-    instance_type: "db.t3.medium"
+    instance_type: "db.t4g.medium"
     storage: 500
     storage_type: gp3
     multi_az: true

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -444,7 +444,7 @@ proxy_servers:
 
 rds_instances:
   - identifier: "pgmain1-production"
-    instance_type: "db.m5.4xlarge"
+    instance_type: "db.m6g.4xlarge"
     storage: 2000
     storage_type: gp3
     multi_az: true
@@ -554,7 +554,7 @@ rds_instances:
       max_connections: "LEAST({DBInstanceClassMemory/9531392},5000)"
 
   - identifier: "pgsynclog2-production"
-    instance_type: "db.m5.xlarge"
+    instance_type: "db.m6g.xlarge"
     storage: 1000
     storage_type: gp3
     multi_az: true
@@ -598,7 +598,7 @@ rds_instances:
       track_io_timing: 1
 
   - identifier: "pgauditcare1-production"
-    instance_type: "db.m5.xlarge"
+    instance_type: "db.m6g.xlarge"
     storage: 7000
     storage_type: gp3
     multi_az: true

--- a/environments/staging/terraform.yml
+++ b/environments/staging/terraform.yml
@@ -334,7 +334,7 @@ proxy_servers:
 
 rds_instances:
   - identifier: "pg0-staging"
-    instance_type: "db.t3.small"
+    instance_type: "db.t4g.small"
     storage: 160
     storage_type: gp3
     multi_az: yes
@@ -345,7 +345,7 @@ rds_instances:
     enable_cross_region_backup: yes
 
   - identifier: "pgformplayer0-staging"
-    instance_type: "db.t3.small"
+    instance_type: "db.t4g.small"
     storage: 160
     storage_type: gp3
     multi_az: yes


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
In order to buy the reserved instances this month, we are consolidating production RDS machines to m6g family and updating the Staging and India RDS instances from t3 to t4g.
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production, India, Staging
