### PR TITLE
Add threaded message on deploy completion

### DIFF
--- a/src/commcare_cloud/commands/deploy/slack.py
+++ b/src/commcare_cloud/commands/deploy/slack.py
@@ -18,7 +18,7 @@ class Emoji(Enum):
 
     slow_reaction = random.choice(['snail', 'turtle', 'tortoise_wag'])
     medium_reaction = random.choice(['meh', 'meh_blue', 'cat-roomba'])
-    fast_reaction = random.choice(['racing_car', 'zap', 'dash', 'rocket'])
+    fast_reaction = random.choice(['racing_car', 'zap', 'dash', 'rocket', 'cat-roomba-exceptionally-fast'])
 
     @property
     def code(self):


### PR DESCRIPTION
Two reasons for this:
* See how long deploy took. There are more systematic ways to do this, but I've sometimes wanted to informally see how long the last few deploys took, on either prod or staging.
* If you "get notified of new replies" on the original deploy message, you get a DM when the deploy is complete.

![Screenshot 2025-01-30 at 8 49 27 AM](https://github.com/user-attachments/assets/e844f727-0872-40ac-b385-7c9c6de01277)

##### Environments Affected
none
