### PR TITLE
[Not actually enforced] Increase DEVICE_LIMIT_PER_USER to 50

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -160,6 +160,7 @@ localsettings:
   CUSTOM_SYNCLOGS_DB: "synclogs_2017-11-01"
   DEPLOY_MACHINE_NAME: "{{ ansible_hostname }}"
   DEVICE_LOGS_ENABLED: no
+  DEVICE_LIMIT_PER_USER: 50
   EULA_COMPLIANCE: True
   EMAIL_SMTP_HOST: email-smtp.us-east-1.amazonaws.com
   EMAIL_SMTP_PORT: 587

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -1231,3 +1231,7 @@ MIN_REPEATER_RATE_LIMIT_DELAY = {{ localsettings.MIN_REPEATER_RATE_LIMIT_DELAY }
 {% if localsettings.MAX_REPEATER_RATE_LIMIT_DELAY is defined %}
 MAX_REPEATER_RATE_LIMIT_DELAY = {{ localsettings.MAX_REPEATER_RATE_LIMIT_DELAY }}
 {% endif %}
+
+{% if localsettings.DEVICE_LIMIT_PER_USER is defined %}
+DEVICE_LIMIT_PER_USER = {{ localsettings.DEVICE_LIMIT_PER_USER }}
+{% endif %}


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi.atlassian.net/browse/SAAS-16355

This rate limiter isn't actually enabled yet, so this change is only to help us get better insight in our metrics, since we have more insight into metrics before exceeding the limit.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production