### PR TITLE
Soft kill celery processes via celery_bash_runner

### DIFF
--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/celery_cron.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/celery_cron.yml
@@ -19,7 +19,20 @@
   tags:
     - cron
 
-- name: Copy celery cron script
+- name: Copy celery bash runner kill cron script
+  become: yes
+  template:
+    src: "celery_bash_runner_kill.sh.j2"
+    dest: "/usr/local/sbin/celery_bash_runner_kill.sh"
+    group: root
+    owner: root
+    mode: 0744
+    backup: yes
+  when: "celery_hours_before_soft_kill"
+  tags:
+    - cron
+
+- name: Copy celery process klil cron script
   become: yes
   template:
     src: "celery_task_kill.sh.j2"
@@ -28,7 +41,7 @@
     owner: root
     mode: 0744
     backup: yes
-  when: "celery_hours_before_soft_kill or celery_hours_before_hard_kill"
+  when: "celery_hours_before_hard_kill"
   tags:
     - cron
 

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/celery_cron.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/celery_cron.yml
@@ -36,7 +36,7 @@
   become: true
   cron:
     name: "Soft kill old celery processes"
-    job: "/usr/local/sbin/celery_task_kill.sh {{ celery_hours_before_soft_kill }} SIGTERM "
+    job: "/usr/local/sbin/celery_bash_runner_kill.sh {{ celery_hours_before_soft_kill }} SIGTERM "
     minute: 15
     hour: "*"
     user: root

--- a/src/commcare_cloud/ansible/roles/commcarehq/tasks/celery_cron.yml
+++ b/src/commcare_cloud/ansible/roles/commcarehq/tasks/celery_cron.yml
@@ -32,7 +32,7 @@
   tags:
     - cron
 
-- name: Copy celery process klil cron script
+- name: Copy celery process kill cron script
   become: yes
   template:
     src: "celery_task_kill.sh.j2"

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/celery_bash_runner_kill.sh.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/celery_bash_runner_kill.sh.j2
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Process to soft kill old celery jobs via supervisor managed process.
+#
+
+HOURS=$1
+MAX_MINUTES=`expr ${HOURS} \* 60 \* 60`
+
+SIG_NAME=$2
+
+PARENT_PIDS=$(ps -eo comm,ppid,etimes | awk '/celeryd:/ { if ( $4 > '"${MAX_MINUTES}"' ) { print $3 } }');
+
+if [ "$PARENT_PIDS" != "" ]; then
+  echo "Shutting down celery bash runners:"
+  echo "Process information with start and elapsed time:"
+  for pid in ${PARENT_PIDS}
+  do
+     if ps -p ${pid} -o pid,cmd | grep -qE 'celery_bash_runner'; then
+        echo "`ps -p ${pid} -o pid,start,etime,cmd`"
+        kill -${SIG_NAME} ${pid}
+  done
+fi

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/celery_bash_runner_kill.sh.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/celery_bash_runner_kill.sh.j2
@@ -15,8 +15,9 @@ if [ "$PARENT_PIDS" != "" ]; then
   echo "Process information with start and elapsed time:"
   for pid in ${PARENT_PIDS}
   do
-     if ps -p ${pid} -o pid,cmd | grep -qE 'celery_bash_runner'; then
-        echo "`ps -p ${pid} -o pid,start,etime,cmd`"
-        kill -${SIG_NAME} ${pid}
+    if ps -p ${pid} -o pid,cmd | grep -qE 'celery_bash_runner'; then
+      echo "`ps -p ${pid} -o pid,start,etime,cmd`"
+      kill -${SIG_NAME} ${pid}
+    fi
   done
 fi

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/celery_bash_runner_kill.sh.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/celery_bash_runner_kill.sh.j2
@@ -4,11 +4,11 @@
 #
 
 HOURS=$1
-MAX_MINUTES=`expr ${HOURS} \* 60 \* 60`
+MAX_SECONDS=`expr ${HOURS} \* 60 \* 60`
 
 SIG_NAME=$2
 
-PARENT_PIDS=$(ps -eo comm,ppid,etimes | awk '/celeryd:/ { if ( $4 > '"${MAX_MINUTES}"' ) { print $3 } }');
+PARENT_PIDS=$(ps -eo comm,ppid,etimes | awk '/celeryd:/ { if ( $4 > '"${MAX_SECONDS}"' ) { print $3 } }');
 
 if [ "$PARENT_PIDS" != "" ]; then
   echo "Shutting down celery bash runners:"

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/celery_task_kill.sh.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/celery_task_kill.sh.j2
@@ -4,11 +4,11 @@
 #
 
 HOURS=$1
-MAX_MINUTES=`expr ${HOURS} \* 60 \* 60`
+MAX_SECONDS=`expr ${HOURS} \* 60 \* 60`
 
 SIG_NAME=$2
 
-PIDS=$(ps -eo comm,pid,etimes | awk '/celeryd:/ { if ( $4 > '"${MAX_MINUTES}"' ) { print $3 } }');
+PIDS=$(ps -eo comm,pid,etimes | awk '/celeryd:/ { if ( $4 > '"${MAX_SECONDS}"' ) { print $3 } }');
 
 if [ "$PIDS" != "" ]; then
   echo "Killing stale celery workers:"


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi.atlassian.net/browse/SAAS-16545

This is an improvement to an existing band-aid solution. The ticket outlines in detail the underlying issue, but basically we've seen celery processes, especially repeat_record_queue workers, fail to shutdown properly when receiving a SIGTERM. The investigation into this is ongoing, but in the meantime we should make this change since in the current state, if a celery process runs into an issue during shut down, supervisor is unaware of it and does not fire up a new worker. This way, supervisor will create a new worker. From what I've seen, the process that fails to shut down stops consuming from the queue, and there is still the hard kill that will come along to clean the rogue process up eventually.

You might ask "why do we do this in the first?". My understanding is that we periodically shut down celery processes to prevent them from outliving the release they are running on. There is some expectation that it might take awhile for a celery process to do a warm shutdown if there are any long running tasks in progress, but I'm not convinced that grace period should be 36 hours (currently our soft kill threshold is 36 hours, and our hard kill threshold is 72 hours, so 72 - 36 = 36).

Writing this out, I'm not convinced we shouldn't just remove these scripts altogether, but it feels like while this rogue celery process issue exists we are better off keeping these scripts to prevent them from building up over time.
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->