### PR TITLE
switch back to db.t3.medium on India

### DIFF
--- a/environments/india/terraform.yml
+++ b/environments/india/terraform.yml
@@ -330,7 +330,7 @@ proxy_servers:
 
 rds_instances:
   - identifier: "pgmain0-india"
-    instance_type: "db.t4g.medium"
+    instance_type: "db.t3.medium"
     storage: 500
     storage_type: gp3
     multi_az: true


### PR DESCRIPTION
switch back to db.t3.medium as we have savings plans for db.t3.medium

<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi.atlassian.net/browse/SAAS-16656
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
India
