### PR TITLE
Skip check when running deploy-stack

### DIFF
--- a/docs/source/installation/2-manual-install.rst
+++ b/docs/source/installation/2-manual-install.rst
@@ -538,17 +538,11 @@ You are now ready to deploy CommCare HQ services.
 
 ::
 
-   $ commcare-cloud cluster deploy-stack -e 'CCHQ_IS_FRESH_INSTALL=1'
+   $ commcare-cloud cluster deploy-stack -e 'CCHQ_IS_FRESH_INSTALL=1' --skip-check
 
 This will run a series of Ansible commands that will take quite a long
-time to run.
-
-If there are failures during the install, which may happen due to timing
-issues, you can continue running the playbook with:
-
-::
-
-   $ commcare-cloud cluster deploy-stack --skip-check -e 'CCHQ_IS_FRESH_INSTALL=1'
+time to run. If there are failures during the install, which may happen due to timing
+issues, you can rerun this command.
 
 Deploy CommCare HQ code
 -----------------------


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
I made a change to docs in https://github.com/dimagi/commcare-cloud/commit/01c3af2fb359c593b01e924e4c5480f38d5163fe that resulted in no longer using `--first-time` when running `deploy-stack`, but needed to explicitly set `--skip-check` since that is set by the first-time option. 
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
