### PR TITLE
Add root password while generating default secrets for HQ

### DIFF
--- a/commcare-cloud-bootstrap/environment/private.yml.j2
+++ b/commcare-cloud-bootstrap/environment/private.yml.j2
@@ -13,7 +13,7 @@ secrets:
       username: 'root'
       password: '{{ generate_password() }}'
       privs:
-        - objs: hqweb2postgres
+        - objs: commcarehq
           type: group
     commcare:
       username: 'commcarehq'


### PR DESCRIPTION
while setting up new region, we ran terraform plan which failed due to root user does not exist in default passwords

