### PR TITLE
Move creating /tmp out of other directories

### DIFF
--- a/src/commcare_cloud/ansible/roles/elasticsearch/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/elasticsearch/tasks/main.yml
@@ -142,6 +142,17 @@
 - debug: msg="If you're just updating the ES conf then you sill need to restart the cluster. Use  the 'es_rolling_restart' playbook."
   when: copy_elasticsearch_conf_result.changed
 
+- name: Create Elasticsearch tmp directory
+  become: yes
+  file:
+    path: "{{ elasticsearch_data_dir }}/tmp"
+    state: directory
+    owner: elasticsearch
+    group: elasticsearch
+    mode: 0755
+  tags:
+    - es_conf
+
 - name: Check if Elasticsearch data directories exist
   stat:
     path: "{{ item }}"
@@ -150,7 +161,6 @@
     - "{{ elasticsearch_data_dir }}"
     - "{{ elasticsearch_data_dir }}/data"
     - "{{ elasticsearch_data_dir }}/logs"
-    - "{{ elasticsearch_data_dir }}/tmp"
 
 - name: Create Elasticsearch data directories if they do not exist
   become: yes


### PR DESCRIPTION
Since this option is configured in `java.opts` and is recently changed so if anyone who will update the config might face issue after es restarts. The commit creates another task and tags it as `es_conf ` to ensure that the directory mentioned in `jvm.opts` exists


