### PR TITLE
Add gevent concurrency to reminder_case_update_bulk_queue

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -48,7 +48,8 @@ celery_processes:
       concurrency: 24
       num_workers: 5
     reminder_case_update_bulk_queue:
-      concurrency: 1
+      pooling: gevent
+      concurrency: 4
     reminder_queue:
       pooling: gevent
       concurrency: 40


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
This queue can see transient spikes in load and should have higher concurrency to deal with these spikes. Given this workload is already parallelized across celery machines, it should be safe to continue increasing concurrency. There is a lock acquired on each case that the rule is run on, so if multiple rules are being processed in parallel, that could lead to some lock timeouts but I don't believe to be a sufficient reason not to make this change.

There are a few different tasks that are sent to this queue. In order of how they are called:
- run_messaging_rule
- run_messaging_rule_for_shard
- sync_case_chunk_for_messaging_rule
- sync_case_for_messaging_rule (only called asynchronously if there is a failure in the above task)
- set_rule_complete

The bottleneck is on `sync_case_chunk_for_messaging_rule` as this does the heavy lifting of running the rule on each case in the chunk it was given. This involves fetching the case from the db, which feels like enough IO that a gevent pool is the correct decision.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production