### PR TITLE
Revert "More concurrency reminder_case_update_bulk_queue"

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -49,7 +49,7 @@ celery_processes:
       num_workers: 5
     reminder_case_update_bulk_queue:
       pooling: gevent
-      concurrency: 16
+      concurrency: 4
     reminder_queue:
       pooling: gevent
       concurrency: 40


### PR DESCRIPTION
Reverts dimagi/commcare-cloud#6493

Looks like we hit a limit elsewhere based on [the average duration](https://app.datadoghq.com/dashboard/bdu-k5b-bz5/celery-overview?fromUser=false&refresh_mode=sliding&tpl_var_celery_queue%5B0%5D=reminder_case_update_bulk_queue&from_ts=1742390259923&to_ts=1742393859923&live=true) for these tasks increased after increasing concurrency more.