### PR TITLE
Ignore errors in check mode for Unarchive Elasticsearch

### DIFF
--- a/src/commcare_cloud/ansible/roles/elasticsearch/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/elasticsearch/tasks/main.yml
@@ -55,6 +55,7 @@
     src: "/home/{{ cchq_user }}/downloads/elasticsearch-{{ elasticsearch_version }}.tar.gz"
     dest: /opt/
     copy: no
+  ignore_errors: '{{ ansible_check_mode }}'
 
 - name: Chown Elasticsearch
   become: yes


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
The new ES tar.gz file is most likely not available at this point when running in check mode, so lets ignore errors for this task when in check mode.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
