### PR TITLE
Stop multiplexing apps index on prod

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -170,7 +170,7 @@ localsettings:
   # When to consider multiplex settings
   ES_MULTIPLEX_TO_VERSION: '6'
   # Index Multiplexer Settings  
-  ES_APPS_INDEX_MULTIPLEXED: True
+  ES_APPS_INDEX_MULTIPLEXED: False # Index swapped
   ES_CASE_SEARCH_INDEX_MULTIPLEXED: False # Index swapped
   ES_CASES_INDEX_MULTIPLEXED: False # Index swapped
   ES_DOMAINS_INDEX_MULTIPLEXED: False # Index swapped


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
This is the last older index on prod. This was swapped a couple of days back and we haven't seen any issues with the newer index. After this PR is applied we would be stopping writes to older apps index and will later delete the index.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production

