### PR TITLE
Update India S3 URL for newer botocore versions

### DIFF
--- a/environments/india/public.yml
+++ b/environments/india/public.yml
@@ -79,7 +79,7 @@ couchdb_cluster_settings:
   n: 3
 
 s3_blob_db_enabled: yes
-s3_blob_db_url: "https://s3.amazonaws.com"
+s3_blob_db_url: "https://s3.ap-south-1.amazonaws.com"
 s3_blob_db_s3_bucket: 'dimagi-commcare-india-blobdb'
 
 root_email: commcarehq-ops+root@dimagi.com


### PR DESCRIPTION
Resolves `ClientError: An error occurred (301) when calling the HeadBucket operation: Moved Permanently`
with `botocore==1.37.15`

This error did not occur with `botocore==1.27.96`
Other versions not tested.

The new URL has been tested and verified to work on both old and new versions of botocore.

https://dimagi.slack.com/archives/CCXQZLECS/p1743020693118459

##### Environments Affected
India
