### PR TITLE
Increase pillow_b2000 machine to r6a.12xlarge temporarily

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -277,7 +277,7 @@ servers:
     count: 1
 
   - server_name: "pillow_b2{i}-production"
-    server_instance_type: r6a.8xlarge
+    server_instance_type: r6a.12xlarge
     network_tier: "app-private"
     az: "b"
     volume_size: 50


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi.atlassian.net/browse/SAAS-16891

This is a temporary increase to accommodate more case pillow processes.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production