### PR TITLE
Incease case pillow processes to 32

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -143,6 +143,6 @@ pillows:
   pillow_b2000:
   # case-sql partitions: 96
     case-pillow:
-      num_processes: 25
-      total_processes: 25
+      num_processes: 33
+      total_processes: 33
       dedicated_migration_process: True


### PR DESCRIPTION
The extra process is for the dedicated migration pillow

<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi.atlassian.net/browse/SAAS-16891

This would in theory be safe to apply on the existing machine size, but we also plan to increase the machine size just to be safe and give us more room to grow if needed: https://github.com/dimagi/commcare-cloud/pull/6506
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production
