### PR TITLE
Limit reprocessing concurrency to 1

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -103,7 +103,7 @@ celery_processes:
       pooling: gevent
       concurrency: 2
     submission_reprocessing_queue:
-      concurrency: 2
+      concurrency: 1
       prefetch_multiplier: 1
     sumologic_logs_queue:
       pooling: gevent


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
This is a bit hacky, but we've seen this queue cause memory issues. Seems like limiting processing to one thing at a time could help (maybe). If not, we could also try moving this to the other celery machines which have much more memory headroom, but again, is a bit hacky and we are better off solving the underlying problem.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production