### PR TITLE
Change from m6a.4xlarge to 8xlarge

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -2,7 +2,7 @@ datadog_pythonagent: True
 django_command_prefix: '{% if inventory_hostname in groups["mobile_webworkers"] %}{{ virtualenv_home }}/bin/ddtrace-run {% endif %}'
 celery_command_prefix: ''
 gunicorn_workers_static_factor: 0
-gunicorn_workers_factor: 4
+gunicorn_workers_factor: 2
 formplayer_memory: "31g"
 formplayer_g1heapregionsize: "16m"
 formplayer_command_args: ''

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -66,7 +66,7 @@ servers:
     server_auto_recovery: true
 
   - server_name: "web_m_a2{i}-production"
-    server_instance_type: m6a.4xlarge
+    server_instance_type: m6a.8xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 40
@@ -76,7 +76,7 @@ servers:
     server_auto_recovery: true
 
   - server_name: "web_m_b2{i}-production"
-    server_instance_type: m6a.4xlarge
+    server_instance_type: m6a.8xlarge
     network_tier: "app-private"
     az: "b"
     volume_size: 40


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Temporary change to ensure trainings go smoothly.

On demand usage per day is for 4xlarge is $16.59, and for 8xlarge is $33.18. That is a difference of $16.59, which for 4 machines is 4 x 16.59 = $66.36 per day. That is just under $200 for 3 days which is how long we plan to have this rolled out for.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production
