### PR TITLE
Give repeat_record_queue more cpu

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -57,7 +57,8 @@ celery_processes:
       concurrency: 1
     repeat_record_queue:
       pooling: gevent
-      concurrency: 72
+      concurrency: 36
+      num_workers: 2
       prefetch_multiplier: 1
     repeat_record_datasource_queue:
       pooling: gevent


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
In theory, the repeat record queue should be strictly I/O bound, however in practice there are some funky repeaters that appear to consume quite a bit of CPU. This makes the roundtrip for the gevent loop take awhile, and thus our throughput for tasks on this queue decreases.

This creates an additional process to give more CPU to this queue.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production