### PR TITLE
Removed build_requirejs from deploy

### DIFF
--- a/src/commcare_cloud/ansible/roles/deploy_hq/tasks/staticfiles_collect.yml
+++ b/src/commcare_cloud/ansible/roles/deploy_hq/tasks/staticfiles_collect.yml
@@ -27,7 +27,6 @@
     - collectstatic --noinput -v 0
     - fix_less_imports_collectstatic
     - compilejsi18n
-    - build_requirejs
 
 - name: Generate Webpack Settings
   # Generates webpack/settings.json so that webpack has the same path


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/pull/36073 migrated the last requirejs pages on HQ to webpack.

I ran a test deploy on staging.

##### Environments Affected
None

