### PR TITLE
Move the submission_reprocessing_queue off of celerybeat

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -69,6 +69,9 @@ celery_processes:
     sms_queue:
       pooling: gevent
       concurrency: 20
+    submission_reprocessing_queue:
+      concurrency: 1
+      prefetch_multiplier: 1
     ucr_indicator_queue:
       concurrency: 3
     ucr_queue:
@@ -102,9 +105,6 @@ celery_processes:
     malt_generation_queue:
       pooling: gevent
       concurrency: 2
-    submission_reprocessing_queue:
-      concurrency: 2
-      prefetch_multiplier: 1
     sumologic_logs_queue:
       pooling: gevent
       concurrency: 50


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi.atlassian.net/browse/SAAS-16482

Tasks on this queue can consume a lot of memory. Celerybeat is a smaller machine than the other celery machines, and sometimes experiences OOMs because of these tasks. We should not subject the celerybeat machine to this since it is important for it to remain up for the sake of periodic tasks.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production
