### PR TITLE
Increase CPU on HQ webworkers

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -44,7 +44,7 @@ servers:
     os: jammy 
 
   - server_name: "web_a2{i}-production"
-    server_instance_type: m6a.2xlarge
+    server_instance_type: c6a.4xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 40
@@ -55,7 +55,7 @@ servers:
     server_auto_recovery: true
 
   - server_name: "web_b2{i}-production"
-    server_instance_type: m6a.2xlarge
+    server_instance_type: c6a.4xlarge
     network_tier: "app-private"
     az: "b"
     volume_size: 40


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi.atlassian.net/browse/SAAS-16942

The price difference is ~$6.50 a day per machine, across 6 machines, ~$40 a day. I view this as a temporary change, and would be more interested in moving API workload onto its own machines, which will also increase costs, but give us better control over fairly different workloads.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production
