### PR TITLE
Downsize mobile webworkers

### DIFF
--- a/environments/backup-production/app-processes.yml
+++ b/environments/backup-production/app-processes.yml
@@ -2,7 +2,7 @@ datadog_pythonagent: True
 django_command_prefix: ''
 celery_command_prefix: ''
 gunicorn_workers_static_factor: 0
-gunicorn_workers_factor: 2
+gunicorn_workers_factor: 4
 formplayer_memory: "1g"
 formplayer_g1heapregionsize: "2m"
 management_commands:

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -66,7 +66,7 @@ servers:
     server_auto_recovery: true
 
   - server_name: "web_m_a2{i}-production"
-    server_instance_type: m6a.8xlarge
+    server_instance_type: m6a.4xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 40
@@ -76,7 +76,7 @@ servers:
     server_auto_recovery: true
 
   - server_name: "web_m_b2{i}-production"
-    server_instance_type: m6a.8xlarge
+    server_instance_type: m6a.4xlarge
     network_tier: "app-private"
     az: "b"
     volume_size: 40


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi.atlassian.net/browse/SAAS-16942

Change mobile webworkers back from m6a.8xlarge to m6a.4xlarge, effectively reverting https://github.com/dimagi/commcare-cloud/pull/6510.
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production