### PR TITLE
Upgrading Ansible dependency for DavidWittman.redis role

### DIFF
--- a/src/commcare_cloud/ansible/requirements.yml
+++ b/src/commcare_cloud/ansible/requirements.yml
@@ -15,8 +15,9 @@ roles:
   - src: git+https://github.com/nickhammond/ansible-logrotate.git
     version: v0.0.5
     name: ansible-logrotate
-  - src: DavidWittman.redis
-    version: 1.2.7
+  - name: DavidWittman.redis
+    src: https://github.com/DavidWittman/ansible-redis.git
+    version: 1.2.12
   - src: sansible.logstash
     version: v2.4.0-latest
   - name: cloudalchemy.prometheus


### PR DESCRIPTION
Ticket : https://dimagi.atlassian.net/browse/SAAS-16650

Environments Affected : ALL `staging, India and production`

We upgraded the DavidWittman.redis role from version 1.2.7 to 1.2.12 using the source from [GitHub](https://github.com/DavidWittman/ansible-redis), as the [Ansible Galaxy version](https://github.com/DavidWittman/ansible-redis) was not up to date. The update was tested in the Monolith environment and is functioning as expected.