### PR TITLE
Upgrading Ansible dependency for sansible.logstash role

### DIFF
--- a/src/commcare_cloud/ansible/requirements.yml
+++ b/src/commcare_cloud/ansible/requirements.yml
@@ -19,7 +19,7 @@ roles:
     src: https://github.com/DavidWittman/ansible-redis.git
     version: 1.2.12
   - src: sansible.logstash
-    version: v2.4.0-latest
+    version: v2.4.4
   - name: cloudalchemy.prometheus
     src: https://github.com/cloudalchemy/ansible-prometheus
     version: 2.15.5


### PR DESCRIPTION
Ticket : https://dimagi.atlassian.net/browse/SAAS-16650

Environments Affected : ALL `staging, India and production`

We upgraded the sansible.logstash role from version v2.4.0-latest to 2.4.4 using the source from the [Ansible Galaxy version](https://galaxy.ansible.com/ui/standalone/roles/sansible/logstash/versions/). The update was tested in the Monolith environment and is functioning as expected.