### PR TITLE
Route API requests to API webworkers if specified

### DIFF
--- a/src/commcare_cloud/ansible/roles/nginx/vars/cchq_ssl.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/cchq_ssl.yml
@@ -8,6 +8,9 @@ nginx_sites:
     - name: "{{ deploy_env }}_commcare_submissions"
       hosts: "{{ groups['mobile_webworkers'] | default('webworkers') }}"
       port: "{{ django_port }}"
+    - name: "{{ deploy_env }}_commcare_api"
+      hosts: "{{ groups['api_webworkers'] | default('webworkers') }}"
+      port: "{{ django_port }}"
     - name: "{{ deploy_env }}_formplayer"
       hosts: formplayer
       port: "{{ formplayer_port }}"
@@ -69,6 +72,14 @@ nginx_sites:
       client_body_buffer_size: 512k
     - name: '~ (/a/[^/]+/(receiver|phone)/|/hq/admin/phone/restore/)'
       balancer: "{{ deploy_env }}_commcare_submissions"
+      proxy_redirect: "http://{{ SITE_HOST }} https://{{ SITE_HOST }}"
+      proxy_next_upstream_tries: 1
+      proxy_read_timeout: 900s
+      proxy_buffers: 8 64k
+      proxy_buffer_size: 64k
+      client_body_buffer_size: 512k
+    - name: '~ (/a/[^/]+/api/)'
+      balancer: "{{ deploy_env }}_commcare_api"
       proxy_redirect: "http://{{ SITE_HOST }} https://{{ SITE_HOST }}"
       proxy_next_upstream_tries: 1
       proxy_read_timeout: 900s


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
In theory this PR alone shouldn't change anything, but just updates the nginx config to route API requests to the api_webworkers group if that group exists, otherwise default to webworkers, similar to how mobile webworkers operates.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All