### PR TITLE
Upgrading Ansible dependency for cloudalchemy.prometheus

### DIFF
--- a/src/commcare_cloud/ansible/requirements.yml
+++ b/src/commcare_cloud/ansible/requirements.yml
@@ -20,9 +20,8 @@ roles:
     version: 1.2.12
   - src: sansible.logstash
     version: v2.4.4
-  - name: cloudalchemy.prometheus
-    src: https://github.com/cloudalchemy/ansible-prometheus
-    version: 2.15.5
+  - src: cloudalchemy.prometheus
+    version: 4.0.0
   - src: cloudalchemy.alertmanager
     version: 0.19.0
   - src: cloudalchemy.grafana


### PR DESCRIPTION
Ticket : https://dimagi.atlassian.net/browse/SAAS-16650

Environments Affected : ALL `staging, India and production`

We upgraded the cloudalchemy.prometheus role from version 2.15.5 to 4.0.0 using the source from the [Ansible Galaxy version](https://galaxy.ansible.com/ui/standalone/roles/cloudalchemy/prometheus/versions/). The update was tested in the Monolith environment and is functioning as expected.
