### PR TITLE
Upgrading Ansible dependency for gantsign.golang role

### DIFF
--- a/src/commcare_cloud/ansible/requirements.yml
+++ b/src/commcare_cloud/ansible/requirements.yml
@@ -32,7 +32,7 @@ roles:
   - src: bdellegrazie.postgres_exporter
     version: v4.1.0
   - src: gantsign.golang
-    version: 3.4.1
+    version: 3.2.1
 
 collections:
   - name: https://github.com/dimagi/commcare-logstash/releases/download/V0.9.5/dimagi-commcare_logstash-0.9.5.tar.gz

--- a/src/commcare_cloud/ansible/requirements.yml
+++ b/src/commcare_cloud/ansible/requirements.yml
@@ -32,7 +32,7 @@ roles:
   - src: bdellegrazie.postgres_exporter
     version: v4.1.0
   - src: gantsign.golang
-    version: 2.3.1  
+    version: 3.4.1
 
 collections:
   - name: https://github.com/dimagi/commcare-logstash/releases/download/V0.9.5/dimagi-commcare_logstash-0.9.5.tar.gz


### PR DESCRIPTION
Ticket : https://dimagi.atlassian.net/browse/SAAS-16650

Environments Affected : ALL `staging, India and production`

Upgraded the Version 3.4.1 of gantsign.golang is not working for us. So, I checked the available versions listed [here](https://galaxy.ansible.com/ui/standalone/roles/gantsign/golang/versions/) and found that version 3.2.1 works fine. The update was tested in the Monolith environment and is functioning as expected