### PR TITLE
Upgrading Ansible dependency for cloudalchemy.alertmanager role

### DIFF
--- a/src/commcare_cloud/ansible/requirements.yml
+++ b/src/commcare_cloud/ansible/requirements.yml
@@ -24,7 +24,7 @@ roles:
     src: https://github.com/cloudalchemy/ansible-prometheus
     version: 2.15.5
   - src: cloudalchemy.alertmanager
-    version: 0.19.0
+    version: 0.19.1
   - src: cloudalchemy.grafana
     version: 0.17.0
   - src: cloudalchemy.node_exporter


### PR DESCRIPTION
Ticket : https://dimagi.atlassian.net/browse/SAAS-16650

Environments Affected : ALL `staging, India and production`

We upgraded the cloudalchemy.alertmanager role from version 0.19.0 to 0.19.1 using the source from the [Ansible Galaxy version](https://galaxy.ansible.com/ui/standalone/roles/cloudalchemy/alertmanager/versions/). The update was tested in the Monolith environment and is functioning as expected.
