### PR TITLE
Upgrading Ansible dependency for cloudalchemy.node_exporter role

### DIFF
--- a/src/commcare_cloud/ansible/requirements.yml
+++ b/src/commcare_cloud/ansible/requirements.yml
@@ -28,7 +28,7 @@ roles:
   - src: cloudalchemy.grafana
     version: 0.17.0
   - src: cloudalchemy.node_exporter
-    version: 0.21.5
+    version: 2.0.0
   - src: bdellegrazie.postgres_exporter
     version: v4.1.0
   - src: gantsign.golang


### PR DESCRIPTION
Ticket : https://dimagi.atlassian.net/browse/SAAS-16650

Environments Affected : ALL `staging, India and production`

We upgraded the cloudalchemy.node_exporter role from version 0.21.5 to 0.21.5 using the source from the [Ansible Galaxy version](https://galaxy.ansible.com/ui/standalone/roles/cloudalchemy/node_exporter/versions/). The update was tested in the Monolith environment and is functioning as expected.