### PR TITLE
Revert "Route API requests to API webworkers if specified"

### DIFF
--- a/src/commcare_cloud/ansible/roles/nginx/vars/cchq_ssl.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/cchq_ssl.yml
@@ -8,9 +8,6 @@ nginx_sites:
     - name: "{{ deploy_env }}_commcare_submissions"
       hosts: "{{ groups['mobile_webworkers'] | default('webworkers') }}"
       port: "{{ django_port }}"
-    - name: "{{ deploy_env }}_commcare_api"
-      hosts: "{{ groups['api_webworkers'] | default('webworkers') }}"
-      port: "{{ django_port }}"
     - name: "{{ deploy_env }}_formplayer"
       hosts: formplayer
       port: "{{ formplayer_port }}"
@@ -72,14 +69,6 @@ nginx_sites:
       client_body_buffer_size: 512k
     - name: '~ (/a/[^/]+/(receiver|phone)/|/hq/admin/phone/restore/)'
       balancer: "{{ deploy_env }}_commcare_submissions"
-      proxy_redirect: "http://{{ SITE_HOST }} https://{{ SITE_HOST }}"
-      proxy_next_upstream_tries: 1
-      proxy_read_timeout: 900s
-      proxy_buffers: 8 64k
-      proxy_buffer_size: 64k
-      client_body_buffer_size: 512k
-    - name: '~ (/a/[^/]+/api/)'
-      balancer: "{{ deploy_env }}_commcare_api"
       proxy_redirect: "http://{{ SITE_HOST }} https://{{ SITE_HOST }}"
       proxy_next_upstream_tries: 1
       proxy_read_timeout: 900s


### PR DESCRIPTION
Reverts dimagi/commcare-cloud#6519

On environments where there are distinct groups for hq and mobile webworkers specified, this change could lead to API requests moving from hq webworkers to all webworkers, including mobile webworkers. There is a fix in progress but safest to just revert for now.