### PR TITLE
[Take 2] Route API requests to api group if available

### DIFF
--- a/src/commcare_cloud/ansible/roles/nginx/vars/cchq_ssl.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/cchq_ssl.yml
@@ -9,7 +9,7 @@ nginx_sites:
       hosts: "{{ groups['mobile_webworkers'] | default('webworkers') }}"
       port: "{{ django_port }}"
     - name: "{{ deploy_env }}_commcare_api"
-      hosts: "{{ groups['api_webworkers'] | default('webworkers') }}"
+      hosts: "{{ groups.get('api_webworkers') or groups.get('hq_webworkers') or groups.get('webworkers') }}"
       port: "{{ django_port }}"
     - name: "{{ deploy_env }}_formplayer"
       hosts: formplayer

--- a/src/commcare_cloud/ansible/roles/nginx/vars/cchq_ssl.yml
+++ b/src/commcare_cloud/ansible/roles/nginx/vars/cchq_ssl.yml
@@ -8,6 +8,9 @@ nginx_sites:
     - name: "{{ deploy_env }}_commcare_submissions"
       hosts: "{{ groups['mobile_webworkers'] | default('webworkers') }}"
       port: "{{ django_port }}"
+    - name: "{{ deploy_env }}_commcare_api"
+      hosts: "{{ groups['api_webworkers'] | default('webworkers') }}"
+      port: "{{ django_port }}"
     - name: "{{ deploy_env }}_formplayer"
       hosts: formplayer
       port: "{{ formplayer_port }}"
@@ -69,6 +72,14 @@ nginx_sites:
       client_body_buffer_size: 512k
     - name: '~ (/a/[^/]+/(receiver|phone)/|/hq/admin/phone/restore/)'
       balancer: "{{ deploy_env }}_commcare_submissions"
+      proxy_redirect: "http://{{ SITE_HOST }} https://{{ SITE_HOST }}"
+      proxy_next_upstream_tries: 1
+      proxy_read_timeout: 900s
+      proxy_buffers: 8 64k
+      proxy_buffer_size: 64k
+      client_body_buffer_size: 512k
+    - name: '~ (/a/[^/]+/api/)'
+      balancer: "{{ deploy_env }}_commcare_api"
       proxy_redirect: "http://{{ SITE_HOST }} https://{{ SITE_HOST }}"
       proxy_next_upstream_tries: 1
       proxy_read_timeout: 900s


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi.atlassian.net/browse/SAAS-17337

Redo of https://github.com/dimagi/commcare-cloud/pull/6519, but updated the syntax to fallback to hq_webworkers _first_, and then all webworkers if that group doesn't exist.

I tested this on staging and it worked, and my understanding is that jinja is inspired by python syntax which this is.
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All