### PR TITLE
Add 16 more case pillow processes

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -144,6 +144,6 @@ pillows:
   pillow_b2000:
   # case-sql partitions: 96
     case-pillow:
-      num_processes: 33
-      total_processes: 33
+      num_processes: 49
+      total_processes: 49 
       dedicated_migration_process: True


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi.atlassian.net/browse/SAAS-16892

Based on [machine resources](https://app.datadoghq.com/dashboard/nbz-bie-nip/host-groups?fromUser=false&refresh_mode=sliding&tpl_var_host%5B0%5D=pillow-b2000-production&from_ts=1743516404510&to_ts=1744121204510&live=true), there is room to add more processes still.

At peaks, memory usage is ~195 GB (conservatively), and each process takes up ~6GB, that is 96GB so memory will be fine. CPU isn't a concern.
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production