### PR TITLE
Add more RAM/CPU to case pillow machine

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -277,7 +277,7 @@ servers:
     count: 1
 
   - server_name: "pillow_b2{i}-production"
-    server_instance_type: r6a.12xlarge
+    server_instance_type: r6a.16xlarge
     network_tier: "app-private"
     az: "b"
     volume_size: 50

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -277,7 +277,7 @@ servers:
     count: 1
 
   - server_name: "pillow_b2{i}-production"
-    server_instance_type: r6a.16xlarge
+    server_instance_type: r6a.24xlarge
     network_tier: "app-private"
     az: "b"
     volume_size: 50


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi.atlassian.net/browse/SAAS-16892

~This is a difference of $23 per day. This increases RAM from 386 to 512. At 48 processes, we are consuming 250 GB of RAM so doubling will put us just around 500GB. I'm not sure if that is quite enough headroom to feel comfortable.~

Decided to increase to r6a.24xlarge instead. So this will be an added $65 per day. 
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production