### PR TITLE
Create command to check deploy diff

### DIFF
--- a/docs/source/reference/1-commcare-cloud/commands.md
+++ b/docs/source/reference/1-commcare-cloud/commands.md
@@ -1206,6 +1206,22 @@ release.
 
 ---
 
+#### ``deploy-diff`` Command
+
+Display pull requests that would be deployed on master now.
+
+```
+commcare-cloud <env> deploy-diff [{commcare,formplayer}]
+```
+
+##### Positional Arguments
+
+###### `{commcare,formplayer}`
+
+Component to check deploy diff for. Default is 'commcare'.
+
+---
+
 #### ``list-releases`` Command
 
 List names that can be passed to `deploy --resume=RELEASE_NAME`

--- a/src/commcare_cloud/commands/deploy/command.py
+++ b/src/commcare_cloud/commands/deploy/command.py
@@ -112,6 +112,7 @@ class DeployDiff(CommandBase):
     def run(self, args, unknown_args):
         check_branch(args)
         environment = get_environment(args.env_name)
+        environment.release_name = 'deploy-diff'
         if args.component == 'formplayer':
             diff = get_formplayer_deploy_diff(environment)
         else:

--- a/src/commcare_cloud/commands/deploy/command.py
+++ b/src/commcare_cloud/commands/deploy/command.py
@@ -11,8 +11,8 @@ from commcare_cloud.commands.ansible.run_module import BadAnsibleResult
 from commcare_cloud.const import DATE_FMT
 from commcare_cloud.commands import shared_args
 from commcare_cloud.commands.command_base import Argument, CommandBase
-from commcare_cloud.commands.deploy.commcare import deploy_commcare
-from commcare_cloud.commands.deploy.formplayer import deploy_formplayer
+from commcare_cloud.commands.deploy.commcare import deploy_commcare, get_commcare_deploy_diff
+from commcare_cloud.commands.deploy.formplayer import deploy_formplayer, get_formplayer_deploy_diff
 from commcare_cloud.environment.main import get_environment
 
 
@@ -94,6 +94,30 @@ class Deploy(CommandBase):
             else:
                 rc = deploy_formplayer(environment, args)
         return rc
+
+class DeployDiff(CommandBase):
+    command = 'deploy-diff'
+    help = (
+        "Display pull requests that would be deployed on master now."
+    )
+
+    arguments = (
+        Argument('component', nargs='?', choices=['commcare', 'formplayer'], default='commcare', help="""
+            Component to check deploy diff for. Default is 'commcare'.
+        """),
+        shared_args.QUIET_ARG,
+        shared_args.BRANCH_ARG,
+    )
+
+    def run(self, args, unknown_args):
+        check_branch(args)
+        environment = get_environment(args.env_name)
+        if args.component == 'formplayer':
+            diff = get_formplayer_deploy_diff(environment)
+        else:
+            diff = get_commcare_deploy_diff(environment, args)
+        diff.print_deployer_diff()
+
 
 
 def _warn_about_non_formplayer_args(args):

--- a/src/commcare_cloud/commands/deploy/command.py
+++ b/src/commcare_cloud/commands/deploy/command.py
@@ -95,6 +95,7 @@ class Deploy(CommandBase):
                 rc = deploy_formplayer(environment, args)
         return rc
 
+
 class DeployDiff(CommandBase):
     command = 'deploy-diff'
     help = (
@@ -118,7 +119,6 @@ class DeployDiff(CommandBase):
         else:
             diff = get_commcare_deploy_diff(environment, args)
         diff.print_deployer_diff()
-
 
 
 def _warn_about_non_formplayer_args(args):

--- a/src/commcare_cloud/commands/deploy/commcare.py
+++ b/src/commcare_cloud/commands/deploy/commcare.py
@@ -25,6 +25,7 @@ from commcare_cloud.events import publish_deploy_event
 from commcare_cloud.const import DATE_FMT
 from commcare_cloud.github import github_repo
 
+
 def get_commcare_deploy_diff(environment, args):
     deploy_revs, rev_diffs = get_deploy_revs_and_diffs_from_defaults(environment, args)
     return _get_code_diff(environment, deploy_revs, False)

--- a/src/commcare_cloud/commands/deploy/commcare.py
+++ b/src/commcare_cloud/commands/deploy/commcare.py
@@ -25,6 +25,10 @@ from commcare_cloud.events import publish_deploy_event
 from commcare_cloud.const import DATE_FMT
 from commcare_cloud.github import github_repo
 
+def get_commcare_deploy_diff(environment, args):
+    deploy_revs, rev_diffs = get_deploy_revs_and_diffs_from_defaults(environment, args)
+    return _get_code_diff(environment, deploy_revs, False)
+
 
 def deploy_commcare(environment, args, unknown_args):
     deploy_revs, rev_diffs = get_deploy_revs_and_diffs_from_defaults(environment, args)

--- a/src/commcare_cloud/commands/deploy/formplayer.py
+++ b/src/commcare_cloud/commands/deploy/formplayer.py
@@ -51,6 +51,10 @@ class VersionInfo(namedtuple("VersionInfo", "commit, message, time, build_time")
         delta = datetime.utcnow() - build_time
         return timeago(delta)
 
+def get_formplayer_deploy_diff(environment):
+    tag_commits = environment.fab_settings_config.tag_deploy_commits
+    repo = github_repo('dimagi/formplayer', require_write_permissions=tag_commits)
+    return get_deploy_diff(environment, repo)
 
 def deploy_formplayer(environment, args):
     if not confirm_environment_time(environment, quiet=args.quiet):
@@ -60,10 +64,7 @@ def deploy_formplayer(environment, args):
     print(color_notice("\nPreparing to deploy Formplayer to: "), end="")
     print(f"{environment.name}\n")
 
-    tag_commits = environment.fab_settings_config.tag_deploy_commits
-    repo = github_repo('dimagi/formplayer', require_write_permissions=tag_commits)
-
-    diff = get_deploy_diff(environment, repo)
+    diff = get_formplayer_deploy_diff(environment)
     diff.print_deployer_diff()
 
     context = DeployContext(

--- a/src/commcare_cloud/commands/deploy/formplayer.py
+++ b/src/commcare_cloud/commands/deploy/formplayer.py
@@ -51,10 +51,12 @@ class VersionInfo(namedtuple("VersionInfo", "commit, message, time, build_time")
         delta = datetime.utcnow() - build_time
         return timeago(delta)
 
+
 def get_formplayer_deploy_diff(environment):
     tag_commits = environment.fab_settings_config.tag_deploy_commits
     repo = github_repo('dimagi/formplayer', require_write_permissions=tag_commits)
     return get_deploy_diff(environment, repo)
+
 
 def deploy_formplayer(environment, args):
     if not confirm_environment_time(environment, quiet=args.quiet):

--- a/src/commcare_cloud/commcare_cloud.py
+++ b/src/commcare_cloud/commcare_cloud.py
@@ -16,7 +16,7 @@ from commcare_cloud.cli_utils import print_command
 from commcare_cloud.colors import color_error
 from commcare_cloud.commands.ansible.downtime import Downtime
 from commcare_cloud.commands.clean_releases import CleanReleases
-from commcare_cloud.commands.deploy.command import Deploy
+from commcare_cloud.commands.deploy.command import Deploy, DeployDiff
 from commcare_cloud.commands.migrations.couchdb import MigrateCouchdb
 from commcare_cloud.commands.migrations.copy_files import CopyFiles
 from commcare_cloud.commands.preindex_views import PreindexViews
@@ -85,6 +85,7 @@ COMMAND_GROUPS = OrderedDict([
         UpdateSupervisorConfs,
         Fab,
         Deploy,
+        DeployDiff,
         ListReleases,
         CleanReleases,
         PreindexViews,


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Just a minor `cchq` command to view the deploy diff, aka the PRs set to go out if we were to deploy right now. It is nice to get the list of PRs without interacting with the `deploy` command directly. I thought about adding a `--diff` option to the deploy command that clearly said "don't actually deploy, just show the diff", but there are already so many arguments for that command that creating a simple new command seemed fine.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None