### PR TITLE
Downsize the CouchDB disk on couch11 from 3500GB to 900GB

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -189,7 +189,7 @@ servers:
     volume_size: 90
     volume_encrypted: yes
     block_device:
-      volume_size: 3500
+      volume_size: 900
       encrypted: yes
     group: "couchdb2"
     os: bionic


### PR DESCRIPTION
**Ticket :** https://dimagi.atlassian.net/browse/SAAS-17334

**Environments Affected :** Production