### PR TITLE
Use Java 17 with Elasticsearch 6

### DIFF
--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -168,7 +168,8 @@ celery_hours_before_soft_kill: ~
 ansible_become_password: "{{ ansible_sudo_pass }}"
 
 # Java version for Formplayer
-java_17_bin_path: /usr/lib/jvm/java-1.17.0-openjdk-amd64/bin
+java_17_home_path: /usr/lib/jvm/java-1.17.0-openjdk-amd64
+java_17_bin_path: '{{ java_17_home_path }}/bin'
 
 #  To find this complete list, you can run:
 #  $ find . -type f | grep templates/supervisor_

--- a/src/commcare_cloud/ansible/roles/elasticsearch/templates/systemd/elasticsearch.service.j2
+++ b/src/commcare_cloud/ansible/roles/elasticsearch/templates/systemd/elasticsearch.service.j2
@@ -8,6 +8,9 @@ After=network-online.target
 Type=simple
 Environment=ES_HOME={{ elasticsearch_home }}
 Environment=ES_PATH_CONF={{ elasticsearch_conf_dir}}
+{% if elasticsearch_version == '6.8.23'%}
+Environment=JAVA_HOME={{ java_17_home_path }}
+{% endif %}
 {% if elasticsearch_version <= '5.6.16'%}
 Environment=CONF_DIR={{ elasticsearch_conf_dir}}
 {% endif %}


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Use Java 17 on Elasticsearch 6.8.23.

Upgrading the java version allows us to use a garbage collection strategy that is a better fit for the size of our infra.

As outlined in [this matrix](https://www.elastic.co/support/matrix#matrix_jvm), Elasticsearch 6 clearly supports this version of Java, and we already have this version of Java installed on machines which makes it really convenient to switch.

This was tested on staging.
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production, India, Staging (environments with Elasticsearch 6.8.23)