### PR TITLE
Double CPU on ES Coordinator machines

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -167,7 +167,7 @@ servers:
       BillTo: USH
 
   - server_name: "escoordinator_a1-production"
-    server_instance_type: r6in.2xlarge
+    server_instance_type: m6in.4xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 30
@@ -175,7 +175,7 @@ servers:
     os: jammy 
 
   - server_name: "escoordinator_b1-production"
-    server_instance_type: r6in.2xlarge
+    server_instance_type: m6in.4xlarge
     network_tier: "db-private"
     az: "b"
     volume_size: 30


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi.atlassian.net/browse/SAAS-17362

After increasing network, we still saw a bottleneck in CPU so increasing CPU as well. We don't need more RAM, hence the change to m6in instead of r6in.
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production