### PR TITLE
More CPU on mobile webworkers

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -66,7 +66,7 @@ servers:
     server_auto_recovery: true
 
   - server_name: "web_m_a2{i}-production"
-    server_instance_type: m6a.4xlarge
+    server_instance_type: c6a.8xlarge
     network_tier: "app-private"
     az: "a"
     volume_size: 40
@@ -76,7 +76,7 @@ servers:
     server_auto_recovery: true
 
   - server_name: "web_m_b2{i}-production"
-    server_instance_type: m6a.4xlarge
+    server_instance_type: c6a.8xlarge
     network_tier: "app-private"
     az: "b"
     volume_size: 40


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi.atlassian.net/browse/SAAS-17362

Add additional CPU to mobile webworkers. We don't need more RAM, so switching from m6a to c6a family.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production 
