### PR TITLE
Increase pgbouncer connections to pgmain

### DIFF
--- a/environments/production/postgresql.yml
+++ b/environments/production/postgresql.yml
@@ -32,7 +32,7 @@ dbs:
   main:
     host: rds_pgmain1
     pgbouncer_endpoint: pgmain_nlb
-    pgbouncer_pool_size: 36
+    pgbouncer_pool_size: 43
     pgbouncer_reserve_pool_size: 0
     pgbouncer_hosts:
       - pgbouncer_a4

--- a/environments/production/postgresql.yml
+++ b/environments/production/postgresql.yml
@@ -90,7 +90,7 @@ dbs:
   repeaters:
     host: rds_pgmain1
     pgbouncer_endpoint: pgmain_nlb
-    pgbouncer_pool_size: 6
+    pgbouncer_pool_size: 12
     pgbouncer_reserve_pool_size: 0
     pgbouncer_hosts:
       - pgbouncer_a4


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi.atlassian.net/browse/SAAS-17395

This is increasing the default pool size on each pgbouncer machine from 36 to 43 for the main database, and from 6 to 12 for the repeaters db, both of which live on pgmain. There are two pgbouncer machines that handle requests for the main db, so this will result in an increase of 14 connections to the main db and 12 connections to the repeaters db.
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production