### PR TITLE
Bump up concurrency for ucr indicator queue

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -74,7 +74,7 @@ celery_processes:
       concurrency: 1
       prefetch_multiplier: 1
     ucr_indicator_queue:
-      concurrency: 3
+      concurrency: 5
     ucr_queue:
       concurrency: 9
       prefetch_multiplier: 1


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
As a follow up to keep up with needs of async ucr indicators processing, bumping the concurrency from 3 to 5 across 4 machines. This means 20 parallel processes for async ucr indicators processing instead of 12.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production

Should be a safe change keeping in mind the resources available on celery machines as of now.