### PR TITLE
Double size of pgshards

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -447,11 +447,11 @@ rds_instances:
       max_connections: "LEAST({DBInstanceClassMemory/9531392},5000)"
 
   - identifier: "pgshard1-production"
-    instance_type: "db.m6g.2xlarge"
+    instance_type: "db.m6g.4xlarge"
     storage: 750
     max_storage: 2500
     storage_type: gp3
-    iops: 15000
+    iops: 20000
     multi_az: true
     engine_version: "14"
     backup_window: "23:00-01:00"
@@ -463,11 +463,11 @@ rds_instances:
       max_connections: "LEAST({DBInstanceClassMemory/9531392},5000)"
 
   - identifier: "pgshard2-production"
-    instance_type: "db.m6g.2xlarge"
+    instance_type: "db.m6g.4xlarge"
     storage: 750
     max_storage: 2500
     storage_type: gp3
-    iops: 15000
+    iops: 20000
     multi_az: true
     engine_version: "14"
     backup_window: "23:00-01:00"
@@ -479,11 +479,11 @@ rds_instances:
       max_connections: "LEAST({DBInstanceClassMemory/9531392},5000)"
 
   - identifier: "pgshard3-production"
-    instance_type: "db.m6g.2xlarge"
+    instance_type: "db.m6g.4xlarge"
     storage: 750
     max_storage: 2500
     storage_type: gp3
-    iops: 15000
+    iops: 20000
     multi_az: true
     engine_version: "14"
     backup_window: "23:00-01:00"
@@ -495,11 +495,11 @@ rds_instances:
       max_connections: "LEAST({DBInstanceClassMemory/9531392},5000)"
 
   - identifier: "pgshard4-production"
-    instance_type: "db.m6g.2xlarge"
+    instance_type: "db.m6g.4xlarge"
     storage: 750
     max_storage: 2500
     storage_type: gp3
-    iops: 15000
+    iops: 20000
     multi_az: true
     engine_version: "14"
     backup_window: "23:00-01:00"
@@ -511,11 +511,11 @@ rds_instances:
       max_connections: "LEAST({DBInstanceClassMemory/9531392},5000)"
 
   - identifier: "pgshard5-production"
-    instance_type: "db.m6g.2xlarge"
+    instance_type: "db.m6g.4xlarge"
     storage: 750
     max_storage: 2500
     storage_type: gp3
-    iops: 15000
+    iops: 20000
     multi_az: true
     engine_version: "14"
     backup_window: "23:00-01:00"


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi.atlassian.net/browse/SAAS-17395

The primary reason for this change is to get access to more IOPS, so we also want to provision enough IOPs on the volume to keep up with the instance capacity (20k).
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production