### PR TITLE
Run compilejsi18n after all translations are compiled

### DIFF
--- a/src/commcare_cloud/ansible/roles/deploy_hq/tasks/staticfiles_collect.yml
+++ b/src/commcare_cloud/ansible/roles/deploy_hq/tasks/staticfiles_collect.yml
@@ -26,7 +26,6 @@
   loop:
     - collectstatic --noinput -v 0
     - fix_less_imports_collectstatic
-    - compilejsi18n
 
 - name: Generate Webpack Settings
   # Generates webpack/settings.json so that webpack has the same path

--- a/src/commcare_cloud/ansible/roles/deploy_hq/tasks/update_translations.yml
+++ b/src/commcare_cloud/ansible/roles/deploy_hq/tasks/update_translations.yml
@@ -7,3 +7,8 @@
   loop:
     - update_django_locales
     - compilemessages -v 0
+
+- name: Compile Django JS Translations
+  command:
+    cmd: ./manage.py compilejsi18n
+    chdir: '{{ code_source }}'

--- a/src/commcare_cloud/ansible/roles/deploy_hq/tasks/update_translations.yml
+++ b/src/commcare_cloud/ansible/roles/deploy_hq/tasks/update_translations.yml
@@ -7,8 +7,4 @@
   loop:
     - update_django_locales
     - compilemessages -v 0
-
-- name: Compile Django JS Translations
-  command:
-    cmd: ./manage.py compilejsi18n
-    chdir: '{{ code_source }}'
+    - compilejsi18n


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/SAAS-17389

<!--- Provide a link to the ticket or document which prompted this change -->
`compilejsi18n` was not generating the desired js translation file with our deploy pipeline. However if the command was run on an already deployed release it generated correct output. 

@millerdev and I tried to test it by breaking the deploy script right after we run this command on staging. We found out that the translation js file was different than what we expected and had far less strings than that were in the translations file.

On looking source of [`compilejsi18n`](https://github.com/zyegfryed/django-statici18n/blob/main/src/statici18n/management/commands/compilejsi18n.py) I found out it is just an wrapper over Django's [JavascriptCatalogue](https://docs.djangoproject.com/en/5.1/topics/i18n/translation/#module-django.views.i18n) view. 
I had a theory that around the time when this runs our JS is not setup by then, which was confirmed when i looked in deploy-hq playbook. We were compiling webpack and compiling translations later. So I tested this change on staging and also on prod to see if the missing translations appear. 
After deploying from the following changes, I was able to get back the translations. 
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All