### PR TITLE
Scale down ES coordinator nodes

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -167,7 +167,7 @@ servers:
       BillTo: USH
 
   - server_name: "escoordinator_a1-production"
-    server_instance_type: m6in.4xlarge
+    server_instance_type: r6a.2xlarge
     network_tier: "db-private"
     az: "a"
     volume_size: 30
@@ -175,7 +175,7 @@ servers:
     os: jammy 
 
   - server_name: "escoordinator_b1-production"
-    server_instance_type: m6in.4xlarge
+    server_instance_type: r6a.2xlarge
     network_tier: "db-private"
     az: "b"
     volume_size: 30


### PR DESCRIPTION
Currently do not have a need for either the additional network or CPU

<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi.atlassian.net/browse/SAAS-17513

Reverts https://github.com/dimagi/commcare-cloud/pull/6534 and https://github.com/dimagi/commcare-cloud/pull/6536
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production