### PR TITLE
When setting up RDS use psycopg prebuilt binary

### DIFF
--- a/src/commcare_cloud/ansible/deploy_postgres.yml
+++ b/src/commcare_cloud/ansible/deploy_postgres.yml
@@ -37,8 +37,7 @@
     - name: Install python-psycopg2 to be able to set up remote postgresql
       become: yes
       block:
-        - apt: name=libpq-dev state=latest
-        - pip: name=psycopg2
+        - pip: name=psycopg2-binary
     - name: Remote PostgreSQL
       include_role:
         name: postgresql_base


### PR DESCRIPTION
Building psycopg2 requires other dependencies and sometimes version issues can cause building binary to fail. Since we use this once and is installed on Django manage machine. And has been tested while setting up eu server

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All