### PR TITLE
Save gunicorn.pid file in www_home

### DIFF
--- a/src/commcare_cloud/ansible/deploy_webworker.yml
+++ b/src/commcare_cloud/ansible/deploy_webworker.yml
@@ -35,7 +35,7 @@
             - notifempty
             - sharedscripts
           scripts:
-            postrotate: "[ -s {{ service_home }}/gunicorn.pid ] && kill -USR1 `cat {{ service_home }}/gunicorn.pid`"
+            postrotate: "[ -s {{ www_home }}/gunicorn.pid ] && kill -USR1 `cat {{ www_home }}/gunicorn.pid`"
 
 # There used to be some code here for updating workers one by one
 # but it's not functionally useful until we're off fab deploy and makes things

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_django.conf.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_django.conf.j2
@@ -12,7 +12,7 @@ command={{ app_processes_config.django_command_prefix }}{{ virtualenv_home }}/bi
     --log-file {{ log_home }}/{{ project }}.gunicorn.log
     --log-level debug
     --statsd-host localhost:8125
-    --pid {{ service_home }}/gunicorn.pid
+    --pid {{ www_home }}/gunicorn.pid
 user={{ cchq_user }}
 autostart=true
 autorestart=true


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
A very late followup to https://dimagi.atlassian.net/browse/SAAS-15962

The service directory is "managed" by commcare-cloud in that [we will clean up non supervisor config files](https://github.com/dimagi/commcare-cloud/blob/7c1e0703ca9f6d4696c5e76718507b89905c2252/src/commcare_cloud/ansible/deploy_commcarehq.yml#L107-L113) in that directory. 

Rather than attempt to whitelist gunicorn.pid, it is easier to just move it up one level into the www_home directory.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None