### PR TITLE
Restart api webworkers if split

### DIFF
--- a/src/commcare_cloud/ansible/restart_commcare_services.yml
+++ b/src/commcare_cloud/ansible/restart_commcare_services.yml
@@ -42,3 +42,9 @@
   vars:
     webworker_hosts: 'mobile_webworkers'
   when: "'mobile_webworkers' in groups"
+
+- name: "Restart api_webworkers (if split)"
+  import_playbook: restart_webworker_services.yml
+  vars:
+    webworker_hosts: 'api_webworkers'
+  when: "'api_webworkers' in groups"


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi.atlassian.net/browse/SAAS-17575

Oversight on my part when adding this new group. I don't expect us to split into more webworker groups than what we currently have, so I don't think it is worth trying to come up with a more dynamic way of doing this so that we don't run into this issue in the future.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All