### PR TITLE
Add `s3_blob_db_url` for EU env 

### DIFF
--- a/environments/eu/public.yml
+++ b/environments/eu/public.yml
@@ -80,7 +80,7 @@ couchdb_cluster_settings:
   n: 3
 
 s3_blob_db_enabled: yes
-s3_blob_db_url: "https://s3.amazonaws.com"
+s3_blob_db_url: "https://s3.eu-west-1.amazonaws.com"
 s3_blob_db_s3_bucket: "dimagi-commcare-eu-blobdb"
 
 root_email: commcarehq-ops+root@dimagi.com


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
This is a requirement after boto upgrade - https://commcare-cloud.readthedocs.io/en/latest/changelog/0086-s3-library-upgrade.html
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
EU

