### PR TITLE
cleanup existing keys for apt

### DIFF
--- a/src/commcare_cloud/ansible/roles/datadog/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/datadog/tasks/main.yml
@@ -20,6 +20,23 @@
     repo: 'deb http://apt.datadoghq.com/ stable main'
     state: absent
 
+# the GPG keys were not getting cleaned up by the apt_key module, so we need to do it manually
+- name: Remove all old datadog key files
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - /etc/apt/keyrings/DATADOG_APT_KEY_382E94DE.gpg
+    - /etc/apt/keyrings/DATADOG_APT_KEY_F14F620E.gpg
+    - /etc/apt/keyrings/DATADOG_APT_KEY_C0962C7D.gpg
+
+# the repository configuration was not getting cleaned up by the apt_repository module, so we need to do it manually
+- name: Remove old datadog repository configuration
+  file:
+    path: /etc/apt/sources.list.d/apt_datadoghq_com.list
+    state: absent
+
+
 - name: Add new datadog apt key
   copy:
     src: DATADOG_APT_KEY_C0962C7D.gpg


### PR DESCRIPTION
When I added newer apt keys for Datadog in https://github.com/dimagi/commcare-cloud/pull/6570, it worked fine for newer machines. 
But when I tried to run it for production machines, I got following error - 

```
E:Conflicting values set for option Signed-By regarding source http://apt.datadoghq.com/ stable: /etc/apt/keyrings/DATADOG_APT_KEY_F14F620E.gpg != /etc/apt/keyrings/DATADOG_APT_KEY_C0962C7D.gpg, E:The list of sources could not be read.
```

The error was because `apt del <key>` was not cleaning the keys and also not cleaning the source lists. I tried the steps mentioned here in `django-manage` machine and was successful. 

So I added them to the playbook which worked fine.

<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi.atlassian.net/browse/SAAS-17510
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All
