### PR TITLE
Update elasticsearch docs to specify body type

### DIFF
--- a/docs/source/reference/firefighting/general.rst
+++ b/docs/source/reference/firefighting/general.rst
@@ -1071,24 +1071,24 @@ Currently on ICDS (maybe on prod/india) shard allocation is disabled. In case a 
   * Turn on auto shard allocation using
     .. code-block::
 
-       curl 'http://<es_url>/_cluster/settings/' -X PUT  --data '{"transient":{"cluster.routing.allocation.enable":"all"}}'
+       curl 'http://<es_url>/_cluster/settings/' -X PUT -H 'Content-Type: application/json' --data '{"transient":{"cluster.routing.allocation.enable":"all"}}'
 
   * Wait for replicas to get assigned.
 
 * Finally **remember to turn off** auto shard allocation using
   .. code-block::
 
-       curl 'http://<es_url>/_cluster/settings/' -X PUT  --data '{"transient":{"cluster.routing.allocation.enable":"none"}}'
+       curl 'http://<es_url>/_cluster/settings/' -X PUT -H 'Content-Type: application/json' --data '{"transient":{"cluster.routing.allocation.enable":"none"}}'
 
 .. code-block::
 
-   curl -XPUT '<es url/ip>:9200/_cluster/settings' -d '{ "transient":
+   curl -XPUT -H 'Content-Type: application/json' '<es url/ip>:9200/_cluster/settings' -d '{ "transient":
      { "cluster.routing.allocation.enable" : "all"
      }
    }'
    # wait for shards to be allocated
    ./scripts/elasticsearch-administer.py <es url> shard_status # all shards should say STARTED
-   curl -XPUT '<es url/ip>:9200/_cluster/settings' -d '{ "transient":
+   curl -XPUT -H 'Content-Type: application/json' '<es url/ip>:9200/_cluster/settings' -d '{ "transient":
      { "cluster.routing.allocation.enable" : "none"
      }
    }'


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
As of v6, elasticsearch requires that any REST request with a body explicitly defines the content type.

https://www.elastic.co/blog/strict-content-type-checking-for-elasticsearch-rest-requests

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
