### PR TITLE
Removed purge_static_files

### DIFF
--- a/src/commcare_cloud/ansible/roles/deploy_hq/tasks/staticfiles_compress.yml
+++ b/src/commcare_cloud/ansible/roles/deploy_hq/tasks/staticfiles_compress.yml
@@ -1,11 +1,7 @@
 - name: Compress static files
   command:
-    cmd: ./manage.py {{ item }}
+    cmd: ./manage.py compress --force -v 0
     chdir: '{{ code_source }}'
-  register: stop_loop_hack
-  when: not stop_loop_hack.failed | default(False)
-  loop:
-    - compress --force -v 0
 
 - name: Push shared staticfiles cache
   when: shared_dir_for_staticfiles

--- a/src/commcare_cloud/ansible/roles/deploy_hq/tasks/staticfiles_compress.yml
+++ b/src/commcare_cloud/ansible/roles/deploy_hq/tasks/staticfiles_compress.yml
@@ -6,7 +6,6 @@
   when: not stop_loop_hack.failed | default(False)
   loop:
     - compress --force -v 0
-    - purge_compressed_files
 
 - name: Push shared staticfiles cache
   when: shared_dir_for_staticfiles


### PR DESCRIPTION
HQ is no longer compressing any javascript files.

There are a couple of places that [hqwebapp/base.html](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/hqwebapp/templates/hqwebapp/base.html) uses `compress js` blocks, but they're all within `if not use_js_bundler` blocks, and `use_js_bundler` is always true now. These remaining `compress js` blocks are being removed in https://github.com/dimagi/commcare-hq/pull/36474

Deploying https://github.com/dimagi/commcare-hq/pull/36474 to staging was failing because there's no more compressed js, which means that `purge_static_files` is no longer necessary, and instead was failing to find the js cache directory. I updated `purge_static_files` in that PR, in https://github.com/dimagi/commcare-hq/pull/36474/commits/92afa00dfeaf6a34f621e44e83743f4a2d55ab13, to return early if the directory isn't found.

This PR is to remove the command altogether. Once this is merged, I'll update https://github.com/dimagi/commcare-hq/pull/36474 to delete `purge_static_files.py` from HQ.

HQ is still compressing stylesheets, so deploy does need to continue to run the compress command.

##### Environments Affected
None