### PR TITLE
Prevent unattended rabbitmq restart disrupting celery

### DIFF
--- a/src/commcare_cloud/ansible/roles/rabbitmq/tasks/install_latest.yml
+++ b/src/commcare_cloud/ansible/roles/rabbitmq/tasks/install_latest.yml
@@ -32,6 +32,14 @@
     state: present
   when: ansible_distribution_version == '22.04'
 
+- name: Blacklist Erlang from unattended upgrades
+  # prevent unattended rabbitmq restart disrupting celery
+  lineinfile:
+    dest: /etc/apt/apt.conf.d/50unattended-upgrades
+    insertafter: '^Unattended-Upgrade::Package-Blacklist \{'
+    regexp: '^\s*"erlang";'
+    line: '    "erlang";'
+
 - name: Add trusted key
   apt_key:
     url: https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey


### PR DESCRIPTION
`lineinfile` will probably work, although could fail under certain conditions. For example, it will not add the blacklist item if an unrelated line after the blacklist (a delimited range in the file) matches the regex. Similarly it will add the item at the wrong place (at the end of the file) if the `regexp` and `insertafter` patterns do not match lines in the file, which seems possible if the file format changed in a subtle way.

This is a pragmatic solution that is probably good enough to meet our needs.

https://dimagi.atlassian.net/browse/SAAS-17458

##### Environments Affected
All.