### PR TITLE
Enable Formplayer APM Traces

### DIFF
--- a/environments/staging/app-processes.yml
+++ b/environments/staging/app-processes.yml
@@ -1,8 +1,9 @@
-# Use the following to enable datadog tracing
+# Use the following to enable datadog tracing for formplayer
 formplayer_command_args: '-javaagent:/home/cchq/dd-java-agent.jar -Dsrc.main.java.org.javarosa.enableOpenTracing=true -Ddd.service=formplayer -Ddd.env=staging -Ddd.trace.sample.rate=1.0'
 
-django_command_prefix: '{{ virtualenv_home }}/bin/ddtrace-run '
-datadog_pythonagent: True
+# Use the following to enable datadog tracing for webworkers aka hq
+# django_command_prefix: '{{ virtualenv_home }}/bin/ddtrace-run '
+# datadog_pythonagent: True
 
 management_commands:
   celery_a1:

--- a/environments/staging/app-processes.yml
+++ b/environments/staging/app-processes.yml
@@ -1,8 +1,8 @@
 # Use the following to enable datadog tracing
-# formplayer_command_args: '-javaagent:/home/cchq/dd-java-agent.jar -Dsrc.main.java.org.javarosa.enableOpenTracing=true -Ddd.service=formplayer -Ddd.env=staging'
+formplayer_command_args: '-javaagent:/home/cchq/dd-java-agent.jar -Dsrc.main.java.org.javarosa.enableOpenTracing=true -Ddd.service=formplayer -Ddd.env=staging'
 
-# django_command_prefix: '{{ virtualenv_home }}/bin/ddtrace-run '
-# datadog_pythonagent: True
+django_command_prefix: '{{ virtualenv_home }}/bin/ddtrace-run '
+datadog_pythonagent: True
 
 management_commands:
   celery_a1:

--- a/environments/staging/app-processes.yml
+++ b/environments/staging/app-processes.yml
@@ -1,5 +1,5 @@
 # Use the following to enable datadog tracing
-formplayer_command_args: '-javaagent:/home/cchq/dd-java-agent.jar -Dsrc.main.java.org.javarosa.enableOpenTracing=true -Ddd.service=formplayer -Ddd.env=staging'
+formplayer_command_args: '-javaagent:/home/cchq/dd-java-agent.jar -Dsrc.main.java.org.javarosa.enableOpenTracing=true -Ddd.service=formplayer -Ddd.env=staging -Ddd.trace.sample.rate=1.0'
 
 django_command_prefix: '{{ virtualenv_home }}/bin/ddtrace-run '
 datadog_pythonagent: True


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
This [PR](https://github.com/dimagi/formplayer/pull/1712) and the corresponding [ticket](https://dimagi.atlassian.net/browse/USH-5218) introduced a feature flag to control whether tracing data is sent to Datadog. Only domains with the flag enabled will have their traces reported.

The motivation for this change was to allow us to set the sampling rate to 100%, ensuring we capture all traces — especially the slower ones that are most valuable for debugging performance issues.

Now that tracing can be toggled per domain, this PR enables it for staging and sets the sampling rate to 100%. Once the Formplayer PR is deployed to production, we’ll do the same there.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Staging
