### PR TITLE
Add support for setting jvm tmp directory for elasticsearch

### DIFF
--- a/src/commcare_cloud/ansible/roles/elasticsearch/templates/config/jvm.options.j2
+++ b/src/commcare_cloud/ansible/roles/elasticsearch/templates/config/jvm.options.j2
@@ -54,7 +54,11 @@
 14-:-XX:InitiatingHeapOccupancyPercent=30
 
 ## JVM temporary directory
+{% if elasticsearch_jvm_tmp_dir is defined %}
+-Djava.io.tmpdir={{ elasticsearch_jvm_tmp_dir }}
+{% else %}
 -Djava.io.tmpdir={{ elasticsearch_data_dir }}/tmp
+{% endif %}
 
 ## heap dumps
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Based on one of the queries that we have received on [Commcare Forum](https://forum.dimagi.com/t/issues-with-changelog-0087-upgrade-to-es-6) - on some of the machines Elasticsearch is not able to boot because JVM is not able to access the default `tmp` directory. I think Vishwa encountered it once and we fixed it manually around that time but it never surfaced again. It was a test machine, so I did not investigate much about the error.  I am still not sure why ES will fail to access the directory which is owned by it's user and where ES is writing the data. But this should unblock Ed to move ahead with the upgrade.
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Possibly some third party environments. 

