### PR TITLE
Enable 100% APM Trace sampling

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -5,9 +5,7 @@ gunicorn_workers_static_factor: 0
 gunicorn_workers_factor: 2
 formplayer_memory: "31g"
 formplayer_g1heapregionsize: "16m"
-formplayer_command_args: ''
-# Use the following to enable datadog tracing
--javaagent:/home/cchq/dd-java-agent.jar -Dsrc.main.java.org.javarosa.enableOpenTracing=true -Ddd.profiling.enabled=true -XX:FlightRecorderOptions=stackdepth=256 -Ddd.service=formplayer -Ddd.env=production -Ddd.trace.sample.rate=1.0'
+formplayer_command_args: '-javaagent:/home/cchq/dd-java-agent.jar -Dsrc.main.java.org.javarosa.enableOpenTracing=true -Ddd.profiling.enabled=true -XX:FlightRecorderOptions=stackdepth=256 -Ddd.service=formplayer -Ddd.env=production -Ddd.trace.sample.rate=1.0'
 management_commands:
   celerybeat_a0:
     run_submission_reprocessing_queue:

--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -7,7 +7,7 @@ formplayer_memory: "31g"
 formplayer_g1heapregionsize: "16m"
 formplayer_command_args: ''
 # Use the following to enable datadog tracing
-# -javaagent:/home/cchq/dd-java-agent.jar -Dsrc.main.java.org.javarosa.enableOpenTracing=true -Ddd.profiling.enabled=true -XX:FlightRecorderOptions=stackdepth=256 -Ddd.service=formplayer -Ddd.env=production -Ddd.trace.sample.rate=0.1'
+-javaagent:/home/cchq/dd-java-agent.jar -Dsrc.main.java.org.javarosa.enableOpenTracing=true -Ddd.profiling.enabled=true -XX:FlightRecorderOptions=stackdepth=256 -Ddd.service=formplayer -Ddd.env=production -Ddd.trace.sample.rate=1.0'
 management_commands:
   celerybeat_a0:
     run_submission_reprocessing_queue:


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
This https://github.com/dimagi/formplayer/pull/1712 and the corresponding [ticket](https://dimagi.atlassian.net/browse/USH-5218) introduced a feature flag to control whether FP tracing data is sent to Datadog. Only domains with the flag enabled will have their traces reported.

The motivation for this change was to allow us to set the sampling rate to 100%, ensuring we capture all traces — especially the slower ones that are most valuable for debugging performance issues.

Now that tracing can be toggled per domain, this PR sets the sampling rate to 100% for production. (This has already been done on staging) - see this [PR](https://github.com/dimagi/commcare-cloud/pull/6594)

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production