### PR TITLE
Bring existing rules to create config-changes log into terraform

### DIFF
--- a/environments/india/terraform.yml
+++ b/environments/india/terraform.yml
@@ -400,3 +400,11 @@ efs_file_systems:
     create_record: yes
     domain_name: "india.commcare.local"
     route_names: "shared-efs"
+
+terraform_imports:
+  - to: module.logshipping.aws_cloudwatch_event_rule.config-changes
+    id: default/config-changes
+  - to: module.logshipping.aws_cloudwatch_event_target.config-changes
+    id: default/config-changes/Id5885852165010
+  - to: module.logshipping.aws_cloudwatch_log_group.config-changes
+    id: /aws/events/config-changes

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -677,3 +677,11 @@ efs_file_systems:
     create_record: yes
     domain_name: "production.commcare.local"
     route_names: "shared-efs"
+
+terraform_imports:
+  - to: 'module.logshipping.aws_cloudwatch_event_rule.config-changes'
+    id: 'default/ConfigChanges'
+  - to: module.logshipping.aws_cloudwatch_event_target.config-changes
+    id: default/ConfigChanges/Id27473066087598
+  - to: module.logshipping.aws_cloudwatch_log_group.config-changes
+    id: /aws/events/config-changes

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -679,8 +679,8 @@ efs_file_systems:
     route_names: "shared-efs"
 
 terraform_imports:
-  - to: 'module.logshipping.aws_cloudwatch_event_rule.config-changes'
-    id: 'default/ConfigChanges'
+  - to: module.logshipping.aws_cloudwatch_event_rule.config-changes
+    id: default/ConfigChanges
   - to: module.logshipping.aws_cloudwatch_event_target.config-changes
     id: default/ConfigChanges/Id27473066087598
   - to: module.logshipping.aws_cloudwatch_log_group.config-changes

--- a/src/commcare_cloud/commands/terraform/templates/imports.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/imports.tf.j2
@@ -1,0 +1,6 @@
+{% for terraform_import in terraform_imports %}
+import {
+  to = {{ terraform_import.to }}
+  id = {{ terraform_import.id|tojson }}
+}
+{% endfor %}

--- a/src/commcare_cloud/commands/terraform/terraform.py
+++ b/src/commcare_cloud/commands/terraform/terraform.py
@@ -187,6 +187,7 @@ def generate_terraform_entrypoint(environment, key_name, run_dir, apply_immediat
             ('variables.tf.j2', 'variables.tf'),
             ('terraform.tfvars.j2', 'terraform.tfvars'),
             ('terraform.lock.hcl.j2', '.terraform.lock.hcl'),
+            ('imports.tf.j2', 'imports.tf'),
     ):
         with open(os.path.join(run_dir, output_file), 'w', encoding='utf-8') as f:
             f.write(render_template(template_file, context, template_root))

--- a/src/commcare_cloud/environment/schemas/terraform.py
+++ b/src/commcare_cloud/environment/schemas/terraform.py
@@ -40,6 +40,7 @@ class TerraformConfig(jsonobject.JsonObject):
     ec2_auto_recovery = jsonobject.ListProperty(lambda: Ec2AutoRecovery, default=None)
     fsx_file_systems = jsonobject.ListProperty(lambda: FsxFileSystem, default=None)
     awsmq = jsonobject.ObjectProperty(lambda: awsmqConfig, default=None)
+    terraform_imports = jsonobject.ListProperty(lambda: TerraformImportsConfig, default=list)
 
     @classmethod
     def wrap(cls, data):
@@ -318,3 +319,9 @@ class FsxFileSystem(jsonobject.JsonObject):
     fsx_name = jsonobject.StringProperty(required=True)
     storage_capacity = jsonobject.IntegerProperty(required=True)
     throughput_capacity = jsonobject.IntegerProperty(required=True)
+
+
+class TerraformImportsConfig(jsonobject.JsonObject):
+    _allow_dynamic_properties = False
+    to = jsonobject.StringProperty(required=True)
+    id = jsonobject.StringProperty(required=True)

--- a/src/commcare_cloud/terraform/modules/logshipping/main.tf
+++ b/src/commcare_cloud/terraform/modules/logshipping/main.tf
@@ -154,3 +154,28 @@ resource "aws_lambda_permission" "allow_cloudwatch_to_call_check_file" {
     principal = "events.amazonaws.com"
     source_arn = aws_cloudwatch_event_rule.check-file-event.arn
 }
+
+resource "aws_cloudwatch_event_rule" "config-changes" {
+  name = "config-changes"
+  event_pattern = jsonencode({
+    source = ["aws.config"],
+    detail-type = ["Config Configuration Item Change"]
+  })
+  lifecycle {
+    ignore_changes = [name]
+  }
+}
+
+resource "aws_cloudwatch_log_group" "config-changes" {
+  name = "/aws/events/config-changes"
+  retention_in_days = 0
+}
+
+resource "aws_cloudwatch_event_target" "config-changes" {
+  target_id = "config-changes"
+  rule = aws_cloudwatch_event_rule.config-changes.name
+  arn = aws_cloudwatch_log_group.config-changes.arn
+  lifecycle {
+    ignore_changes = [target_id]
+  }
+}


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/SAAS-17659

The config changes rule sets it up so that AWS Config changes are logged to a log group in CloudWatch. It was originally manually set up in production and india a long time ago. This change makes it part of our terraform configuration, as is standard.

I implemented this in such a way that I
- allow importing existing resources cleanly
- bring analogous setup to staging and eu

This also introduces some new support for terraform's relatively new [`import` block](https://developer.hashicorp.com/terraform/language/import), which can be used to acknowledge preexisting resources in code rather than requiring manual reconciliation with the terraform import command.

##### Environments Affected
eu, staging
(production and india will have their terraform state updated to match their preexisting AWS state for these resources, but no changes will be made to the AWS state)
