### PR TITLE
Remove importlib-metadata from commcare-cloud

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -67,8 +67,6 @@ greenlet==3.0.0
     # via gevent
 idna==3.7
     # via requests
-importlib-metadata==3.1.0
-    # via commcare-cloud (setup.py)
 jinja2==3.1.6
     # via
     #   ansible-core
@@ -145,8 +143,6 @@ urllib3==1.26.19
     #   requests
 wrapt==1.13.1
     # via deprecated
-zipp==3.19.1
-    # via importlib-metadata
 zope-event==4.5.0
     # via gevent
 zope-interface==5.4.0

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ install_deps = [
     'dimagi-memoized>=1.1.0',
     'dnspython',
     'gitpython',
-    'importlib-metadata==3.1.0',
     'jinja2-cli',
     'jsonobject',
     'netaddr',


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Only useful for versions of python less than 3.8. We don't have any references to this lib in code so it is safe to remove.
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None