### PR TITLE
Bump cryptography to 45.0.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ clint==0.5.1
     # via commcare-cloud (setup.py)
 couchdb-cluster-admin==0.7.2
     # via commcare-cloud (setup.py)
-cryptography==43.0.1
+cryptography==45.0.5
     # via
     #   ansible-core
     #   commcare-cloud (setup.py)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_deps = [
     'boto3>=1.9.131',
     'clint',
     'couchdb-cluster-admin',
-    'cryptography>=42,<44',
+    'cryptography',
     'datadog>=0.2.0',
     'dimagi-memoized>=1.1.0',
     'dnspython',


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi.atlassian.net/browse/SAAS-17775

[Changelog](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst)

This package is only used in the context of caching secrets. If our caching logic fails, it looks like we raise errors, so I'd expect any issues here to be very visible.

I tested running this locally to view some secrets but that is it. 
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None