### PR TITLE
Bump pynacl to 1.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -99,7 +99,7 @@ pygments==2.15.0
     # via ansible-inventory
 pyjwt[crypto]==2.4.0
     # via pygithub
-pynacl==1.4.0
+pynacl==1.5.0
     # via pygithub
 pyparsing==3.0.9
     # via packaging
@@ -128,7 +128,6 @@ six==1.16.0
     # via
     #   commcare-cloud (setup.py)
     #   jsonobject
-    #   pynacl
     #   python-dateutil
 smmap==5.0.0
     # via gitdb


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
[Changelog](https://pypi.org/project/PyNaCl/)

There are two breaking changes:
> BACKWARDS INCOMPATIBLE: Removed support for Python 2.7 and Python 3.5.
> BACKWARDS INCOMPATIBLE: We no longer distribute manylinux1 wheels.

The first gets rid of the depedency on six, and the second I don't think effects us? This package is used by pygithub which is on the latest version already.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None