### PR TITLE
Remove attrs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,8 +22,6 @@ args==0.1.0
     # via clint
 async-timeout==4.0.2
     # via redis
-attrs==21.2.0
-    # via commcare-cloud (setup.py)
 boto3==1.18.57
     # via commcare-cloud (setup.py)
 botocore==1.21.57

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ install_deps = [
     'ansible~=4.3',
     'ansible-inventory==0.6.4',
     'argparse>=1.4',
-    'attrs>=18.1.0',
     'boto3>=1.9.131',
     'clint',
     'couchdb-cluster-admin',


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
I don't see any references to attrs in commcare-cloud. It was first added in [this commit](https://github.com/dimagi/commcare-cloud/commit/6a5a086), and imagine it may have been the case that it didn't end up being used as expected but slipped into requirements?

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None