### PR TITLE
Upgrade attrs to 25.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ args==0.1.0
     # via clint
 async-timeout==4.0.2
     # via redis
-attrs==21.2.0
+attrs==25.3.0
     # via commcare-cloud (setup.py)
 boto3==1.18.57
     # via commcare-cloud (setup.py)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ install_deps = [
     'ansible~=4.3',
     'ansible-inventory==0.6.4',
     'argparse>=1.4',
-    'attrs>=18.1.0',
+    'attrs',
     'boto3>=1.9.131',
     'clint',
     'couchdb-cluster-admin',


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
It is just pretty out of date.

[Changelog](https://www.attrs.org/en/stable/changelog.html)

I didn't spot any breaking changes that would impact our current usages of `attr` in commcare-cloud. Our usages look pretty straightforward.
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None