### PR TITLE
Remove PARSER_CLASS in settings.py

### DIFF
--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -424,7 +424,6 @@ redis_cache = {
     'LOCATION': '{{ redis_url }}',
 {% endif %}
     'OPTIONS': {
-        'PARSER_CLASS': 'redis.connection.HiredisParser',
         'REDIS_CLIENT_KWARGS': {
             'health_check_interval': 15,
         },


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
The motivation for this change is v5 of redis changes the path to this parser, which causes issues. It turns out that in redis-py v4.5.4 (the currently installed version in commcare-hq), if hiredis is installed it defaults to use that parser: https://github.com/redis/redis-py/blob/v4.5.4/redis/connection.py#L512-L515.  This appears to have been supported in redis-py since v3. 

Just to confirm, [hiredis is part of our requirements](https://github.com/dimagi/commcare-hq/blob/4689cd6e4c54fa8e42cb735285e77cb8205d3315/uv.lock#L1560-L1562), so this should work and we shouldn't have to specify `PARSER_CLASS` in settings.

I'm opting to not announce this as it isn't breaking anything. If a self hoster has made a change to the parser used by redis, they are in uncharted territory and it is up to them to debug any issues that might arise in the future. I can't think of anything directly from this change since we are just removing this hardcoded part of localsettings.py.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All
