### PR TITLE
Remove ubuntu_bionic reference

### DIFF
--- a/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
@@ -153,7 +153,7 @@ module "server__{{ server_name }}" {
   enable_cross_region_backup = {{ server_spec.enable_cross_region_backup|tojson }}
 
 {% if server_spec.os == 'bionic' %}
-  server_image = data.aws_ami.ubuntu_bionic.id
+  server_image = "deprecated"
 {% elif server_spec.os == 'jammy' %}
   server_image = data.aws_ami.ubuntu_jammy.id
 {% else %}

--- a/src/commcare_cloud/commands/terraform/templates/variables.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/variables.tf.j2
@@ -12,26 +12,6 @@ variable "vpc_begin_range" {}
 # To do so please visit http://aws.amazon.com/marketplace/pp?sku=3ihdqli79gl9v2jnlzs6nq60h
 
 
-data "aws_ami" "ubuntu_bionic" {
-  # Should match what is in
-  # https://cloud-images.ubuntu.com/locator/ec2/
-  # with search hvm:ebs-ssd bionic amd64
-
-  most_recent = true
-
-  filter {
-    name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  owners = ["099720109477"] # Canonical
-}
-
 data "aws_ami" "ubuntu_jammy" {
   # Should match what is in
   # https://cloud-images.ubuntu.com/locator/ec2/


### PR DESCRIPTION
**Ticket :** https://dimagi.atlassian.net/browse/SAAS-18001

**Environments Affected :** ALL

**Update commcarehq.tf.j2 -**  We're hardcoding the value "deprecated" for bionic servers so that Terraform won't try to look for a real AMI. Since AMI is listed under ignore_changes, this change won't impact existing bionic machines.

**Remove ubuntu_bionic block in variables.tf.j2 -** Since the value is no longer being referenced in code (we hardcoded it), we can safely remove the data source to avoid lookup errors.

This avoids errors without impacting existing servers, thanks to **ignore_changes**.