### PR TITLE
Remove unused source var to fix warning

### DIFF
--- a/src/commcare_cloud/commands/terraform/templates/terraform.tfvars.j2
+++ b/src/commcare_cloud/commands/terraform/templates/terraform.tfvars.j2
@@ -1,4 +1,3 @@
-source = "./modules/commcarehq"
 region = {{ region|tojson }}
 environment = {{ environment|tojson }}
 username = {{ username|tojson }}


### PR DESCRIPTION
**Ticket :** https://dimagi.atlassian.net/browse/SAAS-18008

**Environments :** ALL

This PR removes the unused source variable from `terraform.tfvars` to eliminate Terraform warnings, improve clarity, and ensure clean plan outputs during upgrades. No functional changes to infrastructure.