### PR TITLE
Remove task that downloads ES 5

### DIFF
--- a/src/commcare_cloud/ansible/roles/elasticsearch/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/elasticsearch/tasks/main.yml
@@ -25,13 +25,6 @@
     state: present
   become: yes
 
-- name: Download Elasticsearch 5
-  become: yes
-  copy:
-    src: "elasticsearch-5.6.16.tar.gz"
-    dest: "/home/{{ cchq_user }}/downloads/elasticsearch-{{ elasticsearch_version }}.tar.gz"
-  when: elasticsearch_version == "5.6.16"
-
 - name: Download Elasticsearch 6
   become: yes
   get_url:
@@ -39,7 +32,6 @@
     dest: "/home/{{ cchq_user }}/downloads/elasticsearch-{{ elasticsearch_version }}.tar.gz"
     checksum: "sha256:{{ elasticsearch_download_sha256 }}"
   when: elasticsearch_version is version('6.0.0', '>=') and elasticsearch_version is version('7.0.0', '<')
-
 
 - name: Download Elasticsearch 7
   become: yes


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Simple cleanup. ES 5 is officially no longer supported so this should be safe to remove.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None