### PR TITLE
Default to elasticsearch 6.8.23

### DIFF
--- a/quick_monolith_install/sample-environment/public.yml.j2
+++ b/quick_monolith_install/sample-environment/public.yml.j2
@@ -2,7 +2,7 @@
 {% endraw %}
 elasticsearch_memory: '2048m'
 elasticsearch_cluster_name: '{{env_name}}-es'
-elasticsearch_version: 5.6.16
+elasticsearch_version: 6.8.23
 elasticsearch_download_sha256: 6b035a59337d571ab70cea72cc55225c027ad142fbb07fd8984e54261657c77f.
 
 formplayer_java_version: {% raw %}"{{ java_17_bin_path }}/java"

--- a/src/commcare_cloud/ansible/roles/elasticsearch/defaults/main.yml
+++ b/src/commcare_cloud/ansible/roles/elasticsearch/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-elasticsearch_version: 5.6.16
+elasticsearch_version: 6.8.23
 # https://www.elastic.co/guide/en/elasticsearch/guide/current/heap-sizing.html#_give_half_your_memory_to_lucene
 # Either half the machines RAM or 24 GB. If changing in the future, never want to go over 30 GB
 elasticsearch_memory: "{{ [ansible_memory_mb.real.total // 2, 24576] | min }}m"


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
ES 5 is no longer supported by commcare, so we should be defaulting to 6 for new setups.
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None