### PR TITLE
Make the formplayer archive_db.sh script silent on success

### DIFF
--- a/src/commcare_cloud/ansible/roles/formplayer/files/archive_dbs.sh
+++ b/src/commcare_cloud/ansible/roles/formplayer/files/archive_dbs.sh
@@ -42,8 +42,6 @@ test -d ${dir} || {
     exit 1
 }
 
-echo "find ${dir} -name '*.db' -type f -m${time_suffix}"
-
 while read line
 do
     db="${line}"


### PR DESCRIPTION
This prevents sending useless emails.
Redirecting would also do that, but the output is not helpful at all, so I opted to delete.

##### Environments Affected
all (definitely staging), but super minor
