### PR TITLE
Fix HQ installation for a cluster

### DIFF
--- a/commcare-cloud-bootstrap/environment/private.yml.j2
+++ b/commcare-cloud-bootstrap/environment/private.yml.j2
@@ -32,6 +32,7 @@ localsettings_private:
   BOOKKEEPER_CONTACT_EMAILS: []
   COUCH_USERNAME: 'commcarehq'
   COUCH_PASSWORD: '{{ generate_password() }}'
+  REDIS_PASSWORD: '{{ generate_password() }}'
   BITLY_OAUTH_TOKEN: ''
   DROPBOX_KEY: ''
   DROPBOX_SECRET: ''

--- a/docs/source/installation/troubleshooting.rst
+++ b/docs/source/installation/troubleshooting.rst
@@ -10,7 +10,7 @@ If you are seeing a blank screen with just the words "Internal Server Error" on 
 it means that the django webworker process is not reporting as "down",
 but still failing to bootstrap fully.
 (If you are seeing a more elaborate 500 page, then that is an issue with a single request,
-but ususally does not indicate a more pervasive problem with the site's ability to receive and handle requests in general.)
+but usually does not indicate a more pervasive problem with the site's ability to receive and handle requests in general.)
 Often this is because it is unable to connect to
 a backing service (such as CouchDB, Redis, PostgreSQL, PgBouncer, Elasticsearch, Riak).
 This in turn can fall into a number of categories of issue:

--- a/docs/source/reference/1-commcare-cloud/2-configuration.rst
+++ b/docs/source/reference/1-commcare-cloud/2-configuration.rst
@@ -86,10 +86,9 @@ Each of these files should contain YAML of the following format:
        - <username4>
        ...
 
-The ``present`` section will have a list of users who have access to your servers. The name you add here should be their desired system username, and should correspond to the name of their public key in ``<username>.pub`` under `\ ``_authorized_keys`` <#_authorized_keys>`_.
+The ``present`` section will have a list of users who have access to your servers. The name you add here should be their desired system username, and should correspond to the name of their public key in ``<username>.pub`` under `_authorized_keys`_.
 
-Each ``<username>`` must correspond to that used in a ``<username>.pub``
-under .
+Each ``<username>`` must correspond to that used in a ``<username>.pub`` under `_authorized_keys`_.
 
 The ``absent`` section lists those users whose access you want to remove from your servers when running the user update scripts.
 

--- a/environments/development/public.yml
+++ b/environments/development/public.yml
@@ -97,3 +97,6 @@ commcare_cloud_remote_user: vagrant
 commcare_cloud_root_user: ubuntu
 commcare_cloud_strict_host_key_checking: no
 commcare_cloud_use_vault: no
+
+# add datadisk device for shared directory; applicable for non-monolithic deployments
+datadisk_device: "/dev/xvdbb"

--- a/src/commcare_cloud/ansible/plugins/inventory/csv.py
+++ b/src/commcare_cloud/ansible/plugins/inventory/csv.py
@@ -18,7 +18,7 @@ DOCUMENTATION = """
         - Each group of lines can either be a list of hosts or a list of group var definitions.
         - Hosts are listed with the following required fields (C(hostname), C(host_address))
         - Host groups are specified in group columns e.g. C(group 1), C(group 2) etc.
-        - Host vars are listed in individual colums with headers formatted as follows - C({type}.var: {name}).
+        - Host vars are listed in individual columns with headers formatted as follows - C({type}.var: {name}).
         - The 'type' field must be one of the following (or blank for the default)
             - S: string (default if no type specified)
             - B: boolean ('true' or 't' (case insensitive), anything else is false)

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -415,8 +415,8 @@ REPORT_CACHE = 'redis'
 redis_cache = {
     'BACKEND': 'django_redis.cache.RedisCache',
 {% set redis_url = 'redis://' ~ localsettings.REDIS_HOST ~ ':' ~ localsettings.REDIS_PORT %}
-{% if localsettings.get('REDIS_PASSWORD') %}
-{% set redis_url = 'redis://:' ~ localsettings.REDIS_PASSWORD ~ '@' ~ localsettings.REDIS_HOST ~ ':' ~ localsettings.REDIS_PORT %}
+{% if localsettings_private.get('REDIS_PASSWORD') %}
+{% set redis_url = 'redis://:' ~ localsettings_private.REDIS_PASSWORD ~ '@' ~ localsettings.REDIS_HOST ~ ':' ~ localsettings.REDIS_PORT %}
 {% endif %}
 {% if 'REDIS_DB' in localsettings %}
     'LOCATION': '{{ redis_url }}/{{ localsettings.REDIS_DB }}',

--- a/src/commcare_cloud/ansible/roles/formplayer/templates/application.properties.j2
+++ b/src/commcare_cloud/ansible/roles/formplayer/templates/application.properties.j2
@@ -51,8 +51,8 @@ redis.clusterString={{ groups.redis_cluster_master | join(":" + localsettings.RE
 redis.hostname={{ localsettings.REDIS_HOST }}
 {% endif %}
 
-{% if localsettings.get('REDIS_PASSWORD') %}
-redis.Password={{ localsettings.REDIS_PASSWORD }}
+{% if localsettings_private.get('REDIS_PASSWORD') %}
+redis.Password={{ localsettings_private.REDIS_PASSWORD }}
 {% endif %}
 
 {% if formplayer_sensitive_data_logging %}

--- a/src/commcare_cloud/ansible/roles/redis/meta/main.yml
+++ b/src/commcare_cloud/ansible/roles/redis/meta/main.yml
@@ -2,3 +2,5 @@
 dependencies:
   - role: monit
   - role: DavidWittman.redis
+    vars:
+      redis_password: "{{ localsettings_private.get('REDIS_PASSWORD') }}"

--- a/src/commcare_cloud/ansible/roles/redis/templates/redis_is_master.j2
+++ b/src/commcare_cloud/ansible/roles/redis/templates/redis_is_master.j2
@@ -3,8 +3,8 @@
 # This is a helper script to check if the current redis instance is the master of the replication scheme.
 # This accounts for cases when the local redis instance is down. Since that means this node can't be the master, we handle
 # that gracefully.
-{% if localsettings.get('REDIS_PASSWORD') %}
-REPLICATION_DATA=`redis-cli -a {{ localsettings.REDIS_PASSWORD }} info replication 2> /dev/null`
+{% if localsettings_private.get('REDIS_PASSWORD') %}
+REPLICATION_DATA=`redis-cli -a {{ localsettings_private.REDIS_PASSWORD }} info replication 2> /dev/null`
 {% else %}
 REPLICATION_DATA=`redis-cli  info replication 2> /dev/null`
 {% endif %}

--- a/src/commcare_cloud/ansible/roles/sentry/tasks/snuba.yml
+++ b/src/commcare_cloud/ansible/roles/sentry/tasks/snuba.yml
@@ -39,8 +39,8 @@
   replace:
     path: "{{ snuba_virtualenv_path }}/snuba/snuba/settings.py"
     regexp: "^REDIS_PASSWORD = None"
-    replace: "REDIS_PASSWORD = '{{ localsettings.REDIS_PASSWORD }}'"
-  when: localsettings.REDIS_PASSWORD is defined
+    replace: "REDIS_PASSWORD = '{{ localsettings_private.REDIS_PASSWORD }}'"
+  when: localsettings_private.REDIS_PASSWORD is defined
 
 - name: Create supervisor file
   template:


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Fix issues or make improvements for HQ installation for cluster/monolith:
1. Generate redis password and use it when setting up redis.
2. Add example to show how a shared directory should be configured for a cluster

Earlier attempt: https://github.com/dimagi/commcare-cloud/pull/6604

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None