### PR TITLE
Change growth email on all relevant environments

### DIFF
--- a/environments/backup-production/public.yml
+++ b/environments/backup-production/public.yml
@@ -12,7 +12,7 @@ subscription_change_email: accounts+subchange@dimagi.com
 internal_subscription_change_email: accounts+subchange+internal@dimagi.com
 billing_email: sales@dimagi.com
 invoicing_contact_email: billing-support@dimagi.com
-growth_email: growth@dimagi.com
+growth_email: saas-revenue-team@dimagi.com
 saas_ops_email: saas-ops@dimagi.com
 saas_reporting_email: saas-reporting@dimagi.com
 master_list_email: master-list@dimagi.com

--- a/environments/eu/public.yml
+++ b/environments/eu/public.yml
@@ -96,7 +96,7 @@ subscription_change_email: accounts+subchange@dimagi.com
 internal_subscription_change_email: accounts+subchange+internal@dimagi.com
 billing_email: sales@dimagi.com
 invoicing_contact_email: accounts@dimagi.com
-growth_email: growth@dimagi.com
+growth_email: saas-revenue-team@dimagi.com
 saas_ops_email: saas-ops@dimagi.com
 saas_reporting_email: saas-reporting@dimagi.com
 master_list_email: master-list@dimagi.com

--- a/environments/india/public.yml
+++ b/environments/india/public.yml
@@ -95,7 +95,7 @@ subscription_change_email: accounts+subchange@dimagi.com
 internal_subscription_change_email: accounts+subchange+internal@dimagi.com
 billing_email: sales@dimagi.com
 invoicing_contact_email: accounts@dimagi.com
-growth_email: growth@dimagi.com
+growth_email: saas-revenue-team@dimagi.com
 saas_ops_email: saas-ops@dimagi.com
 saas_reporting_email: saas-reporting@dimagi.com
 master_list_email: master-list@dimagi.com

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -12,7 +12,7 @@ subscription_change_email: accounts+subchange@dimagi.com
 internal_subscription_change_email: accounts+subchange+internal@dimagi.com
 billing_email: sales@dimagi.com
 invoicing_contact_email: accounts@dimagi.com
-growth_email: growth@dimagi.com
+growth_email: saas-revenue-team@dimagi.com
 saas_ops_email: saas-ops@dimagi.com
 saas_reporting_email: saas-reporting@dimagi.com
 master_list_email: master-list@dimagi.com

--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -69,7 +69,7 @@ subscription_change_email: accounts+subchange@dimagi.com
 internal_subscription_change_email: accounts+subchange+internal@dimagi.com
 billing_email: sales@dimagi.com
 invoicing_contact_email: accounts@dimagi.com
-growth_email: growth@dimagi.com
+growth_email: saas-revenue-team@dimagi.com
 saas_ops_email: saas-ops@dimagi.com
 master_list_email: master-list@dimagi.com
 sales_email: sales@dimagi.com

--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -111,7 +111,7 @@ subscription_change_email: accounts+subchange@example.com
 internal_subscription_change_email: accounts+subchange+internal@example.com
 billing_email: sales@example.com
 invoicing_contact_email: accounts@example.com
-growth_email: growth@example.com
+growth_email: saas-revenue-team@example.com
 saas_ops_email: saas-ops@example.com
 saas_reporting_email: null
 master_list_email: master-list@example.com


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/SAAS-16907
Relates to https://github.com/dimagi/commcare-hq/pull/36758
Updates growth email on Dimagi environments to `saas-revenue-team@dimagi.com`

##### Environments Affected
production, eu, india, staging, backup-production, and "example" `growth_email`

