### PR TITLE
encrypted = true for CouchDB EBS volume

### DIFF
--- a/environments/india/terraform.yml
+++ b/environments/india/terraform.yml
@@ -99,7 +99,7 @@ servers:
     network_tier: "db-private"
     az: "a"
     volume_size: 60
-    volume_encrypted: no
+    volume_encrypted: yes
     volume_type: "gp3"
     block_device:
       volume_size: 80
@@ -113,7 +113,7 @@ servers:
     network_tier: "db-private"
     az: "b"
     volume_size: 60
-    volume_encrypted: no
+    volume_encrypted: yes
     volume_type: "gp3"
     block_device: 
       volume_size: 80
@@ -127,7 +127,7 @@ servers:
     network_tier: "db-private"
     az: "c"
     volume_size: 60
-    volume_encrypted: no
+    volume_encrypted: yes
     volume_type: "gp3"
     block_device:
       volume_size: 80


### PR DESCRIPTION
**Ticket :** https://dimagi.atlassian.net/browse/SAAS-18008

**Environment :** India

**Note :**

Recently, we [downsized and encrypted the disk on the Couch servers](https://dimagi.atlassian.net/browse/SAAS-15878). During that process, we missed adding the volume_encrypted: yes parameter in the terraform.yml file. As a result, running terraform plan was marking the volumes for deletion. We've now added the parameter to ensure the volumes remain safe, and everything is running smoothly.