### PR TITLE
instead of AZ `c` use AZ `a` which is similar to that of production

### DIFF
--- a/environments/backup-production/terraform.yml
+++ b/environments/backup-production/terraform.yml
@@ -6,11 +6,11 @@ region: "us-east-2"
 environment: "bk-production"
 ssl_policy: 'ELBSecurityPolicy-FS-1-2-Res-2020-10'
 azs:
+  - "us-east-2a"
   - "us-east-2b"
-  - "us-east-2c"
 az_codes:
+  - a
   - b
-  - c
 vpc_begin_range: "10.212"
 
 ec2_metadata_tokens_required: yes
@@ -19,7 +19,7 @@ servers:
   - server_name: "control_a0-bk-production"
     server_instance_type: t3a.medium
     network_tier: "app-private"
-    az: "c"
+    az: "a"
     volume_size: 20
     group: "control"
     os: jammy
@@ -27,7 +27,7 @@ servers:
   - server_name: "djangomanage_a0-bk-production"
     server_instance_type: t3a.large
     network_tier: "app-private"
-    az: "c"
+    az: "a"
     volume_size: 20
     group: "django_manage"
     os: jammy
@@ -35,7 +35,7 @@ servers:
   - server_name: "web_a{i}-bk-production"
     server_instance_type: t3a.large
     network_tier: "app-private"
-    az: "c"
+    az: "a"
     volume_size: 20
     volume_encrypted: yes
     group: "hq_webworkers"
@@ -55,7 +55,7 @@ servers:
   - server_name: "esmaster_a1-bk-production"
     server_instance_type: t3a.xlarge
     network_tier: "db-private"
-    az: "c"
+    az: "a"
     group: "elasticsearch"
     os: jammy
     volume_size: 20
@@ -72,7 +72,7 @@ servers:
   - server_name: "esmaster_c1-bk-production"
     server_instance_type: t3a.xlarge
     network_tier: "db-private"
-    az: "c"
+    az: "a"
     group: "elasticsearch"
     os: jammy
     volume_size: 20
@@ -81,7 +81,7 @@ servers:
   - server_name: "es_a2{i}-bk-production"
     server_instance_type: t3a.xlarge
     network_tier: "db-private"
-    az: "c"
+    az: "a"
     volume_size: 20
     volume_encrypted: yes
     block_device:
@@ -105,7 +105,7 @@ servers:
   - server_name: "es_a3{i}-bk-production"
     server_instance_type: t3a.xlarge
     network_tier: "db-private"
-    az: "c"
+    az: "a"
     volume_size: 20
     volume_encrypted: yes
     block_device:
@@ -129,7 +129,7 @@ servers:
   - server_name: "couch_a0-bk-production"
     server_instance_type: t3a.small
     network_tier: "db-private"
-    az: "c"
+    az: "a"
     volume_size: 20
     volume_encrypted: yes
     block_device:
@@ -141,7 +141,7 @@ servers:
   - server_name: "rabbit_a0-bk-production"
     server_instance_type: t3a.small
     network_tier: "db-private"
-    az: "c"
+    az: "a"
     volume_size: 20
     volume_encrypted: yes
     group: "rabbitmq"
@@ -150,7 +150,7 @@ servers:
   - server_name: "celery_a{i}-bk-production"
     server_instance_type: t3a.medium
     network_tier: "app-private"
-    az: "c"
+    az: "a"
     volume_size: 20
     volume_encrypted: yes
     group: "celery"
@@ -160,7 +160,7 @@ servers:
   - server_name: "pillow_a{i}-bk-production"
     server_instance_type: t3a.medium
     network_tier: "app-private"
-    az: "c"
+    az: "a"
     volume_size: 20
     group: "pillowtop"
     os: jammy
@@ -169,7 +169,7 @@ servers:
   - server_name: "formplayer_a{i}-bk-production"
     server_instance_type: t3a.small
     network_tier: "app-private"
-    az: "c"
+    az: "a"
     volume_size: 20
     group: "formplayer"
     os: jammy
@@ -178,7 +178,7 @@ servers:
   - server_name: "kafka_a0-bk-production"
     server_instance_type: t3a.small
     network_tier: "db-private"
-    az: "c"
+    az: "a"
     volume_size: 20
     volume_encrypted: no
     group: "kafka"
@@ -187,7 +187,7 @@ servers:
   - server_name: "pgbouncer_a0-bk-production"
     server_instance_type: t3a.small
     network_tier: "db-private"
-    az: "c"
+    az: "a"
     volume_size: 20
     volume_encrypted: yes
     group: "postgresql"
@@ -197,7 +197,7 @@ proxy_servers:
   - server_name: "proxy_a0-bk-production"
     server_instance_type: t3a.large
     network_tier: "public"
-    az: "c"
+    az: "a"
     volume_size: 20
     group: "proxy"
     os: jammy


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
It gets slightly confusing when restoring the volumes from backups, good to keep it consistent with the production.

Do not merge it until all the backup env is destroyed after test.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->

Backup Production

