### PR TITLE
Remove DATABASES[...]['TEST']['SERIALIZE'] setting

### DIFF
--- a/docs/source/services/postgresql/split-partitioned-database.rst
+++ b/docs/source/services/postgresql/split-partitioned-database.rst
@@ -46,9 +46,6 @@ Current database configuration:
            'PASSWORD': 'commcarehq',
            'HOST': 'pg1',
            'PORT': '5432',
-           'TEST': {
-               'SERIALIZE': False,
-           },
        },
        'p1': {
            'ENGINE': 'django.db.backends.postgresql_psycopg2',
@@ -57,9 +54,6 @@ Current database configuration:
            'PASSWORD': 'commcarehq',
            'HOST': 'pg1',
            'PORT': '5432',
-           'TEST': {
-               'SERIALIZE': False,
-           },
        },
    }
 


### PR DESCRIPTION
As of [Django 4.0](https://docs.djangoproject.com/en/5.2/releases/4.0/#id2), `SERIALIZE` test setting is deprecated as it can be inferred from the databases with the `serialized_rollback` option enabled. As of Django 5.0, the setting is removed.

https://dimagi.atlassian.net/browse/SAAS-17626

##### Environments Affected
all/none
