### PR TITLE
Update PR template to include a checkbox to notify devs to ensure to be cognizant of changes that affects multiple envs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,11 @@
 ##### Environments Affected
 <!--- list which environments are affected by this change or None if this doesn't change any environment files -->
 
+
+<!-- Delete this section if the PR does not include any changes that affect any environment -->
+- [ ] If the changes affect multiple environments, I will ensure they are rolled out consistently across all environments.
+
+
 ##### Announce New Release
 <!-- 
 Review https://github.com/dimagi/commcare-cloud/tree/master/changelog#determining-whether-a-change-is-announce-worthy


### PR DESCRIPTION
This came up during a discussion with @gherceg  where we can easily miss that a particular change might be affecting multiple environments. This shows up when we try to apply some other changes and its hard to find context on them. This is a small step to nudge people to think about other environments.


