### PR TITLE
tempororily push couch11 backups to BCP Vault

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -209,6 +209,7 @@ servers:
     block_device:
       volume_size: 1000
       encrypted: yes
+      enable_cross_region_backup: yes
     group: "couchdb2"
     os: bionic
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
To exactly replicate production env in backup production, I want to temporarily push the snapshots from couch11 to our backup regions.
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production



