### PR TITLE
skip ebs snapshots for backup production environment

### DIFF
--- a/environments/backup-production/terraform.yml
+++ b/environments/backup-production/terraform.yml
@@ -4,6 +4,7 @@ state_bucket: dimagi-terraform
 state_bucket_region: "us-east-1"
 region: "us-east-2"
 environment: "bk-production"
+skip_ebs_snapshots: "yes"
 ssl_policy: 'ELBSecurityPolicy-FS-1-2-Res-2020-10'
 azs:
   - "us-east-2b"

--- a/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/commcarehq.tf.j2
@@ -69,6 +69,8 @@ data "aws_iam_role" "data_lifecycle_role" {
   name = "AWSDataLifecycleManagerDefaultRole"
 }
 
+{% if skip_ebs_snapshots != "yes" %}
+
 resource "aws_dlm_lifecycle_policy" "data_volume_backups" {
   description        = "Data Volume Backup Policy"
   execution_role_arn = data.aws_iam_role.data_lifecycle_role.arn
@@ -99,6 +101,7 @@ resource "aws_dlm_lifecycle_policy" "data_volume_backups" {
     }
   }
 }
+{% endif %}
 
 {% if backup_plan %}
 module "backup_plan" {

--- a/src/commcare_cloud/environment/schemas/terraform.py
+++ b/src/commcare_cloud/environment/schemas/terraform.py
@@ -36,6 +36,7 @@ class TerraformConfig(jsonobject.JsonObject):
     ec2_auto_recovery = jsonobject.ListProperty(lambda: Ec2AutoRecovery, default=None)
     fsx_file_systems = jsonobject.ListProperty(lambda: FsxFileSystem, default=None)
     terraform_imports = jsonobject.ListProperty(lambda: TerraformImportsConfig, default=list)
+    skip_ebs_snapshots = jsonobject.StringProperty(default="no")
 
     @classmethod
     def wrap(cls, data):


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
For backup-production environment, do not create ebs snapshots as we would not need them. They also are easy to miss in cleanup and adds overhead of cleaning them up after `terraform destroy` is run on backup-production env.
I have ran terraform plan on all envs and esured that only backup-production removes this lifecycle policy. 
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Backup Production.
Backup Production.