### PR TITLE
Revert "tempororily push couch11 backups to BCP Vault"

### DIFF
--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -209,7 +209,6 @@ servers:
     block_device:
       volume_size: 1000
       encrypted: yes
-      enable_cross_region_backup: yes
     group: "couchdb2"
     os: bionic
 


### PR DESCRIPTION
Reverts dimagi/commcare-cloud#6670 

We have copied the backups, now this is no longer required.