### PR TITLE
update rds engine version to 14.18

### DIFF
--- a/environments/india/terraform.yml
+++ b/environments/india/terraform.yml
@@ -334,7 +334,7 @@ rds_instances:
     storage: 500
     storage_type: gp3
     multi_az: true
-    engine_version: "14.4"
+    engine_version: "14.18"
     params:
       max_connections: "125"
 

--- a/environments/production/terraform.yml
+++ b/environments/production/terraform.yml
@@ -423,7 +423,7 @@ rds_instances:
     storage_type: gp3
     storage_throughput: 500
     multi_az: true
-    engine_version: "14"
+    engine_version: "14.18"
     backup_window: "23:00-01:00"
     backup_retention: 7
     iops: 12000
@@ -447,7 +447,7 @@ rds_instances:
     max_storage: 5000
     storage_type: gp3
     multi_az: true
-    engine_version: "14"
+    engine_version: "14.18"
     backup_window: "23:00-01:00"
     backup_retention: 7
     enable_cross_region_backup: true
@@ -461,7 +461,7 @@ rds_instances:
     storage_type: gp3
     iops: 12000
     multi_az: true
-    engine_version: "14"
+    engine_version: "14.18"
     backup_window: "23:00-01:00"
     backup_retention: 7
     enable_cross_region_backup: true
@@ -477,7 +477,7 @@ rds_instances:
     storage_type: gp3
     iops: 12000
     multi_az: true
-    engine_version: "14"
+    engine_version: "14.18"
     backup_window: "23:00-01:00"
     backup_retention: 7
     enable_cross_region_backup: true
@@ -493,7 +493,7 @@ rds_instances:
     storage_type: gp3
     iops: 12000
     multi_az: true
-    engine_version: "14"
+    engine_version: "14.18"
     backup_window: "23:00-01:00"
     backup_retention: 7
     enable_cross_region_backup: true
@@ -509,7 +509,7 @@ rds_instances:
     storage_type: gp3
     iops: 12000
     multi_az: true
-    engine_version: "14"
+    engine_version: "14.18"
     backup_window: "23:00-01:00"
     backup_retention: 7
     enable_cross_region_backup: true
@@ -525,7 +525,7 @@ rds_instances:
     storage_type: gp3
     iops: 12000
     multi_az: true
-    engine_version: "14"
+    engine_version: "14.18"
     backup_window: "23:00-01:00"
     backup_retention: 7
     enable_cross_region_backup: true
@@ -539,7 +539,7 @@ rds_instances:
     storage: 1000
     storage_type: gp3
     multi_az: true
-    engine_version: "14"
+    engine_version: "14.18"
     backup_retention: 7
     params:
       shared_preload_libraries: pg_stat_statements,pg_transport
@@ -561,7 +561,7 @@ rds_instances:
     storage: 200
     storage_type: gp3
     multi_az: true
-    engine_version: "14"
+    engine_version: "14.18"
     backup_retention: 7
     params:
       shared_preload_libraries: pg_stat_statements,pg_transport
@@ -583,7 +583,7 @@ rds_instances:
     storage: 7000
     storage_type: gp3
     multi_az: true
-    engine_version: "14"
+    engine_version: "14.18"
     backup_window: "23:00-01:00"
     backup_retention: 7
     enable_cross_region_backup: true

--- a/environments/staging/terraform.yml
+++ b/environments/staging/terraform.yml
@@ -347,7 +347,7 @@ rds_instances:
     storage: 160
     storage_type: gp3
     multi_az: yes
-    engine_version: "14"
+    engine_version: "14.18"
     params:
       shared_preload_libraries: pg_stat_statements
       track_io_timing: 1
@@ -358,7 +358,7 @@ rds_instances:
     storage: 160
     storage_type: gp3
     multi_az: yes
-    engine_version: "14.4"
+    engine_version: "14.18"
     params:
       shared_preload_libraries: pg_stat_statements
       track_io_timing: 1


### PR DESCRIPTION
Updating RDS engine version to 14.18 in Production, India and Staging as a part of terraform environmental cleanup.

**Ticket :** https://dimagi.atlassian.net/browse/SAAS-18323