### PR TITLE
ignore exceptions thrown by django redis to ensure we saw custom 500 pages

### DIFF
--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -424,6 +424,7 @@ redis_cache = {
     'LOCATION': '{{ redis_url }}',
 {% endif %}
     'OPTIONS': {
+        'IGNORE_EXCEPTIONS': True, # https://dimagi.atlassian.net/browse/SAAS-14429
         'REDIS_CLIENT_KWARGS': {
             'health_check_interval': 15,
         },


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/SAAS-14429

In one of the issues that we faced, DNS for redis was updated which made redis unreachable to HQ. This caused HQ to display a `Internal Server Error` instead of our custom Sad Danny. 

The stack trace that we would see - 

```
ERROR [django.request] Internal Server Error: /a/new-project/dashboard/project/
Traceback (most recent call last):
  File "/Users/amitphulera/Development/dimagi/commcare-hq/.venv/lib/python3.13/site-packages/django_redis/cache.py", line 29, in _decorator
    return method(self, *args, **kwargs)
  File "/Users/amitphulera/Development/dimagi/commcare-hq/.venv/lib/python3.13/site-packages/django_redis/cache.py", line 99, in _get
    return self.client.get(key, default=default, version=version, client=client)
           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/amitphulera/Development/dimagi/commcare-hq/.venv/lib/python3.13/site-packages/django_redis/client/default.py", line 260, in get
    raise ConnectionInterrupted(connection=client) from e
django_redis.exceptions.ConnectionInterrupted: Redis ConnectionError: Error 61 connecting to 127.0.0.1:6379. Connection refused.
```

We have defined custom 500 handler but that is not triggered because `django-redis` probably errors out before the handler is called. When we asked `django-redis` to ignore the exceptions using `'IGNORE_EXCEPTIONS': True,` then if failed with a sad danny because the session handler was trying to get the session from redis and failed because cache was inaccessible. 

```
Traceback (most recent call last):
  File "/Users/amitphulera/Development/dimagi/commcare-hq/.venv/lib/python3.13/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "/Users/amitphulera/Development/dimagi/commcare-hq/.venv/lib/python3.13/site-packages/django/utils/deprecation.py", line 136, in __call__
    response = self.process_response(request, response)
  File "/Users/amitphulera/Development/dimagi/commcare-hq/.venv/lib/python3.13/site-packages/django/contrib/sessions/middleware.py", line 59, in process_response
    request.session.save()
    ~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/amitphulera/Development/dimagi/commcare-hq/.venv/lib/python3.13/site-packages/django/contrib/sessions/backends/cache.py", line 56, in save
    return self.create()
           ~~~~~~~~~~~^^
  File "/Users/amitphulera/Development/dimagi/commcare-hq/.venv/lib/python3.13/site-packages/django/contrib/sessions/backends/cache.py", line 49, in create
    raise RuntimeError(
    ...<2 lines>...
    )
RuntimeError: Unable to create a new session key. It is likely that the cache is unavailable.
```

I am on fence with the approach because of the following reasons -
- This issue happened only once and that too because of a bad maintenance.
- Not sure if there are category of errors that we don't want to be ignored.
<!--- Provide a link to the ticket or document which prompted this change -->

The process to roll out this change would be - 
- cchq --control <env> update-config
- cchq --control <env> serivce commcare restart

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All

<!-- Delete this section if the PR does not include any changes that affect any environment -->
- [x] If the changes affect multiple environments, I will ensure they are rolled out consistently across all environments.
