### PR TITLE
update rds engine version

### DIFF
--- a/environments/eu/terraform.yml
+++ b/environments/eu/terraform.yml
@@ -331,7 +331,7 @@ rds_instances:
     storage: 500
     storage_type: gp3
     multi_az: true
-    engine_version: "14"
+    engine_version: "14.18"
     params:
       max_connections: "125"
 


### PR DESCRIPTION
Updating RDS engine version to 14.18 in EU.

**Ticket :** https://dimagi.atlassian.net/browse/SAAS-18323