### PR TITLE
Fix restart webworkers command

### DIFF
--- a/src/commcare_cloud/commands/ansible/service.py
+++ b/src/commcare_cloud/commands/ansible/service.py
@@ -1,22 +1,24 @@
 import re
-from abc import ABCMeta, abstractmethod, abstractproperty
-from collections import defaultdict, OrderedDict
-from itertools import groupby
 import sys
+from abc import ABCMeta, abstractmethod, abstractproperty
+from collections import OrderedDict, defaultdict
+from itertools import groupby
 
 import attr
-from clint.textui import puts, indent
+from clint.textui import indent, puts
 
+from commcare_cloud.cli_utils import ask
 from commcare_cloud.colors import color_error
 from commcare_cloud.commands.ansible.helpers import (
-    AnsibleContext, get_django_webworker_name,
-    get_formplayer_spring_instance_name,
+    AnsibleContext,
+    get_all_supervisor_processes_by_host,
     get_celery_workers,
+    get_django_webworker_name,
+    get_formplayer_spring_instance_name,
     get_pillowtop_processes,
-    get_all_supervisor_processes_by_host)
-from commcare_cloud.cli_utils import ask
+)
 from commcare_cloud.commands.ansible.run_module import run_ansible_module
-from commcare_cloud.commands.command_base import CommandBase, Argument
+from commcare_cloud.commands.command_base import Argument, CommandBase
 from commcare_cloud.environment.paths import get_role_defaults
 
 ACTIONS = ['start', 'stop', 'restart', 'status', 'logs', 'help']

--- a/src/commcare_cloud/commands/ansible/service.py
+++ b/src/commcare_cloud/commands/ansible/service.py
@@ -491,7 +491,6 @@ def _restart_commcare_services(environment, limit):
         run_ansible_playbook,
     )
     return run_ansible_playbook(
-
         playbook='restart_commcare_services.yml',
         ansible_context=AnsibleContext(None, environment),
         limit=limit,

--- a/src/commcare_cloud/commands/ansible/service.py
+++ b/src/commcare_cloud/commands/ansible/service.py
@@ -482,7 +482,7 @@ class Webworker(SingleSupervisorService):
         if action == 'restart':
             if process_pattern:
                 raise NotImplementedError("restart --only=... is not supported")
-            return _restart_commcare_services(self.environment, host_pattern, 'webworker')
+            return _restart_webworker_services(self.environment, host_pattern)
         return super().run(action, host_pattern=host_pattern, process_pattern=process_pattern)
 
 

--- a/src/commcare_cloud/commands/ansible/service.py
+++ b/src/commcare_cloud/commands/ansible/service.py
@@ -354,7 +354,9 @@ class Elasticsearch(ServiceBase):
             sys.exit(1)
 
     def _run_rolling_restart_yml(self, tags, limit):
-        from commcare_cloud.commands.ansible.ansible_playbook import run_ansible_playbook
+        from commcare_cloud.commands.ansible.ansible_playbook import (
+            run_ansible_playbook,
+        )
         extra_args = ['--tags={}'.format(tags)]
         if limit:
             extra_args.extend(['--limit={}'.format(limit)])
@@ -495,6 +497,21 @@ def _restart_commcare_services(environment, limit, name="commcare"):
         limit=limit,
         skip_check=True,
         quiet=True,
+    )
+
+
+def _restart_webworker_services(environment, limit):
+    from commcare_cloud.commands.ansible.ansible_playbook import (
+        run_ansible_playbook,
+    )
+
+    return run_ansible_playbook(
+        playbook='restart_webworker_services.yml',
+        ansible_context=AnsibleContext(None, environment),
+        limit=limit,
+        skip_check=True,
+        quiet=True,
+        unknown_args=['-e', 'webworker_hosts=webworkers'],
     )
 
 

--- a/src/commcare_cloud/commands/ansible/service.py
+++ b/src/commcare_cloud/commands/ansible/service.py
@@ -486,13 +486,13 @@ class Webworker(SingleSupervisorService):
         return super().run(action, host_pattern=host_pattern, process_pattern=process_pattern)
 
 
-def _restart_commcare_services(environment, limit, name="commcare"):
-    from commcare_cloud.commands.ansible.ansible_playbook import run_ansible_playbook
+def _restart_commcare_services(environment, limit):
+    from commcare_cloud.commands.ansible.ansible_playbook import (
+        run_ansible_playbook,
+    )
     return run_ansible_playbook(
-        # grep:
-        # restart_commcare_services.yml
-        # restart_webworker_services.yml
-        playbook=f'restart_{name}_services.yml',
+
+        playbook='restart_commcare_services.yml',
         ansible_context=AnsibleContext(None, environment),
         limit=limit,
         skip_check=True,


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
`restart_webworker_services.yml` playbook expects `webworker_hosts` because of which currently `cchq commcare service webworker restart` is failing.
The PR splits up the functionality for commcare restarts and webworker restarts into two different functions.
Paired with @gherceg 
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All
