### PR TITLE
Use gevent in staging xform pillow processes

### DIFF
--- a/environments/staging/app-processes.yml
+++ b/environments/staging/app-processes.yml
@@ -147,6 +147,7 @@ pillows:
       dedicated_migration_process: True
     xform-pillow:
       num_processes: 2
+      gevent_workers: 4
       dedicated_migration_process: True
     group-pillow:
       num_processes: 1


### PR DESCRIPTION
Pre-test for rolling out to production as part of https://dimagi.atlassian.net/browse/SAAS-18518

Roll-out process:
```sh
# update pillow config to add gevent workers
# DO NOT update supervisor to use the new configurations
cchq --control staging update-supervisor-confs

# stop pillow processes
cchq --control staging service pillowtop stop --limit=pillow5

# add partitions and review updated configuration
cchq staging ssh kafka15
su - ansible
/opt/kafka/bin/kafka-topics.sh --describe --bootstrap-server=localhost:9092 --topic form-sql
sudo /opt/kafka/bin/kafka-topics.sh --alter --bootstrap-server=localhost:9092 --topic form-sql --partitions 4
/opt/kafka/bin/kafka-topics.sh --describe --bootstrap-server=localhost:9092 --topic form-sql

# create checkpoints for the new partitions
# the commands for the first two prompts have already been done above
cchq staging django-manage add_kafka_partition form-sql 4

# reread supervisor confs
cchq staging ssh pillow5
sudo -iu cchq
sudo supervisorctl reread
sudo supervisorctl update

# restart pillow processes
cchq --control staging service pillowtop start --limit=pillow5
```

A similar process was used on the case-pillow: https://github.com/dimagi/commcare-cloud/pull/6684

##### Environments Affected
staging
