### PR TITLE
Add more processes to more efficiently use CPU

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -140,8 +140,8 @@ pillows:
     UserGroupsDbKafkaPillow:
       num_processes: 1
   pillow_b2000:
-  # case-sql partitions: 96 = 4 * 24 (one greenlet per partition)
+  # case-sql partitions: 96 = 32 * 3 (one process per core)
     case-pillow:
-      num_processes: 5
-      gevent_workers: 24
+      num_processes: 33
+      gevent_workers: 3
       dedicated_migration_process: True


### PR DESCRIPTION
...at the cost of memory. The plan is to eventually optimize CPU-bound tasks to allow the number of processes to be reduced, but for now 5 is too low because it results in significant pillow lag when all pillow processes become CPU bound concurrently (processing auto-update rules?). The current pillow_b2000 machine has 32 cores, so this should use of all available cores.

https://dimagi.atlassian.net/browse/SAAS-18518

##### Environments Affected
Production