### PR TITLE
Don't use second_line for invoice_from_address

### DIFF
--- a/environments/backup-production/public.yml
+++ b/environments/backup-production/public.yml
@@ -193,8 +193,7 @@ localsettings:
   INACTIVITY_TIMEOUT: 20160
   INVOICE_FROM_ADDRESS:
     'name': "Dimagi, Inc."
-    'first_line': "245 Main Street"
-    'second_line': "2nd Floor"
+    'first_line': "245 Main St, 2nd Floor"
     'city': "Cambridge"
     'region': "MA"
     'postal_code': "02142"

--- a/environments/eu/public.yml
+++ b/environments/eu/public.yml
@@ -167,8 +167,7 @@ localsettings:
   INACTIVITY_TIMEOUT: 20160
   INVOICE_FROM_ADDRESS:
     "name": "Dimagi, Inc."
-    "first_line": "245 Main Street"
-    'second_line': "2nd Floor"
+    "first_line": "245 Main St, 2nd Floor"
     "city": "Cambridge"
     "region": "MA"
     "postal_code": "02142"

--- a/environments/india/public.yml
+++ b/environments/india/public.yml
@@ -160,8 +160,7 @@ localsettings:
   INACTIVITY_TIMEOUT: 20160
   INVOICE_FROM_ADDRESS:
     'name': "Dimagi, Inc."
-    'first_line': "245 Main Street"
-    'second_line': "2nd Floor"
+    'first_line': "245 Main St, 2nd Floor"
     'city': "Cambridge"
     'region': "MA"
     'postal_code': "02142"

--- a/environments/pna/public.yml
+++ b/environments/pna/public.yml
@@ -97,8 +97,7 @@ localsettings:
   HUBSPOT_ACCESS_TOKEN:
   INVOICE_FROM_ADDRESS:
     'name': "Dimagi, Inc."
-    'first_line': "245 Main Street"
-    'second_line': "2nd Floor"
+    'first_line': "245 Main St, 2nd Floor"
     'city': "Cambridge"
     'region': "MA"
     'postal_code': "02142"

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -207,8 +207,7 @@ localsettings:
   INACTIVITY_TIMEOUT: 20160
   INVOICE_FROM_ADDRESS:
     'name': "Dimagi, Inc."
-    'first_line': "245 Main Street"
-    'second_line': "2nd Floor"
+    'first_line': "245 Main St, 2nd Floor"
     'city': "Cambridge"
     'region': "MA"
     'postal_code': "02142"

--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -144,8 +144,7 @@ localsettings:
   HQ_INSTANCE: 'staging'
   INVOICE_FROM_ADDRESS:
     'name': "Dimagi, Inc."
-    'first_line': "245 Main Street"
-    'second_line': "2nd Floor"
+    'first_line': "245 Main St, 2nd Floor"
     'city': "Cambridge"
     'region': "MA"
     'postal_code': "02142"

--- a/quick_monolith_install/sample-environment/public.yml.j2
+++ b/quick_monolith_install/sample-environment/public.yml.j2
@@ -93,8 +93,7 @@ localsettings:
   HUBSPOT_ACCESS_TOKEN:
   INVOICE_FROM_ADDRESS:
     'name': "Dimagi, Inc."
-    'first_line': "245 Main Street"
-    'second_line': "2nd Floor"
+    'first_line': "245 Main St, 2nd Floor"
     'city': "Cambridge"
     'region': "MA"
     'postal_code': "02142"


### PR DESCRIPTION
It's supported by the Address class, which is also used for customer billing addresses, but not by the Invoice PDF template where we put the invoice "from "address, see:
<img width="193" height="125" alt="image" src="https://github.com/user-attachments/assets/a59eeafa-e36a-4549-ad09-340f62b81180" />

Condensing it into a single line does fit the Invoice PDF template:
<img width="245" height="155" alt="image" src="https://github.com/user-attachments/assets/07444990-93d1-4116-a898-23fcb032b9b3" />


<!--- Provide a link to the ticket or document which prompted this change -->
Follow-up to #6692

##### Environments Affected
production, eu, india, backup-production, staging


<!-- Delete this section if the PR does not include any changes that affect any environment -->
- [x] If the changes affect multiple environments, I will ensure they are rolled out consistently across all environments.


