### PR TITLE
Fix auth check for session.db files 

### DIFF
--- a/src/commcare_cloud/commands/terraform/aws.py
+++ b/src/commcare_cloud/commands/terraform/aws.py
@@ -451,6 +451,8 @@ def _sync_sso_to_v1_credentials(aws_session_profile):
                 data = json.load(f)
             except JSONDecodeError:
                 continue
+            except UnicodeDecodeError:
+                continue
 
             if data.get('ProviderType') != 'sso':
                 continue


### PR DESCRIPTION
Install Details: Ubuntu 25.04 / Python 3.13.3

The auth session check trawls through the AWS env looking for JSON files, using a decode exception to skip invalid files. In a clean install for me from this week, this handling path failed because one of the non-JSON files (a sqlite database) was failing with a different exception.

```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x82 in position 98: invalid start byte
```

This PR just adds that handling path to the code, which worked for my install. 

##### Environments Affected
None