### PR TITLE
Fetch code_version explicitly during deploy to fix git checkout race

### DIFF
--- a/src/commcare_cloud/ansible/library/git_setup_release.py
+++ b/src/commcare_cloud/ansible/library/git_setup_release.py
@@ -176,6 +176,13 @@ class Release:
         else:
             self.run(["git", "remote", "update", "--prune"], cwd=repo_mirror)
 
+        # Ensure the requested commit is present even if its branch moved
+        # mid-deploy (e.g. autostaging rebuilt between SHA resolution and
+        # the mirror update), which would leave the SHA unreachable from
+        # any ref and absent after `remote update`.
+        if not self.has_commit(repo_mirror, version):
+            self.run(["git", "fetch", "--no-tags", "origin", version], cwd=repo_mirror)
+
         self.run(["git", "clone", "--no-checkout", "--reference", repo_mirror, repo_url, release_path])
         self.run(["git", "checkout", version], cwd=release_path)
         self.diff['after'][repo_url] = self.get_version(release_path)
@@ -201,6 +208,10 @@ class Release:
 
     def get_version(self, git_repo):
         return self.run(["git", "rev-parse", "HEAD"], cwd=git_repo).stdout.strip()
+
+    def has_commit(self, git_repo, version):
+        return self.run(["git", "cat-file", "-e", f"{version}^{{commit}}"],
+                        cwd=git_repo, check_rc=False).rc == 0
 
     def run(self, args, **kw):
         kw.setdefault("check_rc", True)

--- a/src/commcare_cloud/ansible/library/git_setup_release.py
+++ b/src/commcare_cloud/ansible/library/git_setup_release.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python3
 import os
 import signal
+from collections import namedtuple
 from configparser import ConfigParser
 from os.path import basename
 from pathlib import Path
@@ -8,6 +9,8 @@ from pathlib import Path
 from ansible.module_utils.basic import AnsibleModule
 
 __metaclass__ = type
+
+CommandResult = namedtuple("CommandResult", ["rc", "stdout", "stderr"])
 
 
 DOCUMENTATION = """
@@ -193,19 +196,18 @@ class Release:
         for section in modules.sections():
             mod = modules[section]
             cmd = ["git", "ls-tree", "-z", "-d", "HEAD", "--", mod["path"]]
-            version = self.run(cmd, cwd=repo_path).split()[2]
+            version = self.run(cmd, cwd=repo_path).stdout.split()[2]
             yield mod["path"], mod["url"], version
 
     def get_version(self, git_repo):
-        return self.run(["git", "rev-parse", "HEAD"], cwd=git_repo).strip()
+        return self.run(["git", "rev-parse", "HEAD"], cwd=git_repo).stdout.strip()
 
     def run(self, args, **kw):
         kw.setdefault("check_rc", True)
         if self.key_file:
             ssh = f"ssh -i {self.key_file}"
             kw.setdefault("environ_update", {})["GIT_SSH_COMMAND"] = ssh
-        rc, stdout, stderr = self.run_command(args, **kw)
-        return stdout
+        return CommandResult(*self.run_command(args, **kw))
 
 
 def incomplete_release(dest_tmp, module, result):

--- a/tests/test_deploy/test_git_setup_release.py
+++ b/tests/test_deploy/test_git_setup_release.py
@@ -181,7 +181,7 @@ class TestGitSetupRelease(TestCase):
     def test_bad_version(self):
         release = self.releases / "one"
         refs = self.releases / "refs"
-        with self.assertRaisesRegex(ansible.Fail, f"error: pathspec 'bad-version' did not match"):
+        with self.assertRaisesRegex(ansible.Fail, "couldn't find remote ref bad-version"):
             ansible.run("git_setup_release", {
                 "repo": self.src_repo,
                 "version": "bad-version",


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

Fixes a race during staging deploys where `git checkout <code_version>` fails with `fatal: unable to read tree (<sha>)` even though the SHA exists on GitHub. Happens when an autostaging branch is rebuilt (via \`rebuildstaging\`) between the moment \`code_version\` is resolved from the branch tip (GitHub API, \`commcare.py:154\`) and the moment the target host's mirror runs \`git remote update --prune\`. The old tip is no longer reachable from any ref, so it's never fetched, and the subsequent \`git clone --reference\` can't supply it either.

The fix: after the mirror update, check whether the requested commit is present; if not, fetch it explicitly by SHA. GitHub's uploadpack accepts a fetch-by-SHA for commits still in the object db after a force-push.

Split into two commits:
1. Prefactor `Release.run` to return a `CommandResult` namedtuple so callers can read `.rc` / `.stdout` / `.stderr` at the call site — no behavior change.
2. Add `has_commit` guard + explicit `git fetch --no-tags origin <version>` after the mirror update. Test update for `test_bad_version`: the failure mode shifts from "pathspec did not match" (at checkout) to "couldn't find remote ref bad-version" (at fetch), which is strictly more informative for debugging.

##### Environments Affected

Affects deploy on all environments, but invisibly so other than to fix a race condition. Does not change any actual environment setup.