### PR TITLE
Add support for defining RDS parameter groups

### DIFF
--- a/src/commcare_cloud/commands/terraform/templates/postgresql.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/postgresql.tf.j2
@@ -21,6 +21,10 @@ module "postgresql__{{ rds_instance.identifier }}" {
     monitoring_interval = {{ rds_instance.monitoring_interval|tojson }}
     enable_cross_region_backup = {{ rds_instance.enable_cross_region_backup|tojson }}
   }
+  {%- if rds_instance.parameter_group %}
+  parameter_group_name = module.rds_parameter_group__{{ rds_instance.parameter_group }}.name
+  parameters = []
+  {%- else %}
   parameters = [
     {%- for param in postgresql_params[rds_instance.identifier] %}
     {
@@ -30,6 +34,7 @@ module "postgresql__{{ rds_instance.identifier }}" {
     },
     {%- endfor %}
   ]
+  {%- endif %}
   rds_monitoring_role_arn = module.Users.rds_monitoring_role_arn
   subnet_ids = values(module.network.subnets-db-private)
   vpc_security_group_ids = compact([module.network.rds-sg, module.network.vpn-connections-sg])

--- a/src/commcare_cloud/commands/terraform/templates/postgresql.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/postgresql.tf.j2
@@ -26,7 +26,7 @@ module "postgresql__{{ rds_instance.identifier }}" {
   parameters = []
   {%- else %}
   parameters = [
-    {%- for param in postgresql_params[rds_instance.identifier] %}
+    {%- for param in rds_parameters_by_instance[rds_instance.identifier] %}
     {
       name = {{ param.name|tojson }}
       value = {{ param.value|tojson }}

--- a/src/commcare_cloud/commands/terraform/templates/rds_parameter_group.tf.j2
+++ b/src/commcare_cloud/commands/terraform/templates/rds_parameter_group.tf.j2
@@ -1,0 +1,21 @@
+{%- for group in rds_parameter_groups %}
+module "rds_parameter_group__{{ group.name }}" {
+  source      = "./modules/rds_parameter_group"
+  name        = {{ group.name|tojson }}
+  family      = {{ group.family|tojson }}
+  description = "Database parameter group for {{ group.name }}"
+  parameters = [
+    {%- for param in rds_parameters_by_group[group.name] %}
+    {
+      name = {{ param.name|tojson }}
+      value = {{ param.value|tojson }}
+      apply_method = {{ param.apply_method|tojson }}
+    },
+    {%- endfor %}
+  ]
+  tags = {
+    Environment = var.environment
+    Name        = {{ group.name|tojson }}
+  }
+}
+{%- endfor %}

--- a/src/commcare_cloud/commands/terraform/terraform.py
+++ b/src/commcare_cloud/commands/terraform/terraform.py
@@ -125,6 +125,15 @@ def format_param_for_terraform(param_name, param_value):
     }
 
 
+def validate_references_to_parameter_groups(groups_by_name, rds_instances):
+    for instance in rds_instances:
+        if instance.parameter_group and instance.parameter_group not in groups_by_name:
+            raise ValueError(
+                f"RDS instance '{instance.identifier}' references parameter_group "
+                f"'{instance.parameter_group}', but no group with that name exists"
+            )
+
+
 def get_postgresql_params_by_rds_instance(environment):
     """
     Returns a map from rds_instance identifier to postgresql parameters as accepted by terraform
@@ -151,6 +160,34 @@ def get_postgresql_params_by_rds_instance(environment):
     return rds_instance_to_params
 
 
+def get_rds_parameters_by_parameter_group(environment):
+    groups = environment.terraform_config.rds_parameter_groups
+    if not groups:
+        return {}
+
+    groups_by_name = {g.name: g for g in groups}
+
+    validate_references_to_parameter_groups(
+        groups_by_name,
+        environment.terraform_config.rds_instances,
+    )
+
+    # lifted from get_postgresql_params_by_rds_instance
+    postgresql_variables = get_role_defaults('postgresql_base')
+    postgresql_variables.update(environment.postgresql_config.postgres_override)
+    environment_default_params = {
+        'max_connections': postgresql_variables['postgresql_max_connections'],
+    }
+
+    rds_params_by_group = {}
+    for group in groups:
+        parameters = {**environment_default_params, **group.params}
+        rds_params_by_group[group.name] = [
+            format_param_for_terraform(name, value) for name, value in parameters.items()
+        ]
+    return rds_params_by_group
+
+
 def generate_terraform_entrypoint(environment, key_name, run_dir, apply_immediately):
     context = environment.terraform_config.to_generated_json()
     if key_name not in environment.users_config.dev_users.present:
@@ -167,6 +204,7 @@ def generate_terraform_entrypoint(environment, key_name, run_dir, apply_immediat
         } for username in environment.users_config.dev_users.present],
         'key_name': key_name,
         'postgresql_params': get_postgresql_params_by_rds_instance(environment),
+        'rds_parameters_by_group': get_rds_parameters_by_parameter_group(environment),
         'commcarehq_ssrf_urls_regex': compact_waf_regexes(COMMCAREHQ_SSRF_URLS_REGEX),
         'commcarehq_xml_querystring_urls_regex': compact_waf_regexes(COMMCAREHQ_XML_QUERYSTRING_URLS_REGEX),
         's3_blob_db_s3_bucket': environment.public_vars.get('s3_blob_db_s3_bucket'),
@@ -184,6 +222,7 @@ def generate_terraform_entrypoint(environment, key_name, run_dir, apply_immediat
             ('terraform.tf.j2', 'terraform.tf'),
             ('commcarehq.tf.j2', 'commcarehq.tf'),
             ('postgresql.tf.j2', 'postgresql.tf'),
+            ('rds_parameter_group.tf.j2', 'rds_parameter_group.tf'),
             ('variables.tf.j2', 'variables.tf'),
             ('terraform.tfvars.j2', 'terraform.tfvars'),
             ('terraform.lock.hcl.j2', '.terraform.lock.hcl'),

--- a/src/commcare_cloud/commands/terraform/terraform.py
+++ b/src/commcare_cloud/commands/terraform/terraform.py
@@ -146,7 +146,7 @@ def get_env_default_params(environment):
     }
 
 
-def get_postgresql_params_by_rds_instance(environment):
+def get_rds_parameters_by_instance(environment):
     """
     Returns a map from rds_instance identifier to postgresql parameters as accepted by terraform
 
@@ -200,7 +200,7 @@ def generate_terraform_entrypoint(environment, key_name, run_dir, apply_immediat
             'public_key': environment.get_authorized_key(username)
         } for username in environment.users_config.dev_users.present],
         'key_name': key_name,
-        'postgresql_params': get_postgresql_params_by_rds_instance(environment),
+        'rds_parameters_by_instance': get_rds_parameters_by_instance(environment),
         'rds_parameters_by_group': get_rds_parameters_by_parameter_group(environment),
         'commcarehq_ssrf_urls_regex': compact_waf_regexes(COMMCAREHQ_SSRF_URLS_REGEX),
         'commcarehq_xml_querystring_urls_regex': compact_waf_regexes(COMMCAREHQ_XML_QUERYSTRING_URLS_REGEX),

--- a/src/commcare_cloud/commands/terraform/terraform.py
+++ b/src/commcare_cloud/commands/terraform/terraform.py
@@ -155,12 +155,7 @@ def get_postgresql_params_by_rds_instance(environment):
     environment_default_params = get_env_default_params(environment)
     rds_instance_to_params = {}
     for rds_instance in environment.terraform_config.rds_instances:
-        param_names = set(environment_default_params.keys()) | set(rds_instance.params.keys())
-        combined_params = {
-            param_name: (rds_instance.params[param_name] if param_name in rds_instance.params
-                         else environment_default_params[param_name])
-            for param_name in param_names
-        }
+        combined_params = {**environment_default_params, **rds_instance.params}
         rds_instance_to_params[rds_instance.identifier] = [
             format_param_for_terraform(param_name, param_value)
             for param_name, param_value in combined_params.items()

--- a/src/commcare_cloud/commands/terraform/terraform.py
+++ b/src/commcare_cloud/commands/terraform/terraform.py
@@ -134,17 +134,25 @@ def validate_references_to_parameter_groups(groups_by_name, rds_instances):
             )
 
 
+def get_env_default_params(environment):
+    """
+    This function "hand picks" which defaults we have defined in the default and environment postgres
+    configs that we want to bring over to RDS too
+    """
+    postgresql_variables = get_role_defaults('postgresql_base')
+    postgresql_variables.update(environment.postgresql_config.postgres_override)
+    return {
+        'max_connections': postgresql_variables['postgresql_max_connections'],
+    }
+
+
 def get_postgresql_params_by_rds_instance(environment):
     """
     Returns a map from rds_instance identifier to postgresql parameters as accepted by terraform
 
     See aws db_parameter_group "parameter" argument.
     """
-    postgresql_variables = get_role_defaults('postgresql_base')
-    postgresql_variables.update(environment.postgresql_config.postgres_override)
-    environment_default_params = {
-        'max_connections': postgresql_variables['postgresql_max_connections'],
-    }
+    environment_default_params = get_env_default_params(environment)
     rds_instance_to_params = {}
     for rds_instance in environment.terraform_config.rds_instances:
         param_names = set(environment_default_params.keys()) | set(rds_instance.params.keys())
@@ -172,13 +180,7 @@ def get_rds_parameters_by_parameter_group(environment):
         environment.terraform_config.rds_instances,
     )
 
-    # lifted from get_postgresql_params_by_rds_instance
-    postgresql_variables = get_role_defaults('postgresql_base')
-    postgresql_variables.update(environment.postgresql_config.postgres_override)
-    environment_default_params = {
-        'max_connections': postgresql_variables['postgresql_max_connections'],
-    }
-
+    environment_default_params = get_env_default_params(environment)
     rds_params_by_group = {}
     for group in groups:
         parameters = {**environment_default_params, **group.params}

--- a/src/commcare_cloud/commands/terraform/tests/test_parameter_groups.py
+++ b/src/commcare_cloud/commands/terraform/tests/test_parameter_groups.py
@@ -1,0 +1,33 @@
+from nose.tools import assert_raises
+
+from commcare_cloud.environment.schemas.terraform import RdsParameterGroupConfig
+from commcare_cloud.commands.terraform.terraform import validate_references_to_parameter_groups
+
+
+def _make_group(name, family, params):
+    data = {"name": name, "family": family, "params": params}
+    return RdsParameterGroupConfig.wrap(data)
+
+
+def test_validate_references_to_parameter_groups():
+    # assert valid reference
+    validate_references_to_parameter_groups(
+        {"pg18-params": _make_group("pg18-params", "postgres18", {})},
+        [type("Instance", (), {"identifier": "pg0", "parameter_group": "pg18-params"})],
+    )
+
+    # assert invalid reference
+    with assert_raises(ValueError) as context:
+        validate_references_to_parameter_groups(
+            {},
+            [type("Instance", (), {"identifier": "pg0", "parameter_group": "nonexistent"})],
+        )
+        message = str(context.exception)
+        assert "pg0" in message
+        assert "nonexistent" in message
+
+    # assert parameter_group not required
+    validate_references_to_parameter_groups(
+        {},
+        [type("Instance", (), {"identifier": "pg0", "parameter_group": None})],
+    )

--- a/src/commcare_cloud/environment/schemas/terraform.py
+++ b/src/commcare_cloud/environment/schemas/terraform.py
@@ -211,13 +211,18 @@ class RdsInstanceConfig(jsonobject.JsonObject):
 
     @classmethod
     def wrap(cls, data):
-        if 'params' not in data:
-            data['params'] = {}
-        params = data['params']
-        for name, value in RDS_DEFAULT_PARAMS.items():
-            if name not in params:
-                params[name] = value
-        return super(RdsInstanceConfig, cls).wrap(data)
+        if data.get('params') and data.get('parameter_group'):
+            raise ValueError(
+                f"RDS instance '{data.get('identifier')}' sets both 'parameter_group' "
+                "and 'params'. These are mutually exclusive — when 'parameter_group' "
+                "is set, parameters must be defined on the standalone group."
+            )
+        elif data.get('parameter_group'):
+            return super(RdsInstanceConfig, cls).wrap(data)
+        else:
+            params = data.get('params', {})
+            data['params'] = {**RDS_DEFAULT_PARAMS, **params}
+            return super(RdsInstanceConfig, cls).wrap(data)
 
 
 class RdsParameterGroupConfig(jsonobject.JsonObject):

--- a/src/commcare_cloud/environment/schemas/terraform.py
+++ b/src/commcare_cloud/environment/schemas/terraform.py
@@ -179,6 +179,13 @@ class BlockDevice(jsonobject.JsonObject):
     enable_cross_region_backup = jsonobject.BooleanProperty(default=False)
 
 
+RDS_DEFAULT_PARAMS = {
+    'pg_stat_statements.track': 'all',
+    'pg_stat_statements.max': 10000,
+    'track_activity_query_size': 2048,
+}
+
+
 class RdsInstanceConfig(jsonobject.JsonObject):
     _allow_dynamic_properties = False
     identifier = jsonobject.StringProperty(required=True)
@@ -200,18 +207,12 @@ class RdsInstanceConfig(jsonobject.JsonObject):
     port = 5432
     params = jsonobject.DictProperty()
 
-    _default_params = {
-        'pg_stat_statements.track': 'all',
-        'pg_stat_statements.max': 10000,
-        'track_activity_query_size': 2048,
-    }
-
     @classmethod
     def wrap(cls, data):
         if 'params' not in data:
             data['params'] = {}
         params = data['params']
-        for name, value in cls._default_params.items():
+        for name, value in RDS_DEFAULT_PARAMS.items():
             if name not in params:
                 params[name] = value
         return super(RdsInstanceConfig, cls).wrap(data)

--- a/src/commcare_cloud/environment/schemas/terraform.py
+++ b/src/commcare_cloud/environment/schemas/terraform.py
@@ -34,6 +34,7 @@ class TerraformConfig(jsonobject.JsonObject):
     servers = jsonobject.ListProperty(lambda: ServerConfig)
     proxy_servers = jsonobject.ListProperty(lambda: ServerConfig)
     rds_instances = jsonobject.ListProperty(lambda: RdsInstanceConfig)
+    rds_parameter_groups = jsonobject.ListProperty(lambda: RdsParameterGroupConfig, default=list)
     pgbouncer_nlbs = jsonobject.ListProperty(lambda: PgbouncerNlbs)
     internal_albs = jsonobject.ListProperty(lambda: InternalAlbs)
     elasticache_cluster = jsonobject.ObjectProperty(lambda: ElasticacheClusterConfig, default=None)
@@ -206,6 +207,7 @@ class RdsInstanceConfig(jsonobject.JsonObject):
     maintenance_window = "sat:08:27-sat:08:57"
     port = 5432
     params = jsonobject.DictProperty()
+    parameter_group = jsonobject.StringProperty(default=None)
 
     @classmethod
     def wrap(cls, data):
@@ -216,6 +218,19 @@ class RdsInstanceConfig(jsonobject.JsonObject):
             if name not in params:
                 params[name] = value
         return super(RdsInstanceConfig, cls).wrap(data)
+
+
+class RdsParameterGroupConfig(jsonobject.JsonObject):
+    _allow_dynamic_properties = False
+    name = jsonobject.StringProperty(required=True)
+    family = jsonobject.StringProperty(required=True)
+    params = jsonobject.DictProperty()
+
+    @classmethod
+    def wrap(cls, data):
+        params = data.get('params', {})
+        data['params'] = {**RDS_DEFAULT_PARAMS, **params}
+        return super(RdsParameterGroupConfig, cls).wrap(data)
 
 
 class PgbouncerNlbs(jsonobject.JsonObject):

--- a/src/commcare_cloud/environment/schemas/tests/test_terraform_schema.py
+++ b/src/commcare_cloud/environment/schemas/tests/test_terraform_schema.py
@@ -1,4 +1,6 @@
-from commcare_cloud.environment.schemas.terraform import ServerConfig
+from commcare_cloud.environment.schemas.terraform import (
+    ServerConfig, RdsInstanceConfig, RdsParameterGroupConfig, RDS_DEFAULT_PARAMS,
+)
 
 
 def test_single_server():
@@ -28,3 +30,38 @@ def test_multi_server():
     assert server_spec.get_host_group_name() == 'server_a'
     assert server_spec.get_all_server_names() == ['server_a000-test', 'server_a001-test']
     assert server_spec.get_all_host_names() == ['server_a000', 'server_a001']
+
+
+def test_rds_parameter_group_config():
+    group = RdsParameterGroupConfig.wrap({
+        'name': 'pg18-params-staging',
+        'family': 'postgres18',
+        'params': {
+            'shared_preload_libraries': 'pg_stat_statements',
+        },
+    })
+    assert group.name == 'pg18-params-staging'
+    assert group.family == 'postgres18'
+    assert group.params['shared_preload_libraries'] == 'pg_stat_statements'
+    for param_name in RDS_DEFAULT_PARAMS:
+        assert param_name in group.params, f"Default param {param_name} not applied"
+
+
+def test_rds_instance_config():
+    instance_with_params = RdsInstanceConfig.wrap(
+        {
+            "identifier": "pg0-staging",
+            "instance_type": "db.t4g.large",
+            "storage": 300,
+            "params": {"shared_preload_libraries": "pg_stat_statements"},
+        }
+    )
+    assert instance_with_params.parameter_group is None
+
+    instance_with_param_group = RdsInstanceConfig.wrap({
+        'identifier': 'pg0-staging',
+        'instance_type': 'db.t4g.large',
+        'storage': 300,
+        'parameter_group': 'pg18-params-staging',
+    })
+    assert instance_with_param_group.parameter_group == 'pg18-params-staging'

--- a/src/commcare_cloud/environment/schemas/tests/test_terraform_schema.py
+++ b/src/commcare_cloud/environment/schemas/tests/test_terraform_schema.py
@@ -1,3 +1,4 @@
+from nose.tools import assert_raises
 from commcare_cloud.environment.schemas.terraform import (
     ServerConfig, RdsInstanceConfig, RdsParameterGroupConfig, RDS_DEFAULT_PARAMS,
 )
@@ -65,3 +66,16 @@ def test_rds_instance_config():
         'parameter_group': 'pg18-params-staging',
     })
     assert instance_with_param_group.parameter_group == 'pg18-params-staging'
+
+    with assert_raises(ValueError) as context:
+        RdsInstanceConfig.wrap({
+            'identifier': 'pg0-staging',
+            'instance_type': 'db.t4g.large',
+            'storage': 300,
+            # ensure mutually exclusive
+            'parameter_group': 'pg18-params-staging',
+            'params': {'shared_preload_libraries': 'pg_stat_statements'},
+        })
+    message = str(context.exception)
+    assert 'pg0-staging' in message
+    assert 'mutually exclusive' in message

--- a/src/commcare_cloud/terraform/modules/postgresql/main.tf
+++ b/src/commcare_cloud/terraform/modules/postgresql/main.tf
@@ -1,5 +1,6 @@
 locals {
   create = (var.create && lookup(var.rds_instance, "create", true)) ? true : false
+  use_external_parameter_group = var.parameter_group_name != null
 
   version_parts = regex("^(?P<major>[0-9]+)(?:\\.(?P<minor>[0-9]+))?", var.rds_instance["engine_version"])
   version_parts_number = {
@@ -18,7 +19,8 @@ module "postgresql" {
   create_random_password = false
   create_db_instance = local.create
   create_db_option_group = local.create
-  create_db_parameter_group = local.create
+  create_db_parameter_group = local.use_external_parameter_group ? false : local.create
+  parameter_group_name = var.parameter_group_name
   create_db_subnet_group = local.create
   identifier = var.rds_instance["identifier"]
 

--- a/src/commcare_cloud/terraform/modules/postgresql/variables.tf
+++ b/src/commcare_cloud/terraform/modules/postgresql/variables.tf
@@ -6,6 +6,12 @@ variable "rds_instance" {
 variable "parameters" {
   type = list
 }
+
+variable "parameter_group_name" {
+  description = "Name of an externally managed DB parameter group. When set, inline parameter group creation is disabled."
+  type        = string
+  default     = null
+}
 variable "vpc_security_group_ids" {
   type = list
 }

--- a/src/commcare_cloud/terraform/modules/rds_parameter_group/main.tf
+++ b/src/commcare_cloud/terraform/modules/rds_parameter_group/main.tf
@@ -1,0 +1,20 @@
+resource "aws_db_parameter_group" "this" {
+  name        = var.name
+  family      = var.family
+  description = var.description
+
+  dynamic "parameter" {
+    for_each = var.parameters
+    content {
+      name         = parameter.value.name
+      value        = parameter.value.value
+      apply_method = parameter.value.apply_method
+    }
+  }
+
+  tags = var.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/src/commcare_cloud/terraform/modules/rds_parameter_group/outputs.tf
+++ b/src/commcare_cloud/terraform/modules/rds_parameter_group/outputs.tf
@@ -1,0 +1,9 @@
+output "name" {
+  description = "The name of the DB parameter group"
+  value       = aws_db_parameter_group.this.name
+}
+
+output "id" {
+  description = "The ID of the DB parameter group"
+  value       = aws_db_parameter_group.this.id
+}

--- a/src/commcare_cloud/terraform/modules/rds_parameter_group/variables.tf
+++ b/src/commcare_cloud/terraform/modules/rds_parameter_group/variables.tf
@@ -1,0 +1,31 @@
+variable "name" {
+  description = "Name of the DB parameter group"
+  type        = string
+}
+
+variable "family" {
+  description = "The family of the DB parameter group (e.g. postgres18)"
+  type        = string
+}
+
+variable "description" {
+  description = "Description of the DB parameter group"
+  type        = string
+  default     = ""
+}
+
+variable "parameters" {
+  description = "List of DB parameter maps to apply"
+  type = list(object({
+    name         = string
+    value        = string
+    apply_method = string
+  }))
+  default = []
+}
+
+variable "tags" {
+  description = "Tags to apply to the parameter group"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi.atlassian.net/browse/SAAS-19633

When upgrading postgres via terraform, terraform wants to delete the attached parameter group since it is only referenced by the rds instance, and once upgraded, a new group will be created/attached targeting that new version of postgres.

Ideally, we would first create the new parameter group targeting the new version of postgres, which will then allow us to easily compare the existing parameter group and the new group in the AWS console to see what has changed/new defaults, etc. Once confident, we can then update the engine version and parameter_group at the same time, resulting in a successful upgrade. 

This supports both the existing way of defining parameter "in-line" in the rds instance or defining them in a separate parameter group and linking that group to the instance. If both are defined on an instance, an error is raised.

Example usage
```
rds_instances:

  - identifier: "pgtest-staging"
    instance_type: "db.t3.micro"
    storage: 300
    storage_type: gp3
    multi_az: no
    engine_version: "18.3"
    parameter_group: "pgtest-parameters-v18-staging"

rds_parameter_groups:

  - name: "pgtest-parameters-v18-staging"
    family: "postgres18"
    params:
      rds.force_ssl: 0
      shared_preload_libraries: pg_stat_statements
      track_io_timing: 1
```
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None