### PR TITLE
Skip staging deploy prompt and post diff URL to Slack thread

### DIFF
--- a/src/commcare_cloud/commands/deploy/commcare.py
+++ b/src/commcare_cloud/commands/deploy/commcare.py
@@ -126,6 +126,8 @@ def confirm_deploy(environment, deploy_revs, rev_diffs, args):
     code_diff.print_deployer_diff()
     if code_diff.deployed_commit_matches_latest_commit and not args.quiet:
         _print_same_code_warning(deploy_revs['commcare'])
+    elif environment.name == 'staging':
+        return True
     return _ask_to_deploy(environment.name, args.quiet)
 
 

--- a/src/commcare_cloud/commands/deploy/slack.py
+++ b/src/commcare_cloud/commands/deploy/slack.py
@@ -81,6 +81,12 @@ class SlackClient:
                     "text": {"type": "mrkdwn", "text": chunked_diff_text}
                 }]
                 self._post_message("Deploy diff", diff_blocks, thread_ts=response["ts"])
+        else:
+            diff_blocks = [{
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": "Complete diff: " + context.diff.url}
+            }]
+            self._post_message("Deploy diff", diff_blocks, thread_ts=response["ts"])
 
     def _chunk_diff(self, diff_text, chunk_size=2800):
         # Slack has a limit of 3000 characters per message block


### PR DESCRIPTION
Reduce friction when deploying to staging:

- Staging deploys no longer pause to ask for confirmation when there is new code to deploy.
- The bot now posts a link to the GitHub compare URL in the deploy thread so lurkers can see what's being deployed.

Tested by running a staging deploy.

:blowfish: Review by commit.

##### Environments Affected

staging
