### PR TITLE
Support non-interactive cchq secrets edit

### DIFF
--- a/docs/source/reference/1-commcare-cloud/commands.md
+++ b/docs/source/reference/1-commcare-cloud/commands.md
@@ -827,7 +827,7 @@ Output as CSV
 View and edit secrets through the CLI
 
 ```
-commcare-cloud <env> secrets {view,edit,list-append,list-remove} secret_name
+commcare-cloud <env> secrets [--from-stdin] {view,edit,list-append,list-remove} secret_name
 ```
 
 ##### Positional Arguments
@@ -835,6 +835,13 @@ commcare-cloud <env> secrets {view,edit,list-append,list-remove} secret_name
 ###### `{view,edit,list-append,list-remove}`
 
 ###### `secret_name`
+
+##### Options
+
+###### `--from-stdin`
+
+Read the new secret value from stdin instead of prompting interactively.
+Can only be used with the 'edit' subcommand.
 
 ---
 

--- a/src/commcare_cloud/commands/secrets.py
+++ b/src/commcare_cloud/commands/secrets.py
@@ -49,9 +49,7 @@ class Secrets(CommandBase):
 
     def _secrets_edit(self, environment, secret_name, from_stdin=False):
         if from_stdin:
-            secret_value = sys.stdin.read()
-            if secret_value.endswith('\n'):
-                secret_value = secret_value[:-1]
+            secret_value = sys.stdin.read().strip()
         else:
             environment.secrets_backend.prompt_user_input()
             secret_value = getpass.getpass(f"New value for '{environment.name}' secret '{secret_name}': ")

--- a/src/commcare_cloud/commands/secrets.py
+++ b/src/commcare_cloud/commands/secrets.py
@@ -1,5 +1,6 @@
 import getpass
 import json
+import sys
 
 import yaml
 from clint.textui import puts
@@ -20,14 +21,20 @@ class Secrets(CommandBase):
     arguments = (
         Argument(dest='subcommand', choices=['view', 'edit', 'list-append', 'list-remove']),
         Argument(dest='secret_name'),
+        Argument('--from-stdin', action='store_true', help="""
+            Read the new secret value from stdin instead of prompting interactively.
+            Can only be used with the 'edit' subcommand.
+        """),
     )
 
     def run(self, args, unknown_args):
+        if args.from_stdin and args.subcommand != 'edit':
+            self.parser.error("--from-stdin can only be used with the 'edit' subcommand")
         environment = get_environment(args.env_name)
         if args.subcommand == 'view':
             return self._secrets_view(environment, args.secret_name)
         if args.subcommand == 'edit':
-            return self._secrets_edit(environment, args.secret_name)
+            return self._secrets_edit(environment, args.secret_name, from_stdin=args.from_stdin)
         if args.subcommand == 'list-append':
             return self._secrets_append_to_list(environment, args.secret_name)
         if args.subcommand == 'list-remove':
@@ -40,9 +47,14 @@ class Secrets(CommandBase):
         else:
             print(yaml.safe_dump(secret))
 
-    def _secrets_edit(self, environment, secret_name):
-        environment.secrets_backend.prompt_user_input()
-        secret_value = getpass.getpass("New value for '{}' secret '{}': ".format(environment.name, secret_name))
+    def _secrets_edit(self, environment, secret_name, from_stdin=False):
+        if from_stdin:
+            secret_value = sys.stdin.read()
+            if secret_value.endswith('\n'):
+                secret_value = secret_value[:-1]
+        else:
+            environment.secrets_backend.prompt_user_input()
+            secret_value = getpass.getpass("New value for '{}' secret '{}': ".format(environment.name, secret_name))
         try:
             secret_value = json.loads(secret_value)
         except ValueError:

--- a/src/commcare_cloud/commands/secrets.py
+++ b/src/commcare_cloud/commands/secrets.py
@@ -54,9 +54,7 @@ class Secrets(CommandBase):
                 secret_value = secret_value[:-1]
         else:
             environment.secrets_backend.prompt_user_input()
-            secret_value = getpass.getpass(
-                "New value for '{}' secret '{}': ".format(environment.name, secret_name)
-            )
+            secret_value = getpass.getpass(f"New value for '{environment.name}' secret '{secret_name}': ")
         try:
             secret_value = json.loads(secret_value)
         except ValueError:

--- a/src/commcare_cloud/commands/secrets.py
+++ b/src/commcare_cloud/commands/secrets.py
@@ -54,7 +54,9 @@ class Secrets(CommandBase):
                 secret_value = secret_value[:-1]
         else:
             environment.secrets_backend.prompt_user_input()
-            secret_value = getpass.getpass("New value for '{}' secret '{}': ".format(environment.name, secret_name))
+            secret_value = getpass.getpass(
+                "New value for '{}' secret '{}': ".format(environment.name, secret_name)
+            )
         try:
             secret_value = json.loads(secret_value)
         except ValueError:


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/SAAS-19725 (subtask of https://dimagi.atlassian.net/browse/SAAS-19724)

##### Environments Affected
None — CLI ergonomics only, no environment files change.

## Summary
- Add a `--from-stdin` flag to `cchq <env> secrets edit` so the new value can be piped in instead of typed at a `getpass` prompt:
  ```
  echo "$MY_SECRET" | cchq <env> secrets edit MY_SECRET --from-stdin
  ```
- A single trailing newline is stripped so the common `echo … | …` pattern works without the newline ending up in the stored value. JSON parsing of the value (existing behavior) is preserved.
- `--from-stdin` is rejected with an argparse usage error (exit 2) if paired with any subcommand other than `edit` (`view`, `list-append`, `list-remove`), rather than being silently ignored.

## Test plan
- [x] `echo "hello" | cchq staging secrets edit MY_TEST_SECRET --from-stdin` followed by `cchq staging secrets view MY_TEST_SECRET` returns `hello` (no trailing newline).
- [x] `cchq staging secrets edit MY_TEST_SECRET` without the flag still prompts interactively and works as before.
- [x] `cchq staging secrets edit --help` lists the new option.
- [x] `cchq <env> secrets view FOO --from-stdin` exits non-zero with an argparse usage error mentioning that `--from-stdin` only works with `edit`.