### PR TITLE
Add tooling to manage AWS IAM access keys

### DIFF
--- a/scripts/aws/manage-iam-keys.py
+++ b/scripts/aws/manage-iam-keys.py
@@ -6,7 +6,9 @@ Usage:
     ./scripts/aws/manage-iam-keys.py <aws-profile> <iam-user> <subcommand>
 
 Subcommands:
-    list    Output a JSON list of the user's access keys, including last-used info.
+    list                    Output a JSON list of the user's access keys, including last-used info.
+    deactivate <key-id>     Set the key status to Inactive and print the updated key info.
+    reactivate <key-id>     Set the key status to Active and print the updated key info.
 """
 
 import argparse
@@ -25,6 +27,16 @@ def main():
 
     subparsers.add_parser('list', help="List the user's access keys as JSON.")
 
+    deactivate_parser = subparsers.add_parser(
+        'deactivate', help='Set the given access key to Inactive.'
+    )
+    deactivate_parser.add_argument('key_id', help='Access key ID to deactivate.')
+
+    reactivate_parser = subparsers.add_parser(
+        'reactivate', help='Set the given access key to Active.'
+    )
+    reactivate_parser.add_argument('key_id', help='Access key ID to reactivate.')
+
     args = parser.parse_args()
 
     session = boto3.session.Session(profile_name=args.aws_profile)
@@ -32,6 +44,10 @@ def main():
 
     if args.subcommand == 'list':
         print_json(list_keys(iam, args.iam_user))
+    elif args.subcommand == 'deactivate':
+        print_json(set_key_active(iam, args.iam_user, args.key_id, active=False))
+    elif args.subcommand == 'reactivate':
+        print_json(set_key_active(iam, args.iam_user, args.key_id, active=True))
 
 
 def list_keys(iam, iam_user):
@@ -43,6 +59,22 @@ def list_keys(iam, iam_user):
         )['AccessKeyLastUsed']
         result.append(_format_key_info(key, last_used))
     return result
+
+
+def set_key_active(iam, iam_user, access_key_id, active):
+    status = 'Active' if active else 'Inactive'
+    iam.update_access_key(UserName=iam_user, AccessKeyId=access_key_id, Status=status)
+    return _get_key_info(iam, iam_user, access_key_id)
+
+
+def _get_key_info(iam, iam_user, access_key_id):
+    for key in iam.list_access_keys(UserName=iam_user)['AccessKeyMetadata']:
+        if key['AccessKeyId'] == access_key_id:
+            last_used = iam.get_access_key_last_used(
+                AccessKeyId=access_key_id
+            )['AccessKeyLastUsed']
+            return _format_key_info(key, last_used)
+    raise SystemExit(f"Access key {access_key_id} not found for user {iam_user}.")
 
 
 def _format_key_info(key, last_used):

--- a/scripts/aws/manage-iam-keys.py
+++ b/scripts/aws/manage-iam-keys.py
@@ -7,11 +7,13 @@ Usage:
 
 Subcommands:
     list                    Output a JSON list of the user's access keys, including last-used info.
+    create                  Create a new access key and print its credentials as CSV.
     deactivate <key-id>     Set the key status to Inactive and print the updated key info.
     reactivate <key-id>     Set the key status to Active and print the updated key info.
 """
 
 import argparse
+import csv
 import json
 import sys
 from datetime import datetime
@@ -26,6 +28,10 @@ def main():
     subparsers = parser.add_subparsers(dest='subcommand', required=True)
 
     subparsers.add_parser('list', help="List the user's access keys as JSON.")
+
+    subparsers.add_parser(
+        'create', help='Create a new access key and print its credentials as CSV.'
+    )
 
     deactivate_parser = subparsers.add_parser(
         'deactivate', help='Set the given access key to Inactive.'
@@ -44,6 +50,8 @@ def main():
 
     if args.subcommand == 'list':
         print_json(list_keys(iam, args.iam_user))
+    elif args.subcommand == 'create':
+        print_keyfile(create_key(iam, args.iam_user))
     elif args.subcommand == 'deactivate':
         print_json(set_key_active(iam, args.iam_user, args.key_id, active=False))
     elif args.subcommand == 'reactivate':
@@ -59,6 +67,14 @@ def list_keys(iam, iam_user):
         )['AccessKeyLastUsed']
         result.append(_format_key_info(key, last_used))
     return result
+
+
+def create_key(iam, iam_user):
+    key = iam.create_access_key(UserName=iam_user)['AccessKey']
+    return {
+        'AccessKeyId': key['AccessKeyId'],
+        'SecretAccessKey': key['SecretAccessKey'],
+    }
 
 
 def set_key_active(iam, iam_user, access_key_id, active):
@@ -92,6 +108,12 @@ def _format_key_info(key, last_used):
 def print_json(data):
     json.dump(data, sys.stdout, indent=2, default=_json_default)
     sys.stdout.write('\n')
+
+
+def print_keyfile(key):
+    writer = csv.writer(sys.stdout)
+    writer.writerow(['Access key ID', 'Secret access key'])
+    writer.writerow([key['AccessKeyId'], key['SecretAccessKey']])
 
 
 def _json_default(value):

--- a/scripts/aws/manage-iam-keys.py
+++ b/scripts/aws/manage-iam-keys.py
@@ -10,13 +10,16 @@ Subcommands:
     create                  Create a new access key and print its credentials as CSV.
     deactivate <key-id>     Set the key status to Inactive and print the updated key info.
     reactivate <key-id>     Set the key status to Active and print the updated key info.
+    remove <key-id>         Remove the key and print the information of the removed key. Without --force,
+                            requires the key to be deactivated and last used date to be at least 24 hours
+                            in the past.
 """
 
 import argparse
 import csv
 import json
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 
 import boto3
 
@@ -43,6 +46,15 @@ def main():
     )
     reactivate_parser.add_argument('key_id', help='Access key ID to reactivate.')
 
+    remove_parser = subparsers.add_parser(
+        'remove', help='Remove the given access key.'
+    )
+    remove_parser.add_argument('key_id', help='Access key ID to remove.')
+    remove_parser.add_argument(
+        '--force', action='store_true',
+        help='Skip the deactivated/24h-since-last-used safety check.'
+    )
+
     args = parser.parse_args()
 
     session = boto3.session.Session(profile_name=args.aws_profile)
@@ -56,6 +68,8 @@ def main():
         print_json(set_key_active(iam, args.iam_user, args.key_id, active=False))
     elif args.subcommand == 'reactivate':
         print_json(set_key_active(iam, args.iam_user, args.key_id, active=True))
+    elif args.subcommand == 'remove':
+        print_json(remove_key(iam, args.iam_user, args.key_id, force=args.force))
 
 
 def list_keys(iam, iam_user):
@@ -81,6 +95,23 @@ def set_key_active(iam, iam_user, access_key_id, active):
     status = 'Active' if active else 'Inactive'
     iam.update_access_key(UserName=iam_user, AccessKeyId=access_key_id, Status=status)
     return _get_key_info(iam, iam_user, access_key_id)
+
+
+def remove_key(iam, iam_user, access_key_id, force):
+    info = _get_key_info(iam, iam_user, access_key_id)
+    if not force:
+        if info['Status'] != 'Inactive':
+            raise SystemExit(
+                f"Key {access_key_id} is {info['Status']}; deactivate it first or pass --force."
+            )
+        last_used = info['LastUsedDate']
+        if last_used is not None and (datetime.now(timezone.utc) - last_used).total_seconds() < 24 * 3600:
+            raise SystemExit(
+                f"Key {access_key_id} was last used at {last_used.isoformat()} "
+                f"(less than 24 hours ago); pass --force to remove anyway."
+            )
+    iam.delete_access_key(UserName=iam_user, AccessKeyId=access_key_id)
+    return info
 
 
 def _get_key_info(iam, iam_user, access_key_id):

--- a/scripts/aws/manage-iam-keys.py
+++ b/scripts/aws/manage-iam-keys.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""
+Manage AWS IAM access keys for a given user.
+
+Usage:
+    ./scripts/aws/manage-iam-keys.py <aws-profile> <iam-user> <subcommand>
+
+Subcommands:
+    list    Output a JSON list of the user's access keys, including last-used info.
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime
+
+import boto3
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.strip().splitlines()[0])
+    parser.add_argument('aws_profile', help='AWS profile name to use for credentials.')
+    parser.add_argument('iam_user', help='IAM user whose access keys are managed.')
+    subparsers = parser.add_subparsers(dest='subcommand', required=True)
+
+    subparsers.add_parser('list', help="List the user's access keys as JSON.")
+
+    args = parser.parse_args()
+
+    session = boto3.session.Session(profile_name=args.aws_profile)
+    iam = session.client('iam')
+
+    if args.subcommand == 'list':
+        print_json(list_keys(iam, args.iam_user))
+
+
+def list_keys(iam, iam_user):
+    keys = iam.list_access_keys(UserName=iam_user)['AccessKeyMetadata']
+    result = []
+    for key in keys:
+        last_used = iam.get_access_key_last_used(
+            AccessKeyId=key['AccessKeyId']
+        )['AccessKeyLastUsed']
+        result.append(_format_key_info(key, last_used))
+    return result
+
+
+def _format_key_info(key, last_used):
+    return {
+        'UserName': key['UserName'],
+        'AccessKeyId': key['AccessKeyId'],
+        'Status': key['Status'],
+        'CreateDate': key['CreateDate'],
+        'LastUsedDate': last_used.get('LastUsedDate'),
+        'LastUsedService': last_used.get('ServiceName'),
+        'LastUsedRegion': last_used.get('Region'),
+    }
+
+
+def print_json(data):
+    json.dump(data, sys.stdout, indent=2, default=_json_default)
+    sys.stdout.write('\n')
+
+
+def _json_default(value):
+    if isinstance(value, datetime):
+        return value.isoformat()
+    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
[SAAS-19726](https://dimagi.atlassian.net/browse/SAAS-19726)

- Adds `scripts/aws/manage-iam-keys.py` for inspecting and rotating IAM access keys, building blocks for SES SMTP credential rotation
- Subcommands: `list` (JSON), `create` (CSV in the AWS console download format consumed by `derive_ses_smtp_password.py`), `deactivate`, `reactivate`, `remove`
- `remove` refuses without `--force` unless the key is `Inactive` and either never used or last used 24h+ ago

**Note** for this to work you need an aws profile (e.g. in your `~/.aws/config`) that has access to the IAM keys you're interested in—it'll need to have the correct account number and role.


##### Environments Affected
None — this adds a new standalone script under `scripts/aws/` and does not modify any environment files.

## Test plan
- [x] `./scripts/aws/manage-iam-keys.py ses-iam ses-staging list` outputs a JSON array with `AccessKeyId`, `Status`, `CreateDate`, `LastUsedDate`, `LastUsedService`, `LastUsedRegion`
- [x] `./scripts/aws/manage-iam-keys.py ses-iam ses-swiss create` returns CSV that `derive_ses_smtp_password.py` can consume (extract field 2 as the secret)
- [x] `./scripts/aws/manage-iam-keys.py ses-iam ses-swiss list` shows a key
- [x] `./scripts/aws/manage-iam-keys.py ses-iam ses-swiss remove <key-id> --force` succeeds, even while it's active. (Recreate the key, this time with `> /dev/null` since we don't need to see the output, for the next tests.)
- [x] `./scripts/aws/manage-iam-keys.py ses-iam ses-swiss remove <key-id>` refuses while the key is `Active`
- [x] `./scripts/aws/manage-iam-keys.py ses-iam ses-swiss deactivate <key-id>` flips status to `Inactive`; `reactivate <key-id>` flips it back to `Active` (the deactivate again for the next test)
- [x] `./scripts/aws/manage-iam-keys.py ses-iam ses-swiss remove <key-id>` succeeds for an `Inactive` key that is never-used or last used 24h+ ago



[SAAS-19726]: https://dimagi.atlassian.net/browse/SAAS-19726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ