### PR TITLE
Simplify deploy-tag push now that git 2.49 is the floor

### DIFF
--- a/src/commcare_cloud/commands/deploy/utils.py
+++ b/src/commcare_cloud/commands/deploy/utils.py
@@ -59,12 +59,14 @@ def _push_release_tag(remote_url, sha, tag_name):
             f"-o StrictHostKeyChecking=yes"
         ),
     }
-    git = sh.git.bake("-C", tmp)
     try:
-        git.init("--bare", "-q")
-        git.fetch("--depth=1", "--no-tags", "--filter=blob:none",
-                  remote_url, sha, _env=env)
-        git.push(remote_url, f"{sha}:refs/tags/{tag_name}", _env=env)
+        sh.git.clone(
+            "--bare", "--filter=blob:none", "--depth=1", f"--revision={sha}",
+            remote_url, tmp, _env=env,
+        )
+        sh.git.bake("-C", tmp).push(
+            remote_url, f"{sha}:refs/tags/{tag_name}", _env=env,
+        )
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
 


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/SAAS-19703

- [ ] **Do not merge before 2026-06-19** — six-week announcement window for the git 2.49 minimum (from #6868) must elapse so any third-party operators have had time to upgrade.

Picks up [@millerdev's original suggestion](https://github.com/dimagi/commcare-cloud/pull/6865#discussion_r3173395922) on #6865. Now that #6868 / SAAS-19703 has rolled out the new git 2.49 floor across managed machines, the version-compat workaround in `_push_release_tag` can go away.

The previous `git init --bare` + `git fetch --depth=1 --filter=blob:none ... <sha>` + `git push` dance is replaced by `git clone --bare --filter=blob:none --depth=1 --revision=<sha>` + push. `--revision` was added in git 2.49.

This is a code-clarity change, not a perf one. Bytes-on-the-wire, on-disk size, and network round-trip count are unchanged (both versions already used `--filter=blob:none --depth=1`); wall time is within noise — see comment thread for numbers.

##### Environments Affected

None.