### PR TITLE
Drop overwritten key

### DIFF
--- a/src/commcare_cloud/environment/secrets/secrets.yml
+++ b/src/commcare_cloud/environment/secrets/secrets.yml
@@ -95,7 +95,6 @@
   default: ''
   default_overrides_falsy_values: yes
 - name: KSPLICE_ACTIVATION_KEY
-  legacy_namespace: localsettings_private
   legacy_namespace: secrets
 - name: MAPBOX_ACCESS_TOKEN
   legacy_namespace: localsettings_private


### PR DESCRIPTION
`secrets.yml` gives two values for "legacy_namespace" for "KSPLICE_ACTIVATION_KEY". PyYAML overwrites the first value with the second value:

```python
>>> import yaml
>>> secrets = """
- name: KSPLICE_ACTIVATION_KEY
  legacy_namespace: localsettings_private
  legacy_namespace: secrets
- name: MAPBOX_ACCESS_TOKEN
  legacy_namespace: localsettings_private
  default: ''
"""
>>> yaml.safe_load(secrets)
[{'name': 'KSPLICE_ACTIVATION_KEY',
  'legacy_namespace': 'secrets'},
 {'name': 'MAPBOX_ACCESS_TOKEN',
  'legacy_namespace': 'localsettings_private',
  'default': ''}]
```

This change just removes the first (unused) value.
