### PR TITLE
Make derive_ses_smtp_password.py more naturally scriptable

### DIFF
--- a/scripts/aws/derive_ses_smtp_password.py
+++ b/scripts/aws/derive_ses_smtp_password.py
@@ -2,14 +2,14 @@
 
 # Copy-paste-edited from https://docs.aws.amazon.com/ses/latest/DeveloperGuide/smtp-credentials.html
 # Example Usage:
-#   CREDENTIAL_FILE=/path/to/downloaded/iam_user_name_accessKeys.csv
-#   SES_SECRET=$(cat ${CREDENTIAL_FILE} | head -n2 | tail -n1 | cut -d',' -f2)
-#   ./scripts/aws/derive_ses_smtp_password.py --region us-east-1 --secret ${SES_SECRET}
+#   ./scripts/aws/derive_ses_smtp_password.py --region us-east-1 --csv /path/to/iam_user_name_accessKeys.csv
+#   pbpaste | ./scripts/aws/derive_ses_smtp_password.py --region us-east-1 -
 
 import hmac
 import hashlib
 import base64
 import argparse
+import csv
 
 # Values that are required to calculate the signature. These values should
 # never change.
@@ -35,12 +35,32 @@ def calculateKey(secretAccessKey, region):
     print(smtpPassword.decode('utf-8'))
 
 
+def extract_secret(content, is_csv):
+    if is_csv:
+        rows = list(csv.DictReader(content.splitlines()))
+        if len(rows) != 1:
+            raise ValueError(
+                f'Expected exactly one data row in CSV, got {len(rows)}.'
+            )
+        try:
+            return rows[0]['Secret access key']
+        except KeyError:
+            raise ValueError(
+                'CSV is missing a "Secret access key" column. '
+                'Expected the AWS access keys download format.'
+            )
+    return content.strip()
+
+
 def main():
     parser = argparse.ArgumentParser(description='Convert a Secret Access Key for an IAM user to an SMTP password.')
-    parser.add_argument('--secret',
-            help='The Secret Access Key that you want to convert.',
-            required=True,
-            action="store")
+    parser.add_argument('file',
+            type=argparse.FileType('r'),
+            help='Path to a file containing the Secret Access Key, or "-" to read from stdin.')
+    parser.add_argument('--csv',
+            action='store_true',
+            help='Interpret the input as the CSV file AWS provides when downloading IAM access keys '
+                 '(extracts the "Secret access key" column). Default: input is the secret by itself.')
     parser.add_argument('--region',
             help='The name of the AWS Region that the SMTP password will be used in.',
             required=True,
@@ -63,7 +83,15 @@ def main():
             action="store")
     args = parser.parse_args()
 
-    calculateKey(args.secret.strip(), args.region)
+    with args.file as f:
+        content = f.read()
+
+    try:
+        secret = extract_secret(content, args.csv)
+    except ValueError as e:
+        parser.error(str(e))
+
+    calculateKey(secret, args.region)
 
 
 main()


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/SAAS-19728

Replaces the `--secret <secret>` argument (an anti-pattern: secrets on the command line leak into shell history and `ps`) with a positional file argument that accepts a path or `-` for stdin. Adds a `--csv` flag that interprets the input as the access-keys CSV that AWS provides for download, so you can pipe / pass that file directly without preprocessing.

### Before
```
SES_SECRET=$(cat ${CREDENTIAL_FILE} | head -n2 | tail -n1 | cut -d',' -f2)
./scripts/aws/derive_ses_smtp_password.py --region us-east-1 --secret ${SES_SECRET}
```

### After
```
./scripts/aws/derive_ses_smtp_password.py --region us-east-1 --csv /path/to/iam_user_name_accessKeys.csv
# or
cat /path/to/iam_user_name_accessKeys.csv | ./scripts/aws/derive_ses_smtp_password.py --region us-east-1 --csv 
# or (with just the bare secret in the clipboard)
pbpaste | ./scripts/aws/derive_ses_smtp_password.py --region us-east-1 -
```

### Test plan
Tested the following manually against a real (now-expired) access key before and after the change to make sure the output was in all cases the same as it was previously:

- [x] Bare secret with a file
- [x] Bare secret via stdin (`-`)
- [x] `--csv` with a file
- [x] `--csv` via stdin

I also checked that our internal documentation pointing to this command references the comment in this file and does not provide its own instructions, so it does not need to be updated.