### PR TITLE
Support creating AWS profiles for SES via aws-sign-in

### DIFF
--- a/docs/source/reference/1-commcare-cloud/commands.md
+++ b/docs/source/reference/1-commcare-cloud/commands.md
@@ -1738,7 +1738,7 @@ Set the last applied migration value to this number before running. Will begin r
 Use your MFA device to "sign in" to AWS for &lt;duration&gt; minutes (default 30)
 
 ```
-commcare-cloud <env> aws-sign-in [--duration-minutes DURATION_MINUTES]
+commcare-cloud <env> aws-sign-in [--duration-minutes DURATION_MINUTES] [--ses]
 ```
 
 This will store the temporary session credentials in ~/.aws/credentials
@@ -1751,6 +1751,12 @@ before having to sign in again.
 ###### `--duration-minutes DURATION_MINUTES`
 
 Stay signed in for this many minutes
+
+###### `--ses`
+
+Sign in with the SES profile (used for rotating SES IAM users)
+instead of the default profile. Requires `ses_config` to be set
+in aws.yml.
 
 ---
 

--- a/environments/eu/aws.yml
+++ b/environments/eu/aws.yml
@@ -4,3 +4,8 @@ sso_config:
   sso_region: us-east-1
   sso_account_id: "940482413124"
   region: eu-west-1
+ses_config:
+  iam_username: ses-eu
+  account_id: '437781348816'
+  role_name: EmailAdmin
+  region: us-east-1

--- a/environments/india/aws.yml
+++ b/environments/india/aws.yml
@@ -4,3 +4,8 @@ sso_config:
   sso_region: us-east-1
   sso_account_id: '142460848363'
   region: ap-south-1
+ses_config:
+  iam_username: ses-smtp-user.20200218-102700
+  account_id: '437781348816'
+  role_name: EmailAdmin
+  region: us-east-1

--- a/environments/production/aws.yml
+++ b/environments/production/aws.yml
@@ -4,3 +4,8 @@ sso_config:
   sso_region: us-east-1
   sso_account_id: '051428382917'
   region: us-east-1
+ses_config:
+  iam_username: ses-production
+  account_id: '437781348816'
+  role_name: EmailAdmin
+  region: us-east-1

--- a/environments/staging/aws.yml
+++ b/environments/staging/aws.yml
@@ -4,3 +4,8 @@ sso_config:
   sso_region: us-east-1
   sso_account_id: '737236193635'
   region: us-east-1
+ses_config:
+  iam_username: ses-staging
+  account_id: '437781348816'
+  role_name: EmailAdmin
+  region: us-east-1

--- a/src/commcare_cloud/commands/terraform/aws.py
+++ b/src/commcare_cloud/commands/terraform/aws.py
@@ -443,8 +443,7 @@ def aws_sign_in_for_ses(environment):
 def _ensure_sso_profile_signed_in(
         profile_name, sso_start_url, sso_region, sso_account_id, sso_role_name, region):
     """Make sure ~/.aws/config has a [profile <profile_name>] section, and that we have a valid SSO session."""
-    _ensure_all_dirs(AWS_DOT_DIR)
-    for path in (AWS_SSO_CACHE_DIR, AWS_CLI_CACHE_DIR):
+    for path in (AWS_DOT_DIR, AWS_SSO_CACHE_DIR, AWS_CLI_CACHE_DIR):
         _ensure_all_dirs(path)
 
     # todo: add `... or if _date_modified(AWS_CONFIG_PATH) > _date_modified(AWS_CREDENTIALS_PATH)`

--- a/src/commcare_cloud/commands/terraform/aws.py
+++ b/src/commcare_cloud/commands/terraform/aws.py
@@ -338,8 +338,6 @@ def aws_sign_in(environment, duration_minutes=DEFAULT_SIGN_IN_DURATION_MINUTES, 
 
     _ensure_all_dirs(AWS_DOT_DIR)
     if environment.aws_config.credential_style == 'sso':
-        for path in (AWS_SSO_CACHE_DIR, AWS_CLI_CACHE_DIR):
-            _ensure_all_dirs(path)
         return _aws_sign_in_with_sso(environment)
     else:
         return _aws_sign_in_with_iam(environment.terraform_config.aws_profile, duration_minutes=duration_minutes,
@@ -394,27 +392,45 @@ def _aws_sign_in_with_sso(environment):
              (Always the passed in profile followed by ':session')
     """
     aws_session_profile = '{}:session'.format(environment.terraform_config.aws_profile)
-    # todo: add `... or if _date_modified(AWS_CONFIG_PATH) > _date_modified(AWS_CREDENTIALS_PATH)`
-    if not _has_profile_for_sso(aws_session_profile):
-        puts(color_notice(
-            "Configuring SSO. To further customize, run `aws configure sso "
-            "--profile {}`".format(
-                aws_session_profile)))
-        _write_profile_for_sso(
-            aws_session_profile,
-            sso_start_url=environment.aws_config.sso_config.sso_start_url,
-            sso_account_id=environment.aws_config.sso_config.sso_account_id,
-            sso_region=environment.aws_config.sso_config.sso_region,
-            region=environment.aws_config.sso_config.region,
-        )
-
-    if not _has_valid_session_credentials_for_sso():
-        _refresh_sso_credentials(aws_session_profile)
+    sso_config = environment.aws_config.sso_config
+    _ensure_sso_profile_signed_in(
+        aws_session_profile,
+        sso_start_url=sso_config.sso_start_url,
+        sso_region=sso_config.sso_region,
+        sso_account_id=sso_config.sso_account_id,
+        sso_role_name='PowerUserAccessPlus',
+        region=sso_config.region,
+    )
 
     if not _has_valid_v1_session_credentials(aws_session_profile):
         _sync_sso_to_v1_credentials(aws_session_profile)
 
     return aws_session_profile
+
+
+def _ensure_sso_profile_signed_in(
+        profile_name, sso_start_url, sso_region, sso_account_id, sso_role_name, region):
+    """Make sure ~/.aws/config has a [profile <profile_name>] section, and that we have a valid SSO session."""
+    _ensure_all_dirs(AWS_DOT_DIR)
+    for path in (AWS_SSO_CACHE_DIR, AWS_CLI_CACHE_DIR):
+        _ensure_all_dirs(path)
+
+    # todo: add `... or if _date_modified(AWS_CONFIG_PATH) > _date_modified(AWS_CREDENTIALS_PATH)`
+    if not _has_profile_for_sso(profile_name):
+        puts(color_notice(
+            "Configuring SSO. To further customize, run `aws configure sso "
+            "--profile {}`".format(profile_name)))
+        _write_profile_for_sso(
+            profile_name,
+            sso_start_url=sso_start_url,
+            sso_region=sso_region,
+            sso_account_id=sso_account_id,
+            sso_role_name=sso_role_name,
+            region=region,
+        )
+
+    if not _has_valid_session_credentials_for_sso():
+        _refresh_sso_credentials(profile_name)
 
 
 def _sync_sso_to_v1_credentials(aws_session_profile):
@@ -582,6 +598,7 @@ def _write_profile_for_sso(
         sso_start_url,
         sso_region,
         sso_account_id,
+        sso_role_name,
         region):
     config = configparser.ConfigParser()
     config.read(os.path.realpath(AWS_CONFIG_PATH))
@@ -592,7 +609,7 @@ def _write_profile_for_sso(
     config.set(section, 'sso_start_url', sso_start_url)
     config.set(section, 'sso_region', sso_region)
     config.set(section, 'sso_account_id', sso_account_id)
-    config.set(section, 'sso_role_name', 'PowerUserAccessPlus')
+    config.set(section, 'sso_role_name', sso_role_name)
     config.set(section, 'region', region)
     config.set(section, 'output', 'json')
     with open(AWS_CONFIG_PATH, 'w', encoding='utf-8') as f:

--- a/src/commcare_cloud/commands/terraform/aws.py
+++ b/src/commcare_cloud/commands/terraform/aws.py
@@ -311,13 +311,20 @@ class AwsSignIn(CommandBase):
     arguments = [
         Argument('--duration-minutes', type=int, default=DEFAULT_SIGN_IN_DURATION_MINUTES, help="""
             Stay signed in for this many minutes
-        """)
+        """),
+        Argument('--ses', action='store_true', default=False, help="""
+            Sign in with the SES profile (used for rotating SES IAM users)
+            instead of the default profile. Requires `ses_config` to be set
+            in aws.yml.
+        """),
     ]
 
     def run(self, args, unknown_args):
         environment = get_environment(args.env_name)
-        duration_minutes = args.duration_minutes
-        aws_sign_in(environment, duration_minutes, force_new=True)
+        if args.ses:
+            aws_sign_in_for_ses(environment)
+        else:
+            aws_sign_in(environment, args.duration_minutes, force_new=True)
 
 
 AWS_CREDENTIALS_PATH = os.path.expanduser('~/.aws/credentials')
@@ -406,6 +413,32 @@ def _aws_sign_in_with_sso(environment):
         _sync_sso_to_v1_credentials(aws_session_profile)
 
     return aws_session_profile
+
+
+def aws_sign_in_for_ses(environment):
+    """
+    Create or update an SSO profile named "<aws_profile>:ses" for managing SES IAM users.
+
+    Unlike the default profile, this assumes an EmailAdmin role in the central account
+    where SES IAM users live (defined in the env's `ses_config`).
+    """
+    ses_config = environment.aws_config.ses_config
+    if not ses_config or not ses_config.account_id:
+        raise ValueError(
+            "ses_config is not set in aws.yml for environment {}".format(
+                environment.name))
+
+    aws_ses_profile = '{}:ses'.format(environment.terraform_config.aws_profile)
+    sso_config = environment.aws_config.sso_config
+    _ensure_sso_profile_signed_in(
+        aws_ses_profile,
+        sso_start_url=sso_config.sso_start_url,
+        sso_region=sso_config.sso_region,
+        sso_account_id=ses_config.account_id,
+        sso_role_name=ses_config.role_name,
+        region=ses_config.region,
+    )
+    return aws_ses_profile
 
 
 def _ensure_sso_profile_signed_in(

--- a/src/commcare_cloud/commands/terraform/aws.py
+++ b/src/commcare_cloud/commands/terraform/aws.py
@@ -398,7 +398,7 @@ def _aws_sign_in_with_sso(environment):
     :return: The name of temp session profile.
              (Always the passed in profile followed by ':session')
     """
-    aws_session_profile = '{}:session'.format(environment.terraform_config.aws_profile)
+    aws_session_profile = f'{environment.terraform_config.aws_profile}:session'
     sso_config = environment.aws_config.sso_config
     _ensure_sso_profile_signed_in(
         aws_session_profile,
@@ -425,10 +425,9 @@ def aws_sign_in_for_ses(environment):
     ses_config = environment.aws_config.ses_config
     if not ses_config or not ses_config.account_id:
         raise ValueError(
-            "ses_config is not set in aws.yml for environment {}".format(
-                environment.name))
+            f"ses_config is not set in aws.yml for environment {environment.name}")
 
-    aws_ses_profile = '{}:ses'.format(environment.terraform_config.aws_profile)
+    aws_ses_profile = f'{environment.terraform_config.aws_profile}:ses'
     sso_config = environment.aws_config.sso_config
     _ensure_sso_profile_signed_in(
         aws_ses_profile,
@@ -451,8 +450,8 @@ def _ensure_sso_profile_signed_in(
     # todo: add `... or if _date_modified(AWS_CONFIG_PATH) > _date_modified(AWS_CREDENTIALS_PATH)`
     if not _has_profile_for_sso(profile_name):
         puts(color_notice(
-            "Configuring SSO. To further customize, run `aws configure sso "
-            "--profile {}`".format(profile_name)))
+            "Configuring SSO. To further customize, run "
+            f"`aws configure sso --profile {profile_name}`"))
         _write_profile_for_sso(
             profile_name,
             sso_start_url=sso_start_url,

--- a/src/commcare_cloud/environment/schemas/aws.py
+++ b/src/commcare_cloud/environment/schemas/aws.py
@@ -5,10 +5,18 @@ class AwsConfig(jsonobject.JsonObject):
     _allow_dynamic_properties = False
     credential_style = jsonobject.StringProperty(choices=('sso', 'iam'), default='iam')
     sso_config = jsonobject.ObjectProperty(lambda: SsoConfig, default=None)
+    ses_config = jsonobject.ObjectProperty(lambda: SesConfig, default=None)
 
 
 class SsoConfig(jsonobject.JsonObject):
     sso_start_url = jsonobject.StringProperty()
     sso_region = jsonobject.StringProperty()
     sso_account_id = jsonobject.StringProperty()
+    region = jsonobject.StringProperty()
+
+
+class SesConfig(jsonobject.JsonObject):
+    iam_username = jsonobject.StringProperty()
+    account_id = jsonobject.StringProperty()
+    role_name = jsonobject.StringProperty()
     region = jsonobject.StringProperty()


### PR DESCRIPTION
[SAAS-19727](https://dimagi.atlassian.net/browse/SAAS-19727)

##### Summary

The `manage-iam-keys.py` script in #6872 needs an AWS profile set up the way commcare-cloud already sets up other ones — but pointing at the account where SES lives and with permissions to manage specific IAM user credentials. This is in service of scripting the SES SMTP credential rotation described in [this runbook](https://dimagi.atlassian.net/wiki/spaces/cc/pages/2146599918/How+to+rotate+AWS+SES+SMTP+email+credentials).

This PR adds a `--ses` flag to `cchq <env> aws-sign-in` that reads new config from each env's `aws.yml` and writes out such a profile. The new `<aws_profile>:ses` profiles live alongside the existing `<aws_profile>:session` used by terraform, and a developer doesn't need to know how either is set up.

A couple of things worth flagging for review, since they don't show up in the diff:

- `iam_username` is unused so far — added preemptively for one of the next tasks in https://dimagi.atlassian.net/browse/SAAS-19724, which will use it manage the SES IAM user during rotation.
- `aws_sign_in_for_ses` deliberately skips the v1-credentials sync that the regular SSO flow does. That sync is a terraform compatibility shim; SES tooling uses modern AWS CLI / boto3, which read SSO natively.

##### Environments Affected
production, staging, india, eu — all gain a new `ses_config` block in `aws.yml`. No services or hosts are touched; the field is read only by the new `cchq <env> aws-sign-in --ses` flow.

##### Testing

- [x] `cchq staging aws-sign-in --help` shows the new flag
- [x]  existing terraform tests still pass
- [x] The new `cchq staging aws-sign-in --ses` command creates a profile that works with `manage-iam-keys.py` (clear with `rm -rf ~/.aws/sso ~/.aws/cli` first)
- [x] Normal `cchq staging aws-sign-in` also still works (clear with `rm -rf ~/.aws/sso ~/.aws/cli` first)

[SAAS-19727]: https://dimagi.atlassian.net/browse/SAAS-19727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
