### PR TITLE
Bump urllib3 from 2.6.3 to 2.7.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ DimagiKeyStore
 *~
 /build
 /dist
+/.claude
 /.vscode
 couchdb@*_files
 **/config.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -136,7 +136,7 @@ typing-extensions==4.15.0
     # via
     #   cryptography
     #   pygithub
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   botocore
     #   pygithub


### PR DESCRIPTION
Routine dependency upgrade. Pulls in urllib3 2.7.0, which adds support for HTTP/2 on plain (non-TLS) connections behind an opt-in flag and ships a number of bug fixes and deprecation cleanups. Behavior on existing HTTPS connection pools is unchanged. The upgrade is consumed transitively via `botocore`, `pygithub`, and `requests` — no direct call sites in this repo, so the surface area is small.

Also adds `/.claude` to `.gitignore` so local Claude Code workspace files aren't accidentally committed.

https://dimagi.atlassian.net/browse/SAAS-19747

##### Environments Affected
None
