### PR TITLE
Point GitHub token prompt to fine-grained PAT page

### DIFF
--- a/src/commcare_cloud/github.py
+++ b/src/commcare_cloud/github.py
@@ -56,7 +56,7 @@ def _prompt_for_github_token():
         "sufficient — no write permissions needed."
     ))
     print(color_notice(
-        "Generate a token at https://github.com/settings/tokens "
+        "Generate a token at https://github.com/settings/personal-access-tokens "
         "(scope: public_repo)."
     ))
     return getpass("Github token (or Enter to continue without): ") or None


### PR DESCRIPTION
The token-prompt message in deploy linked to `https://github.com/settings/tokens`, which is the classic (legacy) tokens UI. GitHub now directs users to `https://github.com/settings/personal-access-tokens` for fine-grained PATs, so this updates the printed URL to match.

##### Environments Affected

None — message-only change in the interactive token prompt.