### PR TITLE
Skip GitHub token prompt for `deploy --private`

### DIFF
--- a/src/commcare_cloud/commands/deploy/commcare.py
+++ b/src/commcare_cloud/commands/deploy/commcare.py
@@ -40,7 +40,7 @@ def deploy_commcare(environment, args, unknown_args):
     context = DeployContext(
         service_name="CommCare HQ",
         revision=args.commcare_rev,
-        diff=_get_code_diff(environment, deploy_revs, args.resume),
+        diff=_get_code_diff(environment, deploy_revs, args.resume, skip_token_prompt=args.private),
         start_time=datetime.utcnow(),
         resume=args.resume
     )
@@ -138,14 +138,14 @@ def _ask_to_deploy(env_name, quiet):
 DEPLOY_DIFF = None
 
 
-def _get_code_diff(environment, deploy_revs, is_resume):
+def _get_code_diff(environment, deploy_revs, is_resume, skip_token_prompt=False):
     global DEPLOY_DIFF
     if DEPLOY_DIFF is not None:
         return DEPLOY_DIFF
 
     repo = github_repo(
         'dimagi/commcare-hq',
-        prompt_if_missing=environment.fab_settings_config.generate_deploy_diffs,
+        prompt_if_missing=not skip_token_prompt and environment.fab_settings_config.generate_deploy_diffs,
     )
 
     deployed_version = get_deployed_version(environment)


### PR DESCRIPTION
No ticket — incidental quality-of-life improvement noticed during a private deploy.

##### Environments Affected
None — code-only change, no environment files modified.

## Summary

Skips the interactive GitHub token prompt that can fire during `commcare-cloud <env> deploy commcare --private`. Private deploys don't render the deploy diff or call any authenticated GitHub APIs, so the prompt is unnecessary noise.

The only GitHub call on the `--private` path is an unauthenticated `repo.get_commit()` used to resolve the deploy SHA passed to ansible as `code_version`. Everything else that consumes the diff (`print_deployer_diff`, `record_successful_deploy` → `create_release_tag`, `update_sentry_post_deploy`) is short-circuited for private releases.

## QA
I'll manually do the following

- [x] Run `commcare-cloud <env> deploy --private` in an environment with `generate_deploy_diffs: True` and no `GITHUB_TOKEN` set; confirm no prompt appears and the deploy proceeds.
- [x] Run a non-private deploy in the same conditions; confirm the prompt still appears as before.