### PR TITLE
Enable workflow dispatch on GHA tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Allow the _tests_ workflow to be run against any branch on demand.

##### Environments Affected
None