### PR TITLE
Skip ansible-galaxy install when requirements already satisfied

### DIFF
--- a/src/commcare_cloud/ansible/requirements.yml
+++ b/src/commcare_cloud/ansible/requirements.yml
@@ -35,6 +35,16 @@ roles:
     version: 3.2.1
 
 collections:
-  - name: https://github.com/dimagi/commcare-logstash/releases/download/V0.9.5/dimagi-commcare_logstash-0.9.5.tar.gz
-  - name: https://github.com/dimagi/commcare-prometheus/releases/download/V0.1.10/dimagi-commcare_prometheus-0.1.10.tar.gz
+  # Unclear if ansible-galaxy uses version on tarball installs. However,
+  # version is required here so we can check installed state to avoid the
+  # VERY SLOW --force install when requirements are already satisfied.
+  - name: dimagi.commcare_logstash
+    version: 0.9.5
+    source: https://github.com/dimagi/commcare-logstash/releases/download/V0.9.5/dimagi-commcare_logstash-0.9.5.tar.gz
+    type: url
+  - name: dimagi.commcare_prometheus
+    version: 0.1.10
+    source: https://github.com/dimagi/commcare-prometheus/releases/download/V0.1.10/dimagi-commcare_prometheus-0.1.10.tar.gz
+    type: url
   - name: community.general
+    version: 7.4.0

--- a/src/commcare_cloud/manage_commcare_cloud/install.py
+++ b/src/commcare_cloud/manage_commcare_cloud/install.py
@@ -30,17 +30,15 @@ class Install(CommandBase):
         env['ANSIBLE_ROLES_PATH'] = ANSIBLE_ROLES_PATH
         env['ANSIBLE_COLLECTIONS_PATHS'] = ANSIBLE_COLLECTIONS_PATHS
         requirements_yml = os.path.join(ANSIBLE_DIR, 'requirements.yml')
-        cmd_roles_parts = ['ansible-galaxy', 'install', '-f', '-r', requirements_yml]
-        cmd_collection_parts = ['ansible-galaxy', 'collection', 'install', '-f', '-r', requirements_yml]
-
-        for cmd_parts in (cmd_roles_parts, cmd_collection_parts):
-            cmd = ' '.join(shlex.quote(arg) for arg in cmd_parts)
-            print_command(cmd)
-            try:
-                subprocess.check_output(cmd, shell=True, env=env)
-            except subprocess.CalledProcessError as err:
-                print("process exited with error: %s" % err.returncode)
-                return err.returncode
+        # Uses --force to update roles when required versions change.
+        cmd_parts = ['ansible-galaxy', 'install', '--force', '-r', requirements_yml]
+        cmd = ' '.join(shlex.quote(arg) for arg in cmd_parts)
+        print_command(cmd)
+        try:
+            subprocess.check_output(cmd, shell=True, env=env)
+        except subprocess.CalledProcessError as err:
+            print("process exited with error: %s" % err.returncode)
+            return err.returncode
 
         puts(color_notice("To finish first-time installation, run `manage-commcare-cloud configure`"))
         return 0

--- a/src/commcare_cloud/manage_commcare_cloud/install.py
+++ b/src/commcare_cloud/manage_commcare_cloud/install.py
@@ -2,10 +2,11 @@ import os
 import shlex
 import subprocess
 
+import yaml
 from clint.textui import puts
 
 from commcare_cloud.cli_utils import print_command
-from commcare_cloud.colors import color_notice
+from commcare_cloud.colors import color_notice, color_success
 from commcare_cloud.commands.command_base import CommandBase
 from commcare_cloud.environment.paths import put_virtualenv_bin_on_the_path, \
     ANSIBLE_ROLES_PATH, ANSIBLE_DIR, ANSIBLE_COLLECTIONS_PATHS
@@ -21,15 +22,21 @@ class Install(CommandBase):
     def run(self, args, unknown_args):
         env = os.environ.copy()
         put_virtualenv_bin_on_the_path()
-        if not os.path.exists(ANSIBLE_ROLES_PATH):
-            os.makedirs(ANSIBLE_ROLES_PATH)
-
-        if not os.path.exists(ANSIBLE_COLLECTIONS_PATHS):
-            os.makedirs(ANSIBLE_COLLECTIONS_PATHS)
-
         env['ANSIBLE_ROLES_PATH'] = ANSIBLE_ROLES_PATH
         env['ANSIBLE_COLLECTIONS_PATHS'] = ANSIBLE_COLLECTIONS_PATHS
         requirements_yml = os.path.join(ANSIBLE_DIR, 'requirements.yml')
+
+        if (
+            os.path.exists(ANSIBLE_ROLES_PATH)
+            and os.path.exists(ANSIBLE_COLLECTIONS_PATHS)
+            and requirements_installed(requirements_yml, env)
+        ):
+            puts(color_success("✓ Ansible roles and collections are up to date."))
+            return 0
+
+        os.makedirs(ANSIBLE_ROLES_PATH, exist_ok=True)
+        os.makedirs(ANSIBLE_COLLECTIONS_PATHS, exist_ok=True)
+
         # Uses --force to update roles when required versions change.
         cmd_parts = ['ansible-galaxy', 'install', '--force', '-r', requirements_yml]
         cmd = ' '.join(shlex.quote(arg) for arg in cmd_parts)
@@ -42,3 +49,86 @@ class Install(CommandBase):
 
         puts(color_notice("To finish first-time installation, run `manage-commcare-cloud configure`"))
         return 0
+
+
+def requirements_installed(requirements_yml, env):
+    """Check if every role and collection pinned in requirements_yml is installed at its pinned version."""
+    with open(requirements_yml) as f:
+        requirements = yaml.safe_load(f)
+    return (
+        required_roles(requirements) <= installed_roles(env)
+        and required_collections(requirements) <= installed_collections(env)
+    )
+
+
+def required_roles(requirements):
+    """Set of (name, version) pairs for roles pinned in requirements.
+
+    The name matches what ``ansible-galaxy role list`` reports: the explicit
+    ``name`` if given, otherwise the ``src`` (e.g. a ``namespace.role`` from Galaxy).
+
+    Every role must pin a version so it can be compared against what is
+    installed; an unversioned entry is a configuration error.
+    """
+    return {
+        (role.get('name') or role['src'], get_version(role))
+        for role in requirements.get('roles') or []
+    }
+
+
+def required_collections(requirements):
+    """Set of (name, version) pairs for collections pinned in requirements.
+
+    Every collection must pin a version so it can be compared against what is
+    installed; an unversioned entry is a configuration error.
+    """
+    return {
+        (collection['name'], get_version(collection))
+        for collection in requirements.get('collections') or []
+    }
+
+
+def get_version(requirement):
+    version = requirement.get('version')
+    if not version:
+        raise ValueError(f"Item in requirements.yml has no version: {requirement}")
+    return str(version)
+
+
+def installed_roles(env):
+    output = subprocess.check_output(['ansible-galaxy', 'role', 'list'], env=env).decode()
+    return parse_roles(output)
+
+
+def installed_collections(env):
+    output = subprocess.check_output(['ansible-galaxy', 'collection', 'list'], env=env).decode()
+    return parse_collections(output)
+
+
+def parse_roles(output):
+    """Parse ``ansible-galaxy role list`` output into a set of (name, version) pairs.
+
+    Each role line looks like ``- name, version``; path headers start with ``#``.
+    """
+    installed = set()
+    for line in output.splitlines():
+        line = line.strip()
+        if line.startswith('- '):
+            name, _, version = line[2:].partition(', ')
+            installed.add((name, version))
+    return installed
+
+
+def parse_collections(output):
+    """Parse ``ansible-galaxy collection list`` output into a set of (name, version) pairs.
+
+    The output is a ``namespace.name  version`` table, optionally repeated per
+    collections path, with ``#`` path headers, a ``Collection Version`` header,
+    and a dashed separator line that are all skipped.
+    """
+    installed = set()
+    for line in output.splitlines():
+        parts = line.split()
+        if len(parts) == 2 and '.' in parts[0] and parts[0] != 'Collection':
+            installed.add((parts[0], parts[1]))
+    return installed

--- a/src/commcare_cloud/manage_commcare_cloud/tests/test_install.py
+++ b/src/commcare_cloud/manage_commcare_cloud/tests/test_install.py
@@ -1,0 +1,94 @@
+import os
+
+import yaml
+from testil import assert_raises
+
+from commcare_cloud.manage_commcare_cloud.install import (
+    parse_collections,
+    parse_roles,
+    required_collections,
+    required_roles,
+)
+from commcare_cloud.environment.paths import ANSIBLE_DIR
+
+
+def test_parse_roles():
+    assert parse_roles(ROLE_LIST_OUTPUT) == {
+        ('tmpreaper', '46f8e0b8b8f5732eecc68b08b5e0c392c418e3f3'),
+        ('ansible-logrotate', 'v0.0.5'),
+        ('DavidWittman.redis', '1.2.12'),
+        ('andrewrothstein.couchdb', 'fcb957ed038ab1c4fddcfef6b9c7617dcdeec9b7'),
+    }
+
+
+ROLE_LIST_OUTPUT = """
+# /home/vagrant/commcare-cloud/.venv/lib/python3.10/site-packages/.ansible/roles
+- tmpreaper, 46f8e0b8b8f5732eecc68b08b5e0c392c418e3f3
+- ansible-logrotate, v0.0.5
+- DavidWittman.redis, 1.2.12
+- andrewrothstein.couchdb, fcb957ed038ab1c4fddcfef6b9c7617dcdeec9b7
+"""
+
+
+def test_parse_collections_keeps_same_name_at_different_versions():
+    # community.general is present in two paths at different versions; both kept.
+    assert parse_collections(COLLECTION_LIST_OUTPUT) == {
+        ('amazon.aws', '1.5.1'),
+        ('community.general', '3.8.3'),
+        ('community.general', '7.4.0'),
+        ('dimagi.commcare_logstash', '0.9.5'),
+        ('dimagi.commcare_prometheus', '0.1.10'),
+    }
+
+
+COLLECTION_LIST_OUTPUT = """
+# /home/vagrant/commcare-cloud/.venv/lib/python3.10/site-packages/ansible_collections
+Collection                    Version
+----------------------------- -------
+amazon.aws                    1.5.1
+community.general             3.8.3
+
+# /home/vagrant/commcare-cloud/.venv/lib/python3.10/site-packages/.ansible/ansible_collections
+Collection                 Version
+-------------------------- -------
+community.general          7.4.0
+dimagi.commcare_logstash   0.9.5
+dimagi.commcare_prometheus 0.1.10
+"""
+
+
+def test_required_roles_and_required_collections_on_requirements_yml():
+    with open(os.path.join(ANSIBLE_DIR, "requirements.yml")) as f:
+        yml = yaml.safe_load(f)
+    assert required_roles(yml), "expected required roles"
+    assert required_collections(yml), "expected required collections"
+
+
+def test_required_roles_uses_name_or_src():
+    requirements = {'roles': [
+        {'src': 'git+https://github.com/ANXS/tmpreaper.git',
+         'version': '46f8e0b8', 'name': 'tmpreaper'},
+        {'src': 'sansible.logstash', 'version': 'v2.4.4'},
+    ]}
+    assert required_roles(requirements) == {
+        ('tmpreaper', '46f8e0b8'),
+        ('sansible.logstash', 'v2.4.4'),
+    }
+
+
+def test_required_collections():
+    requirements = {'collections': [
+        {'name': 'community.general', 'version': '7.4.0'},
+        {'name': 'dimagi.commcare_logstash', 'version': '0.9.5',
+         'source': 'https://example.com/x.tar.gz', 'type': 'url'},
+    ]}
+    assert required_collections(requirements) == {
+        ('community.general', '7.4.0'),
+        ('dimagi.commcare_logstash', '0.9.5'),
+    }
+
+
+def test_required_collections_without_version_raises():
+    requirements = {'collections': [{'name': 'community.general'}]}
+    with assert_raises(ValueError):
+        required_collections(requirements)


### PR DESCRIPTION
## Summary

`manage-commcare-cloud install` previously re-ran `ansible-galaxy` with `--force` on every invocation, reinstalling all roles and collections even when nothing had changed. This is very slow. Now the command first checks whether every pinned role and collection is already installed at its required version, and skips the install entirely when everything is up to date — printing a quick confirmation instead.

When requirements are not satisfied, it still does a `--force` install so version changes are picked up correctly.

The speedup in `init.sh` is about 25 seconds: overall run time on a fully synced repo is now about 4s where previously it was ~30s.

### Changes

- Pin versions for all collections in `requirements.yml` (including the two tarball-installed Dimagi collections and `community.general`) so installed state can be compared against requirements.
- Add a fast pre-check in the `install` command that compares pinned roles/collections against the output of `ansible-galaxy role list` / `collection list`.
- Add unit tests covering parsing of `ansible-galaxy` list output and extraction of required roles/collections from `requirements.yml`.

##### Environments Affected
None