### PR TITLE
Ssh server is required

### DIFF
--- a/docs/source/reference/1-commcare-cloud/commands.md
+++ b/docs/source/reference/1-commcare-cloud/commands.md
@@ -177,8 +177,7 @@ Server name/group: postgresql, proxy, webworkers, ... The server
 name/group may be prefixed with 'username@' to login as a
 specific user and may be terminated with '[<n>]' to choose one of
 multiple servers if there is more than one in the group. For
-example: webworkers[0] will pick the first webworker. May also be
-omitted for environments with only a single server.
+example: webworkers[0] will pick the first webworker.
 
 Use '-' for default (django_manage[0])
 
@@ -189,7 +188,7 @@ Use '-' for default (django_manage[0])
 Connect to a remote host with ssh.
 
 ```
-commcare-cloud <env> ssh [--quiet] [server]
+commcare-cloud <env> ssh [--quiet] server
 ```
 
 This will also automatically add the ssh argument `-A`
@@ -208,8 +207,7 @@ Server name/group: postgresql, proxy, webworkers, ... The server
 name/group may be prefixed with 'username@' to login as a
 specific user and may be terminated with '[<n>]' to choose one of
 multiple servers if there is more than one in the group. For
-example: webworkers[0] will pick the first webworker. May also be
-omitted for environments with only a single server.
+example: webworkers[0] will pick the first webworker.
 
 Use '-' for default (django_manage[0])
 
@@ -724,7 +722,7 @@ Don't output the command to be run.
 Connect to a remote host with ssh and open a tmux session.
 
 ```
-commcare-cloud <env> tmux [--quiet] [server] [remote_command]
+commcare-cloud <env> tmux [--quiet] server [remote_command]
 ```
 
 When used with --control, this command skips the slow setup.
@@ -746,8 +744,7 @@ Server name/group: postgresql, proxy, webworkers, ... The server
 name/group may be prefixed with 'username@' to login as a
 specific user and may be terminated with '[<n>]' to choose one of
 multiple servers if there is more than one in the group. For
-example: webworkers[0] will pick the first webworker. May also be
-omitted for environments with only a single server.
+example: webworkers[0] will pick the first webworker.
 
 Use '-' for default (django_manage[0])
 

--- a/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -30,8 +30,7 @@ class Lookup(CommandBase):
         name/group may be prefixed with 'username@' to login as a
         specific user and may be terminated with '[<n>]' to choose one of
         multiple servers if there is more than one in the group. For
-        example: webworkers[0] will pick the first webworker. May also be
-        omitted for environments with only a single server.
+        example: webworkers[0] will pick the first webworker.
 
         Use '-' for default (django_manage[0])
     """

--- a/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
+++ b/src/commcare_cloud/commands/inventory_lookup/inventory_lookup.py
@@ -25,17 +25,18 @@ class Lookup(CommandBase):
     help = """
     Lookup remote hostname or IP address
     """
-    arguments = (
-        Argument("server", nargs="?", help="""
-            Server name/group: postgresql, proxy, webworkers, ... The server
-            name/group may be prefixed with 'username@' to login as a
-            specific user and may be terminated with '[<n>]' to choose one of
-            multiple servers if there is more than one in the group. For
-            example: webworkers[0] will pick the first webworker. May also be
-            omitted for environments with only a single server.
+    SERVER_HELP = """
+        Server name/group: postgresql, proxy, webworkers, ... The server
+        name/group may be prefixed with 'username@' to login as a
+        specific user and may be terminated with '[<n>]' to choose one of
+        multiple servers if there is more than one in the group. For
+        example: webworkers[0] will pick the first webworker. May also be
+        omitted for environments with only a single server.
 
-            Use '-' for default (django_manage[0])
-        """),
+        Use '-' for default (django_manage[0])
+    """
+    arguments = (
+        Argument("server", nargs="?", help=SERVER_HELP),
     )
 
     def lookup_server_address(self, args, allow_multiple=False):
@@ -58,7 +59,8 @@ def lookup_server_address(env_name, server, allow_multiple=False):
 
 class _Ssh(Lookup):
 
-    arguments = Lookup.arguments + (
+    arguments = (
+        Argument("server", help=Lookup.SERVER_HELP),
         Argument("--quiet", action='store_true', default=False, help="""
             Don't output the command to be run.
         """),


### PR DESCRIPTION
Previously ssh without a server caused a traceback with an unhelpful error:
```
TypeError: expected string or bytes-like object
```

`Lookup`'s server has `nargs="?"`, which makes the argument optional. This is valid for `Lookup`, but not for `_Ssh` and its subclasses.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None