### PR TITLE
Fence unpackaged test modules with pytest-unmagic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ manage-commcare-cloud = "commcare_cloud.manage_commcare_cloud.manage_commcare_cl
 test = [
     "docopt",
     "pytest",
-    "pytest-unmagic",
+    "pytest-unmagic>=1.1.0",
     "requests-mock",
 ]
 dev = ["ipdb", "pdbp"]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,4 +3,4 @@ from unmagic import autouse, fence
 from .fixtures import package_patches
 
 autouse(package_patches, __file__)
-fence.install(['commcare_cloud', 'tests'])
+fence.install(['', 'commcare_cloud', 'tests'])

--- a/tests/test_unmagic.py
+++ b/tests/test_unmagic.py
@@ -1,0 +1,20 @@
+import pytest
+from unmagic.fence import is_fenced
+
+
+@pytest.mark.parametrize("module", [
+    "commcare_cloud",
+    "commcare_cloud.commands",
+
+    "test_postgresql_units",  # in src/commcare_cloud/commands/terraform/tests, which has no __init__.py
+
+    "tests",
+    "tests.test_deploy",
+])
+def test_fence(module):
+    def func():
+        ...
+
+    func.__module__ = module
+
+    assert is_fenced(func)

--- a/uv.lock
+++ b/uv.lock
@@ -252,7 +252,7 @@ dev = [
 test = [
     { name = "docopt" },
     { name = "pytest" },
-    { name = "pytest-unmagic" },
+    { name = "pytest-unmagic", specifier = ">=1.1.0" },
     { name = "requests-mock" },
 ]
 
@@ -818,14 +818,14 @@ wheels = [
 
 [[package]]
 name = "pytest-unmagic"
-version = "1.0.1"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/53/7aef49cbf746057d6021d78085c6a7f03aced1c332e725ae1156057edcec/pytest_unmagic-1.0.1.tar.gz", hash = "sha256:5f73e96b31a13041bcd46c3e990f4fb4cedb5b555660d0cb78d8d5d9bc99064a", size = 10439, upload-time = "2025-07-14T13:05:36.183Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/6c/9e38b289b61686169ef3941f4f11958047ed055f34b54ac8f90e5901654d/pytest_unmagic-1.1.0.tar.gz", hash = "sha256:cdde56c72296c2269e4d9eec8cdc67c84c82a431bef0114457ec4800a72ad84c", size = 9255, upload-time = "2026-06-04T20:20:06.171Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/21/9b/e2c66454df73d1ecbb18089f026666743ef52480e295eb6f9c77998b1a63/pytest_unmagic-1.0.1-py3-none-any.whl", hash = "sha256:54a02d746d20943240c9b84e212a9a7e19bc2707cb176f9b1d66677b28260a13", size = 10909, upload-time = "2025-07-14T13:05:35.177Z" },
+    { url = "https://files.pythonhosted.org/packages/24/74/0ad96f4701284205fdefc4cefc711eb7ef593d559d13b4cbbf06b3969bd8/pytest_unmagic-1.1.0-py3-none-any.whl", hash = "sha256:8e98d551e9b165e1e8250299108e87a5f752a13c745f819df7a5f0ee9d4d4144", size = 10262, upload-time = "2026-06-04T20:20:04.998Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The test suite uses `pytest-unmagic`'s fencing to ensure unmagic fixtures are used in our own code. Previously, fencing only covered modules inside the `commcare_cloud` and `tests` packages, so test modules that live in a directory without an `__init__.py` were not fenced.

Upgrades `pytest-unmagic` to `>=1.1.0`, which adds the ability to fence top-level (unpackaged) modules, and turns that on by including `''` in the fence list. The empty `__init__.py` under `terraform/tests` is removed so that directory is unpackaged, as it was before https://github.com/dimagi/commcare-cloud/pull/6903/changes/f5a22f28feb1500b45f964159650027005a68558.

##### Environments Affected
None
