### PR TITLE
Revert "set old access key and secret key to None"

### DIFF
--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -201,8 +201,8 @@ S3_BLOB_DB_SETTINGS = {
 {% if localsettings.get('BLOB_DB_MIGRATING_FROM_S3_TO_S3', False) %}
 OLD_S3_BLOB_DB_SETTINGS = {
     'url': '{{ old_s3_blob_db_url }}',
-    'access_key': None,
-    'secret_key': None,
+    'access_key': {% if old_s3_blob_db_access_key %}'{{ old_s3_blob_db_access_key }}'{% else %}None{% endif %},
+    'secret_key': {% if old_s3_blob_db_secret_key %}'{{ old_s3_blob_db_secret_key }}'{% else %}None{% endif %},
     's3_bucket': '{{ old_s3_blob_db_s3_bucket }}',
     'bulk_delete_chunksize': {{ s3_bulk_delete_chunksize }},
     'config': {'signature_version': 's3v4'},


### PR DESCRIPTION
This reverts commit 4c5921d5b852f59dfd9dd21c4fac91c5f21ea9db. We or third party hosters might need it when they plan to migrate to S3 compatible backend.



##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All

