### PR TITLE
Show a clear error when init.sh is sourced in an unsupported shell

### DIFF
--- a/control/init.sh
+++ b/control/init.sh
@@ -6,9 +6,12 @@ is_sourced=0
 if [ -n "$ZSH_VERSION" ]; then
     [[ $ZSH_EVAL_CONTEXT == *:file* ]] && is_sourced=1
     script_path="$0"
-elif [ -n "$BASH_VERSION" ]; then
+elif [ -n "${BASH_SOURCE[0]}" ]; then
     (return 0 2>/dev/null) && is_sourced=1
     script_path="${BASH_SOURCE[0]}"
+else
+    echo "Script path cannot be found. Exiting"
+    return 1
 fi
 
 if [ "$is_sourced" != 1 ]; then


### PR DESCRIPTION
This tightens the \`elif\` condition from \`\$BASH_VERSION\` (are we in bash?) to \`\${BASH_SOURCE[0]}\` (do we actually have a usable source path?) and adds an \`else\` that exits immediately with a clear message for unrecognized shells.

##### Environments Affected
None