### PR TITLE
Remove older bucket config from staging

### DIFF
--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -105,8 +105,6 @@ s3_blob_db_enabled: yes
 s3_blob_db_url: "https://s3.amazonaws.com"
 s3_blob_db_s3_bucket: 'commcare-staging-blobdb'
 
-old_s3_blob_db_url: "https://s3.amazonaws.com"
-old_s3_blob_db_s3_bucket: 'dimagi-commcare-staging-blobdb'
 
 
 localsettings:
@@ -121,7 +119,6 @@ localsettings:
   BANK_ADDRESS: { 'first_line': "1 Citizens Drive", 'city': "Riverside", 'region': "RI", 'postal_code': "02915" }
   BANK_NAME: "RBS Citizens N.A."
   BANK_SWIFT_CODE: 'CTZIUS33'
-  BLOB_DB_MIGRATING_FROM_S3_TO_S3: True
   CELERY_PERIODIC_QUEUE: 'celery_null'
   CELERY_REPEAT_RECORD_DATASOURCE_QUEUE: "repeat_record_datasource_queue"
   COMMCARE_ANALYTICS_HOST: "https://commcare-analytics-staging.dimagi.com"


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

https://dimagi.atlassian.net/browse/SAAS-19843

Staging will no longer use [MigratingBlobDB](https://github.com/dimagi/commcare-hq/blob/7de180de007feeea4a1a087cc703724cae9fa0d2/corehq/blobs/migratingdb.py#L7-L52) which ensured that reads first go to newer bucket and if object is not found there it looks for them in older buckets. 

I have been tracking the changes in [this](https://app.datadoghq.com/notebook/14726032/s3-migration-staging?refresh_mode=sliding&from_ts=1780916383988&to_ts=1781521183988) notebook.

There are only failing delete requests going to the older bucket which is because check_services puts an object in blob db and then deletes it. Since writes only go to newer bucket so the subsequent delete request will result in 404 which is expected. 

So I am confident that the migration of the bucket on staging is complete and we don't need to check objects in older bucket anymore.

PS - This branch is applied to staging and have smoke tested HQ, things were working fine after applying the changes.
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Staging
