### PR TITLE
Expose a cli command to restart ec2 instances

### DIFF
--- a/docs/source/reference/1-commcare-cloud/commands.md
+++ b/docs/source/reference/1-commcare-cloud/commands.md
@@ -1735,13 +1735,12 @@ have been made to our actual resources in AWS.
 
 ---
 
-#### ``ec2-instance-state`` Command
+#### ``ec2`` Command
 
 Manage the EC2 instance state (start/stop/describe) of hosts in an AWS environment.
 
 ```
-commcare-cloud <env> ec2-instance-state [--no-wait]
-                                        {describe,start,stop,stop_and_start} inventory_group [inventory_group ...]
+commcare-cloud <env> ec2 [--no-wait] {describe,start,stop,stop_and_start} inventory_group [inventory_group ...]
 ```
 
 `start` and `stop` show a check-mode preview of the state transitions
@@ -1755,9 +1754,9 @@ To force setup, use --control-setup=yes instead.
 ##### Example
 
 ```
-commcare-cloud <env> ec2-instance-state describe webworkers
-commcare-cloud <env> ec2-instance-state stop celery:pillowtop
-commcare-cloud <env> ec2-instance-state stop_and_start 10.201.11.133 10.201.11.134
+commcare-cloud <env> ec2 describe webworkers
+commcare-cloud <env> ec2 stop celery:pillowtop
+commcare-cloud <env> ec2 stop_and_start 10.201.11.133 10.201.11.134
 ```
 
 ##### Positional Arguments

--- a/docs/source/reference/1-commcare-cloud/commands.md
+++ b/docs/source/reference/1-commcare-cloud/commands.md
@@ -1744,6 +1744,13 @@ commcare-cloud <env> ec2-instance-state [--no-wait]
                                         {describe,start,stop,stop_and_start} inventory_group [inventory_group ...]
 ```
 
+`start` and `stop` show a check-mode preview of the state transitions
+and ask for confirmation before applying; `stop_and_start` asks for
+confirmation directly (a check-mode preview of a full cycle would show
+no net state change); `describe` just runs.
+
+When used with --control, this command skips the slow setup.
+To force setup, use --control-setup=yes instead.
 
 ##### Example
 
@@ -1766,7 +1773,7 @@ What to do to the matched instances.
 
 One or more inventory items to act on. Each can be a group
 (e.g. `webworkers`), an individual host name or private IP
-(e.g. `10.201.11.133`), or any valid ansible host pattern
+(e.g. `10.201.11.133`), or any ansible host pattern
 (e.g. `celery:pillowtop`).
 
 ##### Options

--- a/docs/source/reference/1-commcare-cloud/commands.md
+++ b/docs/source/reference/1-commcare-cloud/commands.md
@@ -1740,13 +1740,19 @@ have been made to our actual resources in AWS.
 Manage the EC2 instance state (start/stop/describe) of hosts in an AWS environment.
 
 ```
-commcare-cloud <env> ec2 [--no-wait] {describe,start,stop,stop_and_start} inventory_group [inventory_group ...]
+commcare-cloud <env> ec2 [--no-wait] [--unsafe]
+                         {describe,start,stop,stop_and_start} inventory_group [inventory_group ...]
 ```
 
 `start` and `stop` show a check-mode preview of the state transitions
 and ask for confirmation before applying; `stop_and_start` asks for
 confirmation directly (a check-mode preview of a full cycle would show
 no net state change); `describe` just runs.
+
+`stop` and `stop_and_start` will eventually stop the services running
+on the hosts gracefully before stopping the EC2 instances. Until that
+is implemented they stop the instances outright, without draining
+services first, so they must be confirmed by passing `--unsafe`.
 
 When used with --control, this command skips the slow setup.
 To force setup, use --control-setup=yes instead.
@@ -1755,8 +1761,8 @@ To force setup, use --control-setup=yes instead.
 
 ```
 commcare-cloud <env> ec2 describe webworkers
-commcare-cloud <env> ec2 stop celery:pillowtop
-commcare-cloud <env> ec2 stop_and_start 10.201.11.133 10.201.11.134
+commcare-cloud <env> ec2 stop celery:pillowtop --unsafe
+commcare-cloud <env> ec2 stop_and_start 10.201.11.133 10.201.11.134 --unsafe
 ```
 
 ##### Positional Arguments
@@ -1781,6 +1787,12 @@ One or more inventory items to act on. Each can be a group
 
 Return as soon as the state change is issued instead of waiting
 for instances to reach their final state.
+
+###### `--unsafe`
+
+Required to run `stop` and `stop_and_start`, which currently stop
+the EC2 instances without gracefully stopping the services running
+on them first. Has no effect on `describe` or `start`.
 
 ---
 

--- a/docs/source/reference/1-commcare-cloud/commands.md
+++ b/docs/source/reference/1-commcare-cloud/commands.md
@@ -1735,6 +1735,49 @@ have been made to our actual resources in AWS.
 
 ---
 
+#### ``ec2-instance-state`` Command
+
+Manage the EC2 instance state (start/stop/describe) of hosts in an AWS environment.
+
+```
+commcare-cloud <env> ec2-instance-state [--no-wait]
+                                        {describe,start,stop,stop_and_start} inventory_group [inventory_group ...]
+```
+
+
+##### Example
+
+```
+commcare-cloud <env> ec2-instance-state describe webworkers
+commcare-cloud <env> ec2-instance-state stop celery:pillowtop
+commcare-cloud <env> ec2-instance-state stop_and_start 10.201.11.133 10.201.11.134
+```
+
+##### Positional Arguments
+
+###### `{describe,start,stop,stop_and_start}`
+
+What to do to the matched instances.
+`describe` reports their current state without changing anything;
+`start`/`stop` are idempotent;
+`stop_and_start` stops the instances (if running) and starts them again.
+
+###### `inventory_group`
+
+One or more inventory items to act on. Each can be a group
+(e.g. `webworkers`), an individual host name or private IP
+(e.g. `10.201.11.133`), or any valid ansible host pattern
+(e.g. `celery:pillowtop`).
+
+##### Options
+
+###### `--no-wait`
+
+Return as soon as the state change is issued instead of waiting
+for instances to reach their final state.
+
+---
+
 #### ``forward-port`` Command
 
 Port forward to access a remote admin console

--- a/src/commcare_cloud/ansible/ec2_instance_state.yml
+++ b/src/commcare_cloud/ansible/ec2_instance_state.yml
@@ -1,0 +1,23 @@
+---
+# Manage the EC2 instance state (describe/start/stop/stop_and_start) of the
+# targeted hosts. Target selection is by --limit;
+# Run is using the following command:
+# cchq <env> ap ec2_instance_state.yml  -e ec2_instance_state_command=<describe|start|stop|stop_and_start> --limit=<host pattern>
+# Required: -e ec2_instance_state_command=<describe|start|stop|stop_and_start>
+# Optional: -e ec2_instance_state_wait=<true|false>
+#           -e ec2_instance_state_region=<aws region>
+- name: Manage EC2 instance state
+  hosts: all
+  gather_facts: false
+  pre_tasks:
+    - name: Require an explicit --limit that is not 'all'
+      run_once: true
+      delegate_to: localhost
+      fail:
+        msg: >-
+          This playbook changes EC2 instance state and must be scoped with an
+          explicit --limit. Refusing to run without --limit or against 'all'
+          hosts. Pass --limit=<host pattern> 
+      when: ansible_limit is not defined or ansible_limit == 'all'
+  roles:
+    - role: ec2_instance_state

--- a/src/commcare_cloud/ansible/roles/ec2_instance_state/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/ec2_instance_state/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+
+- name: Fail for hosts without an ec2_instance_id host var
+  run_once: true
+  delegate_to: localhost
+  fail:
+    msg: >-
+      No ec2_instance_id host var for: {{ _hosts_without_instance_id | join(', ') }}.
+      Run 'commcare-cloud <env> aws-fill-inventory' to populate it from AWS.
+  when: _hosts_without_instance_id | length > 0
+  vars:
+    _hosts_without_instance_id: >-
+      {{ ansible_play_batch
+         | map('extract', hostvars)
+         | selectattr('ec2_instance_id', 'undefined')
+         | map(attribute='inventory_hostname')
+         | list }}
+
+- name: "Run EC2 {{ ec2_instance_state_command }} on the play's instances"
+  run_once: true
+  delegate_to: localhost
+  become: false
+  ec2_instance_state:
+    instance_ids: >-
+      {{ ansible_play_batch
+         | map('extract', hostvars, 'ec2_instance_id')
+         | list }}
+    command: "{{ ec2_instance_state_command }}"
+    wait: "{{ ec2_instance_state_wait | default(omit) }}"
+    region: "{{ ec2_instance_state_region | default(omit) }}"

--- a/src/commcare_cloud/ansible/roles/ec2_instance_state/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/ec2_instance_state/tasks/main.yml
@@ -20,6 +20,7 @@
   run_once: true
   delegate_to: localhost
   become: false
+  register: _ec2_instance_state_result
   ec2_instance_state:
     instance_ids: >-
       {{ ansible_play_batch
@@ -28,3 +29,14 @@
     command: "{{ ec2_instance_state_command }}"
     wait: "{{ ec2_instance_state_wait | default(omit) }}"
     region: "{{ ec2_instance_state_region | default(omit) }}"
+
+- name: Show EC2 instance state
+  run_once: true
+  delegate_to: localhost
+  loop: "{{ _ec2_instance_state_result.instances }}"
+  loop_control:
+    label: "{{ item.instance_id }}"
+  debug:
+    msg: >-
+      {{ item.name }} ({{ item.instance_id }}) [{{ item.private_ip }}]:
+      {{ item.previous_state }} -> {{ item.current_state }}

--- a/src/commcare_cloud/commands/ec2_instance_state.py
+++ b/src/commcare_cloud/commands/ec2_instance_state.py
@@ -27,12 +27,17 @@ class Ec2InstanceState(CommandBase):
     confirmation directly (a check-mode preview of a full cycle would show
     no net state change); `describe` just runs.
 
+    `stop` and `stop_and_start` will eventually stop the services running
+    on the hosts gracefully before stopping the EC2 instances. Until that
+    is implemented they stop the instances outright, without draining
+    services first, so they must be confirmed by passing `--unsafe`.
+
     Example:
 
     ```
     commcare-cloud <env> ec2 describe webworkers
-    commcare-cloud <env> ec2 stop celery:pillowtop
-    commcare-cloud <env> ec2 stop_and_start 10.201.11.133 10.201.11.134
+    commcare-cloud <env> ec2 stop celery:pillowtop --unsafe
+    commcare-cloud <env> ec2 stop_and_start 10.201.11.133 10.201.11.134 --unsafe
     ```
     """
 
@@ -55,6 +60,11 @@ class Ec2InstanceState(CommandBase):
             Return as soon as the state change is issued instead of waiting
             for instances to reach their final state.
         """),
+        Argument('--unsafe', action='store_true', help="""
+            Required to run `stop` and `stop_and_start`, which currently stop
+            the EC2 instances without gracefully stopping the services running
+            on them first. Has no effect on `describe` or `start`.
+        """),
         shared_args.SKIP_CHECK_ARG,
         shared_args.QUIET_ARG,
     )
@@ -66,6 +76,12 @@ class Ec2InstanceState(CommandBase):
             raise CommandError(
                 "ec2 can only be used in AWS environments "
                 f"(no terraform config found for {environment.name!r})")
+
+        if args.action in ('stop', 'stop_and_start') and not args.unsafe:
+            raise CommandError(
+                f"{args.action!r} currently stops the EC2 instances without "
+                "gracefully stopping the services running on them first. "
+                "Pass --unsafe if you understand this and want to proceed.")
 
         instance_ids_by_host = get_instance_ids_by_host(environment, args.inventory_group)
 

--- a/src/commcare_cloud/commands/ec2_instance_state.py
+++ b/src/commcare_cloud/commands/ec2_instance_state.py
@@ -77,7 +77,6 @@ class Ec2InstanceState(CommandBase):
                 "Target a specific group, host, or pattern instead.")
 
         self.log("Matched hosts:")
-        print(instance_ids_by_host)
         for host, instance_id in instance_ids_by_host.items():
             puts("  {} ({})".format(host, instance_id))
 

--- a/src/commcare_cloud/commands/ec2_instance_state.py
+++ b/src/commcare_cloud/commands/ec2_instance_state.py
@@ -111,9 +111,15 @@ def get_instance_ids_by_host(environment, inventory_items):
         raise CommandError("No hosts in inventory match {!r}".format(pattern))
 
     instance_ids_by_host = {}
+    hosts_without_instance_id = []
     for host in hosts:
         instance_id = host.vars.get('ec2_instance_id')
         if instance_id:
             instance_ids_by_host[host.name] = instance_id
-    
+        else:
+            hosts_without_instance_id.append(host.name)
+
+    if hosts_without_instance_id:
+        raise CommandError(f"No 'ec2_instance_id' host var for: {', '.join(hosts_without_instance_id)}")
+
     return instance_ids_by_host

--- a/src/commcare_cloud/commands/ec2_instance_state.py
+++ b/src/commcare_cloud/commands/ec2_instance_state.py
@@ -65,7 +65,7 @@ class Ec2InstanceState(CommandBase):
         if not is_aws_env(environment):
             raise CommandError(
                 "ec2-instance-state can only be used in AWS environments "
-                "(no terraform config found for {!r})".format(environment.name))
+                f"(no terraform config found for {environment.name!r})")
 
         instance_ids_by_host = get_instance_ids_by_host(environment, args.inventory_group)
 
@@ -73,8 +73,8 @@ class Ec2InstanceState(CommandBase):
                      if not host.implicit}
         if set(instance_ids_by_host) >= all_hosts:
             raise CommandError(
-                "Refusing to run ec2-instance-state against all hosts in {!r}. "
-                "Target a specific group, host, or pattern instead.".format(environment.name))
+                f"Refusing to run ec2-instance-state against all hosts in {environment.name!r}. "
+                "Target a specific group, host, or pattern instead.")
 
         self.log("Matched hosts:")
         print(instance_ids_by_host)

--- a/src/commcare_cloud/commands/ec2_instance_state.py
+++ b/src/commcare_cloud/commands/ec2_instance_state.py
@@ -18,7 +18,7 @@ ACTIONS = ['describe', 'start', 'stop', 'stop_and_start']
 
 
 class Ec2InstanceState(CommandBase):
-    command = 'ec2-instance-state'
+    command = 'ec2'
     help = """
     Manage the EC2 instance state (start/stop/describe) of hosts in an AWS environment.
 
@@ -30,9 +30,9 @@ class Ec2InstanceState(CommandBase):
     Example:
 
     ```
-    commcare-cloud <env> ec2-instance-state describe webworkers
-    commcare-cloud <env> ec2-instance-state stop celery:pillowtop
-    commcare-cloud <env> ec2-instance-state stop_and_start 10.201.11.133 10.201.11.134
+    commcare-cloud <env> ec2 describe webworkers
+    commcare-cloud <env> ec2 stop celery:pillowtop
+    commcare-cloud <env> ec2 stop_and_start 10.201.11.133 10.201.11.134
     ```
     """
 
@@ -64,7 +64,7 @@ class Ec2InstanceState(CommandBase):
         environment = ansible_context.environment
         if not is_aws_env(environment):
             raise CommandError(
-                "ec2-instance-state can only be used in AWS environments "
+                "ec2 can only be used in AWS environments "
                 f"(no terraform config found for {environment.name!r})")
 
         instance_ids_by_host = get_instance_ids_by_host(environment, args.inventory_group)
@@ -73,7 +73,7 @@ class Ec2InstanceState(CommandBase):
                      if not host.implicit}
         if set(instance_ids_by_host) >= all_hosts:
             raise CommandError(
-                f"Refusing to run ec2-instance-state against all hosts in {environment.name!r}. "
+                f"Refusing to run ec2 command against all hosts in {environment.name!r}. "
                 "Target a specific group, host, or pattern instead.")
 
         self.log("Matched hosts:")

--- a/src/commcare_cloud/commands/ec2_instance_state.py
+++ b/src/commcare_cloud/commands/ec2_instance_state.py
@@ -1,0 +1,120 @@
+import json
+
+from clint.textui import puts
+
+from commcare_cloud.commands import shared_args
+from commcare_cloud.commands.ansible.ansible_playbook import (
+    run_ansible_playbook,
+)
+from commcare_cloud.commands.ansible.helpers import AnsibleContext
+from commcare_cloud.commands.command_base import (
+    Argument,
+    CommandBase,
+    CommandError,
+)
+from commcare_cloud.commands.terraform.aws import is_aws_env
+
+ACTIONS = ['describe', 'start', 'stop', 'stop_and_start']
+
+
+class Ec2InstanceState(CommandBase):
+    command = 'ec2-instance-state'
+    help = """
+    Manage the EC2 instance state (start/stop/describe) of hosts in an AWS environment.
+
+    `start` and `stop` show a check-mode preview of the state transitions
+    and ask for confirmation before applying; `stop_and_start` asks for
+    confirmation directly (a check-mode preview of a full cycle would show
+    no net state change); `describe` just runs.
+
+    Example:
+
+    ```
+    commcare-cloud <env> ec2-instance-state describe webworkers
+    commcare-cloud <env> ec2-instance-state stop celery:pillowtop
+    commcare-cloud <env> ec2-instance-state stop_and_start 10.201.11.133 10.201.11.134
+    ```
+    """
+
+    run_setup_on_control_by_default = False
+
+    arguments = (
+        Argument('action', choices=ACTIONS, help="""
+            What to do to the matched instances.
+            `describe` reports their current state without changing anything;
+            `start`/`stop` are idempotent;
+            `stop_and_start` stops the instances (if running) and starts them again.
+        """),
+        Argument('inventory_group', nargs='+', help="""
+            One or more inventory items to act on. Each can be a group
+            (e.g. `webworkers`), an individual host name or private IP
+            (e.g. `10.201.11.133`), or any ansible host pattern
+            (e.g. `celery:pillowtop`).
+        """),
+        Argument('--no-wait', action='store_true', help="""
+            Return as soon as the state change is issued instead of waiting
+            for instances to reach their final state.
+        """),
+        shared_args.SKIP_CHECK_ARG,
+        shared_args.QUIET_ARG,
+    )
+
+    def run(self, args, unknown_args):
+        ansible_context = AnsibleContext(args)
+        environment = ansible_context.environment
+        if not is_aws_env(environment):
+            raise CommandError(
+                "ec2-instance-state can only be used in AWS environments "
+                "(no terraform config found for {!r})".format(environment.name))
+
+        instance_ids_by_host = get_instance_ids_by_host(environment, args.inventory_group)
+
+        all_hosts = {host.name for host in environment.inventory_manager.get_hosts('all')
+                     if not host.implicit}
+        if set(instance_ids_by_host) >= all_hosts:
+            raise CommandError(
+                "Refusing to run ec2-instance-state against all hosts in {!r}. "
+                "Target a specific group, host, or pattern instead.".format(environment.name))
+
+        self.log("Matched hosts:")
+        print(instance_ids_by_host)
+        for host, instance_id in instance_ids_by_host.items():
+            puts("  {} ({})".format(host, instance_id))
+
+        extra_vars = {
+            'ec2_instance_state_command': args.action,
+            'ec2_instance_state_wait': not args.no_wait,
+        }
+
+        describe = args.action == 'describe'
+        return run_ansible_playbook(
+            'ec2_instance_state.yml',
+            ansible_context,
+            # describe is read-only; apply it directly without prompting
+            skip_check=args.skip_check or describe,
+            quiet=args.quiet or describe,
+            # A check-mode stop_and_start predicts no net state change, so its
+            # diff preview is empty and misleading; confirm directly instead.
+            always_skip_check=args.action == 'stop_and_start',
+            limit=','.join(instance_ids_by_host),
+            unknown_args=['-e', json.dumps(extra_vars)] + list(unknown_args),
+        )
+
+
+def get_instance_ids_by_host(environment, inventory_items):
+    """Resolve inventory items to {host name: ec2_instance_id}, in inventory order."""
+    pattern = ','.join(inventory_items)
+    # Exclude ansible's implicit localhost, which get_hosts returns for
+    # 'localhost'/'127.0.0.1' patterns even when it is not in the inventory.
+    hosts = [host for host in environment.inventory_manager.get_hosts(pattern)
+             if not host.implicit]
+    if not hosts:
+        raise CommandError("No hosts in inventory match {!r}".format(pattern))
+
+    instance_ids_by_host = {}
+    for host in hosts:
+        instance_id = host.vars.get('ec2_instance_id')
+        if instance_id:
+            instance_ids_by_host[host.name] = instance_id
+    
+    return instance_ids_by_host

--- a/src/commcare_cloud/commcare_cloud.py
+++ b/src/commcare_cloud/commcare_cloud.py
@@ -13,6 +13,7 @@ from commcare_cloud.colors import color_error
 from commcare_cloud.commands.ansible.downtime import Downtime
 from commcare_cloud.commands.clean_releases import CleanReleases
 from commcare_cloud.commands.deploy.command import Deploy, DeployDiff
+from commcare_cloud.commands.ec2_instance_state import Ec2InstanceState
 from commcare_cloud.commands.migrations.couchdb import MigrateCouchdb
 from commcare_cloud.commands.migrations.copy_files import CopyFiles
 from commcare_cloud.commands.preindex_views import PreindexViews
@@ -99,6 +100,7 @@ COMMAND_GROUPS = OrderedDict([
         AwsSignIn,
         AwsList,
         AwsFillInventory,
+        Ec2InstanceState,
         ForwardPort,
     ])
 ])


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Building on top of https://github.com/dimagi/commcare-cloud/pull/6905, we are exposing a cli which will help us to do restarts of ec2 instances. 

The PR creates a role, a playbook and a cli for `ec2_instance_state` command. 

The role would be used later in the playbooks where we would be issuing start and stop commands to the instances. 

The playbook was required to expose the role for the CLI.
##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All

