### PR TITLE
Ansible 4.10 upgrade plan

### DIFF
--- a/docs/plans/ansible-upgrade.md
+++ b/docs/plans/ansible-upgrade.md
@@ -12,9 +12,9 @@ with thin automated coverage today. CI (`.tests/tests.sh`) `--syntax-check`s
 `py3,commcarehq`-tagged subset of it against a `localhost`/`local`-connection
 test env, then byte-compiles the rendered `localsettings.py`. So most roles are
 parse-checked but never run, and standalone playbooks outside `deploy_stack.yml`
-(`deploy_hq.yml`, `deploy_postgres.yml`, the
-`restart_*`/`deploy_citusdb`/`deploy_proxy` set, etc.) get neither. That
-coverage gap is the upgrade's biggest risk, so the test tickets come first.
+(`deploy_hq.yml`, `deploy_postgres.yml`, the `restart_*` / `deploy_citusdb` /
+`deploy_proxy` set, etc.) get neither. That coverage gap is the upgrade's
+biggest risk, so the test tickets come first.
 
 Sequence: clean up deprecations and build a test safety net first, then step
 through versions. The interpreter may move in two hops: **3.10 → 3.12** (spans
@@ -27,18 +27,8 @@ tests pass early — #26 optional).
    conditionals (v5), arithmetic outside `{{ }}` (v6), embedded-template
    conditionals (v8/CVE-2023-5764), and non-boolean `when:` as an error + native
    Jinja + inverted trust model (v12). → tickets 17–19.
-2. **Collection removals** in every major — in-use ones must be pinned and
-   installed explicitly. → #7–10.
-3. **The monitoring-install automation is removed** — see
-   Appendix B. The archived `cloudalchemy.*` roles, the 2020-vintage
-   `dimagi.commcare_prometheus` collection, and their transitive
-   `gantsign.golang` + `bdellegrazie.postgres_exporter` were the biggest cluster
-   of incompatible/abandoned deps. Rather than vendor or re-base them, #12
-   *deletes* the Prometheus install automation outright and documents
-   user-managed Prometheus, keeping only the app-level metrics integration. This
-   clears the cluster before the Ansible-10 bump (#24) in one move.
-4. **Python floor jumps** (3.10 @ v9, 3.12 @ v13) and **UTF-8 locale enforced at
-   startup** (v7).
+2. **Collection removals** in every major version. Pin and explicitly install
+   collectinos that were removed from Ansible. → #7–10.
 
 ---
 
@@ -67,12 +57,12 @@ Acceptance: none remain; 22.04 path unaffected.
 #### 3. CI lint + syntax for all playbooks
 Add `ansible-lint` (dev dep) and extend `--syntax-check` to cover the
 top-level playbooks *not* reached by the existing `deploy_stack.yml` check —
-`deploy_hq.yml`, `deploy_postgres.yml`, the
-`restart_*`/`deploy_citusdb`/`deploy_proxy` set, etc. (`deploy_stack.yml` and
-its ~18 imports are already syntax-checked by `.tests/tests.sh`; `deploy_prometheus.yml`
-is excluded — it's being removed in #12); capture existing violations as a
-baseline. Full FQCN module normalization is low-priority baseline debt (short
-names resolve fine; collection moves are handled by #7–8).
+`deploy_hq.yml`, `deploy_postgres.yml`, the `restart_*` / `deploy_citusdb` /
+`deploy_proxy` set, etc. (`deploy_stack.yml` and its ~18 imports are already
+syntax-checked by `.tests/tests.sh`; `deploy_prometheus.yml` is excluded — it's
+being removed in #12); capture existing violations as a baseline. Full FQCN
+module normalization is low-priority baseline debt (short names resolve fine;
+collection moves are handled by #7–8).
 Acceptance: new non-blocking `lint.yml` fails on new violations; green on day one.
 
 #### 4. Refresh Vagrant harness to 22.04
@@ -89,7 +79,7 @@ Acceptance: `molecule test` converge + idempotence green locally and in CI on 22
 
 #### 6. Molecule coverage for critical roles
 Add Molecule converge/idempotence scenarios for the operationally critical,
-untested roles: postgresql(_base), pgbouncer, couchdb2, kafka, redis, rabbitmq,
+untested roles: postgresql(_base), pgbouncer, couchdb2, kafka, redis,
 elasticsearch, nginx, proxy/haproxy. Likely one Jira ticket per role/group.
 Acceptance: each converges twice with no changes; basic service-up asserts.
 Depends: 5.
@@ -107,7 +97,7 @@ Acceptance: `ansible-galaxy install -r` resolves the collection; Molecule
 postgres (#6) + syntax clean.
 Depends: ideally 6.
 
-#### 8. Adopt `ansible.posix` (declare + migrate `synchronize`/`authorized_key`)
+#### 8. Adopt `ansible.posix`
 Add `ansible.posix` to `requirements.yml`, then FQCN-ify `synchronize` /
 `authorized_key` in `roles/deploy_hq/tasks/staticfiles_*` and
 `roles/setup_auth_keys.yml`.
@@ -138,62 +128,36 @@ covers the survivors: `DavidWittman.redis`, `sansible.logstash`, the
 `andrewrothstein.*` couchdb roles.
 Acceptance: role compat matrix complete; orphaned pins removed or justified.
 
-#### 12. Remove the Prometheus install automation (keep app-level metrics integration)
-**Decision (Slack thread below):** commcare-cloud will no longer *install* the
-Prometheus monitoring stack. Operators who want Prometheus/Grafana stand it up
-themselves following Prometheus' own docs. This deletes the largest cluster of
-archived/incompatible dependencies in one move — so none of it needs vendoring,
-version-bumping, or an upstream cutover.
-Grafana is in scope: it's confirmed to be exclusively the Prometheus dashboard
-front-end here (`cloudalchemy.grafana`, the `grafana` inventory group, and
-`grafana_*` vars are referenced only by `deploy_prometheus.yml`), with no
-standalone use — so it's removed along with everything else that playbook owns.
-**Remove (each confirmed referenced only by `deploy_prometheus.yml`):**
-- `deploy_prometheus.yml` (the whole server-install playbook — prometheus,
-  alertmanager, grafana, node_exporter, and the dimagi collection's ~18 exporter
-  roles). It is not imported by `deploy_stack.yml` and is not a CLI subcommand,
-  so removal is self-contained.
-- `requirements.yml` pins: `dimagi.commcare_prometheus`,
-  `cloudalchemy.prometheus` / `.alertmanager` / `.grafana` / `.node_exporter`,
-  `bdellegrazie.postgres_exporter`, `gantsign.golang`.
-- `group_vars/prometheus.yml` and `group_vars/alertmanager.yml` (server
-  scrape/alert config).
-- `environment/schemas/prometheus.py` + its wiring in `environment/main.py` (the
-  `prometheus_config` property/import). **Caveat:** this schema also carries
-  `prometheus_monitoring_enabled`, the toggle for the *kept* app-level feature —
-  so preserve a supported way to set that flag (keep just that field, or document
-  the override) while dropping the server-only `grafana_security` + scrape config.
-- The orphaned `grafana_nginx_ssl_cert` / `grafana_nginx_ssl_key` defs in
-  `roles/nginx/vars/main.yml` (defined, never rendered).
-- The `dimagi.commcare_prometheus` expectations in
-  `manage_commcare_cloud/tests/test_install.py` (update so the suite stays green).
+#### 12. Remove the Prometheus install automation
+Remove `deploy_prometheus.yml` and all dependencies used only by it from
+`requirements.yml`.
+- Check references to `prometheus` / `grafana` / `alertmanager` /
+  `node_exporter` / `bdellegrazie.postgres_exporter` / `gantsign.golang`.
+- Check relevance of `group_vars/prometheus.yml`, `group_vars/alertmanager.yml`,
+  `environment/schemas/prometheus.py` + its wiring in `environment/main.py`.
+  **Caveat:** this schema also carries `prometheus_monitoring_enabled`, the
+  toggle for the *kept* app-level feature, so preserve a supported way to set
+  that flag
 - The `prometheus`/`alertmanager`/`grafana`/`prometheus_proxy` inventory groups
-  become unused — drop them from example environments where present (minor).
-**Keep** (app-level, gated by `prometheus_monitoring_enabled`, independent of the
-server install — boundary confirmed clean): the `localsettings.py.j2`
-metrics-provider injection; `supervisor_prometheus.conf.j2` +
-`django_bash_runner.sh.j2`; the `PROMETHEUS_MULTIPROC_DIR` /
-`PROMETHEUS_PUSHGATEWAY_HOST` env wiring in the `commcarehq` role tasks
-(webworkers/pillowtop/management_commands/celery); the gated "Prometheus
-Supervisor Config" / "Prometheus Django runner" plays in `deploy_commcarehq.yml`;
-and `prometheus_monitoring_enabled` / `metrics_home` in `group_vars/all.yml`. HQ
-still exposes `/metrics`; an operator-run Prometheus scrapes it. (The pushgateway
-host becomes operator-supplied, since its config left with the server vars.)
-**Docs:** rewrite the Prometheus install section of
-`docs/source/operations/3-monitoring.rst` (the `cchq <env> aps deploy_prometheus.yml`
-instructions) to say Prometheus/Grafana setup is the operator's responsibility
-(link Prometheus' docs); drop the now-moot changelog
-`docs/source/changelog/0057-update-prometheus-variable.md`. The Datadog metrics
-listing in that rst is unrelated and stays.
-`dimagi.commcare_logstash` / `deploy_logstash.yml` are unrelated and stay.
+  become unused — drop them from example environments where present.
+- Remove Prometheus installation docs.
+- Keep app-level, gated by `prometheus_monitoring_enabled`, independent of the
+  server install: the `localsettings.py.j2` metrics-provider injection;
+  `supervisor_prometheus.conf.j2` + `django_bash_runner.sh.j2`; the
+  `PROMETHEUS_MULTIPROC_DIR` / `PROMETHEUS_PUSHGATEWAY_HOST` env wiring in the
+  `commcarehq` role tasks (webworkers/pillowtop/management_commands/celery); the
+  gated "Prometheus Supervisor Config" / "Prometheus Django runner" plays in
+  `deploy_commcarehq.yml`; and `prometheus_monitoring_enabled` / `metrics_home`
+  in `group_vars/all.yml`. HQ still exposes `/metrics`; Prometheus scrapes it.
+- Publish a change log entry: while Prometheus is still supported for
+  monitoring, commcare-cloud will no longer install the Prometheus monitoring
+  stack. Operators who want Prometheus/Grafana can stand it up themselves
+  following Prometheus' own docs.
 Prior art — both **close here**, superseded by removal:
 [#6520](https://github.com/dimagi/commcare-cloud/pull/6520) /
-[#6524](https://github.com/dimagi/commcare-cloud/pull/6524) (the cloudalchemy
-bump attempts).
-Acceptance: `deploy_prometheus.yml`, the seven monitoring pins,
-`group_vars/{prometheus,alertmanager}.yml`, and `schemas/prometheus.py` are gone;
-no `cloudalchemy.*` / `dimagi.commcare_prometheus` / `gantsign.golang` /
-`bdellegrazie.postgres_exporter` ref remains anywhere; `test_install.py` and the
+[#6524](https://github.com/dimagi/commcare-cloud/pull/6524) — the cloudalchemy
+upgrade attempts.
+Acceptance: `deploy_prometheus.yml` et al are gone; `test_install.py` and the
 monitoring docs are updated; `deploy-stack` is unaffected; and with
 `prometheus_monitoring_enabled` still settable + set to `True`, the
 `deploy_commcarehq` path renders localsettings + supervisor configs
@@ -202,18 +166,18 @@ Depends: ideally 6.
 Decision thread:
 https://dimagi.slack.com/archives/CNQ636095/p1781277055592099?thread_ts=1781210489.586889&cid=CNQ636095
 
-#### 13. Vendor or replace `tmpreaper` (`ANXS/tmpreaper`, dead since 2017)
-Abandoned but trivial; used in several playbooks. Risk is removed syntax
-(`with_items`, bare `warn:`, string-bool `when:`) failing on the target core.
-Fork into the repo as a local role under `roles/` (preferred — a maintainable
-copy we can fix forward) or replace with a few inline tasks; re-point
-`requirements.yml` / refs.
+#### 13. Vendor or replace `tmpreaper`
+Abandoned but trivial (`ANXS/tmpreaper`, dead since 2017); used in several
+playbooks. Risk is removed syntax (`with_items`, bare `warn:`, string-bool
+`when:`) failing on the target core. Fork into the repo as a local role under
+`roles/` (preferred — a maintainable copy we can fix forward) or replace with a
+few inline tasks; re-point `requirements.yml` / refs.
 Acceptance: resolves to a repo-local role (or inline tasks); no abandoned pin
 remains; touched-role Molecule green on the target core.
 
-#### 14. Vendor or replace `ansible-logrotate` (`nickhammond`, dead since 2018)
-Same approach as #13. Heavily used — it's a `meta` dependency of `common`, so
-nearly every host pulls it; test broadly.
+#### 14. Vendor or replace `ansible-logrotate`
+Same approach as #13 (`nickhammond`, dead since 2018). Heavily used — it's a
+`meta` dependency of `common`, so nearly every host pulls it; test broadly.
 Acceptance: resolves to a repo-local role (or inline tasks); no abandoned pin
 remains; `common`-dependent role Molecules green on the target core.
 
@@ -223,11 +187,12 @@ remains; `common`-dependent role Molecules green on the target core.
 ~15, mostly `ping.yml`; removed in core 2.14.
 Acceptance: none remain; lint clean.
 
-#### 16. Convert `with_*` to `loop:` — largest change (~125 across ~21 files)
-Add appropriate filters/`lookup`. Mechanical; split on playbook and role.
+#### 16. Convert `with_*` to `loop:`
+Largest change: ~125 across ~21 files. Add appropriate filters/`lookup`.
+Mechanical; split on playbook and role.
 Prior art: [#6209](https://github.com/dimagi/commcare-cloud/pull/6209) /
 [#6235](https://github.com/dimagi/commcare-cloud/pull/6235) carry the same kind
-of mechanical loop/`include_tasks` rewrite, but they close in #17 (see there).
+of mechanical loop/`include_tasks` rewrite; they close in #17.
 Acceptance: no `with_*` keys remain; touched role Molecules green.
 Depends: 6 (interleave with 7–8, 15).
 
@@ -289,28 +254,23 @@ Acceptance: CLI imports succeed on each target core; verified at 12→14 (#28).
 ### Version bumps — sequential, after cleanup + a full test pass
 
 #### 24. Ansible 4 → 10 (core 2.11→2.17)
-The core/package bump. Ansible 10 is the highest reachable on Python 3.10.
+The core/package upgrade. Ansible 10 is the highest reachable on Python 3.10.
 Raise the `ansible` pin and `min_ansible_version`; re-pin collections to
-core-2.17-compatible versions. Because all removed syntax was fixed on 4.10 in
-the cleanup band — and the archived monitoring stack was removed outright (#12)
-rather than carried forward — this is a pure pin change with nothing left to
-break, and can be green and merged on its own. The surviving-role re-pins (#25)
-are a version-coupled follow-on that depends on this step but is *not* a
-precondition of declaring it done.
+core-2.17-compatible versions.
 Prior art: Dependabot [#6895](https://github.com/dimagi/commcare-cloud/pull/6895)
 (ansible 4→10.7.0) and [#6444](https://github.com/dimagi/commcare-cloud/pull/6444)
 (ansible-core 2.11→2.17.7) — **close both here** (they only touch the pin, so
 can't merge until the cleanup band is done).
-Acceptance: core 2.17 installs; `deploy_hq.yml` syntax-check green on 2.17;
-full Molecule suite green on 10.
+Acceptance: core 2.17 installs; `deploy_hq.yml` syntax-check green; full
+Molecule suite green on Ansible 10.
 Fallback: bisect via 6/8 if failures are hard to localize.
-Depends: 7–23 (incl. 12).
+Depends: 7–23
 
 #### 25. Re-pin surviving standalone roles + re-test
 Bump the still-maintained roles to their newest releases and re-test on core
 2.17: `DavidWittman.redis`, `sansible.logstash`, the `andrewrothstein.*` SHAs
 (couchdb, couchdb-cluster). Done here because verification needs the new core.
-Acceptance: each touched role's Molecule (#6) green on 10; pins updated.
+Acceptance: each touched role's Molecule (#6) green on Ansible 10; pins updated.
 Depends: 24.
 
 #### 26. Controller Python 3.10 → 3.12
@@ -324,8 +284,7 @@ Depends: 24 (with 25 green).
 Isolates the v12 templating overhaul, where #19 gets exercised and most breakage
 is expected. Re-pin collections.
 Prior art: Dependabot [#6758](https://github.com/dimagi/commcare-cloud/pull/6758)
-(ansible 4→12.2.0) is the pin diff for this jump — **close it here** (rebased
-onto the #24 result).
+**close it here**.
 Acceptance: full suite green on 12 with zero templating/conditional errors.
 Depends: 26, 19.
 
@@ -353,9 +312,7 @@ Acceptance: clean monolith install + re-converge with zero unexpected changes.
 Depends: 29, 5.
 
 #### 31. Docs
-New minimum Python, upgrade outcome, Molecule/Vagrant workflows,
-changelog. (The Prometheus "operator-managed" doc change lands with #12; this
-ticket covers the rest.)
+New minimum Python, upgrade outcome, Molecule/Vagrant workflows, changelog.
 Acceptance: a new contributor can run the ansible test suite from docs alone.
 Depends: 30.
 
@@ -439,30 +396,6 @@ against GitHub archived flag + last push, June 2026):
 | `ansible-logrotate` | nickhammond/ansible-logrotate | **DEAD** | **2018-10** (v0.0.5) | trivial role — vendor or replace (#14) |
 | `dimagi.commcare_logstash` | dimagi/commcare-logstash | Dimagi | 2022-01 (0.9.5) | re-test; we own it (#9) |
 | `community.general` | (collection) | active | pinned 7.4.0 | bump in lockstep with core (#9) |
-
-**Why the monitoring stack is removed rather than upgraded (#12):**
-`deploy_prometheus.yml` is the only consumer of the whole monitoring dependency
-chain. It imports `dimagi.commcare_prometheus.prometheus` / `.alertmanager`
-(whose `meta` declare `dependencies: [cloudalchemy.prometheus]` /
-`[cloudalchemy.alertmanager]`), and imports `cloudalchemy.grafana` /
-`cloudalchemy.node-exporter` **directly** (note the legacy hyphen); the dimagi
-collection's exporter roles pull `bdellegrazie.postgres_exporter` and
-`gantsign.golang` transitively. **All four cloudalchemy roles are archived and
-frozen** (the #6524 "0.21.5 → 0.21.5" no-op proved node_exporter can't move),
-their maintained successors floor at core 2.12 / 2.14, and the dimagi collection
-last released in 2020 — so carrying them forward meant vendoring and
-cross-version-fixing a stack we don't otherwise need. Since `deploy_prometheus.yml`
-is **not** part of `deploy-stack` and **not** a CLI subcommand, deleting it (plus
-the seven pins and the two server `group_vars` files) is self-contained and
-removes the entire cluster at once. The app-level metrics integration is a
-*separate*, cleanly-decoupled concern (gated by `prometheus_monitoring_enabled`
-in `group_vars/all.yml`, never touching the install roles), so it stays and HQ
-keeps exposing `/metrics` for an operator-managed Prometheus to scrape.
-
-If managed monitoring is ever wanted back, the modern upstream successors are
-`prometheus.prometheus` (`requires_ansible >=2.14.0,<=2.21.99`, bundles
-prometheus/alertmanager/node_exporter/postgres_exporter) and `grafana.grafana`
-(`>=2.12.0,<3.0.0`) — both core-2.14+, so only adoptable post-bump.
 
 ---
 

--- a/docs/plans/ansible-upgrade.md
+++ b/docs/plans/ansible-upgrade.md
@@ -59,9 +59,6 @@ Remove `deploy_prometheus.yml` and all dependencies used only by it from
   `node_exporter` / `bdellegrazie.postgres_exporter` / `gantsign.golang`.
 - Check relevance of `group_vars/prometheus.yml`, `group_vars/alertmanager.yml`,
   `environment/schemas/prometheus.py` + its wiring in `environment/main.py`.
-  **Caveat:** this schema also carries `prometheus_monitoring_enabled`, the
-  toggle for the *kept* app-level feature, so preserve a supported way to set
-  that flag
 - The `prometheus`/`alertmanager`/`grafana`/`prometheus_proxy` inventory groups
   become unused — drop them from example environments where present.
 - Remove Prometheus installation docs.
@@ -86,7 +83,6 @@ monitoring docs are updated; `deploy-stack` is unaffected; and with
 `prometheus_monitoring_enabled` still settable + set to `True`, the
 `deploy_commcarehq` path renders localsettings + supervisor configs
 (syntax/Molecule green with the flag both on and off).
-Depends: ideally 7.
 Decision thread:
 https://dimagi.slack.com/archives/CNQ636095/p1781277055592099?thread_ts=1781210489.586889&cid=CNQ636095
 

--- a/docs/plans/ansible-upgrade.md
+++ b/docs/plans/ansible-upgrade.md
@@ -1,5 +1,7 @@
 # Ansible Upgrade + Test Coverage — Jira Backlog
 
+**Epic:** [SAAS-19886](https://dimagi.atlassian.net/browse/SAAS-19886)
+
 ## Context
 
 commcare-cloud is pinned to **Ansible 4.10 (core 2.11)** on **controller Python
@@ -46,11 +48,13 @@ on its own, so that each bump (26/29/30) is a pin change with nothing left to fi
 Used once in `ops_tool.py` (`git.Repo(search_parent_directories=True)`); replace
 with a `subprocess` git call and remove from `pyproject.toml`/`uv.lock`.
 Acceptance: repo root still resolves; dep gone; tests green.
+Ticket: [SAAS-19887](https://dimagi.atlassian.net/browse/SAAS-19887)
 
 #### 2. Remove stale Ubuntu 18.04 references
 18.04 is unsupported. Search `18.04|bionic`.
 Delete `ansible_distribution_version == '18.04'` branches.
 Acceptance: none remain; 22.04 path unaffected.
+Ticket: [SAAS-19888](https://dimagi.atlassian.net/browse/SAAS-19888)
 
 #### 3. Remove the CitusDB automation
 CitusDB is no longer used; remove its install/management automation.
@@ -73,6 +77,7 @@ CitusDB is no longer used; remove its install/management automation.
 - Remove CitusDB docs (`docs/source/services/postgresql/upgrade_citusdb.rst`;
   trim citus from `postgresql.rst`) and publish a changelog entry.
 Acceptance: no `citus` references remain; `deploy-stack` unaffected.
+Ticket: [SAAS-19889](https://dimagi.atlassian.net/browse/SAAS-19889)
 
 #### 4. Remove the RabbitMQ automation
 The Celery broker has migrated to Redis (changelog `0096`; RabbitMQ support
@@ -97,6 +102,7 @@ ended 2026-06-01), so RabbitMQ is no longer used — remove its automation.
   action: remove `[rabbitmq]` from inventory.
 Acceptance: no rabbitmq/AMQP install references remain; `deploy-stack` and
 Celery (on the Redis broker) are unaffected; `test_getinventory.py` is updated.
+Ticket: [SAAS-19890](https://dimagi.atlassian.net/browse/SAAS-19890)
 
 #### 5. Remove the Prometheus install automation
 Remove `deploy_prometheus.yml` and all dependencies used only by it from
@@ -131,6 +137,7 @@ monitoring docs are updated; `deploy-stack` is unaffected; and with
 (syntax/Molecule green with the flag both on and off).
 Decision thread:
 https://dimagi.slack.com/archives/CNQ636095/p1781277055592099?thread_ts=1781210489.586889&cid=CNQ636095
+Ticket: [SAAS-19891](https://dimagi.atlassian.net/browse/SAAS-19891)
 
 ### Safety net — build verification before touching versions
 

--- a/docs/plans/ansible-upgrade.md
+++ b/docs/plans/ansible-upgrade.md
@@ -72,12 +72,11 @@ CitusDB is no longer used; remove its install/management automation.
   unused — drop them from example environments where present.
 - Remove CitusDB docs (`docs/source/services/postgresql/upgrade_citusdb.rst`;
   trim citus from `postgresql.rst`) and publish a changelog entry.
-Acceptance: no `citus` references remain; `deploy_postgres` / `deploy_db` and the
-postgres Molecule (#9) are green without them; `deploy-stack` unaffected.
+Acceptance: no `citus` references remain; `deploy-stack` unaffected.
 
 #### 4. Remove the RabbitMQ automation
-The Celery broker has migrated to Redis (changelog `0096`; RabbitMQ support ended
-2026-06-01), so RabbitMQ is no longer used — remove its automation.
+The Celery broker has migrated to Redis (changelog `0096`; RabbitMQ support
+ended 2026-06-01), so RabbitMQ is no longer used — remove its automation.
 - Delete `deploy_rabbitmq.yml` and the `roles/rabbitmq/` role.
 - Remove the rabbitmq import/host blocks from `deploy_db.yml` and the rabbitmq
   plays in `ping.yml`, `stop_servers.yml`, `status_check.yml`, and
@@ -91,13 +90,13 @@ The Celery broker has migrated to Redis (changelog `0096`; RabbitMQ support ende
 - The `rabbitmq` inventory group becomes unused — drop the `[rabbitmq:children]`
   blocks from the example/inventory templates and the `AMQP_*` / `OLD_AMQP_*`
   env wiring from example environments.
+- Graham: something failed on removing the `[rabbitmq]` group from inventory.ini
+  Since then, he's done it again and can't reproduce the issue.
 - Remove RabbitMQ docs (`docs/source/services/rabbitmq/*`) and the
-  commcare-ports / firefighting references; publish a changelog entry.
-- **Caveat:** confirm no live environment still points `BROKER_URL` at AMQP
-  before removing — the localsettings broker wiring is shared with the (kept)
-  Redis broker, so touch only the AMQP-specific paths.
-Acceptance: no rabbitmq/AMQP install references remain; `deploy-stack` and Celery
-(on the Redis broker) are unaffected; `test_getinventory.py` is updated.
+  commcare-ports / firefighting references; publish a changelog entry  with
+  action: remove `[rabbitmq]` from inventory.
+Acceptance: no rabbitmq/AMQP install references remain; `deploy-stack` and
+Celery (on the Redis broker) are unaffected; `test_getinventory.py` is updated.
 
 #### 5. Remove the Prometheus install automation
 Remove `deploy_prometheus.yml` and all dependencies used only by it from

--- a/docs/plans/ansible-upgrade.md
+++ b/docs/plans/ansible-upgrade.md
@@ -12,30 +12,31 @@ with thin automated coverage today. CI (`.tests/tests.sh`) `--syntax-check`s
 `py3,commcarehq`-tagged subset of it against a `localhost`/`local`-connection
 test env, then byte-compiles the rendered `localsettings.py`. So most roles are
 parse-checked but never run, and standalone playbooks outside `deploy_stack.yml`
-(`deploy_hq.yml`, `deploy_prometheus.yml`, `deploy_postgres.yml`, the
+(`deploy_hq.yml`, `deploy_postgres.yml`, the
 `restart_*`/`deploy_citusdb`/`deploy_proxy` set, etc.) get neither. That
 coverage gap is the upgrade's biggest risk, so the test tickets come first.
 
 Sequence: clean up deprecations and build a test safety net first, then step
 through versions. The interpreter may move in two hops: **3.10 → 3.12** (spans
 Ansible 10–12), then **3.12 → 3.14** at the 12 → 14 jump (or one hop if 3.14
-tests pass early — #32 optional).
+tests pass early — #26 optional).
 
 ### Highest-risk changes (v5–v14)
 
 1. **Templating/conditional strictness**, peaking at core 2.19: string-boolean
    conditionals (v5), arithmetic outside `{{ }}` (v6), embedded-template
    conditionals (v8/CVE-2023-5764), and non-boolean `when:` as an error + native
-   Jinja + inverted trust model (v12). → tickets 21–23.
+   Jinja + inverted trust model (v12). → tickets 17–19.
 2. **Collection removals** in every major — in-use ones must be pinned and
    installed explicitly. → #7–10.
-3. **Collection upgrades/replacements** — see Appendix B. All four archived
-   cloudalchemy roles are removed **on 4.10, ahead of the Ansible-10 bump**, so
-   that bump (#28) stays a pure pin change: #12–13 self-contain the dimagi
-   collection (prometheus, then alertmanager), #14 cuts the release and adopts it
-   on 4.10, #15–16 vendor the two direct refs (grafana, then node_exporter) as
-   repo-local roles. #31 is then an *optional* post-Ansible-10 swap of those
-   vendored roles to upstream collections.
+3. **The monitoring-install automation is removed** — see
+   Appendix B. The archived `cloudalchemy.*` roles, the 2020-vintage
+   `dimagi.commcare_prometheus` collection, and their transitive
+   `gantsign.golang` + `bdellegrazie.postgres_exporter` were the biggest cluster
+   of incompatible/abandoned deps. Rather than vendor or re-base them, #12
+   *deletes* the Prometheus install automation outright and documents
+   user-managed Prometheus, keeping only the app-level metrics integration. This
+   clears the cluster before the Ansible-10 bump (#24) in one move.
 4. **Python floor jumps** (3.10 @ v9, 3.12 @ v13) and **UTF-8 locale enforced at
    startup** (v7).
 
@@ -44,11 +45,10 @@ tests pass early — #32 optional).
 ## Backlog
 
 "Depends" = ticket numbers. 1–2 are housekeeping; 3–6 build the test safety net;
-7–27 are version-agnostic cleanup (7–18 dependency work; 19–27 deprecation
-edits) and parallelize within their bands; 28–37 are mostly sequential version
-bumps + rollout (31 is optional — see there). Every cleanup ticket (7–27) must
-leave the tree green on 4.10 on its own, so that each bump (28/33/34) is a pin
-change with nothing left to fix.
+7–23 are version-agnostic cleanup (7–14 dependency work; 15–23 deprecation
+edits) and parallelize within their bands; 24–31 are mostly sequential version
+bumps + rollout. Every cleanup ticket (7–23) must leave the tree green on 4.10
+on its own, so that each bump (24/27/28) is a pin change with nothing left to fix.
 
 ### Housekeeping — independent, do first
 
@@ -67,12 +67,12 @@ Acceptance: none remain; 22.04 path unaffected.
 #### 3. CI lint + syntax for all playbooks
 Add `ansible-lint` (dev dep) and extend `--syntax-check` to cover the
 top-level playbooks *not* reached by the existing `deploy_stack.yml` check —
-`deploy_hq.yml`, `deploy_prometheus.yml`, `deploy_postgres.yml`, the
+`deploy_hq.yml`, `deploy_postgres.yml`, the
 `restart_*`/`deploy_citusdb`/`deploy_proxy` set, etc. (`deploy_stack.yml` and
-its ~18 imports are already syntax-checked by `.tests/tests.sh`); capture
-existing violations as a baseline. Full FQCN module normalization is
-low-priority baseline debt (short names resolve fine; collection moves are
-handled by #7–8).
+its ~18 imports are already syntax-checked by `.tests/tests.sh`; `deploy_prometheus.yml`
+is excluded — it's being removed in #12); capture existing violations as a
+baseline. Full FQCN module normalization is low-priority baseline debt (short
+names resolve fine; collection moves are handled by #7–8).
 Acceptance: new non-blocking `lint.yml` fails on new violations; green on day one.
 
 #### 4. Refresh Vagrant harness to 22.04
@@ -113,12 +113,14 @@ Add `ansible.posix` to `requirements.yml`, then FQCN-ify `synchronize` /
 `roles/setup_auth_keys.yml`.
 Acceptance: collection installs; refs resolve to `ansible.posix.*`; lint clean.
 
-#### 9. Audit `community.general` + the Dimagi collections
+#### 9. Audit `community.general` + `dimagi.commcare_logstash`
 Decide whether `community.general 7.4.0` is still required and at what version,
-and confirm `dimagi.commcare_prometheus` / `dimagi.commcare_logstash` load on
-the target cores. Record each collection's `requires_ansible` and confirm it
+and confirm `dimagi.commcare_logstash` loads on the target cores. (The other
+Dimagi collection, `dimagi.commcare_prometheus`, is removed in #12, so it drops
+out of this audit.) Record each collection's `requires_ansible` and confirm it
 admits core 2.21 (v14 excludes incompatible collections by default).
-Acceptance: necessity decision recorded; a compat-matrix entry per collection.
+Acceptance: necessity decision recorded; a compat-matrix entry per surviving
+collection.
 
 #### 10. Removed-collection audit (collections dropped v5–v14)
 The repo uses short module names (FQCN is ~6 tasks total), so grep the *short
@@ -129,103 +131,78 @@ Acceptance: nothing in-use silently disappears at any version step; pins added.
 
 #### 11. Standalone-role maintenance audit; drop orphaned roles
 Use the Appendix B matrix as the baseline: for each *role* in `requirements.yml`
-record archived flag, last activity, target-core compatibility.
-`bdellegrazie.postgres_exporter` and `gantsign.golang` appear only in
-`requirements.yml` *directly*, but both are **transitive deps** of
-`dimagi.commcare_prometheus` role metas (its `postgres_exporter` →
-`bdellegrazie.postgres_exporter`; `agg_pushgateway_exporter` /
-`airflow_exporter` → `gantsign.golang`) — not orphaned. Record the consumer;
-neither is droppable as-is. (`gantsign.golang`'s version bump is #30; the four
-`cloudalchemy.*` roles are handled across #12–16, with #31 the optional
-post-Ansible-10 upstream swap; the dead trivial roles are #17–18.)
+record archived flag, last activity, target-core compatibility. The monitoring
+roles (`cloudalchemy.*`, plus the transitive `gantsign.golang` /
+`bdellegrazie.postgres_exporter`) are removed wholesale in #12, so this ticket
+covers the survivors: `DavidWittman.redis`, `sansible.logstash`, the
+`andrewrothstein.*` couchdb roles.
 Acceptance: role compat matrix complete; orphaned pins removed or justified.
 
-#### 12. Vendor the `prometheus` install into `dimagi.commcare_prometheus`
-`cloudalchemy.prometheus` is archived and uses bare `include:` (removed in
-Ansible 9 / core 2.16), so it must go before the Ansible-10 bump (#28). The dimagi collection's
-`prometheus` role pulls it via a `meta` dependency; make that role carry its own
-install instead. The collection already ships ~16 self-contained roles, so this
-fits its design; **do not** re-base on `prometheus.prometheus` — its
-`requires_ansible >=2.14` floor would break the collection on core 2.11.
-This is a change in the **separate `dimagi/commcare-prometheus` repo** (last
-released 2020-10): replace the `cloudalchemy.prometheus` `meta` dep with vendored
-install tasks, written cross-version-safe (the #19–23 discipline) to run on
-**core 2.11 → 2.21**; set a permissive `requires_ansible` (≥2.11). **No release
-yet** — #14 cuts one release once alertmanager (#13) is also done.
-Prior art: [#6520](https://github.com/dimagi/commcare-cloud/pull/6520)
-(the in-place `cloudalchemy.prometheus` bump attempt) — **close here**,
-superseded by vendoring the install.
-Acceptance: the collection's `prometheus` role `meta` no longer lists
-`cloudalchemy.prometheus`; the vendored install is cross-version-safe (proven at
-#14's release/adopt).
+#### 12. Remove the Prometheus install automation (keep app-level metrics integration)
+**Decision (Slack thread below):** commcare-cloud will no longer *install* the
+Prometheus monitoring stack. Operators who want Prometheus/Grafana stand it up
+themselves following Prometheus' own docs. This deletes the largest cluster of
+archived/incompatible dependencies in one move — so none of it needs vendoring,
+version-bumping, or an upstream cutover.
+Grafana is in scope: it's confirmed to be exclusively the Prometheus dashboard
+front-end here (`cloudalchemy.grafana`, the `grafana` inventory group, and
+`grafana_*` vars are referenced only by `deploy_prometheus.yml`), with no
+standalone use — so it's removed along with everything else that playbook owns.
+**Remove (each confirmed referenced only by `deploy_prometheus.yml`):**
+- `deploy_prometheus.yml` (the whole server-install playbook — prometheus,
+  alertmanager, grafana, node_exporter, and the dimagi collection's ~18 exporter
+  roles). It is not imported by `deploy_stack.yml` and is not a CLI subcommand,
+  so removal is self-contained.
+- `requirements.yml` pins: `dimagi.commcare_prometheus`,
+  `cloudalchemy.prometheus` / `.alertmanager` / `.grafana` / `.node_exporter`,
+  `bdellegrazie.postgres_exporter`, `gantsign.golang`.
+- `group_vars/prometheus.yml` and `group_vars/alertmanager.yml` (server
+  scrape/alert config).
+- `environment/schemas/prometheus.py` + its wiring in `environment/main.py` (the
+  `prometheus_config` property/import). **Caveat:** this schema also carries
+  `prometheus_monitoring_enabled`, the toggle for the *kept* app-level feature —
+  so preserve a supported way to set that flag (keep just that field, or document
+  the override) while dropping the server-only `grafana_security` + scrape config.
+- The orphaned `grafana_nginx_ssl_cert` / `grafana_nginx_ssl_key` defs in
+  `roles/nginx/vars/main.yml` (defined, never rendered).
+- The `dimagi.commcare_prometheus` expectations in
+  `manage_commcare_cloud/tests/test_install.py` (update so the suite stays green).
+- The `prometheus`/`alertmanager`/`grafana`/`prometheus_proxy` inventory groups
+  become unused — drop them from example environments where present (minor).
+**Keep** (app-level, gated by `prometheus_monitoring_enabled`, independent of the
+server install — boundary confirmed clean): the `localsettings.py.j2`
+metrics-provider injection; `supervisor_prometheus.conf.j2` +
+`django_bash_runner.sh.j2`; the `PROMETHEUS_MULTIPROC_DIR` /
+`PROMETHEUS_PUSHGATEWAY_HOST` env wiring in the `commcarehq` role tasks
+(webworkers/pillowtop/management_commands/celery); the gated "Prometheus
+Supervisor Config" / "Prometheus Django runner" plays in `deploy_commcarehq.yml`;
+and `prometheus_monitoring_enabled` / `metrics_home` in `group_vars/all.yml`. HQ
+still exposes `/metrics`; an operator-run Prometheus scrapes it. (The pushgateway
+host becomes operator-supplied, since its config left with the server vars.)
+**Docs:** rewrite the Prometheus install section of
+`docs/source/operations/3-monitoring.rst` (the `cchq <env> aps deploy_prometheus.yml`
+instructions) to say Prometheus/Grafana setup is the operator's responsibility
+(link Prometheus' docs); drop the now-moot changelog
+`docs/source/changelog/0057-update-prometheus-variable.md`. The Datadog metrics
+listing in that rst is unrelated and stays.
+`dimagi.commcare_logstash` / `deploy_logstash.yml` are unrelated and stay.
+Prior art — both **close here**, superseded by removal:
+[#6520](https://github.com/dimagi/commcare-cloud/pull/6520) /
+[#6524](https://github.com/dimagi/commcare-cloud/pull/6524) (the cloudalchemy
+bump attempts).
+Acceptance: `deploy_prometheus.yml`, the seven monitoring pins,
+`group_vars/{prometheus,alertmanager}.yml`, and `schemas/prometheus.py` are gone;
+no `cloudalchemy.*` / `dimagi.commcare_prometheus` / `gantsign.golang` /
+`bdellegrazie.postgres_exporter` ref remains anywhere; `test_install.py` and the
+monitoring docs are updated; `deploy-stack` is unaffected; and with
+`prometheus_monitoring_enabled` still settable + set to `True`, the
+`deploy_commcarehq` path renders localsettings + supervisor configs
+(syntax/Molecule green with the flag both on and off).
 Depends: ideally 6.
-Open question on how to proceed with this upgrade:
+Decision thread:
 https://dimagi.slack.com/archives/CNQ636095/p1781277055592099?thread_ts=1781210489.586889&cid=CNQ636095
 
-#### 13. Vendor the `alertmanager` install into `dimagi.commcare_prometheus`
-Same pattern as #12 for the collection's `alertmanager` role (archived
-`cloudalchemy.alertmanager`, also bare-`include:`-based). Edit
-`dimagi/commcare-prometheus` only; again **no release here** — #14 cuts a single
-release covering both vendorings.
-Acceptance: the collection's `alertmanager` role `meta` no longer lists
-`cloudalchemy.alertmanager`; the vendored install is cross-version-safe.
-Depends: 12 (same collection/repo, sequential).
-
-#### 14. Release `dimagi.commcare_prometheus` + adopt it on 4.10
-Cut **one** new release of `dimagi/commcare-prometheus` carrying the #12 + #13
-vendoring (one release for both, not one per role — that keeps the upstream
-edits as their own steps and the release/adopt as a single logical step here).
-In commcare-cloud: bump the `dimagi.commcare_prometheus` pin to that release and
-**drop the `cloudalchemy.prometheus` + `cloudalchemy.alertmanager` pins** from
-`requirements.yml` (only the dimagi collection needed them).
-`deploy_prometheus.yml`'s `dimagi.commcare_prometheus.prometheus` / `.alertmanager`
-refs are unchanged — now backed by the vendored install.
-After this, the collection no longer pulls any cloudalchemy role; it still pulls
-`bdellegrazie.postgres_exporter` and `gantsign.golang` transitively (via its
-`postgres_exporter` and Go-exporter roles) — addressed in #11/#30, not here.
-Acceptance: new collection release with no `cloudalchemy.*` in any role's `meta`;
-pin bumped and both pins gone; monitoring still converges on 4.10; the vendored
-install runs clean through core 2.21 (re-verified at #28/#33/#34).
-Depends: 12, 13.
-
-#### 15. Vendor `cloudalchemy.grafana` as a repo-local role (on 4.10)
-`cloudalchemy.grafana` is archived and referenced **directly** in
-`deploy_prometheus.yml`. Its maintained upstream successor `grafana.grafana`
-floors at core 2.12, so it *cannot* be adopted on 4.10 — instead fork it into a
-repo-local role under `roles/` (the #17/#18 pattern — a copy we can fix forward)
-and fix its removed syntax cross-version-safe (core 2.11 → 2.21, the #19–23
-discipline):
-- 8× bare `include:` → `include_tasks:` (`tasks/main.yml`) — `include:` removed
-  in core 2.16.
-- 1× `warn: false` (`tasks/dashboards.yml`) — removed in core 2.14.
-- The `with_*` loops are deprecated-not-removed — fold into #20's mechanical
-  pass, not required to survive the Ansible-10 bump.
-Re-point `deploy_prometheus.yml` to the repo-local role and **drop the
-`cloudalchemy.grafana` pin**. Without this, the Ansible-10 bump (#28) could not be
-green and merged on its own (its `deploy_prometheus.yml` grafana path would be
-dead), which is why the upstream swap (#31) is deferred and optional.
-Acceptance: resolves to a repo-local role; no `cloudalchemy.grafana` pin/ref
-remains; monitoring converges on 4.10; role syntax-checks clean (re-verified on
-the new core at #28).
-Depends: ideally 6.
-
-#### 16. Vendor `cloudalchemy.node_exporter` as a repo-local role (on 4.10)
-Same approach as #15 for `cloudalchemy.node-exporter` (note the legacy hyphen),
-the other direct ref in `deploy_prometheus.yml`. Its successor
-`prometheus.prometheus.node_exporter` floors at core 2.14. The removed-syntax
-surface is smaller:
-- 1× `warn: false` (`tasks/preflight.yml`) — removed in core 2.14; `main.yml`
-  already uses `import_tasks`, so this subfile is the only hard break.
-- The `with_*` loops fold into #20, not required to survive the Ansible-10 bump.
-Re-point the ref and **drop the `cloudalchemy.node_exporter` pin**. With #14 + #15,
-this removes the **last** cloudalchemy pin — zero `cloudalchemy.*` remains
-anywhere, all on 4.10, before the Ansible-10 bump (#28).
-Acceptance: resolves to a repo-local role; no `cloudalchemy.node_exporter`
-pin/ref remains; monitoring converges on 4.10; role syntax-checks clean
-(re-verified at #28).
-Depends: ideally 6 (independent of #15).
-
-#### 17. Vendor or replace `tmpreaper` (`ANXS/tmpreaper`, dead since 2017)
+#### 13. Vendor or replace `tmpreaper` (`ANXS/tmpreaper`, dead since 2017)
 Abandoned but trivial; used in several playbooks. Risk is removed syntax
 (`with_items`, bare `warn:`, string-bool `when:`) failing on the target core.
 Fork into the repo as a local role under `roles/` (preferred — a maintainable
@@ -234,27 +211,27 @@ copy we can fix forward) or replace with a few inline tasks; re-point
 Acceptance: resolves to a repo-local role (or inline tasks); no abandoned pin
 remains; touched-role Molecule green on the target core.
 
-#### 18. Vendor or replace `ansible-logrotate` (`nickhammond`, dead since 2018)
-Same approach as #17. Heavily used — it's a `meta` dependency of `common`, so
+#### 14. Vendor or replace `ansible-logrotate` (`nickhammond`, dead since 2018)
+Same approach as #13. Heavily used — it's a `meta` dependency of `common`, so
 nearly every host pulls it; test broadly.
 Acceptance: resolves to a repo-local role (or inline tasks); no abandoned pin
 remains; `common`-dependent role Molecules green on the target core.
 
 ### Deprecation cleanup — version-agnostic, run on 4.10
 
-#### 19. Remove `warn:` on command/shell
+#### 15. Remove `warn:` on command/shell
 ~15, mostly `ping.yml`; removed in core 2.14.
 Acceptance: none remain; lint clean.
 
-#### 20. Convert `with_*` to `loop:` — largest change (~125 across ~21 files)
+#### 16. Convert `with_*` to `loop:` — largest change (~125 across ~21 files)
 Add appropriate filters/`lookup`. Mechanical; split on playbook and role.
 Prior art: [#6209](https://github.com/dimagi/commcare-cloud/pull/6209) /
 [#6235](https://github.com/dimagi/commcare-cloud/pull/6235) carry the same kind
-of mechanical loop/`include_tasks` rewrite, but they close in #21 (see there).
+of mechanical loop/`include_tasks` rewrite, but they close in #17 (see there).
 Acceptance: no `with_*` keys remain; touched role Molecules green.
-Depends: 6 (interleave with 7–8, 19).
+Depends: 6 (interleave with 7–8, 15).
 
-#### 21. Normalize shorthand, boolean, and string-boolean conditionals
+#### 17. Normalize shorthand, boolean, and string-boolean conditionals
 - Convert `action:`/`debug: msg=` to mapping form
 - `no/yes` → `false/true`.
 - **v5:** `when:` no longer coerces `"true"/"false"` strings (any non-empty
@@ -264,16 +241,16 @@ Prior art: [#6209](https://github.com/dimagi/commcare-cloud/pull/6209) /
 [#6235](https://github.com/dimagi/commcare-cloud/pull/6235) ("changes for
 ansible upgrade 9.1.0/9.2.0") are the `include:` → `include_tasks:` +
 module-shorthand rewrites — **close both here**. Their `include_tasks` portion
-also satisfies the mechanical work noted in #20.
+also satisfies the mechanical work noted in #16.
 Acceptance: lint clean; no `when:` relies on implicit string→bool.
 
-#### 22. Move arithmetic/concatenation inside Jinja (Ansible 6/core 2.13)
+#### 18. Move arithmetic/concatenation inside Jinja (Ansible 6/core 2.13)
 Arithmetic and concatenation are no longer allowed *outside* a Jinja template.
 `'[1] + {{ [2] }}'` → `'{{ [1] + [2] }}'`. Grep `}}` adjacent to operators.
 Acceptance: lint clean. Hard to fully detect on 4.10, so re-verify at 4→10.
 Depends: 6.
 
-#### 23. Harden conditional templating — highest-risk (the v8 + v12 arc)
+#### 19. Harden conditional templating — highest-risk (the v8 + v12 arc)
 - **v8/CVE-2023-5764** (core 2.15): embedded-template conditionals fail "unsafe"
   — reference untrusted values as plain Jinja vars, not embedded templates.
 - **v12** (core 2.19): non-boolean `when:` is now an error — make conditionals
@@ -282,139 +259,105 @@ Depends: 6.
   trusted strings render, and `omit` in loops drops immediately — flag dependents.
 Build the candidate list from a repo-wide grep of `when:` / `failed_when:` /
 `changed_when:` / `assert`.
-Acceptance: triaged on 4.10; full verification only on core 2.15 & 2.19 (see #33).
+Acceptance: triaged on 4.10; full verification only on core 2.15 & 2.19 (see #27).
 Depends: 6.
 
-#### 24. Fix ansible.cfg Galaxy URL
+#### 20. Fix ansible.cfg Galaxy URL
 `old-galaxy.ansible.com` → `galaxy.ansible.com`.
 Acceptance: galaxy installs resolve.
 
-#### 25. Update custom plugins/modules for the newer core API
+#### 21. Update custom plugins/modules for the newer core API
 `module_utils._text` → `module_utils.common.text.converters`; `logging.warn` →
 `warning`. Re-verify `cchq_aws_secret.py` and `library/*` against the target
 `AnsibleModule`. Files: `plugins/inventory/csv.py`,
 `plugins/lookup/cchq_aws_secret.py`, `library/*`.
 Acceptance: import/run on target core; `test_csv_inventory.py` passes.
 
-#### 26. Audit in-code `ansible.*` imports + version gate
+#### 22. Audit in-code `ansible.*` imports + version gate
 Review CLI imports (`InventoryManager`, `DataLoader`, `VariableManager`,
 vault/dumper helpers) for API drift; raise `min_ansible_version` (currently
 `2.10.0`) on each step.
 Acceptance: CLI imports succeed per target core; gate matches shipped version.
 
-#### 27. Audit Ansible 13/core-2.20 behavior changes
+#### 23. Audit Ansible 13/core-2.20 behavior changes
 Prefer `ansible_facts.*` over bare `ansible_*` facts (`INJECT_FACTS_AS_VARS`
 flips to `False` in 2.24); the `failed_when` suppressed-error key is now
 `failed_when_suppressed_exception`. `include_vars`: `extensions`/`ignore_files`
 must be lists, not strings.
-Acceptance: CLI imports succeed on each target core; verified at 12→14 (#34).
+Acceptance: CLI imports succeed on each target core; verified at 12→14 (#28).
 
 ### Version bumps — sequential, after cleanup + a full test pass
 
-#### 28. Ansible 4 → 10 (core 2.11→2.17)
+#### 24. Ansible 4 → 10 (core 2.11→2.17)
 The core/package bump. Ansible 10 is the highest reachable on Python 3.10.
 Raise the `ansible` pin and `min_ansible_version`; re-pin collections to
-core-2.17-compatible versions. Because all removed syntax — including the
-monitoring roles (#12–16) — was fixed on 4.10 in the cleanup band, this is a
-pure pin change with nothing left to break, and can be green and merged on its
-own. The surviving-role re-pins (#29) and `gantsign.golang` (#30) are
-version-coupled follow-ons that depend on this step but are *not* preconditions
-of declaring it done.
+core-2.17-compatible versions. Because all removed syntax was fixed on 4.10 in
+the cleanup band — and the archived monitoring stack was removed outright (#12)
+rather than carried forward — this is a pure pin change with nothing left to
+break, and can be green and merged on its own. The surviving-role re-pins (#25)
+are a version-coupled follow-on that depends on this step but is *not* a
+precondition of declaring it done.
 Prior art: Dependabot [#6895](https://github.com/dimagi/commcare-cloud/pull/6895)
 (ansible 4→10.7.0) and [#6444](https://github.com/dimagi/commcare-cloud/pull/6444)
 (ansible-core 2.11→2.17.7) — **close both here** (they only touch the pin, so
 can't merge until the cleanup band is done).
-Acceptance: core 2.17 installs; `deploy_hq.yml` **and `deploy_prometheus.yml`**
-syntax-check green on 2.17 (the latter proves #12–16 survived the bump);
+Acceptance: core 2.17 installs; `deploy_hq.yml` syntax-check green on 2.17;
 full Molecule suite green on 10.
 Fallback: bisect via 6/8 if failures are hard to localize.
-Depends: 7–27 (incl. 12–16).
+Depends: 7–23 (incl. 12).
 
-#### 29. Re-pin surviving standalone roles + re-test
+#### 25. Re-pin surviving standalone roles + re-test
 Bump the still-maintained roles to their newest releases and re-test on core
 2.17: `DavidWittman.redis`, `sansible.logstash`, the `andrewrothstein.*` SHAs
 (couchdb, couchdb-cluster). Done here because verification needs the new core.
 Acceptance: each touched role's Molecule (#6) green on 10; pins updated.
-Depends: 28.
+Depends: 24.
 
-#### 30. Bump `gantsign.golang`
-A live transitive dep (the collection's `agg_pushgateway_exporter` /
-`airflow_exporter` use it to build Go exporters), so it can't be dropped.
-Version-coupled: its latest (3.5.0) *requires core ≥2.17*, so it can only move
-at/after the Ansible-10 bump (#28) — bump it here.
-Acceptance: bumped and resolving on core 2.17; the two collection roles still
-build their exporters.
-Depends: 11, 28.
-
-#### 31. (Optional) Swap vendored grafana + node_exporter to upstream collections
-**Not a precondition of the Ansible-10 bump (#28)** — #15–16 already made these roles run on core
-2.17 as repo-local vendored copies, so the stack is green on 10 without this.
-This is a follow-on modernization that retires the vendored fork in favor of
-maintained upstream collections (less to maintain forward). Their successors
-floor at core 2.12 / 2.14, so it can only run post-Ansible-10. Do it when the fork
-maintenance burden justifies it; skip it otherwise.
-- Add `prometheus.prometheus` (`requires_ansible >=2.14.0,<=2.21.99`, for its
-  `node_exporter` role) and `grafana.grafana` (`>=2.12.0,<3.0.0`) to
-  `requirements.yml`. `prometheus.prometheus` pulls `community.general
-  >=1.0.0`, satisfied by the pinned 7.4.0 — coordinate with #9.
-- Compute and apply the `group_vars/` remap for the two roles: `grafana_*` →
-  `grafana.grafana` vars, `node_exporter_*` →
-  `prometheus.prometheus.node_exporter` vars (read from their upstream docs).
-- Swap `deploy_prometheus.yml` refs from the repo-local roles →
-  `grafana.grafana` and `prometheus.prometheus.node_exporter`, then delete the
-  vendored grafana/node_exporter roles from `roles/`.
-Prior art: [#6524](https://github.com/dimagi/commcare-cloud/pull/6524)
-(the in-place node_exporter bump — its "0.21.5 → 0.21.5" no-op proved the
-role is frozen) — **close here**, superseded by the #15–16 vendoring + this swap.
-Acceptance: upstream collections installed and consumed; vendored
-grafana/node_exporter roles deleted; monitoring Molecule/Vagrant stack
-converges on core ≥2.14; metrics scrape end-to-end (see Glossary).
-Depends: 15, 16, 28.
-
-#### 32. Controller Python 3.10 → 3.12
+#### 26. Controller Python 3.10 → 3.12
 3.12 is the latest Python explicitly supported by Ansible 10–12. Raise
 `requires-python`, `.python-version`, CI matrix, base images; refresh `uv.lock`.
 Optional: install + run tests on 3.14; if no blockers, jump to 3.14 here.
 Acceptance: full suite green on Python 3.14 or 3.12 / Ansible 10.
-Depends: 28 (with 29–30 green; 31 is optional and not required here).
+Depends: 24 (with 25 green).
 
-#### 33. Ansible 10 → 12 (core 2.17→2.19)
-Isolates the v12 templating overhaul, where #23 gets exercised and most breakage
+#### 27. Ansible 10 → 12 (core 2.17→2.19)
+Isolates the v12 templating overhaul, where #19 gets exercised and most breakage
 is expected. Re-pin collections.
 Prior art: Dependabot [#6758](https://github.com/dimagi/commcare-cloud/pull/6758)
 (ansible 4→12.2.0) is the pin diff for this jump — **close it here** (rebased
-onto the #28 result).
+onto the #24 result).
 Acceptance: full suite green on 12 with zero templating/conditional errors.
-Depends: 32, 23.
+Depends: 26, 19.
 
-#### 34. Ansible 12 → 14 (core 2.19→2.21)
-Confirm #27 changes and the per-collection `requires_ansible` gate (#9); final
-collection re-pin. Runs on the #32 interpreter (3.12, or 3.14 if the #32
+#### 28. Ansible 12 → 14 (core 2.19→2.21)
+Confirm #23 changes and the per-collection `requires_ansible` gate (#9); final
+collection re-pin. Runs on the #26 interpreter (3.12, or 3.14 if the #26
 optional was taken).
 Acceptance: full suite green on 14.
-Depends: 33, 27.
+Depends: 27, 23.
 
-#### 35. Controller Python 3.12 → 3.14
-Skip if #32 already reached 3.14. Core 2.20+ are the first to officially support
+#### 29. Controller Python 3.12 → 3.14
+Skip if #26 already reached 3.14. Core 2.20+ are the first to officially support
 Python 3.14. Raise `requires-python`, `.python-version`, CI matrix, base images;
 refresh `uv.lock`. Verify own deps publish 3.14 wheels (esp. `cryptography`);
 fall back to 3.13 if necessary.
 Acceptance: full suite green.
-Depends: 34.
+Depends: 28.
 
 ### Validation & rollout
 
-#### 36. Full-stack sign-off
+#### 30. Full-stack sign-off
 End-to-end `deploy-stack` on Vagrant and the `tests/cloud/` Docker harness
 against the final stack; idempotence pass.
 Acceptance: clean monolith install + re-converge with zero unexpected changes.
-Depends: 35, 5.
+Depends: 29, 5.
 
-#### 37. Docs
+#### 31. Docs
 New minimum Python, upgrade outcome, Molecule/Vagrant workflows,
-changelog.
+changelog. (The Prometheus "operator-managed" doc change lands with #12; this
+ticket covers the rest.)
 Acceptance: a new contributor can run the ansible test suite from docs alone.
-Depends: 36.
+Depends: 30.
 
 ---
 
@@ -423,12 +366,11 @@ Depends: 36.
 - **Converge** (Ansible/Molecule): apply a role/playbook to a target host. A run
   *converges* when it completes with no errors. Paired with **idempotence** — a
   second run reports **zero changes** — this is the standard pass condition for
-  Molecule scenarios (#5, #6) and full-stack re-runs (#36).
+  Molecule scenarios (#5, #6) and full-stack re-runs (#30).
 - **Scrape** (Prometheus): Prometheus' pull model — it periodically fetches the
-  `/metrics` HTTP endpoint each exporter exposes (e.g. node_exporter on `:9100`).
-  "Metrics scrape end-to-end" means the whole chain works: exporters are up and
-  serving, Prometheus is configured to pull them, and each target registers as
-  **up** on Prometheus' `/targets` page.
+  `/metrics` HTTP endpoint a target exposes. After #12, HQ still exposes its
+  metrics endpoint (the kept app-level integration), but the Prometheus server
+  that scrapes it is operator-managed, not installed by commcare-cloud.
 
 ---
 
@@ -460,70 +402,67 @@ https://docs.ansible.com/projects/ansible/latest/reference_appendices/release_an
 A previous contributor, pvisweswar, attempted this upgrade
 ([SAAS-14998](https://dimagi.atlassian.net/browse/SAAS-14998) /
 [SAAS-16650](https://dimagi.atlassian.net/browse/SAAS-16650)) and stalled on
-unmaintained standalone Galaxy roles. The artifacts are still open and may be
-useful prior art:
+unmaintained standalone Galaxy roles — chiefly the monitoring stack. The
+artifacts are still open and may be useful prior art:
 
 - [#6209](https://github.com/dimagi/commcare-cloud/pull/6209) /
   [#6235](https://github.com/dimagi/commcare-cloud/pull/6235) ("changes for
   ansible upgrade 9.1.0 / 9.2.0", branches `ansible/upgrade`,
   `ansible/upgrade-9.2.0`) — the `include:` → `include_tasks:` and
-  module-shorthand cleanups (overlaps #20–21 here).
+  module-shorthand cleanups (overlaps #16–17 here).
 - [#6520](https://github.com/dimagi/commcare-cloud/pull/6520) /
   [#6524](https://github.com/dimagi/commcare-cloud/pull/6524) ("Upgrading
   Ansible dependency for cloudalchemy.prometheus / node_exporter",
   [SAAS-16650](https://dimagi.atlassian.net/browse/SAAS-16650)) — the attempt to
   move the monitoring roles forward. #6524 bumps node_exporter "0.21.5 → 0.21.5"
   — a no-op, because the role is frozen at its final release. That dead end is
-  the core finding below.
+  what motivates removing the monitoring install outright (#12) instead of
+  upgrading it.
 
 **Maintenance audit of every dependency in `ansible/requirements.yml`** (checked
 against GitHub archived flag + last push, June 2026):
 
 | Dependency | Repo | State | Last activity | Verdict |
 |--|--|--|--|--|
-| `cloudalchemy.prometheus` | cloudalchemy/ansible-prometheus | **ARCHIVED 2023-03** | rel 4.0.0 (2021-05) | **DEAD** → vendored into `dimagi.commcare_prometheus` on 4.10 (#12, released/adopted in #14) |
-| `cloudalchemy.alertmanager` | cloudalchemy/ansible-alertmanager | **ARCHIVED 2023-03** | rel 0.19.1 (2020-09) | **DEAD** → vendored into `dimagi.commcare_prometheus` on 4.10 (#13, released/adopted in #14) |
-| `cloudalchemy.grafana` | cloudalchemy/ansible-grafana | **ARCHIVED 2023-05** | rel 0.17.0 (2020-03) | **DEAD** → vendored repo-local on 4.10 (#15; fixes 8× `include:` + 1× `warn:`); optional upstream swap → `grafana.grafana` post-Ansible-10 (#31) |
-| `cloudalchemy.node_exporter` | cloudalchemy/ansible-node-exporter | **ARCHIVED 2023-03** | rel 2.0.0 (2021-04) | **DEAD** → vendored repo-local on 4.10 (#16; fixes 1× `warn:` in `preflight.yml`); optional upstream swap → `prometheus.prometheus.node_exporter` post-bump (#31, renamed `node-exporter`→`node_exporter`) |
-| `bdellegrazie.postgres_exporter` | bdellegrazie/ansible-role-postgres_exporter | stale | 2022-12 | **transitive dep** of `dimagi.commcare_prometheus.postgres_exporter` (its `meta` requires it) — not orphaned; stale (2022). Keep/re-test (#11) |
-| `gantsign.golang` | gantsign/ansible-role-golang | active | rel 3.5.0 (2025-04) | **transitive dep** of the collection's `agg_pushgateway_exporter` + `airflow_exporter` (build Go exporters) — not orphaned; **version-coupled** (latest *requires* core ≥2.17), bump at #30 (#11) |
-| `DavidWittman.redis` | DavidWittman/ansible-redis | semi-active | rel 1.2.12 (2024-01), 57 open issues | re-test on target core; bump if needed (#29) |
-| `sansible.logstash` | sansible/logstash | low activity | v2.4.4 | re-test on target core (#29) |
-| `andrewrothstein.couchdb` | andrewrothstein/ansible-couchdb | maintained | 2024-06 (SHA-pinned, no releases) | re-test; keep SHA pin (#29) |
-| `andrewrothstein.couchdb-cluster-*` | dimagi/ansible-couchdb-cluster | Dimagi fork | 2023-03 (SHA-pinned) | we own it — fix forward if it breaks (#29) |
-| `tmpreaper` (`ANXS/tmpreaper`) | ANXS/tmpreaper | **DEAD** | **2017-07** | trivial role — vendor or replace (#17) |
-| `ansible-logrotate` | nickhammond/ansible-logrotate | **DEAD** | **2018-10** (v0.0.5) | trivial role — vendor or replace (#18) |
-| `dimagi.commcare_prometheus` | dimagi/commcare-prometheus | Dimagi, stale | rel 0.1.10 (**2020-10**) | **cross-repo work required** (#12–14) — see below |
+| `cloudalchemy.prometheus` | cloudalchemy/ansible-prometheus | **ARCHIVED 2023-03** | rel 4.0.0 (2021-05) | **DEAD** → removed with the Prometheus install automation (#12) |
+| `cloudalchemy.alertmanager` | cloudalchemy/ansible-alertmanager | **ARCHIVED 2023-03** | rel 0.19.1 (2020-09) | **DEAD** → removed (#12) |
+| `cloudalchemy.grafana` | cloudalchemy/ansible-grafana | **ARCHIVED 2023-05** | rel 0.17.0 (2020-03) | **DEAD** → removed (#12) |
+| `cloudalchemy.node_exporter` | cloudalchemy/ansible-node-exporter | **ARCHIVED 2023-03** | rel 2.0.0 (2021-04) | **DEAD** → removed (#12) |
+| `bdellegrazie.postgres_exporter` | bdellegrazie/ansible-role-postgres_exporter | stale | 2022-12 | transitive dep of `dimagi.commcare_prometheus.postgres_exporter` — removed with it (#12) |
+| `gantsign.golang` | gantsign/ansible-role-golang | active | rel 3.5.0 (2025-04) | transitive dep of the collection's Go-exporter roles — removed with it (#12); only the monitoring stack used it |
+| `dimagi.commcare_prometheus` | dimagi/commcare-prometheus | Dimagi, stale | rel 0.1.10 (**2020-10**) | only consumed by `deploy_prometheus.yml` → removed (#12) |
+| `DavidWittman.redis` | DavidWittman/ansible-redis | semi-active | rel 1.2.12 (2024-01), 57 open issues | re-test on target core; bump if needed (#25) |
+| `sansible.logstash` | sansible/logstash | low activity | v2.4.4 | re-test on target core (#25) |
+| `andrewrothstein.couchdb` | andrewrothstein/ansible-couchdb | maintained | 2024-06 (SHA-pinned, no releases) | re-test; keep SHA pin (#25) |
+| `andrewrothstein.couchdb-cluster-*` | dimagi/ansible-couchdb-cluster | Dimagi fork | 2023-03 (SHA-pinned) | we own it — fix forward if it breaks (#25) |
+| `tmpreaper` (`ANXS/tmpreaper`) | ANXS/tmpreaper | **DEAD** | **2017-07** | trivial role — vendor or replace (#13) |
+| `ansible-logrotate` | nickhammond/ansible-logrotate | **DEAD** | **2018-10** (v0.0.5) | trivial role — vendor or replace (#14) |
 | `dimagi.commcare_logstash` | dimagi/commcare-logstash | Dimagi | 2022-01 (0.9.5) | re-test; we own it (#9) |
 | `community.general` | (collection) | active | pinned 7.4.0 | bump in lockstep with core (#9) |
 
-**Why the cloudalchemy roles can't just be deleted:**
-`deploy_prometheus.yml` imports `dimagi.commcare_prometheus.prometheus` and
-`...alertmanager`, and those vendored roles' `meta/main.yml` declare
-`dependencies: [cloudalchemy.prometheus]` / `[cloudalchemy.alertmanager]`.
-Grafana and node-exporter are imported from cloudalchemy **directly** in the
-playbook (`cloudalchemy.grafana`, `cloudalchemy.node-exporter` — note the legacy
-hyphen). So two of the four archived roles (prometheus, alertmanager) are
-pulled in *transitively through a separate, 2020-vintage Dimagi-owned
-collection repo* — those are removed on 4.10 in #12–14 by self-containing that
-collection (editing `dimagi/commcare-prometheus` in #12–13, then releasing +
-bumping the pin in #14).
-The other two (grafana, node_exporter) are direct refs. Their maintained
-upstream successors floor at core 2.12 / 2.14, so they *cannot* be adopted on
-4.10. To keep the bump (#28) free of monitoring breakage and independently
-mergeable, #15–16 instead vendor them as repo-local roles and fix their removed
-syntax cross-version-safe on 4.10 (the same treatment #12–14 give
-prometheus/alertmanager, and #17/#18 give tmpreaper/logrotate). The upstream
-cutover (#31) then becomes an *optional* post-bump cleanup, not a bump
-precondition. After #12–16, no `cloudalchemy.*` pin or ref survives into the
-bump.
+**Why the monitoring stack is removed rather than upgraded (#12):**
+`deploy_prometheus.yml` is the only consumer of the whole monitoring dependency
+chain. It imports `dimagi.commcare_prometheus.prometheus` / `.alertmanager`
+(whose `meta` declare `dependencies: [cloudalchemy.prometheus]` /
+`[cloudalchemy.alertmanager]`), and imports `cloudalchemy.grafana` /
+`cloudalchemy.node-exporter` **directly** (note the legacy hyphen); the dimagi
+collection's exporter roles pull `bdellegrazie.postgres_exporter` and
+`gantsign.golang` transitively. **All four cloudalchemy roles are archived and
+frozen** (the #6524 "0.21.5 → 0.21.5" no-op proved node_exporter can't move),
+their maintained successors floor at core 2.12 / 2.14, and the dimagi collection
+last released in 2020 — so carrying them forward meant vendoring and
+cross-version-fixing a stack we don't otherwise need. Since `deploy_prometheus.yml`
+is **not** part of `deploy-stack` and **not** a CLI subcommand, deleting it (plus
+the seven pins and the two server `group_vars` files) is self-contained and
+removes the entire cluster at once. The app-level metrics integration is a
+*separate*, cleanly-decoupled concern (gated by `prometheus_monitoring_enabled`
+in `group_vars/all.yml`, never touching the install roles), so it stays and HQ
+keeps exposing `/metrics` for an operator-managed Prometheus to scrape.
 
-**Successor target versions** for the optional #31 swap (both admit the v14
-ceiling, confirmed via `meta/runtime.yml`): `prometheus.prometheus`
-`requires_ansible >=2.14.0,<=2.21.99` (bundles prometheus, alertmanager,
-node_exporter, *and* postgres_exporter roles); `grafana.grafana`
-`requires_ansible >=2.12.0,<3.0.0`. The 2.12 / 2.14 floors are why these can't
-be adopted on 4.10 — hence the #15–16 vendoring steps.
+If managed monitoring is ever wanted back, the modern upstream successors are
+`prometheus.prometheus` (`requires_ansible >=2.14.0,<=2.21.99`, bundles
+prometheus/alertmanager/node_exporter/postgres_exporter) and `grafana.grafana`
+(`>=2.12.0,<3.0.0`) — both core-2.14+, so only adoptable post-bump.
 
 ---
 
@@ -532,16 +471,14 @@ be adopted on 4.10 — hence the #15–16 vendoring steps.
 - **Depends** should be encoded as ticket links in the ticket description.
 - **Acceptance** should include ticket links where appropriate.
 - **Verification layers:** lint + syntax (CI, #3); Molecule converge/idempotence
-  (#5, #6); Vagrant + `tests/cloud/` full-stack (#4, #36); pytest CLI suite on
+  (#5, #6); Vagrant + `tests/cloud/` full-stack (#4, #30); pytest CLI suite on
   the target Python/core.
 - **Local constraint:** ansible is never run on the dev machine — bumps are
   validated in CI and on Vagrant/Docker targets only.
 - **Open questions:** confirm...
   - 14.x has a stable collection set at execution.
   - whether `community.general 7.4.0` needs bumping in lockstep with the cores.
-  - that we need to maintain prometheus/grafana automation at all.
-  - whether `prometheus.prometheus` / `grafana.grafana` defaults differ enough
-    from the cloudalchemy roles to need group_vars remapping beyond the #31
-    cutover's estimate.
+  - ~~whether we need to maintain prometheus/grafana automation at all~~ —
+    **resolved:** no; #12 removes it and documents operator-managed Prometheus.
   - add an Ansible 11 stop only if the SSH/Windows or docker-default changes
     prove relevant (unlikely — commcare-cloud targets Linux).

--- a/docs/plans/ansible-upgrade.md
+++ b/docs/plans/ansible-upgrade.md
@@ -1,0 +1,478 @@
+# Ansible Upgrade + Test Coverage — Jira Backlog
+
+## Context
+
+commcare-cloud is pinned to **Ansible 4.10 (core 2.11)** on **controller Python
+3.10** — years past EOL, blocking security fixes and modern syntax. Goal: reach
+**Ansible 14 (core 2.21)** on **Python 3.14**.
+
+Scale: 53 roles, 63 playbooks, ~307 YAML files, plus custom modules/plugins,
+with thin automated coverage today. CI (`.tests/tests.sh`) `--syntax-check`s
+`deploy_stack.yml` (the ~18 playbooks it imports) and *executes* only the
+`py3,commcarehq`-tagged subset of it against a `localhost`/`local`-connection
+test env, then byte-compiles the rendered `localsettings.py`. So most roles are
+parse-checked but never run, and standalone playbooks outside `deploy_stack.yml`
+(`deploy_hq.yml`, `deploy_prometheus.yml`, `deploy_postgres.yml`, the
+`restart_*`/`deploy_citusdb`/`deploy_proxy` set, etc.) get neither. That
+coverage gap is the upgrade's biggest risk, so the test tickets come first.
+
+Sequence: clean up deprecations and build a test safety net first, then step
+through versions. The interpreter may move in two hops: **3.10 → 3.12** (spans
+Ansible 10–12), then **3.12 → 3.14** at the 12 → 14 jump (or one hop if 3.14
+tests pass early — #28 optional).
+
+### Highest-risk changes (v5–v14)
+
+1. **Templating/conditional strictness**, peaking at core 2.19: string-boolean
+   conditionals (v5), arithmetic outside `{{ }}` (v6), embedded-template
+   conditionals (v8/CVE-2023-5764), and non-boolean `when:` as an error + native
+   Jinja + inverted trust model (v12). → tickets 17–19.
+2. **Collection removals** in every major — in-use ones must be pinned and
+   installed explicitly. → #7–10.
+3. **Collection upgrades/replacements** — see Appendix B. Broken out across
+   #12 (self-contain the dimagi collection + adopt on 4.10, removing 2 of 4
+   cloudalchemy roles) and #27 (grafana + node_exporter to upstream at the bump).
+4. **Python floor jumps** (3.10 @ v9, 3.12 @ v13) and **UTF-8 locale enforced at
+   startup** (v7).
+
+---
+
+## Backlog
+
+"Depends" = ticket numbers. 1–2 are housekeeping; 3–6 build the test safety net;
+7–23 are version-agnostic cleanup (7–14 dependency work, 15–23 deprecation
+edits) and parallelize within their bands; 24–33 are strictly sequential version
+bumps + rollout.
+
+### Housekeeping — independent, do first
+
+#### 1. Drop `gitpython`
+Used once in `ops_tool.py` (`git.Repo(search_parent_directories=True)`); replace
+with a `subprocess` git call and remove from `pyproject.toml`/`uv.lock`.
+Acceptance: repo root still resolves; dep gone; tests green.
+
+#### 2. Remove stale Ubuntu 18.04 references
+18.04 is unsupported. Search `18.04|bionic`.
+Delete `ansible_distribution_version == '18.04'` branches.
+Acceptance: none remain; 22.04 path unaffected.
+
+### Safety net — build verification before touching versions
+
+#### 3. CI lint + syntax for all playbooks
+Add `ansible-lint` (dev dep) and extend `--syntax-check` to cover the
+top-level playbooks *not* reached by the existing `deploy_stack.yml` check —
+`deploy_hq.yml`, `deploy_prometheus.yml`, `deploy_postgres.yml`, the
+`restart_*`/`deploy_citusdb`/`deploy_proxy` set, etc. (`deploy_stack.yml` and
+its ~18 imports are already syntax-checked by `.tests/tests.sh`); capture
+existing violations as a baseline. Full FQCN module normalization is
+low-priority baseline debt (short names resolve fine; collection moves are
+handled by #7–8).
+Acceptance: new non-blocking `lint.yml` fails on new violations; green on day one.
+
+#### 4. Refresh Vagrant harness to 22.04
+`Vagrantfile` is `ubuntu/bionic64` (18.04); upgrade it, verify provisioning,
+document the local full-stack flow.
+Acceptance: `vagrant up` + `deploy-stack` completes on 22.04 on current Ansible.
+
+#### 5. Molecule scaffolding + one reference role
+Add Molecule (docker driver) with a shared base config and a worked example for
+one simple role (e.g. `swap` or `logrotate`, which already has a `tests/` stub).
+Wire a Molecule job into CI. Document "how to add a Molecule scenario." Keep
+test code separate from production code.
+Acceptance: `molecule test` converge + idempotence green locally and in CI on 22.04.
+
+#### 6. Molecule coverage for critical roles
+Add Molecule converge/idempotence scenarios for the operationally critical,
+untested roles: postgresql(_base), pgbouncer, couchdb2, kafka, redis, rabbitmq,
+elasticsearch, nginx, proxy/haproxy. Likely one Jira ticket per role/group.
+Acceptance: each converges twice with no changes; basic service-up asserts.
+Depends: 5.
+
+### Dependency work — collections + roles, version-agnostic, run on 4.10
+
+#### 7. Adopt `community.postgresql` (declare + migrate `postgresql_*`)
+Add `community.postgresql` to `requirements.yml`, then FQCN-ify
+`postgresql_user/db/privs/set/query` and drop `encrypted:` (removed in core 2.15).
+Files:
+- `roles/postgresql_base/tasks/set_up_dbs.yml`
+- `roles/postgresql_base/tasks/main.yml`
+- any playbook needing a `collections:` entry.
+Acceptance: `ansible-galaxy install -r` resolves the collection; Molecule
+postgres (#6) + syntax clean.
+Depends: ideally 6.
+
+#### 8. Adopt `ansible.posix` (declare + migrate `synchronize`/`authorized_key`)
+Add `ansible.posix` to `requirements.yml`, then FQCN-ify `synchronize` /
+`authorized_key` in `roles/deploy_hq/tasks/staticfiles_*` and
+`roles/setup_auth_keys.yml`.
+Acceptance: collection installs; refs resolve to `ansible.posix.*`; lint clean.
+
+#### 9. Audit `community.general` + the Dimagi collections
+Decide whether `community.general 7.4.0` is still required and at what version,
+and confirm `dimagi.commcare_prometheus` / `dimagi.commcare_logstash` load on
+the target cores. Record each collection's `requires_ansible` and confirm it
+admits core 2.21 (v14 excludes incompatible collections by default).
+Acceptance: necessity decision recorded; a compat-matrix entry per collection.
+
+#### 10. Removed-collection audit (collections dropped v5–v14)
+The repo uses short module names (FQCN is ~6 tasks total), so grep the *short
+module names* of every collection removed from the `ansible` package across
+v5–v14 (per each version's changelog). Pin and explicitly install any still in
+use.
+Acceptance: nothing in-use silently disappears at any version step; pins added.
+
+#### 11. Standalone-role maintenance audit; drop orphaned roles
+Use the Appendix B matrix as the baseline: for each *role* in `requirements.yml`
+record archived flag, last activity, target-core compatibility.
+`bdellegrazie.postgres_exporter` and `gantsign.golang` appear only in
+`requirements.yml` *directly*, but both are **transitive deps** of
+`dimagi.commcare_prometheus` role metas (its `postgres_exporter` →
+`bdellegrazie.postgres_exporter`; `agg_pushgateway_exporter` /
+`airflow_exporter` → `gantsign.golang`) — not orphaned. Record the consumer;
+neither is droppable as-is. (`gantsign.golang`'s version bump is #26; the
+`cloudalchemy.*` roles are #12/#27; the dead trivial roles are #13–14.)
+Acceptance: role compat matrix complete; orphaned pins removed or justified.
+
+#### 12. Replace cloudalchemy in `dimagi.commcare_prometheus` + adopt on 4.10
+Make the collection carry its own `prometheus`/`alertmanager` install so it
+no longer depends on the archived cloudalchemy roles. This removes two of the
+four cloudalchemy roles (the other two are direct refs, handled in #27). The
+collection already ships ~16 self-contained roles of its own, so this fits its
+design; **do not** re-base on `prometheus.prometheus` — that imposes a
+`requires_ansible >=2.14` floor and would break the collection on core 2.11.
+- In `dimagi/commcare-prometheus` (separate repo, last released 2020-10):
+  replace the `cloudalchemy.prometheus` / `cloudalchemy.alertmanager` `meta`
+  deps with vendored install tasks, written cross-version-safe (the #15–19
+  discipline) to run on **core 2.11 → 2.21**; set a permissive
+  `requires_ansible` (≥2.11); cut a new release.
+- In commcare-cloud: bump the `dimagi.commcare_prometheus` pin to the new
+  release, then **drop the `cloudalchemy.prometheus` +
+  `cloudalchemy.alertmanager` pins** from `requirements.yml` (only the dimagi
+  roles needed them). `deploy_prometheus.yml`'s
+  `dimagi.commcare_prometheus.prometheus` / `.alertmanager` refs are
+  unchanged — now backed by the vendored install.
+This removes only the *archived* cloudalchemy deps; the collection still pulls
+`bdellegrazie.postgres_exporter` and `gantsign.golang` transitively (via its
+`postgres_exporter` and Go-exporter roles) — maintained-ish, not addressed here.
+Prior art: [#6520](https://github.com/dimagi/commcare-cloud/pull/6520)
+(the in-place `cloudalchemy.prometheus` bump attempt) — **close here**,
+superseded by vendoring the install.
+Acceptance: new release with no `cloudalchemy.*` in any role's `meta`;
+commcare-cloud pin bumped and those two pins gone; monitoring still converges
+on 4.10; the vendored roles install clean through core 2.21 (re-verified at
+#24/#29/#30).
+Depends: ideally 6.
+Open question on how to proceed with this upgrade:
+https://dimagi.slack.com/archives/CNQ636095/p1781277055592099?thread_ts=1781210489.586889&cid=CNQ636095
+
+#### 13. Vendor or replace `tmpreaper` (`ANXS/tmpreaper`, dead since 2017)
+Abandoned but trivial; used in several playbooks. Risk is removed syntax
+(`with_items`, bare `warn:`, string-bool `when:`) failing on the target core.
+Fork into the repo as a local role under `roles/` (preferred — a maintainable
+copy we can fix forward) or replace with a few inline tasks; re-point
+`requirements.yml` / refs.
+Acceptance: resolves to a repo-local role (or inline tasks); no abandoned pin
+remains; touched-role Molecule green on the target core.
+
+#### 14. Vendor or replace `ansible-logrotate` (`nickhammond`, dead since 2018)
+Same approach as #13. Heavily used — it's a `meta` dependency of `common`, so
+nearly every host pulls it; test broadly.
+Acceptance: resolves to a repo-local role (or inline tasks); no abandoned pin
+remains; `common`-dependent role Molecules green on the target core.
+
+### Deprecation cleanup — version-agnostic, run on 4.10
+
+#### 15. Remove `warn:` on command/shell
+~15, mostly `ping.yml`; removed in core 2.14.
+Acceptance: none remain; lint clean.
+
+#### 16. Convert `with_*` to `loop:` — largest change (~125 across ~21 files)
+Add appropriate filters/`lookup`. Mechanical; split on playbook and role.
+Prior art: [#6209](https://github.com/dimagi/commcare-cloud/pull/6209) /
+[#6235](https://github.com/dimagi/commcare-cloud/pull/6235) carry the same kind
+of mechanical loop/`include_tasks` rewrite, but they close in #17 (see there).
+Acceptance: no `with_*` keys remain; touched role Molecules green.
+Depends: 6 (interleave with 7–8, 15).
+
+#### 17. Normalize shorthand, boolean, and string-boolean conditionals
+- Convert `action:`/`debug: msg=` to mapping form
+- `no/yes` → `false/true`.
+- **v5:** `when:` no longer coerces `"true"/"false"` strings (any non-empty
+  string is truthy) — inspect `when:`/`failed_when:`/`changed_when:` on string
+  vars and add `| bool`. Silent change: found by inspection, not lint.
+Prior art: [#6209](https://github.com/dimagi/commcare-cloud/pull/6209) /
+[#6235](https://github.com/dimagi/commcare-cloud/pull/6235) ("changes for
+ansible upgrade 9.1.0/9.2.0") are the `include:` → `include_tasks:` +
+module-shorthand rewrites — **close both here**. Their `include_tasks` portion
+also satisfies the mechanical work noted in #16.
+Acceptance: lint clean; no `when:` relies on implicit string→bool.
+
+#### 18. Move arithmetic/concatenation inside Jinja (Ansible 6/core 2.13)
+Arithmetic and concatenation are no longer allowed *outside* a Jinja template.
+`'[1] + {{ [2] }}'` → `'{{ [1] + [2] }}'`. Grep `}}` adjacent to operators.
+Acceptance: lint clean. Hard to fully detect on 4.10, so re-verify at 4→10.
+Depends: 6.
+
+#### 19. Harden conditional templating — highest-risk (the v8 + v12 arc)
+- **v8/CVE-2023-5764** (core 2.15): embedded-template conditionals fail "unsafe"
+  — reference untrusted values as plain Jinja vars, not embedded templates.
+- **v12** (core 2.19): non-boolean `when:` is now an error — make conditionals
+  explicitly boolean.
+- **v12 native Jinja + trust model:** non-strings don't auto-stringify, only
+  trusted strings render, and `omit` in loops drops immediately — flag dependents.
+Build the candidate list from a repo-wide grep of `when:` / `failed_when:` /
+`changed_when:` / `assert`.
+Acceptance: triaged on 4.10; full verification only on core 2.15 & 2.19 (see #29).
+Depends: 6.
+
+#### 20. Fix ansible.cfg Galaxy URL
+`old-galaxy.ansible.com` → `galaxy.ansible.com`.
+Acceptance: galaxy installs resolve.
+
+#### 21. Update custom plugins/modules for the newer core API
+`module_utils._text` → `module_utils.common.text.converters`; `logging.warn` →
+`warning`. Re-verify `cchq_aws_secret.py` and `library/*` against the target
+`AnsibleModule`. Files: `plugins/inventory/csv.py`,
+`plugins/lookup/cchq_aws_secret.py`, `library/*`.
+Acceptance: import/run on target core; `test_csv_inventory.py` passes.
+
+#### 22. Audit in-code `ansible.*` imports + version gate
+Review CLI imports (`InventoryManager`, `DataLoader`, `VariableManager`,
+vault/dumper helpers) for API drift; raise `min_ansible_version` (currently
+`2.10.0`) on each step.
+Acceptance: CLI imports succeed per target core; gate matches shipped version.
+
+#### 23. Audit Ansible 13/core-2.20 behavior changes
+Prefer `ansible_facts.*` over bare `ansible_*` facts (`INJECT_FACTS_AS_VARS`
+flips to `False` in 2.24); the `failed_when` suppressed-error key is now
+`failed_when_suppressed_exception`. `include_vars`: `extensions`/`ignore_files`
+must be lists, not strings.
+Acceptance: CLI imports succeed on each target core; verified at 12→14 (#30).
+
+### Version bumps — sequential, after cleanup + a full test pass
+
+#### 24. Ansible 4 → 10 (core 2.11→2.17)
+The core/package bump. Ansible 10 is the highest reachable on Python 3.10.
+Raise the `ansible` pin and `min_ansible_version`; re-pin collections to
+core-2.17-compatible versions. This step gets the `deploy_hq.yml` path green
+on 10; the monitoring stack (#27), surviving-role re-pins (#25), and
+`gantsign.golang` (#26) complete the full "green on 10" sign-off and each
+depend on this step.
+Prior art: Dependabot [#6895](https://github.com/dimagi/commcare-cloud/pull/6895)
+(ansible 4→10.7.0) and [#6444](https://github.com/dimagi/commcare-cloud/pull/6444)
+(ansible-core 2.11→2.17.7) — **close both here** (they only touch the pin, so
+can't merge until the cleanup band is done). Breaks `deploy_prometheus.yml`?
+Acceptance: core 2.17 installs; `deploy_hq.yml` syntax + Molecule suite green on 10.
+Fallback: bisect via 6/8 if failures are hard to localize.
+Depends: 7–23.
+
+#### 25. Re-pin surviving standalone roles + re-test
+Bump the still-maintained roles to their newest releases and re-test on core
+2.17: `DavidWittman.redis`, `sansible.logstash`, the `andrewrothstein.*` SHAs
+(couchdb, couchdb-cluster). Done here because verification needs the new core.
+Acceptance: each touched role's Molecule (#6) green on 10; pins updated.
+Depends: 24.
+
+#### 26. Bump `gantsign.golang`
+A live transitive dep (the collection's `agg_pushgateway_exporter` /
+`airflow_exporter` use it to build Go exporters), so it can't be dropped.
+Version-coupled: its latest (3.5.0) *requires core ≥2.17*, so it can only move
+at/after the bump — bump it here.
+Acceptance: bumped and resolving on core 2.17; the two collection roles still
+build their exporters.
+Depends: 11, 24.
+
+#### 27. Cut over grafana + node_exporter to maintained upstream collections
+The remaining, genuinely core-gated half: the two cloudalchemy roles
+referenced **directly** in `deploy_prometheus.yml` (`cloudalchemy.grafana`,
+`cloudalchemy.node-exporter`). Their maintained successors floor at core
+2.12 / 2.14, so this is verified only once #24 has crossed that floor; the
+archived roles carry no `requires_ansible` ceiling so they don't block #24,
+but they break on the new core until this lands — so it co-lands with #24.
+(prometheus + alertmanager were already removed on 4.10 in #12.) This is the
+first PR that references these successor collections, so it adds and consumes
+them in one atomic change:
+- Add `prometheus.prometheus` (`requires_ansible >=2.14.0,<=2.21.99`, for its
+  `node_exporter` role) and `grafana.grafana` (`>=2.12.0,<3.0.0`) to
+  `requirements.yml`. `prometheus.prometheus` pulls `community.general
+  >=1.0.0`, satisfied by the pinned 7.4.0 — coordinate with #9.
+- Compute and apply the `group_vars/` remap for the two roles: `grafana_*` →
+  `grafana.grafana` vars, `node_exporter_*` →
+  `prometheus.prometheus.node_exporter` vars (read from their upstream docs).
+- Swap `deploy_prometheus.yml` refs `cloudalchemy.grafana` →
+  `grafana.grafana` and `cloudalchemy.node-exporter` →
+  `prometheus.prometheus.node_exporter`, then drop the two remaining
+  `cloudalchemy.*` pins.
+Prior art: [#6524](https://github.com/dimagi/commcare-cloud/pull/6524)
+(the in-place node_exporter bump — its "0.21.5 → 0.21.5" no-op proved the
+role is frozen) — **close here**, superseded by this migration.
+Acceptance: zero `cloudalchemy.*` refs remain anywhere (the last two pins
+gone, #12 removed the rest); monitoring Molecule/Vagrant stack converges on
+core ≥2.14; metrics scrape end-to-end (see Glossary).
+Depends: 24.
+
+#### 28. Controller Python 3.10 → 3.12
+3.12 is the latest Python explicitly supported by Ansible 10–12. Raise
+`requires-python`, `.python-version`, CI matrix, base images; refresh `uv.lock`.
+Optional: install + run tests on 3.14; if no blockers, jump to 3.14 here.
+Acceptance: full suite green on Python 3.14 or 3.12 / Ansible 10.
+Depends: 24 (with 25–27 green).
+
+#### 29. Ansible 10 → 12 (core 2.17→2.19)
+Isolates the v12 templating overhaul, where #19 gets exercised and most breakage
+is expected. Re-pin collections.
+Prior art: Dependabot [#6758](https://github.com/dimagi/commcare-cloud/pull/6758)
+(ansible 4→12.2.0) is the pin diff for this jump — **close it here** (rebased
+onto the #24 result).
+Acceptance: full suite green on 12 with zero templating/conditional errors.
+Depends: 28, 19.
+
+#### 30. Ansible 12 → 14 (core 2.19→2.21)
+Confirm #23 changes and the per-collection `requires_ansible` gate (#9); final
+collection re-pin. Runs on the #28 interpreter (3.12, or 3.14 if the #28
+optional was taken).
+Acceptance: full suite green on 14.
+Depends: 29, 23.
+
+#### 31. Controller Python 3.12 → 3.14
+Skip if #28 already reached 3.14. Core 2.20+ are the first to officially support
+Python 3.14. Raise `requires-python`, `.python-version`, CI matrix, base images;
+refresh `uv.lock`. Verify own deps publish 3.14 wheels (esp. `cryptography`);
+fall back to 3.13 if necessary.
+Acceptance: full suite green.
+Depends: 30.
+
+### Validation & rollout
+
+#### 32. Full-stack sign-off
+End-to-end `deploy-stack` on Vagrant and the `tests/cloud/` Docker harness
+against the final stack; idempotence pass.
+Acceptance: clean monolith install + re-converge with zero unexpected changes.
+Depends: 31, 5.
+
+#### 33. Docs
+New minimum Python, upgrade outcome, Molecule/Vagrant workflows,
+changelog.
+Acceptance: a new contributor can run the ansible test suite from docs alone.
+Depends: 32.
+
+---
+
+## Glossary
+
+- **Converge** (Ansible/Molecule): apply a role/playbook to a target host. A run
+  *converges* when it completes with no errors. Paired with **idempotence** — a
+  second run reports **zero changes** — this is the standard pass condition for
+  Molecule scenarios (#5, #6) and full-stack re-runs (#32).
+- **Scrape** (Prometheus): Prometheus' pull model — it periodically fetches the
+  `/metrics` HTTP endpoint each exporter exposes (e.g. node_exporter on `:9100`).
+  "Metrics scrape end-to-end" means the whole chain works: exporters are up and
+  serving, Prometheus is configured to pull them, and each target registers as
+  **up** on Prometheus' `/targets` page.
+
+---
+
+## Appendix A: Ansible/Python version matrix
+
+Version → core → control-node Python (for sequencing):
+
+| Ansible | core | Control Python | Status |
+|--|--|--|--|
+| 4  | 2.11 | 3.10 | Unmaintained (EOL) |
+| 5  | 2.12 | 3.10-? | Unmaintained (EOL) |
+| 6  | 2.13 | 3.10-? | Unmaintained (EOL) |
+| 7  | 2.14 | 3.10-? | Unmaintained (EOL) |
+| 8  | 2.15 | 3.10-? | Unmaintained (EOL) |
+| 9  | 2.16 | 3.10-? | Unmaintained (EOL) |
+| 10 | 2.17 | 3.10–3.12 | Unmaintained (EOL) |
+| 11 | 2.18 | 3.11–3.13 | EOL Dec 2025 |
+| 12 | 2.19 | 3.11–3.13 | EOL Dec 2025 |
+| 13 | 2.20 | 3.12–3.14 | Current |
+| 14 | 2.21 | 3.12–3.14 | Recently released as of June 2026? |
+
+Support windows are *tested-against*, not enforced — `requires-python` is a
+floor only (no upper-bound pin or runtime guard).
+
+https://docs.ansible.com/projects/ansible/latest/reference_appendices/release_and_maintenance.html
+
+## Appendix B: Role dependency landscape
+
+A previous contributor, pvisweswar, attempted this upgrade
+([SAAS-14998](https://dimagi.atlassian.net/browse/SAAS-14998) /
+[SAAS-16650](https://dimagi.atlassian.net/browse/SAAS-16650)) and stalled on
+unmaintained standalone Galaxy roles. The artifacts are still open and may be
+useful prior art:
+
+- [#6209](https://github.com/dimagi/commcare-cloud/pull/6209) /
+  [#6235](https://github.com/dimagi/commcare-cloud/pull/6235) ("changes for
+  ansible upgrade 9.1.0 / 9.2.0", branches `ansible/upgrade`,
+  `ansible/upgrade-9.2.0`) — the `include:` → `include_tasks:` and
+  module-shorthand cleanups (overlaps #16–17 here).
+- [#6520](https://github.com/dimagi/commcare-cloud/pull/6520) /
+  [#6524](https://github.com/dimagi/commcare-cloud/pull/6524) ("Upgrading
+  Ansible dependency for cloudalchemy.prometheus / node_exporter",
+  [SAAS-16650](https://dimagi.atlassian.net/browse/SAAS-16650)) — the attempt to
+  move the monitoring roles forward. #6524 bumps node_exporter "0.21.5 → 0.21.5"
+  — a no-op, because the role is frozen at its final release. That dead end is
+  the core finding below.
+
+**Maintenance audit of every dependency in `ansible/requirements.yml`** (checked
+against GitHub archived flag + last push, June 2026):
+
+| Dependency | Repo | State | Last activity | Verdict |
+|--|--|--|--|--|
+| `cloudalchemy.prometheus` | cloudalchemy/ansible-prometheus | **ARCHIVED 2023-03** | rel 4.0.0 (2021-05) | **DEAD** → vendored into `dimagi.commcare_prometheus` on 4.10 (#12) |
+| `cloudalchemy.alertmanager` | cloudalchemy/ansible-alertmanager | **ARCHIVED 2023-03** | rel 0.19.1 (2020-09) | **DEAD** → vendored into `dimagi.commcare_prometheus` on 4.10 (#12) |
+| `cloudalchemy.node_exporter` | cloudalchemy/ansible-node-exporter | **ARCHIVED 2023-03** | rel 2.0.0 (2021-04) | **DEAD** → `prometheus.prometheus` at the bump (#27) (also renamed `node-exporter`→`node_exporter`) |
+| `cloudalchemy.grafana` | cloudalchemy/ansible-grafana | **ARCHIVED 2023-05** | rel 0.17.0 (2020-03) | **DEAD** → `grafana.grafana` at the bump (#27) |
+| `bdellegrazie.postgres_exporter` | bdellegrazie/ansible-role-postgres_exporter | stale | 2022-12 | **transitive dep** of `dimagi.commcare_prometheus.postgres_exporter` (its `meta` requires it) — not orphaned; stale (2022). Keep/re-test (#11) |
+| `gantsign.golang` | gantsign/ansible-role-golang | active | rel 3.5.0 (2025-04) | **transitive dep** of the collection's `agg_pushgateway_exporter` + `airflow_exporter` (build Go exporters) — not orphaned; **version-coupled** (latest *requires* core ≥2.17), bump at #26 (#11) |
+| `DavidWittman.redis` | DavidWittman/ansible-redis | semi-active | rel 1.2.12 (2024-01), 57 open issues | re-test on target core; bump if needed (#25) |
+| `sansible.logstash` | sansible/logstash | low activity | v2.4.4 | re-test on target core (#25) |
+| `andrewrothstein.couchdb` | andrewrothstein/ansible-couchdb | maintained | 2024-06 (SHA-pinned, no releases) | re-test; keep SHA pin (#25) |
+| `andrewrothstein.couchdb-cluster-*` | dimagi/ansible-couchdb-cluster | Dimagi fork | 2023-03 (SHA-pinned) | we own it — fix forward if it breaks (#25) |
+| `tmpreaper` (`ANXS/tmpreaper`) | ANXS/tmpreaper | **DEAD** | **2017-07** | trivial role — vendor or replace (#13) |
+| `ansible-logrotate` | nickhammond/ansible-logrotate | **DEAD** | **2018-10** (v0.0.5) | trivial role — vendor or replace (#14) |
+| `dimagi.commcare_prometheus` | dimagi/commcare-prometheus | Dimagi, stale | rel 0.1.10 (**2020-10**) | **cross-repo work required** (#12) — see below |
+| `dimagi.commcare_logstash` | dimagi/commcare-logstash | Dimagi | 2022-01 (0.9.5) | re-test; we own it (#9) |
+| `community.general` | (collection) | active | pinned 7.4.0 | bump in lockstep with core (#9) |
+
+**Why the cloudalchemy roles can't just be deleted:**
+`deploy_prometheus.yml` imports `dimagi.commcare_prometheus.prometheus` and
+`...alertmanager`, and those vendored roles' `meta/main.yml` declare
+`dependencies: [cloudalchemy.prometheus]` / `[cloudalchemy.alertmanager]`.
+Grafana and node-exporter are imported from cloudalchemy **directly** in the
+playbook (`cloudalchemy.grafana`, `cloudalchemy.node-exporter` — note the legacy
+hyphen). So two of the four archived roles (prometheus, alertmanager) are
+pulled in *transitively through a separate, 2020-vintage Dimagi-owned
+collection repo* — those are removed on 4.10 in #12 by self-containing that
+collection (editing `dimagi/commcare-prometheus` and bumping the pin here).
+The other two (grafana, node_exporter) are direct refs whose maintained
+successors floor at core 2.12 / 2.14, so they cut over to upstream only at the
+bump (#27).
+
+**Successor target versions** (both admit the v14 ceiling, confirmed via
+`meta/runtime.yml`): `prometheus.prometheus` `requires_ansible >=2.14.0,<=2.21.99`
+(bundles prometheus, alertmanager, node_exporter, *and* postgres_exporter roles);
+`grafana.grafana` `requires_ansible >=2.12.0,<3.0.0`.
+
+---
+
+## Notes
+
+- **Depends** should be encoded as ticket links in the ticket description.
+- **Acceptance** should include ticket links where appropriate.
+- **Verification layers:** lint + syntax (CI, #3); Molecule converge/idempotence
+  (#5, #6); Vagrant + `tests/cloud/` full-stack (#4, #32); pytest CLI suite on
+  the target Python/core.
+- **Local constraint:** ansible is never run on the dev machine — bumps are
+  validated in CI and on Vagrant/Docker targets only.
+- **Open questions:** confirm...
+  - 14.x has a stable collection set at execution.
+  - whether `community.general 7.4.0` needs bumping in lockstep with the cores.
+  - that we need to maintain prometheus/grafana automation at all.
+  - whether `prometheus.prometheus` / `grafana.grafana` defaults differ enough
+    from the cloudalchemy roles to need group_vars remapping beyond the #27
+    cutover's estimate.
+  - add an Ansible 11 stop only if the SSH/Windows or docker-default changes
+    prove relevant (unlikely — commcare-cloud targets Linux).

--- a/docs/plans/ansible-upgrade.md
+++ b/docs/plans/ansible-upgrade.md
@@ -19,19 +19,23 @@ coverage gap is the upgrade's biggest risk, so the test tickets come first.
 Sequence: clean up deprecations and build a test safety net first, then step
 through versions. The interpreter may move in two hops: **3.10 → 3.12** (spans
 Ansible 10–12), then **3.12 → 3.14** at the 12 → 14 jump (or one hop if 3.14
-tests pass early — #28 optional).
+tests pass early — #32 optional).
 
 ### Highest-risk changes (v5–v14)
 
 1. **Templating/conditional strictness**, peaking at core 2.19: string-boolean
    conditionals (v5), arithmetic outside `{{ }}` (v6), embedded-template
    conditionals (v8/CVE-2023-5764), and non-boolean `when:` as an error + native
-   Jinja + inverted trust model (v12). → tickets 17–19.
+   Jinja + inverted trust model (v12). → tickets 21–23.
 2. **Collection removals** in every major — in-use ones must be pinned and
    installed explicitly. → #7–10.
-3. **Collection upgrades/replacements** — see Appendix B. Broken out across
-   #12 (self-contain the dimagi collection + adopt on 4.10, removing 2 of 4
-   cloudalchemy roles) and #27 (grafana + node_exporter to upstream at the bump).
+3. **Collection upgrades/replacements** — see Appendix B. All four archived
+   cloudalchemy roles are removed **on 4.10, ahead of the Ansible-10 bump**, so
+   that bump (#28) stays a pure pin change: #12–13 self-contain the dimagi
+   collection (prometheus, then alertmanager), #14 cuts the release and adopts it
+   on 4.10, #15–16 vendor the two direct refs (grafana, then node_exporter) as
+   repo-local roles. #31 is then an *optional* post-Ansible-10 swap of those
+   vendored roles to upstream collections.
 4. **Python floor jumps** (3.10 @ v9, 3.12 @ v13) and **UTF-8 locale enforced at
    startup** (v7).
 
@@ -40,9 +44,11 @@ tests pass early — #28 optional).
 ## Backlog
 
 "Depends" = ticket numbers. 1–2 are housekeeping; 3–6 build the test safety net;
-7–23 are version-agnostic cleanup (7–14 dependency work, 15–23 deprecation
-edits) and parallelize within their bands; 24–33 are strictly sequential version
-bumps + rollout.
+7–27 are version-agnostic cleanup (7–18 dependency work; 19–27 deprecation
+edits) and parallelize within their bands; 28–37 are mostly sequential version
+bumps + rollout (31 is optional — see there). Every cleanup ticket (7–27) must
+leave the tree green on 4.10 on its own, so that each bump (28/33/34) is a pin
+change with nothing left to fix.
 
 ### Housekeeping — independent, do first
 
@@ -129,43 +135,97 @@ record archived flag, last activity, target-core compatibility.
 `dimagi.commcare_prometheus` role metas (its `postgres_exporter` →
 `bdellegrazie.postgres_exporter`; `agg_pushgateway_exporter` /
 `airflow_exporter` → `gantsign.golang`) — not orphaned. Record the consumer;
-neither is droppable as-is. (`gantsign.golang`'s version bump is #26; the
-`cloudalchemy.*` roles are #12/#27; the dead trivial roles are #13–14.)
+neither is droppable as-is. (`gantsign.golang`'s version bump is #30; the four
+`cloudalchemy.*` roles are handled across #12–16, with #31 the optional
+post-Ansible-10 upstream swap; the dead trivial roles are #17–18.)
 Acceptance: role compat matrix complete; orphaned pins removed or justified.
 
-#### 12. Replace cloudalchemy in `dimagi.commcare_prometheus` + adopt on 4.10
-Make the collection carry its own `prometheus`/`alertmanager` install so it
-no longer depends on the archived cloudalchemy roles. This removes two of the
-four cloudalchemy roles (the other two are direct refs, handled in #27). The
-collection already ships ~16 self-contained roles of its own, so this fits its
-design; **do not** re-base on `prometheus.prometheus` — that imposes a
-`requires_ansible >=2.14` floor and would break the collection on core 2.11.
-- In `dimagi/commcare-prometheus` (separate repo, last released 2020-10):
-  replace the `cloudalchemy.prometheus` / `cloudalchemy.alertmanager` `meta`
-  deps with vendored install tasks, written cross-version-safe (the #15–19
-  discipline) to run on **core 2.11 → 2.21**; set a permissive
-  `requires_ansible` (≥2.11); cut a new release.
-- In commcare-cloud: bump the `dimagi.commcare_prometheus` pin to the new
-  release, then **drop the `cloudalchemy.prometheus` +
-  `cloudalchemy.alertmanager` pins** from `requirements.yml` (only the dimagi
-  roles needed them). `deploy_prometheus.yml`'s
-  `dimagi.commcare_prometheus.prometheus` / `.alertmanager` refs are
-  unchanged — now backed by the vendored install.
-This removes only the *archived* cloudalchemy deps; the collection still pulls
-`bdellegrazie.postgres_exporter` and `gantsign.golang` transitively (via its
-`postgres_exporter` and Go-exporter roles) — maintained-ish, not addressed here.
+#### 12. Vendor the `prometheus` install into `dimagi.commcare_prometheus`
+`cloudalchemy.prometheus` is archived and uses bare `include:` (removed in
+Ansible 9 / core 2.16), so it must go before the Ansible-10 bump (#28). The dimagi collection's
+`prometheus` role pulls it via a `meta` dependency; make that role carry its own
+install instead. The collection already ships ~16 self-contained roles, so this
+fits its design; **do not** re-base on `prometheus.prometheus` — its
+`requires_ansible >=2.14` floor would break the collection on core 2.11.
+This is a change in the **separate `dimagi/commcare-prometheus` repo** (last
+released 2020-10): replace the `cloudalchemy.prometheus` `meta` dep with vendored
+install tasks, written cross-version-safe (the #19–23 discipline) to run on
+**core 2.11 → 2.21**; set a permissive `requires_ansible` (≥2.11). **No release
+yet** — #14 cuts one release once alertmanager (#13) is also done.
 Prior art: [#6520](https://github.com/dimagi/commcare-cloud/pull/6520)
 (the in-place `cloudalchemy.prometheus` bump attempt) — **close here**,
 superseded by vendoring the install.
-Acceptance: new release with no `cloudalchemy.*` in any role's `meta`;
-commcare-cloud pin bumped and those two pins gone; monitoring still converges
-on 4.10; the vendored roles install clean through core 2.21 (re-verified at
-#24/#29/#30).
+Acceptance: the collection's `prometheus` role `meta` no longer lists
+`cloudalchemy.prometheus`; the vendored install is cross-version-safe (proven at
+#14's release/adopt).
 Depends: ideally 6.
 Open question on how to proceed with this upgrade:
 https://dimagi.slack.com/archives/CNQ636095/p1781277055592099?thread_ts=1781210489.586889&cid=CNQ636095
 
-#### 13. Vendor or replace `tmpreaper` (`ANXS/tmpreaper`, dead since 2017)
+#### 13. Vendor the `alertmanager` install into `dimagi.commcare_prometheus`
+Same pattern as #12 for the collection's `alertmanager` role (archived
+`cloudalchemy.alertmanager`, also bare-`include:`-based). Edit
+`dimagi/commcare-prometheus` only; again **no release here** — #14 cuts a single
+release covering both vendorings.
+Acceptance: the collection's `alertmanager` role `meta` no longer lists
+`cloudalchemy.alertmanager`; the vendored install is cross-version-safe.
+Depends: 12 (same collection/repo, sequential).
+
+#### 14. Release `dimagi.commcare_prometheus` + adopt it on 4.10
+Cut **one** new release of `dimagi/commcare-prometheus` carrying the #12 + #13
+vendoring (one release for both, not one per role — that keeps the upstream
+edits as their own steps and the release/adopt as a single logical step here).
+In commcare-cloud: bump the `dimagi.commcare_prometheus` pin to that release and
+**drop the `cloudalchemy.prometheus` + `cloudalchemy.alertmanager` pins** from
+`requirements.yml` (only the dimagi collection needed them).
+`deploy_prometheus.yml`'s `dimagi.commcare_prometheus.prometheus` / `.alertmanager`
+refs are unchanged — now backed by the vendored install.
+After this, the collection no longer pulls any cloudalchemy role; it still pulls
+`bdellegrazie.postgres_exporter` and `gantsign.golang` transitively (via its
+`postgres_exporter` and Go-exporter roles) — addressed in #11/#30, not here.
+Acceptance: new collection release with no `cloudalchemy.*` in any role's `meta`;
+pin bumped and both pins gone; monitoring still converges on 4.10; the vendored
+install runs clean through core 2.21 (re-verified at #28/#33/#34).
+Depends: 12, 13.
+
+#### 15. Vendor `cloudalchemy.grafana` as a repo-local role (on 4.10)
+`cloudalchemy.grafana` is archived and referenced **directly** in
+`deploy_prometheus.yml`. Its maintained upstream successor `grafana.grafana`
+floors at core 2.12, so it *cannot* be adopted on 4.10 — instead fork it into a
+repo-local role under `roles/` (the #17/#18 pattern — a copy we can fix forward)
+and fix its removed syntax cross-version-safe (core 2.11 → 2.21, the #19–23
+discipline):
+- 8× bare `include:` → `include_tasks:` (`tasks/main.yml`) — `include:` removed
+  in core 2.16.
+- 1× `warn: false` (`tasks/dashboards.yml`) — removed in core 2.14.
+- The `with_*` loops are deprecated-not-removed — fold into #20's mechanical
+  pass, not required to survive the Ansible-10 bump.
+Re-point `deploy_prometheus.yml` to the repo-local role and **drop the
+`cloudalchemy.grafana` pin**. Without this, the Ansible-10 bump (#28) could not be
+green and merged on its own (its `deploy_prometheus.yml` grafana path would be
+dead), which is why the upstream swap (#31) is deferred and optional.
+Acceptance: resolves to a repo-local role; no `cloudalchemy.grafana` pin/ref
+remains; monitoring converges on 4.10; role syntax-checks clean (re-verified on
+the new core at #28).
+Depends: ideally 6.
+
+#### 16. Vendor `cloudalchemy.node_exporter` as a repo-local role (on 4.10)
+Same approach as #15 for `cloudalchemy.node-exporter` (note the legacy hyphen),
+the other direct ref in `deploy_prometheus.yml`. Its successor
+`prometheus.prometheus.node_exporter` floors at core 2.14. The removed-syntax
+surface is smaller:
+- 1× `warn: false` (`tasks/preflight.yml`) — removed in core 2.14; `main.yml`
+  already uses `import_tasks`, so this subfile is the only hard break.
+- The `with_*` loops fold into #20, not required to survive the Ansible-10 bump.
+Re-point the ref and **drop the `cloudalchemy.node_exporter` pin**. With #14 + #15,
+this removes the **last** cloudalchemy pin — zero `cloudalchemy.*` remains
+anywhere, all on 4.10, before the Ansible-10 bump (#28).
+Acceptance: resolves to a repo-local role; no `cloudalchemy.node_exporter`
+pin/ref remains; monitoring converges on 4.10; role syntax-checks clean
+(re-verified at #28).
+Depends: ideally 6 (independent of #15).
+
+#### 17. Vendor or replace `tmpreaper` (`ANXS/tmpreaper`, dead since 2017)
 Abandoned but trivial; used in several playbooks. Risk is removed syntax
 (`with_items`, bare `warn:`, string-bool `when:`) failing on the target core.
 Fork into the repo as a local role under `roles/` (preferred — a maintainable
@@ -174,27 +234,27 @@ copy we can fix forward) or replace with a few inline tasks; re-point
 Acceptance: resolves to a repo-local role (or inline tasks); no abandoned pin
 remains; touched-role Molecule green on the target core.
 
-#### 14. Vendor or replace `ansible-logrotate` (`nickhammond`, dead since 2018)
-Same approach as #13. Heavily used — it's a `meta` dependency of `common`, so
+#### 18. Vendor or replace `ansible-logrotate` (`nickhammond`, dead since 2018)
+Same approach as #17. Heavily used — it's a `meta` dependency of `common`, so
 nearly every host pulls it; test broadly.
 Acceptance: resolves to a repo-local role (or inline tasks); no abandoned pin
 remains; `common`-dependent role Molecules green on the target core.
 
 ### Deprecation cleanup — version-agnostic, run on 4.10
 
-#### 15. Remove `warn:` on command/shell
+#### 19. Remove `warn:` on command/shell
 ~15, mostly `ping.yml`; removed in core 2.14.
 Acceptance: none remain; lint clean.
 
-#### 16. Convert `with_*` to `loop:` — largest change (~125 across ~21 files)
+#### 20. Convert `with_*` to `loop:` — largest change (~125 across ~21 files)
 Add appropriate filters/`lookup`. Mechanical; split on playbook and role.
 Prior art: [#6209](https://github.com/dimagi/commcare-cloud/pull/6209) /
 [#6235](https://github.com/dimagi/commcare-cloud/pull/6235) carry the same kind
-of mechanical loop/`include_tasks` rewrite, but they close in #17 (see there).
+of mechanical loop/`include_tasks` rewrite, but they close in #21 (see there).
 Acceptance: no `with_*` keys remain; touched role Molecules green.
-Depends: 6 (interleave with 7–8, 15).
+Depends: 6 (interleave with 7–8, 19).
 
-#### 17. Normalize shorthand, boolean, and string-boolean conditionals
+#### 21. Normalize shorthand, boolean, and string-boolean conditionals
 - Convert `action:`/`debug: msg=` to mapping form
 - `no/yes` → `false/true`.
 - **v5:** `when:` no longer coerces `"true"/"false"` strings (any non-empty
@@ -204,16 +264,16 @@ Prior art: [#6209](https://github.com/dimagi/commcare-cloud/pull/6209) /
 [#6235](https://github.com/dimagi/commcare-cloud/pull/6235) ("changes for
 ansible upgrade 9.1.0/9.2.0") are the `include:` → `include_tasks:` +
 module-shorthand rewrites — **close both here**. Their `include_tasks` portion
-also satisfies the mechanical work noted in #16.
+also satisfies the mechanical work noted in #20.
 Acceptance: lint clean; no `when:` relies on implicit string→bool.
 
-#### 18. Move arithmetic/concatenation inside Jinja (Ansible 6/core 2.13)
+#### 22. Move arithmetic/concatenation inside Jinja (Ansible 6/core 2.13)
 Arithmetic and concatenation are no longer allowed *outside* a Jinja template.
 `'[1] + {{ [2] }}'` → `'{{ [1] + [2] }}'`. Grep `}}` adjacent to operators.
 Acceptance: lint clean. Hard to fully detect on 4.10, so re-verify at 4→10.
 Depends: 6.
 
-#### 19. Harden conditional templating — highest-risk (the v8 + v12 arc)
+#### 23. Harden conditional templating — highest-risk (the v8 + v12 arc)
 - **v8/CVE-2023-5764** (core 2.15): embedded-template conditionals fail "unsafe"
   — reference untrusted values as plain Jinja vars, not embedded templates.
 - **v12** (core 2.19): non-boolean `when:` is now an error — make conditionals
@@ -222,76 +282,77 @@ Depends: 6.
   trusted strings render, and `omit` in loops drops immediately — flag dependents.
 Build the candidate list from a repo-wide grep of `when:` / `failed_when:` /
 `changed_when:` / `assert`.
-Acceptance: triaged on 4.10; full verification only on core 2.15 & 2.19 (see #29).
+Acceptance: triaged on 4.10; full verification only on core 2.15 & 2.19 (see #33).
 Depends: 6.
 
-#### 20. Fix ansible.cfg Galaxy URL
+#### 24. Fix ansible.cfg Galaxy URL
 `old-galaxy.ansible.com` → `galaxy.ansible.com`.
 Acceptance: galaxy installs resolve.
 
-#### 21. Update custom plugins/modules for the newer core API
+#### 25. Update custom plugins/modules for the newer core API
 `module_utils._text` → `module_utils.common.text.converters`; `logging.warn` →
 `warning`. Re-verify `cchq_aws_secret.py` and `library/*` against the target
 `AnsibleModule`. Files: `plugins/inventory/csv.py`,
 `plugins/lookup/cchq_aws_secret.py`, `library/*`.
 Acceptance: import/run on target core; `test_csv_inventory.py` passes.
 
-#### 22. Audit in-code `ansible.*` imports + version gate
+#### 26. Audit in-code `ansible.*` imports + version gate
 Review CLI imports (`InventoryManager`, `DataLoader`, `VariableManager`,
 vault/dumper helpers) for API drift; raise `min_ansible_version` (currently
 `2.10.0`) on each step.
 Acceptance: CLI imports succeed per target core; gate matches shipped version.
 
-#### 23. Audit Ansible 13/core-2.20 behavior changes
+#### 27. Audit Ansible 13/core-2.20 behavior changes
 Prefer `ansible_facts.*` over bare `ansible_*` facts (`INJECT_FACTS_AS_VARS`
 flips to `False` in 2.24); the `failed_when` suppressed-error key is now
 `failed_when_suppressed_exception`. `include_vars`: `extensions`/`ignore_files`
 must be lists, not strings.
-Acceptance: CLI imports succeed on each target core; verified at 12→14 (#30).
+Acceptance: CLI imports succeed on each target core; verified at 12→14 (#34).
 
 ### Version bumps — sequential, after cleanup + a full test pass
 
-#### 24. Ansible 4 → 10 (core 2.11→2.17)
+#### 28. Ansible 4 → 10 (core 2.11→2.17)
 The core/package bump. Ansible 10 is the highest reachable on Python 3.10.
 Raise the `ansible` pin and `min_ansible_version`; re-pin collections to
-core-2.17-compatible versions. This step gets the `deploy_hq.yml` path green
-on 10; the monitoring stack (#27), surviving-role re-pins (#25), and
-`gantsign.golang` (#26) complete the full "green on 10" sign-off and each
-depend on this step.
+core-2.17-compatible versions. Because all removed syntax — including the
+monitoring roles (#12–16) — was fixed on 4.10 in the cleanup band, this is a
+pure pin change with nothing left to break, and can be green and merged on its
+own. The surviving-role re-pins (#29) and `gantsign.golang` (#30) are
+version-coupled follow-ons that depend on this step but are *not* preconditions
+of declaring it done.
 Prior art: Dependabot [#6895](https://github.com/dimagi/commcare-cloud/pull/6895)
 (ansible 4→10.7.0) and [#6444](https://github.com/dimagi/commcare-cloud/pull/6444)
 (ansible-core 2.11→2.17.7) — **close both here** (they only touch the pin, so
-can't merge until the cleanup band is done). Breaks `deploy_prometheus.yml`?
-Acceptance: core 2.17 installs; `deploy_hq.yml` syntax + Molecule suite green on 10.
+can't merge until the cleanup band is done).
+Acceptance: core 2.17 installs; `deploy_hq.yml` **and `deploy_prometheus.yml`**
+syntax-check green on 2.17 (the latter proves #12–16 survived the bump);
+full Molecule suite green on 10.
 Fallback: bisect via 6/8 if failures are hard to localize.
-Depends: 7–23.
+Depends: 7–27 (incl. 12–16).
 
-#### 25. Re-pin surviving standalone roles + re-test
+#### 29. Re-pin surviving standalone roles + re-test
 Bump the still-maintained roles to their newest releases and re-test on core
 2.17: `DavidWittman.redis`, `sansible.logstash`, the `andrewrothstein.*` SHAs
 (couchdb, couchdb-cluster). Done here because verification needs the new core.
 Acceptance: each touched role's Molecule (#6) green on 10; pins updated.
-Depends: 24.
+Depends: 28.
 
-#### 26. Bump `gantsign.golang`
+#### 30. Bump `gantsign.golang`
 A live transitive dep (the collection's `agg_pushgateway_exporter` /
 `airflow_exporter` use it to build Go exporters), so it can't be dropped.
 Version-coupled: its latest (3.5.0) *requires core ≥2.17*, so it can only move
-at/after the bump — bump it here.
+at/after the Ansible-10 bump (#28) — bump it here.
 Acceptance: bumped and resolving on core 2.17; the two collection roles still
 build their exporters.
-Depends: 11, 24.
+Depends: 11, 28.
 
-#### 27. Cut over grafana + node_exporter to maintained upstream collections
-The remaining, genuinely core-gated half: the two cloudalchemy roles
-referenced **directly** in `deploy_prometheus.yml` (`cloudalchemy.grafana`,
-`cloudalchemy.node-exporter`). Their maintained successors floor at core
-2.12 / 2.14, so this is verified only once #24 has crossed that floor; the
-archived roles carry no `requires_ansible` ceiling so they don't block #24,
-but they break on the new core until this lands — so it co-lands with #24.
-(prometheus + alertmanager were already removed on 4.10 in #12.) This is the
-first PR that references these successor collections, so it adds and consumes
-them in one atomic change:
+#### 31. (Optional) Swap vendored grafana + node_exporter to upstream collections
+**Not a precondition of the Ansible-10 bump (#28)** — #15–16 already made these roles run on core
+2.17 as repo-local vendored copies, so the stack is green on 10 without this.
+This is a follow-on modernization that retires the vendored fork in favor of
+maintained upstream collections (less to maintain forward). Their successors
+floor at core 2.12 / 2.14, so it can only run post-Ansible-10. Do it when the fork
+maintenance burden justifies it; skip it otherwise.
 - Add `prometheus.prometheus` (`requires_ansible >=2.14.0,<=2.21.99`, for its
   `node_exporter` role) and `grafana.grafana` (`>=2.12.0,<3.0.0`) to
   `requirements.yml`. `prometheus.prometheus` pulls `community.general
@@ -299,62 +360,61 @@ them in one atomic change:
 - Compute and apply the `group_vars/` remap for the two roles: `grafana_*` →
   `grafana.grafana` vars, `node_exporter_*` →
   `prometheus.prometheus.node_exporter` vars (read from their upstream docs).
-- Swap `deploy_prometheus.yml` refs `cloudalchemy.grafana` →
-  `grafana.grafana` and `cloudalchemy.node-exporter` →
-  `prometheus.prometheus.node_exporter`, then drop the two remaining
-  `cloudalchemy.*` pins.
+- Swap `deploy_prometheus.yml` refs from the repo-local roles →
+  `grafana.grafana` and `prometheus.prometheus.node_exporter`, then delete the
+  vendored grafana/node_exporter roles from `roles/`.
 Prior art: [#6524](https://github.com/dimagi/commcare-cloud/pull/6524)
 (the in-place node_exporter bump — its "0.21.5 → 0.21.5" no-op proved the
-role is frozen) — **close here**, superseded by this migration.
-Acceptance: zero `cloudalchemy.*` refs remain anywhere (the last two pins
-gone, #12 removed the rest); monitoring Molecule/Vagrant stack converges on
-core ≥2.14; metrics scrape end-to-end (see Glossary).
-Depends: 24.
+role is frozen) — **close here**, superseded by the #15–16 vendoring + this swap.
+Acceptance: upstream collections installed and consumed; vendored
+grafana/node_exporter roles deleted; monitoring Molecule/Vagrant stack
+converges on core ≥2.14; metrics scrape end-to-end (see Glossary).
+Depends: 15, 16, 28.
 
-#### 28. Controller Python 3.10 → 3.12
+#### 32. Controller Python 3.10 → 3.12
 3.12 is the latest Python explicitly supported by Ansible 10–12. Raise
 `requires-python`, `.python-version`, CI matrix, base images; refresh `uv.lock`.
 Optional: install + run tests on 3.14; if no blockers, jump to 3.14 here.
 Acceptance: full suite green on Python 3.14 or 3.12 / Ansible 10.
-Depends: 24 (with 25–27 green).
+Depends: 28 (with 29–30 green; 31 is optional and not required here).
 
-#### 29. Ansible 10 → 12 (core 2.17→2.19)
-Isolates the v12 templating overhaul, where #19 gets exercised and most breakage
+#### 33. Ansible 10 → 12 (core 2.17→2.19)
+Isolates the v12 templating overhaul, where #23 gets exercised and most breakage
 is expected. Re-pin collections.
 Prior art: Dependabot [#6758](https://github.com/dimagi/commcare-cloud/pull/6758)
 (ansible 4→12.2.0) is the pin diff for this jump — **close it here** (rebased
-onto the #24 result).
+onto the #28 result).
 Acceptance: full suite green on 12 with zero templating/conditional errors.
-Depends: 28, 19.
+Depends: 32, 23.
 
-#### 30. Ansible 12 → 14 (core 2.19→2.21)
-Confirm #23 changes and the per-collection `requires_ansible` gate (#9); final
-collection re-pin. Runs on the #28 interpreter (3.12, or 3.14 if the #28
+#### 34. Ansible 12 → 14 (core 2.19→2.21)
+Confirm #27 changes and the per-collection `requires_ansible` gate (#9); final
+collection re-pin. Runs on the #32 interpreter (3.12, or 3.14 if the #32
 optional was taken).
 Acceptance: full suite green on 14.
-Depends: 29, 23.
+Depends: 33, 27.
 
-#### 31. Controller Python 3.12 → 3.14
-Skip if #28 already reached 3.14. Core 2.20+ are the first to officially support
+#### 35. Controller Python 3.12 → 3.14
+Skip if #32 already reached 3.14. Core 2.20+ are the first to officially support
 Python 3.14. Raise `requires-python`, `.python-version`, CI matrix, base images;
 refresh `uv.lock`. Verify own deps publish 3.14 wheels (esp. `cryptography`);
 fall back to 3.13 if necessary.
 Acceptance: full suite green.
-Depends: 30.
+Depends: 34.
 
 ### Validation & rollout
 
-#### 32. Full-stack sign-off
+#### 36. Full-stack sign-off
 End-to-end `deploy-stack` on Vagrant and the `tests/cloud/` Docker harness
 against the final stack; idempotence pass.
 Acceptance: clean monolith install + re-converge with zero unexpected changes.
-Depends: 31, 5.
+Depends: 35, 5.
 
-#### 33. Docs
+#### 37. Docs
 New minimum Python, upgrade outcome, Molecule/Vagrant workflows,
 changelog.
 Acceptance: a new contributor can run the ansible test suite from docs alone.
-Depends: 32.
+Depends: 36.
 
 ---
 
@@ -363,7 +423,7 @@ Depends: 32.
 - **Converge** (Ansible/Molecule): apply a role/playbook to a target host. A run
   *converges* when it completes with no errors. Paired with **idempotence** — a
   second run reports **zero changes** — this is the standard pass condition for
-  Molecule scenarios (#5, #6) and full-stack re-runs (#32).
+  Molecule scenarios (#5, #6) and full-stack re-runs (#36).
 - **Scrape** (Prometheus): Prometheus' pull model — it periodically fetches the
   `/metrics` HTTP endpoint each exporter exposes (e.g. node_exporter on `:9100`).
   "Metrics scrape end-to-end" means the whole chain works: exporters are up and
@@ -407,7 +467,7 @@ useful prior art:
   [#6235](https://github.com/dimagi/commcare-cloud/pull/6235) ("changes for
   ansible upgrade 9.1.0 / 9.2.0", branches `ansible/upgrade`,
   `ansible/upgrade-9.2.0`) — the `include:` → `include_tasks:` and
-  module-shorthand cleanups (overlaps #16–17 here).
+  module-shorthand cleanups (overlaps #20–21 here).
 - [#6520](https://github.com/dimagi/commcare-cloud/pull/6520) /
   [#6524](https://github.com/dimagi/commcare-cloud/pull/6524) ("Upgrading
   Ansible dependency for cloudalchemy.prometheus / node_exporter",
@@ -421,19 +481,19 @@ against GitHub archived flag + last push, June 2026):
 
 | Dependency | Repo | State | Last activity | Verdict |
 |--|--|--|--|--|
-| `cloudalchemy.prometheus` | cloudalchemy/ansible-prometheus | **ARCHIVED 2023-03** | rel 4.0.0 (2021-05) | **DEAD** → vendored into `dimagi.commcare_prometheus` on 4.10 (#12) |
-| `cloudalchemy.alertmanager` | cloudalchemy/ansible-alertmanager | **ARCHIVED 2023-03** | rel 0.19.1 (2020-09) | **DEAD** → vendored into `dimagi.commcare_prometheus` on 4.10 (#12) |
-| `cloudalchemy.node_exporter` | cloudalchemy/ansible-node-exporter | **ARCHIVED 2023-03** | rel 2.0.0 (2021-04) | **DEAD** → `prometheus.prometheus` at the bump (#27) (also renamed `node-exporter`→`node_exporter`) |
-| `cloudalchemy.grafana` | cloudalchemy/ansible-grafana | **ARCHIVED 2023-05** | rel 0.17.0 (2020-03) | **DEAD** → `grafana.grafana` at the bump (#27) |
+| `cloudalchemy.prometheus` | cloudalchemy/ansible-prometheus | **ARCHIVED 2023-03** | rel 4.0.0 (2021-05) | **DEAD** → vendored into `dimagi.commcare_prometheus` on 4.10 (#12, released/adopted in #14) |
+| `cloudalchemy.alertmanager` | cloudalchemy/ansible-alertmanager | **ARCHIVED 2023-03** | rel 0.19.1 (2020-09) | **DEAD** → vendored into `dimagi.commcare_prometheus` on 4.10 (#13, released/adopted in #14) |
+| `cloudalchemy.grafana` | cloudalchemy/ansible-grafana | **ARCHIVED 2023-05** | rel 0.17.0 (2020-03) | **DEAD** → vendored repo-local on 4.10 (#15; fixes 8× `include:` + 1× `warn:`); optional upstream swap → `grafana.grafana` post-Ansible-10 (#31) |
+| `cloudalchemy.node_exporter` | cloudalchemy/ansible-node-exporter | **ARCHIVED 2023-03** | rel 2.0.0 (2021-04) | **DEAD** → vendored repo-local on 4.10 (#16; fixes 1× `warn:` in `preflight.yml`); optional upstream swap → `prometheus.prometheus.node_exporter` post-bump (#31, renamed `node-exporter`→`node_exporter`) |
 | `bdellegrazie.postgres_exporter` | bdellegrazie/ansible-role-postgres_exporter | stale | 2022-12 | **transitive dep** of `dimagi.commcare_prometheus.postgres_exporter` (its `meta` requires it) — not orphaned; stale (2022). Keep/re-test (#11) |
-| `gantsign.golang` | gantsign/ansible-role-golang | active | rel 3.5.0 (2025-04) | **transitive dep** of the collection's `agg_pushgateway_exporter` + `airflow_exporter` (build Go exporters) — not orphaned; **version-coupled** (latest *requires* core ≥2.17), bump at #26 (#11) |
-| `DavidWittman.redis` | DavidWittman/ansible-redis | semi-active | rel 1.2.12 (2024-01), 57 open issues | re-test on target core; bump if needed (#25) |
-| `sansible.logstash` | sansible/logstash | low activity | v2.4.4 | re-test on target core (#25) |
-| `andrewrothstein.couchdb` | andrewrothstein/ansible-couchdb | maintained | 2024-06 (SHA-pinned, no releases) | re-test; keep SHA pin (#25) |
-| `andrewrothstein.couchdb-cluster-*` | dimagi/ansible-couchdb-cluster | Dimagi fork | 2023-03 (SHA-pinned) | we own it — fix forward if it breaks (#25) |
-| `tmpreaper` (`ANXS/tmpreaper`) | ANXS/tmpreaper | **DEAD** | **2017-07** | trivial role — vendor or replace (#13) |
-| `ansible-logrotate` | nickhammond/ansible-logrotate | **DEAD** | **2018-10** (v0.0.5) | trivial role — vendor or replace (#14) |
-| `dimagi.commcare_prometheus` | dimagi/commcare-prometheus | Dimagi, stale | rel 0.1.10 (**2020-10**) | **cross-repo work required** (#12) — see below |
+| `gantsign.golang` | gantsign/ansible-role-golang | active | rel 3.5.0 (2025-04) | **transitive dep** of the collection's `agg_pushgateway_exporter` + `airflow_exporter` (build Go exporters) — not orphaned; **version-coupled** (latest *requires* core ≥2.17), bump at #30 (#11) |
+| `DavidWittman.redis` | DavidWittman/ansible-redis | semi-active | rel 1.2.12 (2024-01), 57 open issues | re-test on target core; bump if needed (#29) |
+| `sansible.logstash` | sansible/logstash | low activity | v2.4.4 | re-test on target core (#29) |
+| `andrewrothstein.couchdb` | andrewrothstein/ansible-couchdb | maintained | 2024-06 (SHA-pinned, no releases) | re-test; keep SHA pin (#29) |
+| `andrewrothstein.couchdb-cluster-*` | dimagi/ansible-couchdb-cluster | Dimagi fork | 2023-03 (SHA-pinned) | we own it — fix forward if it breaks (#29) |
+| `tmpreaper` (`ANXS/tmpreaper`) | ANXS/tmpreaper | **DEAD** | **2017-07** | trivial role — vendor or replace (#17) |
+| `ansible-logrotate` | nickhammond/ansible-logrotate | **DEAD** | **2018-10** (v0.0.5) | trivial role — vendor or replace (#18) |
+| `dimagi.commcare_prometheus` | dimagi/commcare-prometheus | Dimagi, stale | rel 0.1.10 (**2020-10**) | **cross-repo work required** (#12–14) — see below |
 | `dimagi.commcare_logstash` | dimagi/commcare-logstash | Dimagi | 2022-01 (0.9.5) | re-test; we own it (#9) |
 | `community.general` | (collection) | active | pinned 7.4.0 | bump in lockstep with core (#9) |
 
@@ -445,16 +505,25 @@ Grafana and node-exporter are imported from cloudalchemy **directly** in the
 playbook (`cloudalchemy.grafana`, `cloudalchemy.node-exporter` — note the legacy
 hyphen). So two of the four archived roles (prometheus, alertmanager) are
 pulled in *transitively through a separate, 2020-vintage Dimagi-owned
-collection repo* — those are removed on 4.10 in #12 by self-containing that
-collection (editing `dimagi/commcare-prometheus` and bumping the pin here).
-The other two (grafana, node_exporter) are direct refs whose maintained
-successors floor at core 2.12 / 2.14, so they cut over to upstream only at the
-bump (#27).
+collection repo* — those are removed on 4.10 in #12–14 by self-containing that
+collection (editing `dimagi/commcare-prometheus` in #12–13, then releasing +
+bumping the pin in #14).
+The other two (grafana, node_exporter) are direct refs. Their maintained
+upstream successors floor at core 2.12 / 2.14, so they *cannot* be adopted on
+4.10. To keep the bump (#28) free of monitoring breakage and independently
+mergeable, #15–16 instead vendor them as repo-local roles and fix their removed
+syntax cross-version-safe on 4.10 (the same treatment #12–14 give
+prometheus/alertmanager, and #17/#18 give tmpreaper/logrotate). The upstream
+cutover (#31) then becomes an *optional* post-bump cleanup, not a bump
+precondition. After #12–16, no `cloudalchemy.*` pin or ref survives into the
+bump.
 
-**Successor target versions** (both admit the v14 ceiling, confirmed via
-`meta/runtime.yml`): `prometheus.prometheus` `requires_ansible >=2.14.0,<=2.21.99`
-(bundles prometheus, alertmanager, node_exporter, *and* postgres_exporter roles);
-`grafana.grafana` `requires_ansible >=2.12.0,<3.0.0`.
+**Successor target versions** for the optional #31 swap (both admit the v14
+ceiling, confirmed via `meta/runtime.yml`): `prometheus.prometheus`
+`requires_ansible >=2.14.0,<=2.21.99` (bundles prometheus, alertmanager,
+node_exporter, *and* postgres_exporter roles); `grafana.grafana`
+`requires_ansible >=2.12.0,<3.0.0`. The 2.12 / 2.14 floors are why these can't
+be adopted on 4.10 — hence the #15–16 vendoring steps.
 
 ---
 
@@ -463,7 +532,7 @@ bump (#27).
 - **Depends** should be encoded as ticket links in the ticket description.
 - **Acceptance** should include ticket links where appropriate.
 - **Verification layers:** lint + syntax (CI, #3); Molecule converge/idempotence
-  (#5, #6); Vagrant + `tests/cloud/` full-stack (#4, #32); pytest CLI suite on
+  (#5, #6); Vagrant + `tests/cloud/` full-stack (#4, #36); pytest CLI suite on
   the target Python/core.
 - **Local constraint:** ansible is never run on the dev machine — bumps are
   validated in CI and on Vagrant/Docker targets only.
@@ -472,7 +541,7 @@ bump (#27).
   - whether `community.general 7.4.0` needs bumping in lockstep with the cores.
   - that we need to maintain prometheus/grafana automation at all.
   - whether `prometheus.prometheus` / `grafana.grafana` defaults differ enough
-    from the cloudalchemy roles to need group_vars remapping beyond the #27
+    from the cloudalchemy roles to need group_vars remapping beyond the #31
     cutover's estimate.
   - add an Ansible 11 stop only if the SSH/Windows or docker-default changes
     prove relevant (unlikely — commcare-cloud targets Linux).

--- a/docs/plans/ansible-upgrade.md
+++ b/docs/plans/ansible-upgrade.md
@@ -151,11 +151,13 @@ etc. (`deploy_stack.yml` and its ~18 imports are already syntax-checked by
 is low-priority baseline debt (short names resolve fine; collection moves are
 handled by #10–11).
 Acceptance: new non-blocking `lint.yml` fails on new violations; green on day one.
+Ticket: [SAAS-19958](https://dimagi.atlassian.net/browse/SAAS-19958)
 
 #### 7. Refresh Vagrant harness to 22.04
 `Vagrantfile` is `ubuntu/bionic64` (18.04); upgrade it, verify provisioning,
 document the local full-stack flow.
 Acceptance: `vagrant up` + `deploy-stack` completes on 22.04 on current Ansible.
+Ticket: [SAAS-19959](https://dimagi.atlassian.net/browse/SAAS-19959)
 
 #### 8. Molecule scaffolding + one reference role
 Add Molecule (docker driver) with a shared base config and a worked example for
@@ -163,6 +165,7 @@ one simple role (e.g. `swap` or `logrotate`, which already has a `tests/` stub).
 Wire a Molecule job into CI. Document "how to add a Molecule scenario." Keep
 test code separate from production code.
 Acceptance: `molecule test` converge + idempotence green locally and in CI on 22.04.
+Ticket: [SAAS-19960](https://dimagi.atlassian.net/browse/SAAS-19960)
 
 #### 9. Molecule coverage for critical roles
 Add Molecule converge/idempotence scenarios for the operationally critical,
@@ -170,6 +173,7 @@ untested roles: postgresql(_base), pgbouncer, couchdb2, kafka, redis,
 elasticsearch, nginx, proxy/haproxy. Likely one Jira ticket per role/group.
 Acceptance: each converges twice with no changes; basic service-up asserts.
 Depends: 8.
+Ticket: [SAAS-19961](https://dimagi.atlassian.net/browse/SAAS-19961)
 
 ### Dependency work — collections + roles, version-agnostic, run on 4.10
 

--- a/docs/plans/ansible-upgrade.md
+++ b/docs/plans/ansible-upgrade.md
@@ -28,16 +28,16 @@ tests pass early — #26 optional).
    conditionals (v8/CVE-2023-5764), and non-boolean `when:` as an error + native
    Jinja + inverted trust model (v12). → tickets 17–19.
 2. **Collection removals** in every major version. Pin and explicitly install
-   collectinos that were removed from Ansible. → #7–10.
+   collectinos that were removed from Ansible. → #8–11.
 
 ---
 
 ## Backlog
 
-"Depends" = ticket numbers. 1–2 are housekeeping; 3–6 build the test safety net;
-7–23 are version-agnostic cleanup (7–14 dependency work; 15–23 deprecation
+"Depends" = ticket numbers. 1–3 are housekeeping; 4–7 build the test safety net;
+8–23 are version-agnostic cleanup (8–14 dependency work; 15–23 deprecation
 edits) and parallelize within their bands; 24–31 are mostly sequential version
-bumps + rollout. Every cleanup ticket (7–23) must leave the tree green on 4.10
+bumps + rollout. Every cleanup ticket (8–23) must leave the tree green on 4.10
 on its own, so that each bump (24/27/28) is a pin change with nothing left to fix.
 
 ### Housekeeping — independent, do first
@@ -52,83 +52,7 @@ Acceptance: repo root still resolves; dep gone; tests green.
 Delete `ansible_distribution_version == '18.04'` branches.
 Acceptance: none remain; 22.04 path unaffected.
 
-### Safety net — build verification before touching versions
-
-#### 3. CI lint + syntax for all playbooks
-Add `ansible-lint` (dev dep) and extend `--syntax-check` to cover the
-top-level playbooks *not* reached by the existing `deploy_stack.yml` check —
-`deploy_hq.yml`, `deploy_postgres.yml`, the `restart_*` / `deploy_citusdb` /
-`deploy_proxy` set, etc. (`deploy_stack.yml` and its ~18 imports are already
-syntax-checked by `.tests/tests.sh`; `deploy_prometheus.yml` is excluded — it's
-being removed in #12); capture existing violations as a baseline. Full FQCN
-module normalization is low-priority baseline debt (short names resolve fine;
-collection moves are handled by #7–8).
-Acceptance: new non-blocking `lint.yml` fails on new violations; green on day one.
-
-#### 4. Refresh Vagrant harness to 22.04
-`Vagrantfile` is `ubuntu/bionic64` (18.04); upgrade it, verify provisioning,
-document the local full-stack flow.
-Acceptance: `vagrant up` + `deploy-stack` completes on 22.04 on current Ansible.
-
-#### 5. Molecule scaffolding + one reference role
-Add Molecule (docker driver) with a shared base config and a worked example for
-one simple role (e.g. `swap` or `logrotate`, which already has a `tests/` stub).
-Wire a Molecule job into CI. Document "how to add a Molecule scenario." Keep
-test code separate from production code.
-Acceptance: `molecule test` converge + idempotence green locally and in CI on 22.04.
-
-#### 6. Molecule coverage for critical roles
-Add Molecule converge/idempotence scenarios for the operationally critical,
-untested roles: postgresql(_base), pgbouncer, couchdb2, kafka, redis,
-elasticsearch, nginx, proxy/haproxy. Likely one Jira ticket per role/group.
-Acceptance: each converges twice with no changes; basic service-up asserts.
-Depends: 5.
-
-### Dependency work — collections + roles, version-agnostic, run on 4.10
-
-#### 7. Adopt `community.postgresql` (declare + migrate `postgresql_*`)
-Add `community.postgresql` to `requirements.yml`, then FQCN-ify
-`postgresql_user/db/privs/set/query` and drop `encrypted:` (removed in core 2.15).
-Files:
-- `roles/postgresql_base/tasks/set_up_dbs.yml`
-- `roles/postgresql_base/tasks/main.yml`
-- any playbook needing a `collections:` entry.
-Acceptance: `ansible-galaxy install -r` resolves the collection; Molecule
-postgres (#6) + syntax clean.
-Depends: ideally 6.
-
-#### 8. Adopt `ansible.posix`
-Add `ansible.posix` to `requirements.yml`, then FQCN-ify `synchronize` /
-`authorized_key` in `roles/deploy_hq/tasks/staticfiles_*` and
-`roles/setup_auth_keys.yml`.
-Acceptance: collection installs; refs resolve to `ansible.posix.*`; lint clean.
-
-#### 9. Audit `community.general` + `dimagi.commcare_logstash`
-Decide whether `community.general 7.4.0` is still required and at what version,
-and confirm `dimagi.commcare_logstash` loads on the target cores. (The other
-Dimagi collection, `dimagi.commcare_prometheus`, is removed in #12, so it drops
-out of this audit.) Record each collection's `requires_ansible` and confirm it
-admits core 2.21 (v14 excludes incompatible collections by default).
-Acceptance: necessity decision recorded; a compat-matrix entry per surviving
-collection.
-
-#### 10. Removed-collection audit (collections dropped v5–v14)
-The repo uses short module names (FQCN is ~6 tasks total), so grep the *short
-module names* of every collection removed from the `ansible` package across
-v5–v14 (per each version's changelog). Pin and explicitly install any still in
-use.
-Acceptance: nothing in-use silently disappears at any version step; pins added.
-
-#### 11. Standalone-role maintenance audit; drop orphaned roles
-Use the Appendix B matrix as the baseline: for each *role* in `requirements.yml`
-record archived flag, last activity, target-core compatibility. The monitoring
-roles (`cloudalchemy.*`, plus the transitive `gantsign.golang` /
-`bdellegrazie.postgres_exporter`) are removed wholesale in #12, so this ticket
-covers the survivors: `DavidWittman.redis`, `sansible.logstash`, the
-`andrewrothstein.*` couchdb roles.
-Acceptance: role compat matrix complete; orphaned pins removed or justified.
-
-#### 12. Remove the Prometheus install automation
+#### 3. Remove the Prometheus install automation
 Remove `deploy_prometheus.yml` and all dependencies used only by it from
 `requirements.yml`.
 - Check references to `prometheus` / `grafana` / `alertmanager` /
@@ -162,9 +86,85 @@ monitoring docs are updated; `deploy-stack` is unaffected; and with
 `prometheus_monitoring_enabled` still settable + set to `True`, the
 `deploy_commcarehq` path renders localsettings + supervisor configs
 (syntax/Molecule green with the flag both on and off).
-Depends: ideally 6.
+Depends: ideally 7.
 Decision thread:
 https://dimagi.slack.com/archives/CNQ636095/p1781277055592099?thread_ts=1781210489.586889&cid=CNQ636095
+
+### Safety net — build verification before touching versions
+
+#### 4. CI lint + syntax for all playbooks
+Add `ansible-lint` (dev dep) and extend `--syntax-check` to cover the
+top-level playbooks *not* reached by the existing `deploy_stack.yml` check —
+`deploy_hq.yml`, `deploy_postgres.yml`, the `restart_*` / `deploy_citusdb` /
+`deploy_proxy` set, etc. (`deploy_stack.yml` and its ~18 imports are already
+syntax-checked by `.tests/tests.sh`; `deploy_prometheus.yml` is excluded — it's
+being removed in #3); capture existing violations as a baseline. Full FQCN
+module normalization is low-priority baseline debt (short names resolve fine;
+collection moves are handled by #8–9).
+Acceptance: new non-blocking `lint.yml` fails on new violations; green on day one.
+
+#### 5. Refresh Vagrant harness to 22.04
+`Vagrantfile` is `ubuntu/bionic64` (18.04); upgrade it, verify provisioning,
+document the local full-stack flow.
+Acceptance: `vagrant up` + `deploy-stack` completes on 22.04 on current Ansible.
+
+#### 6. Molecule scaffolding + one reference role
+Add Molecule (docker driver) with a shared base config and a worked example for
+one simple role (e.g. `swap` or `logrotate`, which already has a `tests/` stub).
+Wire a Molecule job into CI. Document "how to add a Molecule scenario." Keep
+test code separate from production code.
+Acceptance: `molecule test` converge + idempotence green locally and in CI on 22.04.
+
+#### 7. Molecule coverage for critical roles
+Add Molecule converge/idempotence scenarios for the operationally critical,
+untested roles: postgresql(_base), pgbouncer, couchdb2, kafka, redis,
+elasticsearch, nginx, proxy/haproxy. Likely one Jira ticket per role/group.
+Acceptance: each converges twice with no changes; basic service-up asserts.
+Depends: 6.
+
+### Dependency work — collections + roles, version-agnostic, run on 4.10
+
+#### 8. Adopt `community.postgresql` (declare + migrate `postgresql_*`)
+Add `community.postgresql` to `requirements.yml`, then FQCN-ify
+`postgresql_user/db/privs/set/query` and drop `encrypted:` (removed in core 2.15).
+Files:
+- `roles/postgresql_base/tasks/set_up_dbs.yml`
+- `roles/postgresql_base/tasks/main.yml`
+- any playbook needing a `collections:` entry.
+Acceptance: `ansible-galaxy install -r` resolves the collection; Molecule
+postgres (#7) + syntax clean.
+Depends: ideally 7.
+
+#### 9. Adopt `ansible.posix`
+Add `ansible.posix` to `requirements.yml`, then FQCN-ify `synchronize` /
+`authorized_key` in `roles/deploy_hq/tasks/staticfiles_*` and
+`roles/setup_auth_keys.yml`.
+Acceptance: collection installs; refs resolve to `ansible.posix.*`; lint clean.
+
+#### 10. Audit `community.general` + `dimagi.commcare_logstash`
+Decide whether `community.general 7.4.0` is still required and at what version,
+and confirm `dimagi.commcare_logstash` loads on the target cores. (The other
+Dimagi collection, `dimagi.commcare_prometheus`, is removed in #3, so it drops
+out of this audit.) Record each collection's `requires_ansible` and confirm it
+admits core 2.21 (v14 excludes incompatible collections by default).
+Acceptance: necessity decision recorded; a compat-matrix entry per surviving
+collection.
+
+#### 11. Removed-collection audit (collections dropped v5–v14)
+The repo uses short module names (FQCN is ~6 tasks total), so grep the *short
+module names* of every collection removed from the `ansible` package across
+v5–v14 (per each version's changelog). Pin and explicitly install any still in
+use.
+Acceptance: nothing in-use silently disappears at any version step; pins added.
+
+#### 12. Standalone-role maintenance audit; drop orphaned roles
+Use the Appendix B matrix as the baseline: for each *role* in `requirements.yml`
+record archived flag, last activity, target-core compatibility. The monitoring
+roles (`cloudalchemy.*`, plus the transitive `gantsign.golang` /
+`bdellegrazie.postgres_exporter`) are removed wholesale in #3, so this ticket
+covers the survivors: `DavidWittman.redis`, `sansible.logstash`, the
+`andrewrothstein.*` couchdb roles.
+Acceptance: role compat matrix complete; orphaned pins removed or justified.
 
 #### 13. Vendor or replace `tmpreaper`
 Abandoned but trivial (`ANXS/tmpreaper`, dead since 2017); used in several
@@ -194,7 +194,7 @@ Prior art: [#6209](https://github.com/dimagi/commcare-cloud/pull/6209) /
 [#6235](https://github.com/dimagi/commcare-cloud/pull/6235) carry the same kind
 of mechanical loop/`include_tasks` rewrite; they close in #17.
 Acceptance: no `with_*` keys remain; touched role Molecules green.
-Depends: 6 (interleave with 7–8, 15).
+Depends: 7 (interleave with 8–9, 15).
 
 #### 17. Normalize shorthand, boolean, and string-boolean conditionals
 - Convert `action:`/`debug: msg=` to mapping form
@@ -213,7 +213,7 @@ Acceptance: lint clean; no `when:` relies on implicit string→bool.
 Arithmetic and concatenation are no longer allowed *outside* a Jinja template.
 `'[1] + {{ [2] }}'` → `'{{ [1] + [2] }}'`. Grep `}}` adjacent to operators.
 Acceptance: lint clean. Hard to fully detect on 4.10, so re-verify at 4→10.
-Depends: 6.
+Depends: 7.
 
 #### 19. Harden conditional templating — highest-risk (the v8 + v12 arc)
 - **v8/CVE-2023-5764** (core 2.15): embedded-template conditionals fail "unsafe"
@@ -225,7 +225,7 @@ Depends: 6.
 Build the candidate list from a repo-wide grep of `when:` / `failed_when:` /
 `changed_when:` / `assert`.
 Acceptance: triaged on 4.10; full verification only on core 2.15 & 2.19 (see #27).
-Depends: 6.
+Depends: 7.
 
 #### 20. Fix ansible.cfg Galaxy URL
 `old-galaxy.ansible.com` → `galaxy.ansible.com`.
@@ -264,13 +264,13 @@ can't merge until the cleanup band is done).
 Acceptance: core 2.17 installs; `deploy_hq.yml` syntax-check green; full
 Molecule suite green on Ansible 10.
 Fallback: bisect via 6/8 if failures are hard to localize.
-Depends: 7–23
+Depends: 8–23
 
 #### 25. Re-pin surviving standalone roles + re-test
 Bump the still-maintained roles to their newest releases and re-test on core
 2.17: `DavidWittman.redis`, `sansible.logstash`, the `andrewrothstein.*` SHAs
 (couchdb, couchdb-cluster). Done here because verification needs the new core.
-Acceptance: each touched role's Molecule (#6) green on Ansible 10; pins updated.
+Acceptance: each touched role's Molecule (#7) green on Ansible 10; pins updated.
 Depends: 24.
 
 #### 26. Controller Python 3.10 → 3.12
@@ -289,7 +289,7 @@ Acceptance: full suite green on 12 with zero templating/conditional errors.
 Depends: 26, 19.
 
 #### 28. Ansible 12 → 14 (core 2.19→2.21)
-Confirm #23 changes and the per-collection `requires_ansible` gate (#9); final
+Confirm #23 changes and the per-collection `requires_ansible` gate (#10); final
 collection re-pin. Runs on the #26 interpreter (3.12, or 3.14 if the #26
 optional was taken).
 Acceptance: full suite green on 14.
@@ -309,7 +309,7 @@ Depends: 28.
 End-to-end `deploy-stack` on Vagrant and the `tests/cloud/` Docker harness
 against the final stack; idempotence pass.
 Acceptance: clean monolith install + re-converge with zero unexpected changes.
-Depends: 29, 5.
+Depends: 29, 6.
 
 #### 31. Docs
 New minimum Python, upgrade outcome, Molecule/Vagrant workflows, changelog.
@@ -323,9 +323,9 @@ Depends: 30.
 - **Converge** (Ansible/Molecule): apply a role/playbook to a target host. A run
   *converges* when it completes with no errors. Paired with **idempotence** — a
   second run reports **zero changes** — this is the standard pass condition for
-  Molecule scenarios (#5, #6) and full-stack re-runs (#30).
+  Molecule scenarios (#6, #7) and full-stack re-runs (#30).
 - **Scrape** (Prometheus): Prometheus' pull model — it periodically fetches the
-  `/metrics` HTTP endpoint a target exposes. After #12, HQ still exposes its
+  `/metrics` HTTP endpoint a target exposes. After #3, HQ still exposes its
   metrics endpoint (the kept app-level integration), but the Prometheus server
   that scrapes it is operator-managed, not installed by commcare-cloud.
 
@@ -373,7 +373,7 @@ artifacts are still open and may be useful prior art:
   [SAAS-16650](https://dimagi.atlassian.net/browse/SAAS-16650)) — the attempt to
   move the monitoring roles forward. #6524 bumps node_exporter "0.21.5 → 0.21.5"
   — a no-op, because the role is frozen at its final release. That dead end is
-  what motivates removing the monitoring install outright (#12) instead of
+  what motivates removing the monitoring install outright (#3) instead of
   upgrading it.
 
 **Maintenance audit of every dependency in `ansible/requirements.yml`** (checked
@@ -381,21 +381,21 @@ against GitHub archived flag + last push, June 2026):
 
 | Dependency | Repo | State | Last activity | Verdict |
 |--|--|--|--|--|
-| `cloudalchemy.prometheus` | cloudalchemy/ansible-prometheus | **ARCHIVED 2023-03** | rel 4.0.0 (2021-05) | **DEAD** → removed with the Prometheus install automation (#12) |
-| `cloudalchemy.alertmanager` | cloudalchemy/ansible-alertmanager | **ARCHIVED 2023-03** | rel 0.19.1 (2020-09) | **DEAD** → removed (#12) |
-| `cloudalchemy.grafana` | cloudalchemy/ansible-grafana | **ARCHIVED 2023-05** | rel 0.17.0 (2020-03) | **DEAD** → removed (#12) |
-| `cloudalchemy.node_exporter` | cloudalchemy/ansible-node-exporter | **ARCHIVED 2023-03** | rel 2.0.0 (2021-04) | **DEAD** → removed (#12) |
-| `bdellegrazie.postgres_exporter` | bdellegrazie/ansible-role-postgres_exporter | stale | 2022-12 | transitive dep of `dimagi.commcare_prometheus.postgres_exporter` — removed with it (#12) |
-| `gantsign.golang` | gantsign/ansible-role-golang | active | rel 3.5.0 (2025-04) | transitive dep of the collection's Go-exporter roles — removed with it (#12); only the monitoring stack used it |
-| `dimagi.commcare_prometheus` | dimagi/commcare-prometheus | Dimagi, stale | rel 0.1.10 (**2020-10**) | only consumed by `deploy_prometheus.yml` → removed (#12) |
+| `cloudalchemy.prometheus` | cloudalchemy/ansible-prometheus | **ARCHIVED 2023-03** | rel 4.0.0 (2021-05) | **DEAD** → removed with the Prometheus install automation (#3) |
+| `cloudalchemy.alertmanager` | cloudalchemy/ansible-alertmanager | **ARCHIVED 2023-03** | rel 0.19.1 (2020-09) | **DEAD** → removed (#3) |
+| `cloudalchemy.grafana` | cloudalchemy/ansible-grafana | **ARCHIVED 2023-05** | rel 0.17.0 (2020-03) | **DEAD** → removed (#3) |
+| `cloudalchemy.node_exporter` | cloudalchemy/ansible-node-exporter | **ARCHIVED 2023-03** | rel 2.0.0 (2021-04) | **DEAD** → removed (#3) |
+| `bdellegrazie.postgres_exporter` | bdellegrazie/ansible-role-postgres_exporter | stale | 2022-12 | transitive dep of `dimagi.commcare_prometheus.postgres_exporter` — removed with it (#3) |
+| `gantsign.golang` | gantsign/ansible-role-golang | active | rel 3.5.0 (2025-04) | transitive dep of the collection's Go-exporter roles — removed with it (#3); only the monitoring stack used it |
+| `dimagi.commcare_prometheus` | dimagi/commcare-prometheus | Dimagi, stale | rel 0.1.10 (**2020-10**) | only consumed by `deploy_prometheus.yml` → removed (#3) |
 | `DavidWittman.redis` | DavidWittman/ansible-redis | semi-active | rel 1.2.12 (2024-01), 57 open issues | re-test on target core; bump if needed (#25) |
 | `sansible.logstash` | sansible/logstash | low activity | v2.4.4 | re-test on target core (#25) |
 | `andrewrothstein.couchdb` | andrewrothstein/ansible-couchdb | maintained | 2024-06 (SHA-pinned, no releases) | re-test; keep SHA pin (#25) |
 | `andrewrothstein.couchdb-cluster-*` | dimagi/ansible-couchdb-cluster | Dimagi fork | 2023-03 (SHA-pinned) | we own it — fix forward if it breaks (#25) |
 | `tmpreaper` (`ANXS/tmpreaper`) | ANXS/tmpreaper | **DEAD** | **2017-07** | trivial role — vendor or replace (#13) |
 | `ansible-logrotate` | nickhammond/ansible-logrotate | **DEAD** | **2018-10** (v0.0.5) | trivial role — vendor or replace (#14) |
-| `dimagi.commcare_logstash` | dimagi/commcare-logstash | Dimagi | 2022-01 (0.9.5) | re-test; we own it (#9) |
-| `community.general` | (collection) | active | pinned 7.4.0 | bump in lockstep with core (#9) |
+| `dimagi.commcare_logstash` | dimagi/commcare-logstash | Dimagi | 2022-01 (0.9.5) | re-test; we own it (#10) |
+| `community.general` | (collection) | active | pinned 7.4.0 | bump in lockstep with core (#10) |
 
 ---
 
@@ -403,8 +403,8 @@ against GitHub archived flag + last push, June 2026):
 
 - **Depends** should be encoded as ticket links in the ticket description.
 - **Acceptance** should include ticket links where appropriate.
-- **Verification layers:** lint + syntax (CI, #3); Molecule converge/idempotence
-  (#5, #6); Vagrant + `tests/cloud/` full-stack (#4, #30); pytest CLI suite on
+- **Verification layers:** lint + syntax (CI, #4); Molecule converge/idempotence
+  (#6, #7); Vagrant + `tests/cloud/` full-stack (#5, #30); pytest CLI suite on
   the target Python/core.
 - **Local constraint:** ansible is never run on the dev machine — bumps are
   validated in CI and on Vagrant/Docker targets only.
@@ -412,6 +412,6 @@ against GitHub archived flag + last push, June 2026):
   - 14.x has a stable collection set at execution.
   - whether `community.general 7.4.0` needs bumping in lockstep with the cores.
   - ~~whether we need to maintain prometheus/grafana automation at all~~ —
-    **resolved:** no; #12 removes it and documents operator-managed Prometheus.
+    **resolved:** no; #3 removes it and documents operator-managed Prometheus.
   - add an Ansible 11 stop only if the SSH/Windows or docker-default changes
     prove relevant (unlikely — commcare-cloud targets Linux).

--- a/docs/plans/ansible-upgrade.md
+++ b/docs/plans/ansible-upgrade.md
@@ -19,26 +19,26 @@ biggest risk, so the test tickets come first.
 Sequence: clean up deprecations and build a test safety net first, then step
 through versions. The interpreter may move in two hops: **3.10 → 3.12** (spans
 Ansible 10–12), then **3.12 → 3.14** at the 12 → 14 jump (or one hop if 3.14
-tests pass early — #26 optional).
+tests pass early — #28 optional).
 
 ### Highest-risk changes (v5–v14)
 
 1. **Templating/conditional strictness**, peaking at core 2.19: string-boolean
    conditionals (v5), arithmetic outside `{{ }}` (v6), embedded-template
    conditionals (v8/CVE-2023-5764), and non-boolean `when:` as an error + native
-   Jinja + inverted trust model (v12). → tickets 17–19.
+   Jinja + inverted trust model (v12). → tickets 19–21.
 2. **Collection removals** in every major version. Pin and explicitly install
-   collectinos that were removed from Ansible. → #8–11.
+   collectinos that were removed from Ansible. → #10–13.
 
 ---
 
 ## Backlog
 
-"Depends" = ticket numbers. 1–3 are housekeeping; 4–7 build the test safety net;
-8–23 are version-agnostic cleanup (8–14 dependency work; 15–23 deprecation
-edits) and parallelize within their bands; 24–31 are mostly sequential version
-bumps + rollout. Every cleanup ticket (8–23) must leave the tree green on 4.10
-on its own, so that each bump (24/27/28) is a pin change with nothing left to fix.
+"Depends" = ticket numbers. 1–5 are housekeeping; 6–9 build the test safety net;
+10–25 are version-agnostic cleanup (10–16 dependency work; 17–25 deprecation
+edits) and parallelize within their bands; 26–33 are mostly sequential version
+bumps + rollout. Every cleanup ticket (10–25) must leave the tree green on 4.10
+on its own, so that each bump (26/29/30) is a pin change with nothing left to fix.
 
 ### Housekeeping — independent, do first
 
@@ -52,7 +52,54 @@ Acceptance: repo root still resolves; dep gone; tests green.
 Delete `ansible_distribution_version == '18.04'` branches.
 Acceptance: none remain; 22.04 path unaffected.
 
-#### 3. Remove the Prometheus install automation
+#### 3. Remove the CitusDB automation
+CitusDB is no longer used; remove its install/management automation.
+- Delete `deploy_citusdb.yml` and the `roles/citusdb/` role.
+- Remove the citus import/host blocks from `deploy_db.yml` and the `!citusdb`
+  exclusions in `deploy_postgres.yml` / `wipe_postgres.yml` /
+  `setup_pg_standby.yml` and the `pg_upgrade_*` playbooks.
+- Untangle the PostgreSQL coupling (the non-trivial part): the
+  `citusdb_master` / `citusdb_worker` routing in
+  `environment/schemas/postgresql.py`, the citus worker ACL block in
+  `roles/postgresql_base/templates/pg_hba.conf.j2`, the
+  `allow_direct_citusdb_access` default, and the citus pgbouncer vars
+  (`roles/citusdb/vars/pgbouncer_workers.yml` + `roles/pgbouncer` routing).
+- Drop `group_vars/citusdb_master.yml` / `citusdb_worker.yml`, the `Citusdb`
+  service class in `commands/ansible/service.py`, the citus monitoring entries
+  (`roles/datadog/defaults/main.yml`, `monitors/pg_replication_delay.yml`), and
+  the citus host in `environments/development/postgresql.yml`.
+- The `citusdb` / `citusdb_master` / `citusdb_worker` inventory groups become
+  unused — drop them from example environments where present.
+- Remove CitusDB docs (`docs/source/services/postgresql/upgrade_citusdb.rst`;
+  trim citus from `postgresql.rst`) and publish a changelog entry.
+Acceptance: no `citus` references remain; `deploy_postgres` / `deploy_db` and the
+postgres Molecule (#9) are green without them; `deploy-stack` unaffected.
+
+#### 4. Remove the RabbitMQ automation
+The Celery broker has migrated to Redis (changelog `0096`; RabbitMQ support ended
+2026-06-01), so RabbitMQ is no longer used — remove its automation.
+- Delete `deploy_rabbitmq.yml` and the `roles/rabbitmq/` role.
+- Remove the rabbitmq import/host blocks from `deploy_db.yml` and the rabbitmq
+  plays in `ping.yml`, `stop_servers.yml`, `status_check.yml`, and
+  `deploy_cloudwatch_logs.yml`.
+- Drop `group_vars/rabbitmq.yml`, the `RabbitMq` service class in
+  `commands/ansible/service.py`, the `rabbit` forward-port in
+  `inventory_lookup.py`, the rabbitmq datadog integration
+  (`roles/datadog/defaults/main.yml` + `templates/rabbitmq.yaml.j2`), the Celery
+  Flower AMQP wiring (`supervisor_celery_flower.conf.j2`), and the rabbitmq
+  alias in `roles/common/templates/etc_aliases.j2`.
+- The `rabbitmq` inventory group becomes unused — drop the `[rabbitmq:children]`
+  blocks from the example/inventory templates and the `AMQP_*` / `OLD_AMQP_*`
+  env wiring from example environments.
+- Remove RabbitMQ docs (`docs/source/services/rabbitmq/*`) and the
+  commcare-ports / firefighting references; publish a changelog entry.
+- **Caveat:** confirm no live environment still points `BROKER_URL` at AMQP
+  before removing — the localsettings broker wiring is shared with the (kept)
+  Redis broker, so touch only the AMQP-specific paths.
+Acceptance: no rabbitmq/AMQP install references remain; `deploy-stack` and Celery
+(on the Redis broker) are unaffected; `test_getinventory.py` is updated.
+
+#### 5. Remove the Prometheus install automation
 Remove `deploy_prometheus.yml` and all dependencies used only by it from
 `requirements.yml`.
 - Check references to `prometheus` / `grafana` / `alertmanager` /
@@ -88,39 +135,39 @@ https://dimagi.slack.com/archives/CNQ636095/p1781277055592099?thread_ts=17812104
 
 ### Safety net — build verification before touching versions
 
-#### 4. CI lint + syntax for all playbooks
+#### 6. CI lint + syntax for all playbooks
 Add `ansible-lint` (dev dep) and extend `--syntax-check` to cover the
 top-level playbooks *not* reached by the existing `deploy_stack.yml` check —
-`deploy_hq.yml`, `deploy_postgres.yml`, the `restart_*` / `deploy_citusdb` /
-`deploy_proxy` set, etc. (`deploy_stack.yml` and its ~18 imports are already
-syntax-checked by `.tests/tests.sh`; `deploy_prometheus.yml` is excluded — it's
-being removed in #3); capture existing violations as a baseline. Full FQCN
-module normalization is low-priority baseline debt (short names resolve fine;
-collection moves are handled by #8–9).
+`deploy_hq.yml`, `deploy_postgres.yml`, the `restart_*` / `deploy_proxy` set,
+etc. (`deploy_stack.yml` and its ~18 imports are already syntax-checked by
+`.tests/tests.sh`; `deploy_prometheus.yml` is excluded — it's being removed in
+#5); capture existing violations as a baseline. Full FQCN module normalization
+is low-priority baseline debt (short names resolve fine; collection moves are
+handled by #10–11).
 Acceptance: new non-blocking `lint.yml` fails on new violations; green on day one.
 
-#### 5. Refresh Vagrant harness to 22.04
+#### 7. Refresh Vagrant harness to 22.04
 `Vagrantfile` is `ubuntu/bionic64` (18.04); upgrade it, verify provisioning,
 document the local full-stack flow.
 Acceptance: `vagrant up` + `deploy-stack` completes on 22.04 on current Ansible.
 
-#### 6. Molecule scaffolding + one reference role
+#### 8. Molecule scaffolding + one reference role
 Add Molecule (docker driver) with a shared base config and a worked example for
 one simple role (e.g. `swap` or `logrotate`, which already has a `tests/` stub).
 Wire a Molecule job into CI. Document "how to add a Molecule scenario." Keep
 test code separate from production code.
 Acceptance: `molecule test` converge + idempotence green locally and in CI on 22.04.
 
-#### 7. Molecule coverage for critical roles
+#### 9. Molecule coverage for critical roles
 Add Molecule converge/idempotence scenarios for the operationally critical,
 untested roles: postgresql(_base), pgbouncer, couchdb2, kafka, redis,
 elasticsearch, nginx, proxy/haproxy. Likely one Jira ticket per role/group.
 Acceptance: each converges twice with no changes; basic service-up asserts.
-Depends: 6.
+Depends: 8.
 
 ### Dependency work — collections + roles, version-agnostic, run on 4.10
 
-#### 8. Adopt `community.postgresql` (declare + migrate `postgresql_*`)
+#### 10. Adopt `community.postgresql` (declare + migrate `postgresql_*`)
 Add `community.postgresql` to `requirements.yml`, then FQCN-ify
 `postgresql_user/db/privs/set/query` and drop `encrypted:` (removed in core 2.15).
 Files:
@@ -128,41 +175,41 @@ Files:
 - `roles/postgresql_base/tasks/main.yml`
 - any playbook needing a `collections:` entry.
 Acceptance: `ansible-galaxy install -r` resolves the collection; Molecule
-postgres (#7) + syntax clean.
-Depends: ideally 7.
+postgres (#9) + syntax clean.
+Depends: ideally 9.
 
-#### 9. Adopt `ansible.posix`
+#### 11. Adopt `ansible.posix`
 Add `ansible.posix` to `requirements.yml`, then FQCN-ify `synchronize` /
 `authorized_key` in `roles/deploy_hq/tasks/staticfiles_*` and
 `roles/setup_auth_keys.yml`.
 Acceptance: collection installs; refs resolve to `ansible.posix.*`; lint clean.
 
-#### 10. Audit `community.general` + `dimagi.commcare_logstash`
+#### 12. Audit `community.general` + `dimagi.commcare_logstash`
 Decide whether `community.general 7.4.0` is still required and at what version,
 and confirm `dimagi.commcare_logstash` loads on the target cores. (The other
-Dimagi collection, `dimagi.commcare_prometheus`, is removed in #3, so it drops
+Dimagi collection, `dimagi.commcare_prometheus`, is removed in #5, so it drops
 out of this audit.) Record each collection's `requires_ansible` and confirm it
 admits core 2.21 (v14 excludes incompatible collections by default).
 Acceptance: necessity decision recorded; a compat-matrix entry per surviving
 collection.
 
-#### 11. Removed-collection audit (collections dropped v5–v14)
+#### 13. Removed-collection audit (collections dropped v5–v14)
 The repo uses short module names (FQCN is ~6 tasks total), so grep the *short
 module names* of every collection removed from the `ansible` package across
 v5–v14 (per each version's changelog). Pin and explicitly install any still in
 use.
 Acceptance: nothing in-use silently disappears at any version step; pins added.
 
-#### 12. Standalone-role maintenance audit; drop orphaned roles
+#### 14. Standalone-role maintenance audit; drop orphaned roles
 Use the Appendix B matrix as the baseline: for each *role* in `requirements.yml`
 record archived flag, last activity, target-core compatibility. The monitoring
 roles (`cloudalchemy.*`, plus the transitive `gantsign.golang` /
-`bdellegrazie.postgres_exporter`) are removed wholesale in #3, so this ticket
+`bdellegrazie.postgres_exporter`) are removed wholesale in #5, so this ticket
 covers the survivors: `DavidWittman.redis`, `sansible.logstash`, the
 `andrewrothstein.*` couchdb roles.
 Acceptance: role compat matrix complete; orphaned pins removed or justified.
 
-#### 13. Vendor or replace `tmpreaper`
+#### 15. Vendor or replace `tmpreaper`
 Abandoned but trivial (`ANXS/tmpreaper`, dead since 2017); used in several
 playbooks. Risk is removed syntax (`with_items`, bare `warn:`, string-bool
 `when:`) failing on the target core. Fork into the repo as a local role under
@@ -171,28 +218,28 @@ few inline tasks; re-point `requirements.yml` / refs.
 Acceptance: resolves to a repo-local role (or inline tasks); no abandoned pin
 remains; touched-role Molecule green on the target core.
 
-#### 14. Vendor or replace `ansible-logrotate`
-Same approach as #13 (`nickhammond`, dead since 2018). Heavily used — it's a
+#### 16. Vendor or replace `ansible-logrotate`
+Same approach as #15 (`nickhammond`, dead since 2018). Heavily used — it's a
 `meta` dependency of `common`, so nearly every host pulls it; test broadly.
 Acceptance: resolves to a repo-local role (or inline tasks); no abandoned pin
 remains; `common`-dependent role Molecules green on the target core.
 
 ### Deprecation cleanup — version-agnostic, run on 4.10
 
-#### 15. Remove `warn:` on command/shell
+#### 17. Remove `warn:` on command/shell
 ~15, mostly `ping.yml`; removed in core 2.14.
 Acceptance: none remain; lint clean.
 
-#### 16. Convert `with_*` to `loop:`
+#### 18. Convert `with_*` to `loop:`
 Largest change: ~125 across ~21 files. Add appropriate filters/`lookup`.
 Mechanical; split on playbook and role.
 Prior art: [#6209](https://github.com/dimagi/commcare-cloud/pull/6209) /
 [#6235](https://github.com/dimagi/commcare-cloud/pull/6235) carry the same kind
-of mechanical loop/`include_tasks` rewrite; they close in #17.
+of mechanical loop/`include_tasks` rewrite; they close in #19.
 Acceptance: no `with_*` keys remain; touched role Molecules green.
-Depends: 7 (interleave with 8–9, 15).
+Depends: 9 (interleave with 10–11, 17).
 
-#### 17. Normalize shorthand, boolean, and string-boolean conditionals
+#### 19. Normalize shorthand, boolean, and string-boolean conditionals
 - Convert `action:`/`debug: msg=` to mapping form
 - `no/yes` → `false/true`.
 - **v5:** `when:` no longer coerces `"true"/"false"` strings (any non-empty
@@ -202,16 +249,16 @@ Prior art: [#6209](https://github.com/dimagi/commcare-cloud/pull/6209) /
 [#6235](https://github.com/dimagi/commcare-cloud/pull/6235) ("changes for
 ansible upgrade 9.1.0/9.2.0") are the `include:` → `include_tasks:` +
 module-shorthand rewrites — **close both here**. Their `include_tasks` portion
-also satisfies the mechanical work noted in #16.
+also satisfies the mechanical work noted in #18.
 Acceptance: lint clean; no `when:` relies on implicit string→bool.
 
-#### 18. Move arithmetic/concatenation inside Jinja (Ansible 6/core 2.13)
+#### 20. Move arithmetic/concatenation inside Jinja (Ansible 6/core 2.13)
 Arithmetic and concatenation are no longer allowed *outside* a Jinja template.
 `'[1] + {{ [2] }}'` → `'{{ [1] + [2] }}'`. Grep `}}` adjacent to operators.
 Acceptance: lint clean. Hard to fully detect on 4.10, so re-verify at 4→10.
-Depends: 7.
+Depends: 9.
 
-#### 19. Harden conditional templating — highest-risk (the v8 + v12 arc)
+#### 21. Harden conditional templating — highest-risk (the v8 + v12 arc)
 - **v8/CVE-2023-5764** (core 2.15): embedded-template conditionals fail "unsafe"
   — reference untrusted values as plain Jinja vars, not embedded templates.
 - **v12** (core 2.19): non-boolean `when:` is now an error — make conditionals
@@ -220,36 +267,36 @@ Depends: 7.
   trusted strings render, and `omit` in loops drops immediately — flag dependents.
 Build the candidate list from a repo-wide grep of `when:` / `failed_when:` /
 `changed_when:` / `assert`.
-Acceptance: triaged on 4.10; full verification only on core 2.15 & 2.19 (see #27).
-Depends: 7.
+Acceptance: triaged on 4.10; full verification only on core 2.15 & 2.19 (see #29).
+Depends: 9.
 
-#### 20. Fix ansible.cfg Galaxy URL
+#### 22. Fix ansible.cfg Galaxy URL
 `old-galaxy.ansible.com` → `galaxy.ansible.com`.
 Acceptance: galaxy installs resolve.
 
-#### 21. Update custom plugins/modules for the newer core API
+#### 23. Update custom plugins/modules for the newer core API
 `module_utils._text` → `module_utils.common.text.converters`; `logging.warn` →
 `warning`. Re-verify `cchq_aws_secret.py` and `library/*` against the target
 `AnsibleModule`. Files: `plugins/inventory/csv.py`,
 `plugins/lookup/cchq_aws_secret.py`, `library/*`.
 Acceptance: import/run on target core; `test_csv_inventory.py` passes.
 
-#### 22. Audit in-code `ansible.*` imports + version gate
+#### 24. Audit in-code `ansible.*` imports + version gate
 Review CLI imports (`InventoryManager`, `DataLoader`, `VariableManager`,
 vault/dumper helpers) for API drift; raise `min_ansible_version` (currently
 `2.10.0`) on each step.
 Acceptance: CLI imports succeed per target core; gate matches shipped version.
 
-#### 23. Audit Ansible 13/core-2.20 behavior changes
+#### 25. Audit Ansible 13/core-2.20 behavior changes
 Prefer `ansible_facts.*` over bare `ansible_*` facts (`INJECT_FACTS_AS_VARS`
 flips to `False` in 2.24); the `failed_when` suppressed-error key is now
 `failed_when_suppressed_exception`. `include_vars`: `extensions`/`ignore_files`
 must be lists, not strings.
-Acceptance: CLI imports succeed on each target core; verified at 12→14 (#28).
+Acceptance: CLI imports succeed on each target core; verified at 12→14 (#30).
 
 ### Version bumps — sequential, after cleanup + a full test pass
 
-#### 24. Ansible 4 → 10 (core 2.11→2.17)
+#### 26. Ansible 4 → 10 (core 2.11→2.17)
 The core/package upgrade. Ansible 10 is the highest reachable on Python 3.10.
 Raise the `ansible` pin and `min_ansible_version`; re-pin collections to
 core-2.17-compatible versions.
@@ -260,57 +307,57 @@ can't merge until the cleanup band is done).
 Acceptance: core 2.17 installs; `deploy_hq.yml` syntax-check green; full
 Molecule suite green on Ansible 10.
 Fallback: bisect via 6/8 if failures are hard to localize.
-Depends: 8–23
+Depends: 10–25
 
-#### 25. Re-pin surviving standalone roles + re-test
+#### 27. Re-pin surviving standalone roles + re-test
 Bump the still-maintained roles to their newest releases and re-test on core
 2.17: `DavidWittman.redis`, `sansible.logstash`, the `andrewrothstein.*` SHAs
 (couchdb, couchdb-cluster). Done here because verification needs the new core.
-Acceptance: each touched role's Molecule (#7) green on Ansible 10; pins updated.
-Depends: 24.
+Acceptance: each touched role's Molecule (#9) green on Ansible 10; pins updated.
+Depends: 26.
 
-#### 26. Controller Python 3.10 → 3.12
+#### 28. Controller Python 3.10 → 3.12
 3.12 is the latest Python explicitly supported by Ansible 10–12. Raise
 `requires-python`, `.python-version`, CI matrix, base images; refresh `uv.lock`.
 Optional: install + run tests on 3.14; if no blockers, jump to 3.14 here.
 Acceptance: full suite green on Python 3.14 or 3.12 / Ansible 10.
-Depends: 24 (with 25 green).
+Depends: 26 (with 27 green).
 
-#### 27. Ansible 10 → 12 (core 2.17→2.19)
-Isolates the v12 templating overhaul, where #19 gets exercised and most breakage
+#### 29. Ansible 10 → 12 (core 2.17→2.19)
+Isolates the v12 templating overhaul, where #21 gets exercised and most breakage
 is expected. Re-pin collections.
 Prior art: Dependabot [#6758](https://github.com/dimagi/commcare-cloud/pull/6758)
 **close it here**.
 Acceptance: full suite green on 12 with zero templating/conditional errors.
-Depends: 26, 19.
+Depends: 28, 21.
 
-#### 28. Ansible 12 → 14 (core 2.19→2.21)
-Confirm #23 changes and the per-collection `requires_ansible` gate (#10); final
-collection re-pin. Runs on the #26 interpreter (3.12, or 3.14 if the #26
+#### 30. Ansible 12 → 14 (core 2.19→2.21)
+Confirm #25 changes and the per-collection `requires_ansible` gate (#12); final
+collection re-pin. Runs on the #28 interpreter (3.12, or 3.14 if the #28
 optional was taken).
 Acceptance: full suite green on 14.
-Depends: 27, 23.
+Depends: 29, 25.
 
-#### 29. Controller Python 3.12 → 3.14
-Skip if #26 already reached 3.14. Core 2.20+ are the first to officially support
+#### 31. Controller Python 3.12 → 3.14
+Skip if #28 already reached 3.14. Core 2.20+ are the first to officially support
 Python 3.14. Raise `requires-python`, `.python-version`, CI matrix, base images;
 refresh `uv.lock`. Verify own deps publish 3.14 wheels (esp. `cryptography`);
 fall back to 3.13 if necessary.
 Acceptance: full suite green.
-Depends: 28.
+Depends: 30.
 
 ### Validation & rollout
 
-#### 30. Full-stack sign-off
+#### 32. Full-stack sign-off
 End-to-end `deploy-stack` on Vagrant and the `tests/cloud/` Docker harness
 against the final stack; idempotence pass.
 Acceptance: clean monolith install + re-converge with zero unexpected changes.
-Depends: 29, 6.
+Depends: 31, 8.
 
-#### 31. Docs
+#### 33. Docs
 New minimum Python, upgrade outcome, Molecule/Vagrant workflows, changelog.
 Acceptance: a new contributor can run the ansible test suite from docs alone.
-Depends: 30.
+Depends: 32.
 
 ---
 
@@ -319,9 +366,9 @@ Depends: 30.
 - **Converge** (Ansible/Molecule): apply a role/playbook to a target host. A run
   *converges* when it completes with no errors. Paired with **idempotence** — a
   second run reports **zero changes** — this is the standard pass condition for
-  Molecule scenarios (#6, #7) and full-stack re-runs (#30).
+  Molecule scenarios (#8, #9) and full-stack re-runs (#32).
 - **Scrape** (Prometheus): Prometheus' pull model — it periodically fetches the
-  `/metrics` HTTP endpoint a target exposes. After #3, HQ still exposes its
+  `/metrics` HTTP endpoint a target exposes. After #5, HQ still exposes its
   metrics endpoint (the kept app-level integration), but the Prometheus server
   that scrapes it is operator-managed, not installed by commcare-cloud.
 
@@ -362,14 +409,14 @@ artifacts are still open and may be useful prior art:
   [#6235](https://github.com/dimagi/commcare-cloud/pull/6235) ("changes for
   ansible upgrade 9.1.0 / 9.2.0", branches `ansible/upgrade`,
   `ansible/upgrade-9.2.0`) — the `include:` → `include_tasks:` and
-  module-shorthand cleanups (overlaps #16–17 here).
+  module-shorthand cleanups (overlaps #18–19 here).
 - [#6520](https://github.com/dimagi/commcare-cloud/pull/6520) /
   [#6524](https://github.com/dimagi/commcare-cloud/pull/6524) ("Upgrading
   Ansible dependency for cloudalchemy.prometheus / node_exporter",
   [SAAS-16650](https://dimagi.atlassian.net/browse/SAAS-16650)) — the attempt to
   move the monitoring roles forward. #6524 bumps node_exporter "0.21.5 → 0.21.5"
   — a no-op, because the role is frozen at its final release. That dead end is
-  what motivates removing the monitoring install outright (#3) instead of
+  what motivates removing the monitoring install outright (#5) instead of
   upgrading it.
 
 **Maintenance audit of every dependency in `ansible/requirements.yml`** (checked
@@ -377,21 +424,21 @@ against GitHub archived flag + last push, June 2026):
 
 | Dependency | Repo | State | Last activity | Verdict |
 |--|--|--|--|--|
-| `cloudalchemy.prometheus` | cloudalchemy/ansible-prometheus | **ARCHIVED 2023-03** | rel 4.0.0 (2021-05) | **DEAD** → removed with the Prometheus install automation (#3) |
-| `cloudalchemy.alertmanager` | cloudalchemy/ansible-alertmanager | **ARCHIVED 2023-03** | rel 0.19.1 (2020-09) | **DEAD** → removed (#3) |
-| `cloudalchemy.grafana` | cloudalchemy/ansible-grafana | **ARCHIVED 2023-05** | rel 0.17.0 (2020-03) | **DEAD** → removed (#3) |
-| `cloudalchemy.node_exporter` | cloudalchemy/ansible-node-exporter | **ARCHIVED 2023-03** | rel 2.0.0 (2021-04) | **DEAD** → removed (#3) |
-| `bdellegrazie.postgres_exporter` | bdellegrazie/ansible-role-postgres_exporter | stale | 2022-12 | transitive dep of `dimagi.commcare_prometheus.postgres_exporter` — removed with it (#3) |
-| `gantsign.golang` | gantsign/ansible-role-golang | active | rel 3.5.0 (2025-04) | transitive dep of the collection's Go-exporter roles — removed with it (#3); only the monitoring stack used it |
-| `dimagi.commcare_prometheus` | dimagi/commcare-prometheus | Dimagi, stale | rel 0.1.10 (**2020-10**) | only consumed by `deploy_prometheus.yml` → removed (#3) |
-| `DavidWittman.redis` | DavidWittman/ansible-redis | semi-active | rel 1.2.12 (2024-01), 57 open issues | re-test on target core; bump if needed (#25) |
-| `sansible.logstash` | sansible/logstash | low activity | v2.4.4 | re-test on target core (#25) |
-| `andrewrothstein.couchdb` | andrewrothstein/ansible-couchdb | maintained | 2024-06 (SHA-pinned, no releases) | re-test; keep SHA pin (#25) |
-| `andrewrothstein.couchdb-cluster-*` | dimagi/ansible-couchdb-cluster | Dimagi fork | 2023-03 (SHA-pinned) | we own it — fix forward if it breaks (#25) |
-| `tmpreaper` (`ANXS/tmpreaper`) | ANXS/tmpreaper | **DEAD** | **2017-07** | trivial role — vendor or replace (#13) |
-| `ansible-logrotate` | nickhammond/ansible-logrotate | **DEAD** | **2018-10** (v0.0.5) | trivial role — vendor or replace (#14) |
-| `dimagi.commcare_logstash` | dimagi/commcare-logstash | Dimagi | 2022-01 (0.9.5) | re-test; we own it (#10) |
-| `community.general` | (collection) | active | pinned 7.4.0 | bump in lockstep with core (#10) |
+| `cloudalchemy.prometheus` | cloudalchemy/ansible-prometheus | **ARCHIVED 2023-03** | rel 4.0.0 (2021-05) | **DEAD** → removed with the Prometheus install automation (#5) |
+| `cloudalchemy.alertmanager` | cloudalchemy/ansible-alertmanager | **ARCHIVED 2023-03** | rel 0.19.1 (2020-09) | **DEAD** → removed (#5) |
+| `cloudalchemy.grafana` | cloudalchemy/ansible-grafana | **ARCHIVED 2023-05** | rel 0.17.0 (2020-03) | **DEAD** → removed (#5) |
+| `cloudalchemy.node_exporter` | cloudalchemy/ansible-node-exporter | **ARCHIVED 2023-03** | rel 2.0.0 (2021-04) | **DEAD** → removed (#5) |
+| `bdellegrazie.postgres_exporter` | bdellegrazie/ansible-role-postgres_exporter | stale | 2022-12 | transitive dep of `dimagi.commcare_prometheus.postgres_exporter` — removed with it (#5) |
+| `gantsign.golang` | gantsign/ansible-role-golang | active | rel 3.5.0 (2025-04) | transitive dep of the collection's Go-exporter roles — removed with it (#5); only the monitoring stack used it |
+| `dimagi.commcare_prometheus` | dimagi/commcare-prometheus | Dimagi, stale | rel 0.1.10 (**2020-10**) | only consumed by `deploy_prometheus.yml` → removed (#5) |
+| `DavidWittman.redis` | DavidWittman/ansible-redis | semi-active | rel 1.2.12 (2024-01), 57 open issues | re-test on target core; bump if needed (#27) |
+| `sansible.logstash` | sansible/logstash | low activity | v2.4.4 | re-test on target core (#27) |
+| `andrewrothstein.couchdb` | andrewrothstein/ansible-couchdb | maintained | 2024-06 (SHA-pinned, no releases) | re-test; keep SHA pin (#27) |
+| `andrewrothstein.couchdb-cluster-*` | dimagi/ansible-couchdb-cluster | Dimagi fork | 2023-03 (SHA-pinned) | we own it — fix forward if it breaks (#27) |
+| `tmpreaper` (`ANXS/tmpreaper`) | ANXS/tmpreaper | **DEAD** | **2017-07** | trivial role — vendor or replace (#15) |
+| `ansible-logrotate` | nickhammond/ansible-logrotate | **DEAD** | **2018-10** (v0.0.5) | trivial role — vendor or replace (#16) |
+| `dimagi.commcare_logstash` | dimagi/commcare-logstash | Dimagi | 2022-01 (0.9.5) | re-test; we own it (#12) |
+| `community.general` | (collection) | active | pinned 7.4.0 | bump in lockstep with core (#12) |
 
 ---
 
@@ -399,8 +446,8 @@ against GitHub archived flag + last push, June 2026):
 
 - **Depends** should be encoded as ticket links in the ticket description.
 - **Acceptance** should include ticket links where appropriate.
-- **Verification layers:** lint + syntax (CI, #4); Molecule converge/idempotence
-  (#6, #7); Vagrant + `tests/cloud/` full-stack (#5, #30); pytest CLI suite on
+- **Verification layers:** lint + syntax (CI, #6); Molecule converge/idempotence
+  (#8, #9); Vagrant + `tests/cloud/` full-stack (#7, #32); pytest CLI suite on
   the target Python/core.
 - **Local constraint:** ansible is never run on the dev machine — bumps are
   validated in CI and on Vagrant/Docker targets only.
@@ -408,6 +455,6 @@ against GitHub archived flag + last push, June 2026):
   - 14.x has a stable collection set at execution.
   - whether `community.general 7.4.0` needs bumping in lockstep with the cores.
   - ~~whether we need to maintain prometheus/grafana automation at all~~ —
-    **resolved:** no; #3 removes it and documents operator-managed Prometheus.
+    **resolved:** no; #5 removes it and documents operator-managed Prometheus.
   - add an Ansible 11 stop only if the SSH/Windows or docker-default changes
     prove relevant (unlikely — commcare-cloud targets Linux).


### PR DESCRIPTION
The document on this branch outlines the plan to upgrade Ansible from 4.10 to 14. The plan will be used as a reference for tickets that track the migration work. Initial tickets will be created from commit https://github.com/dimagi/commcare-cloud/commit/352c2f88a51b222f9998470bfe830db50382c5c8.

There is no expectation that this PR will be merged into master.

##### Environments Affected
None.