### PR TITLE
Fix pip uninstall uv

### DIFF
--- a/src/commcare_cloud/ansible/roles/common_installs/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/common_installs/tasks/main.yml
@@ -103,4 +103,4 @@
   become: yes
   pip:
     name: [uv]
-    absent: true
+    state: absent


### PR DESCRIPTION
Ansible `pip` module config error discovered while testing `deploy-stack` on staging.

Introduced in https://github.com/dimagi/commcare-cloud/pull/6894/changes/43a4ae5ca816dc6813bd8ca1dacf6eaeac817f84

##### Environments Affected
None.
