### PR TITLE
[Part - 1] : Use prebuilt static files on deploys - Add util to download static files

### DIFF
--- a/docs/source/reference/1-commcare-cloud/commands.md
+++ b/docs/source/reference/1-commcare-cloud/commands.md
@@ -1175,6 +1175,7 @@ Deploy CommCare
 ```
 commcare-cloud <env> deploy [--resume RELEASE_NAME] [--private] [-l SUBSET] [--keep-days KEEP_DAYS] [--skip-record]
                             [--commcare-rev COMMCARE_REV] [--ignore-kafka-checkpoint-warning] [--update-config]
+                            [--prebuilt-static]
                             [{commcare,formplayer} ...]
 ```
 
@@ -1223,6 +1224,14 @@ Do not block deploy if Kafka checkpoints are unavailable.
 
 Generate new localsettings.py rather than copying from the previous
 release.
+
+###### `--prebuilt-static`
+
+Fetch the prebuilt static files artifact for the deployed commit
+from GitHub Actions instead of relying solely on the on-host
+build. Requires a GitHub token (GITHUB_TOKEN env var or
+config.py) with Actions read access on dimagi/commcare-hq.
+Falls back to the on-host build if the artifact is unavailable.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-09-prebuilt-static-slice-1.md
+++ b/docs/superpowers/plans/2026-07-09-prebuilt-static-slice-1.md
@@ -1,0 +1,567 @@
+# Prebuilt Static Files — Slice 1 (Fetch to Control Machine) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When `cchq <env> deploy commcare --prebuilt-static` is run, download the prebuilt `REQUIRED_STATIC_FILES.zip` GitHub Actions artifact for the exact deploy commit onto the control machine (unwrapping GitHub's outer zip once), and pass its availability/path to the ansible play — without changing any deploy behavior yet.
+
+**Architecture:** All fetch logic lives in Python inside the deploy command (per the spec: "keep the HTTP/lookup logic in a small testable helper rather than inline ansible"), running *before* `run_ansible_playbook`. The token from `get_github_credentials_no_prompt()` (the same one used for the deploy summary) never reaches ansible; only the non-secret results (`static_artifact_available`, `static_artifact_path`) are passed as `-e` vars for slice 2 to consume. Opt-in is a new `--prebuilt-static` CLI flag on the deploy command — no environment config or schema change. Any failure → warn and fall back silently to the unchanged on-host build.
+
+**Tech Stack:** Python 3, `requests` (already a dependency), `zipfile` (stdlib), `pytest` + `requests_mock` (already used in `tests/test_deploy/test_formplayer_deploy.py`) for tests.
+
+**Spec:** `docs/superpowers/specs/2026-06-25-prebuilt-static-from-github-design.md` (Slice 1 of "Build approach: vertical slices").
+
+## Global Constraints
+
+- The GitHub token must never appear in ansible `-e` args, process listings, or printed output.
+- No change to any existing deploy behavior: `staticfiles_collect` / `staticfiles_compress` still run unconditionally; a fetch failure must never fail the deploy. Deploys without `--prebuilt-static` must be byte-for-byte identical to today.
+- Artifact name is `staticfiles-<sha>` where `<sha>` is the **full 40-char deploy commit** (`code_version`). Verified against commcare-hq `.github/workflows/build-static.yml`: `name: staticfiles-${{ github.sha }}`. Fetching by `code_version` is what guarantees the static files match the commit being deployed.
+- Inner zip layout (verified in commcare-hq `copy_required_static_files.py`): entries are bare top-level static dirs (`hqwebapp/`, `CACHE/`, `jsi18n/`, `webpack/`, ...) — no wrapper directory. Slice 2 unzips it directly into `{{ code_source }}/staticfiles/`.
+- Waiting policy: if the artifact isn't available yet, wait **only while the build-static workflow run for the deploy SHA is queued or in progress** (30s interval, 1800s ceiling). No run, or a run that concluded without success → fail fast to the on-host fallback. Never poll blindly.
+- GitHub API endpoints: `https://api.github.com/repos/dimagi/commcare-hq/actions/artifacts` (artifact lookup/download) and `https://api.github.com/repos/dimagi/commcare-hq/actions/workflows/build-static.yml/runs?head_sha=<sha>` (run status).
+- Run tests from the repo root: `pytest tests/test_deploy/... -v` (venv assumed active).
+
+---
+
+### Task 1: Artifact fetch helper (`static_artifact.py`)
+
+**Files:**
+- Create: `src/commcare_cloud/commands/deploy/static_artifact.py`
+- Test: `tests/test_deploy/test_static_artifact.py` (create)
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces: `fetch_static_artifact(token: str, sha: str, dest_dir: str, timeout: int = 1800, interval: int = 30, sleep=time.sleep) -> Optional[str]` — returns the absolute path of the inner `REQUIRED_STATIC_FILES.zip` on success, `None` when the artifact isn't available (no build for the SHA, build failed, or build didn't finish within the timeout). Raises `requests.RequestException` / `zipfile.BadZipFile` on hard errors (caller handles). Consumed by Task 2.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_deploy/test_static_artifact.py`:
+
+```python
+import io
+import zipfile
+from pathlib import Path
+
+import requests_mock
+
+from commcare_cloud.commands.deploy.static_artifact import (
+    ARTIFACTS_URL,
+    RUNS_URL,
+    fetch_static_artifact,
+)
+
+SHA = "abc123"
+LIST_URL = f"{ARTIFACTS_URL}?name=staticfiles-{SHA}"
+RUNS_QUERY_URL = f"{RUNS_URL}?head_sha={SHA}"
+DOWNLOAD_URL = f"{ARTIFACTS_URL}/999/zip"
+
+NOT_FOUND = {"total_count": 0, "artifacts": []}
+
+
+def _runs_response(status, conclusion=None):
+    return {"workflow_runs": [{"status": status, "conclusion": conclusion}]}
+
+
+def _zip_bytes(entries):
+    """entries: dict of {name: bytes} -> zip file bytes"""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, data in entries.items():
+            zf.writestr(name, data)
+    return buf.getvalue()
+
+
+def _inner_zip():
+    # entries are bare top-level static dirs, per copy_required_static_files
+    return _zip_bytes({"CACHE/manifest.json": b"{}", "hqwebapp/js/main.js": b""})
+
+
+def _outer_zip():
+    return _zip_bytes({"REQUIRED_STATIC_FILES.zip": _inner_zip()})
+
+
+def _found_response():
+    return {"total_count": 1, "artifacts": [
+        {"id": 999, "name": f"staticfiles-{SHA}", "expired": False,
+         "archive_download_url": DOWNLOAD_URL},
+    ]}
+
+
+def test_artifact_found_immediately(tmp_path):
+    with requests_mock.Mocker() as m:
+        m.get(LIST_URL, json=_found_response())
+        m.get(DOWNLOAD_URL, content=_outer_zip())
+        result = fetch_static_artifact("tok", SHA, str(tmp_path))
+    assert result is not None
+    assert Path(result).name == "REQUIRED_STATIC_FILES.zip"
+    # the inner zip is a valid zip containing the static tree
+    assert "CACHE/manifest.json" in zipfile.ZipFile(result).namelist()
+
+
+def test_waits_while_build_is_running(tmp_path):
+    sleeps = []
+    with requests_mock.Mocker() as m:
+        m.get(LIST_URL, [
+            {"json": NOT_FOUND},
+            {"json": NOT_FOUND},
+            {"json": _found_response()},
+        ])
+        m.get(RUNS_QUERY_URL, json=_runs_response("in_progress"))
+        m.get(DOWNLOAD_URL, content=_outer_zip())
+        result = fetch_static_artifact(
+            "tok", SHA, str(tmp_path), timeout=1800, interval=30, sleep=sleeps.append)
+    assert result is not None
+    assert sleeps == [30, 30]
+
+
+def test_no_workflow_run_fails_fast(tmp_path):
+    sleeps = []
+    with requests_mock.Mocker() as m:
+        m.get(LIST_URL, json=NOT_FOUND)
+        m.get(RUNS_QUERY_URL, json={"workflow_runs": []})
+        result = fetch_static_artifact(
+            "tok", SHA, str(tmp_path), timeout=1800, interval=30, sleep=sleeps.append)
+    assert result is None
+    assert sleeps == []  # no waiting when there is no build to wait for
+    assert m.call_count == 2  # one artifact check + one run check
+
+
+def test_failed_build_fails_fast(tmp_path):
+    sleeps = []
+    with requests_mock.Mocker() as m:
+        m.get(LIST_URL, json=NOT_FOUND)
+        m.get(RUNS_QUERY_URL, json=_runs_response("completed", "failure"))
+        result = fetch_static_artifact(
+            "tok", SHA, str(tmp_path), timeout=1800, interval=30, sleep=sleeps.append)
+    assert result is None
+    assert sleeps == []
+
+
+def test_completed_build_rechecks_artifact_once(tmp_path):
+    # Build finished successfully between our artifact check and run check:
+    # one final artifact lookup catches it.
+    with requests_mock.Mocker() as m:
+        m.get(LIST_URL, [{"json": NOT_FOUND}, {"json": _found_response()}])
+        m.get(RUNS_QUERY_URL, json=_runs_response("completed", "success"))
+        m.get(DOWNLOAD_URL, content=_outer_zip())
+        result = fetch_static_artifact(
+            "tok", SHA, str(tmp_path), timeout=1800, interval=30, sleep=lambda s: None)
+    assert result is not None
+
+
+def test_build_still_running_at_timeout_returns_none(tmp_path):
+    with requests_mock.Mocker() as m:
+        m.get(LIST_URL, json=NOT_FOUND)
+        m.get(RUNS_QUERY_URL, json=_runs_response("in_progress"))
+        result = fetch_static_artifact(
+            "tok", SHA, str(tmp_path), timeout=60, interval=30, sleep=lambda s: None)
+    assert result is None
+    # waited 30, 60 -> ceiling reached after 2 sleeps; 3 artifact checks + 3 run checks
+    assert m.call_count == 6
+
+
+def test_expired_artifact_is_ignored(tmp_path):
+    expired = {"total_count": 1, "artifacts": [
+        {"id": 5, "name": f"staticfiles-{SHA}", "expired": True,
+         "archive_download_url": DOWNLOAD_URL},
+    ]}
+    with requests_mock.Mocker() as m:
+        m.get(LIST_URL, json=expired)
+        m.get(RUNS_QUERY_URL, json={"workflow_runs": []})
+        result = fetch_static_artifact(
+            "tok", SHA, str(tmp_path), timeout=1800, interval=30, sleep=lambda s: None)
+    assert result is None
+
+
+def test_single_wrapped_download_is_used_as_is(tmp_path):
+    # If GitHub ever returns the staticfiles zip directly (not zip-of-zip),
+    # skip the unwrap and return the download itself.
+    with requests_mock.Mocker() as m:
+        m.get(LIST_URL, json=_found_response())
+        m.get(DOWNLOAD_URL, content=_inner_zip())
+        result = fetch_static_artifact("tok", SHA, str(tmp_path))
+    assert result is not None
+    assert "CACHE/manifest.json" in zipfile.ZipFile(result).namelist()
+
+
+def test_token_is_sent_as_bearer(tmp_path):
+    with requests_mock.Mocker() as m:
+        m.get(LIST_URL, json=_found_response())
+        m.get(DOWNLOAD_URL, content=_outer_zip())
+        fetch_static_artifact("tok", SHA, str(tmp_path))
+    for request in m.request_history:
+        assert request.headers["Authorization"] == "Bearer tok"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_deploy/test_static_artifact.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'commcare_cloud.commands.deploy.static_artifact'`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/commcare_cloud/commands/deploy/static_artifact.py`:
+
+```python
+"""Fetch the prebuilt REQUIRED_STATIC_FILES.zip GitHub Actions artifact.
+
+The 'Build Static Files' workflow in dimagi/commcare-hq uploads an artifact
+named ``staticfiles-<full commit sha>`` for each push to autostaging, so
+fetching by the deploy's ``code_version`` guarantees the static files match
+the deployed commit. The artifact-download endpoint wraps the zip in an
+outer zip; this module unwraps that outer layer once and returns the inner
+zip, which slice 2 pushes to the hosts.
+
+See docs/superpowers/specs/2026-06-25-prebuilt-static-from-github-design.md
+"""
+import os
+import time
+import zipfile
+
+import requests
+
+ARTIFACTS_URL = "https://api.github.com/repos/dimagi/commcare-hq/actions/artifacts"
+RUNS_URL = ("https://api.github.com/repos/dimagi/commcare-hq"
+            "/actions/workflows/build-static.yml/runs")
+INNER_ZIP_NAME = "REQUIRED_STATIC_FILES.zip"
+POLL_TIMEOUT = 1800
+POLL_INTERVAL = 30
+REQUEST_TIMEOUT = 60
+RUNNING_STATUSES = ("queued", "in_progress", "pending", "waiting", "requested")
+
+
+def fetch_static_artifact(token, sha, dest_dir,
+                          timeout=POLL_TIMEOUT, interval=POLL_INTERVAL,
+                          sleep=time.sleep):
+    """Download the staticfiles artifact for ``sha`` into ``dest_dir``.
+
+    If the artifact isn't available yet, waits while the build-static
+    workflow run for ``sha`` is queued or in progress (up to ``timeout``).
+    Returns the path to the inner REQUIRED_STATIC_FILES.zip, or None if
+    the artifact isn't available (no build for the SHA, build failed, or
+    build didn't finish in time). Network and zip errors propagate; the
+    caller treats any exception as "artifact unavailable".
+    """
+    download_url = _wait_for_artifact(token, sha, timeout, interval, sleep)
+    if download_url is None:
+        return None
+    download_path = _download(token, download_url, dest_dir)
+    return _unwrap_once(download_path, dest_dir)
+
+
+def _wait_for_artifact(token, sha, timeout, interval, sleep):
+    waited = 0
+    while True:
+        download_url = _get_artifact_download_url(token, sha)
+        if download_url is not None:
+            return download_url
+        status, conclusion = _get_workflow_run(token, sha)
+        if status in RUNNING_STATUSES:
+            if waited >= timeout:
+                return None
+            sleep(interval)
+            waited += interval
+            continue
+        if status == "completed" and conclusion == "success":
+            # build finished between the two checks above; the artifact
+            # should be listed now — one final lookup
+            return _get_artifact_download_url(token, sha)
+        # no build for this sha, or it concluded without success
+        return None
+
+
+def _get_workflow_run(token, sha):
+    """Return (status, conclusion) of the build-static run for sha.
+
+    (None, None) when the workflow never ran for this commit.
+    """
+    response = requests.get(
+        RUNS_URL,
+        params={"head_sha": sha},
+        headers=_headers(token),
+        timeout=REQUEST_TIMEOUT,
+    )
+    response.raise_for_status()
+    runs = response.json()["workflow_runs"]
+    if runs:
+        return runs[0]["status"], runs[0]["conclusion"]
+    return None, None
+
+
+def _get_artifact_download_url(token, sha):
+    response = requests.get(
+        ARTIFACTS_URL,
+        params={"name": f"staticfiles-{sha}"},
+        headers=_headers(token),
+        timeout=REQUEST_TIMEOUT,
+    )
+    response.raise_for_status()
+    artifacts = [a for a in response.json()["artifacts"] if not a["expired"]]
+    if artifacts:
+        return artifacts[0]["archive_download_url"]
+    return None
+
+
+def _download(token, download_url, dest_dir):
+    # GitHub responds 302 to a short-lived blob URL; requests follows it
+    # and drops the Authorization header on the cross-host redirect.
+    download_path = os.path.join(dest_dir, "artifact-download.zip")
+    with requests.get(
+        download_url,
+        headers=_headers(token),
+        timeout=REQUEST_TIMEOUT,
+        stream=True,
+    ) as response:
+        response.raise_for_status()
+        with open(download_path, "wb") as f:
+            for chunk in response.iter_content(chunk_size=1024 * 1024):
+                f.write(chunk)
+    return download_path
+
+
+def _unwrap_once(download_path, dest_dir):
+    """Remove GitHub's outer zip wrapper, if present.
+
+    The artifact endpoint returns a zip whose single entry is our
+    REQUIRED_STATIC_FILES.zip. If the download is not wrapped that way,
+    use it as-is.
+    """
+    with zipfile.ZipFile(download_path) as outer:
+        if outer.namelist() == [INNER_ZIP_NAME]:
+            return outer.extract(INNER_ZIP_NAME, dest_dir)
+    return download_path
+
+
+def _headers(token):
+    return {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_deploy/test_static_artifact.py -v`
+Expected: PASS (9 tests)
+
+Note: `requests_mock` returns content directly with no 302 redirect, so the `test_token_is_sent_as_bearer` assertion over `request_history` validates both real requests carry the header; the redirect-stripping behavior is requests' own and not under test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/commcare_cloud/commands/deploy/static_artifact.py tests/test_deploy/test_static_artifact.py
+git commit -m "Add GitHub static artifact fetch helper"
+```
+
+---
+
+### Task 2: `--prebuilt-static` CLI flag wired into `deploy_commcare`
+
+**Files:**
+- Modify: `src/commcare_cloud/commands/deploy/command.py` (`Deploy.arguments` ~line 28–64; `_warn_about_non_formplayer_args` ~line 120–135)
+- Modify: `src/commcare_cloud/commands/deploy/commcare.py` (imports ~line 1–27; `deploy_commcare` ~line 52–70)
+- Test: `tests/test_deploy/test_prebuilt_static_args.py` (create)
+
+**Interfaces:**
+- Consumes: `fetch_static_artifact(token, sha, dest_dir)` (Task 1); existing `get_github_credentials_no_prompt()` from `commcare_cloud.github`; `args.prebuilt_static: bool` (defined here).
+- Produces: extra ansible args `["-e", "static_artifact_available=true", "-e", "static_artifact_path=<path>"]` on success, `[]` otherwise. Slice 2's ansible plays will consume these vars; in slice 1 they are inert (no play references them).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_deploy/test_prebuilt_static_args.py`:
+
+```python
+from unittest.mock import Mock, patch
+
+from commcare_cloud.commands.deploy import commcare
+from commcare_cloud.commands.deploy.commcare import get_prebuilt_static_args
+
+
+def _args(prebuilt_static=True):
+    return Mock(prebuilt_static=prebuilt_static)
+
+
+def test_returns_args_when_artifact_fetched():
+    with patch.object(commcare, "get_github_credentials_no_prompt", return_value="tok"), \
+            patch.object(commcare, "fetch_static_artifact",
+                         return_value="/tmp/x/REQUIRED_STATIC_FILES.zip") as fetch:
+        args = get_prebuilt_static_args(_args(), "abc123")
+    assert args == [
+        "-e", "static_artifact_available=true",
+        "-e", "static_artifact_path=/tmp/x/REQUIRED_STATIC_FILES.zip",
+    ]
+    token, sha, dest_dir = fetch.call_args[0]
+    assert (token, sha) == ("tok", "abc123")
+
+
+def test_noop_without_flag():
+    with patch.object(commcare, "fetch_static_artifact") as fetch:
+        assert get_prebuilt_static_args(_args(prebuilt_static=False), "abc123") == []
+    fetch.assert_not_called()
+
+
+def test_noop_when_no_token():
+    with patch.object(commcare, "get_github_credentials_no_prompt", return_value=None), \
+            patch.object(commcare, "fetch_static_artifact") as fetch:
+        assert get_prebuilt_static_args(_args(), "abc123") == []
+    fetch.assert_not_called()
+
+
+def test_falls_back_when_artifact_not_found():
+    with patch.object(commcare, "get_github_credentials_no_prompt", return_value="tok"), \
+            patch.object(commcare, "fetch_static_artifact", return_value=None):
+        assert get_prebuilt_static_args(_args(), "abc123") == []
+
+
+def test_falls_back_on_fetch_error():
+    with patch.object(commcare, "get_github_credentials_no_prompt", return_value="tok"), \
+            patch.object(commcare, "fetch_static_artifact",
+                         side_effect=Exception("boom")):
+        assert get_prebuilt_static_args(_args(), "abc123") == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_deploy/test_prebuilt_static_args.py -v`
+Expected: FAIL with `ImportError: cannot import name 'get_prebuilt_static_args'`
+
+- [ ] **Step 3: Add the CLI flag**
+
+In `src/commcare_cloud/commands/deploy/command.py`, add to `Deploy.arguments` after `--update-config` (~line 61):
+
+```python
+        Argument('--prebuilt-static', action='store_true', help="""
+            Fetch the prebuilt static files artifact for the deployed commit
+            from GitHub Actions instead of relying solely on the on-host
+            build. Requires a GitHub token (GITHUB_TOKEN env var or
+            config.py) with Actions read access on dimagi/commcare-hq.
+            Falls back to the on-host build if the artifact is unavailable.
+        """),
+```
+
+And add `'--prebuilt-static',` to the list in `_warn_about_non_formplayer_args` (after `'--update-config',`) so a formplayer-only deploy warns that it's ignored.
+
+- [ ] **Step 4: Implement `get_prebuilt_static_args` and call it from `deploy_commcare`**
+
+In `src/commcare_cloud/commands/deploy/commcare.py`, add imports (near the existing ones at the top):
+
+```python
+import tempfile
+
+from commcare_cloud.commands.deploy.static_artifact import fetch_static_artifact
+from commcare_cloud.github import get_github_credentials_no_prompt, github_repo
+```
+
+(`github_repo` is already imported from `commcare_cloud.github` — extend that line rather than adding a duplicate import.)
+
+Add the function (below `deploy_commcare`):
+
+```python
+def get_prebuilt_static_args(args, deploy_commit):
+    """Ansible -e args pointing at the prebuilt static artifact, or [].
+
+    Fetches the artifact onto the control machine when --prebuilt-static
+    is passed and a GitHub token is available. Any failure falls back to
+    the on-host static build (returns []). The token itself is never
+    passed to ansible.
+    """
+    if not args.prebuilt_static:
+        return []
+    token = get_github_credentials_no_prompt()
+    if not token:
+        print(color_notice(
+            "--prebuilt-static was passed but no GitHub token is "
+            "configured (GITHUB_TOKEN env var or config.py). "
+            "Falling back to the on-host static build."
+        ))
+        return []
+    print(color_summary(">> Fetching prebuilt static files artifact"))
+    dest_dir = tempfile.mkdtemp(prefix="commcare-static-artifact-")
+    try:
+        zip_path = fetch_static_artifact(token, deploy_commit, dest_dir)
+    except Exception as err:
+        print(color_error(f"Error fetching prebuilt static artifact: {err}"))
+        zip_path = None
+    if zip_path is None:
+        print(color_notice(
+            "Prebuilt static artifact unavailable. "
+            "Falling back to the on-host static build."
+        ))
+        return []
+    print(color_summary(f"Prebuilt static artifact downloaded: {zip_path}"))
+    return [
+        "-e", "static_artifact_available=true",
+        "-e", f"static_artifact_path={zip_path}",
+    ]
+```
+
+In `deploy_commcare`, immediately after `ansible_args.extend(["-e", f"code_version={context.diff.deploy_commit}"])` (line ~53):
+
+```python
+    ansible_args.extend(get_prebuilt_static_args(args, context.diff.deploy_commit))
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest tests/test_deploy/test_prebuilt_static_args.py tests/test_deploy/test_command.py -v`
+Expected: PASS. `test_command.py` must still pass unchanged — its invocations don't pass `--prebuilt-static`, so `args.prebuilt_static` is `False` and `get_prebuilt_static_args` returns `[]` without touching the network. (If any of its fake `args` objects lack the attribute, that's a real integration break — fix by ensuring the tests build args through the argument parser, not by loosening `get_prebuilt_static_args`.)
+
+- [ ] **Step 6: Check the flag renders in CLI help and autogenerated docs**
+
+Run: `COMMCARE_CLOUD_ENVIRONMENTS=tests/test_envs commcare-cloud staging deploy --help`
+Expected: `--prebuilt-static` listed with its help text.
+
+Run: `./tests/test_autogen_docs.sh` (this repo autogenerates command docs from parsers; if it reports a diff, run the regeneration command it names and include the regenerated docs in the commit).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/commcare_cloud/commands/deploy/command.py src/commcare_cloud/commands/deploy/commcare.py tests/test_deploy/test_prebuilt_static_args.py
+# plus any regenerated docs from step 6
+git commit -m "Add --prebuilt-static deploy flag to fetch static artifact"
+```
+
+---
+
+### Task 3: End-to-end verification
+
+**Files:** none (verification only).
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: slice 1 acceptance evidence.
+
+- [ ] **Step 1: Run the full deploy test suite**
+
+Run: `pytest tests/test_deploy/ -v`
+Expected: PASS
+
+- [ ] **Step 2: Manual verification against the real GitHub API (no deploy needed)**
+
+
+With a GitHub token that has `Actions: Read` on dimagi/commcare-hq, and `<sha>` the full commit SHA of a recent `autostaging` push with a completed "Build Static Files" run (the token is prompted with hidden input — never typed on the command line or stored in shell history):
+
+```bash
+python - <<'EOF'
+import tempfile, zipfile
+from getpass import getpass
+from commcare_cloud.commands.deploy.static_artifact import fetch_static_artifact
+path = fetch_static_artifact(getpass("GitHub token: "), '<sha>', tempfile.mkdtemp())
+print(path)
+print(zipfile.ZipFile(path).namelist()[:10])
+EOF
+```
+
+Expected: prints a path ending in `REQUIRED_STATIC_FILES.zip` and entries rooted at bare static dirs (`CACHE/...`, `hqwebapp/...`, `jsi18n/...`, `webpack/...`) — confirming the layout established from the commcare-hq source holds for the real artifact.
+
+- [ ] **Step 3: Staging deploy with the flag**
+
+Run a staging deploy with `--prebuilt-static`. Expected console output includes `>> Fetching prebuilt static files artifact` and `Prebuilt static artifact downloaded: ...`, and the deploy then proceeds **identically to before** (collect/compress still run on hosts). Also run one deploy *without* the flag and confirm no new output appears.
+
+---
+
+## Out of scope for this plan (slice 2+)
+
+- Pushing the zip to hosts, host-side unzip into `{{ code_source }}/staticfiles/`, manifest/CACHE distribution.
+- `when: not static_artifact_available` gating of `staticfiles_collect` / `staticfiles_compress` in `deploy_hq.yml`.
+- Cleanup of the control-machine temp dir after distribution.
+- Hardening/messaging polish (slice 3).

--- a/docs/superpowers/specs/2026-06-25-prebuilt-static-from-github-design.md
+++ b/docs/superpowers/specs/2026-06-25-prebuilt-static-from-github-design.md
@@ -1,0 +1,238 @@
+# Pull prebuilt static files from GitHub during deploy
+
+## Status
+
+Phase 1 design — Dimagi internal deploys only (proof of mechanism).
+
+## Problem
+
+Today, every CommCare HQ deploy builds static files **on the hosts** via the
+`deploy_hq` ansible role: `staticfiles_collect` (on webworkers + proxy) runs
+`resource_static`, `collectstatic`, `fix_less_imports_collectstatic`,
+`generate_webpack_settings`, and `yarn build`; `staticfiles_compress` (on
+`proxy[0]`) runs `compress --force` and distributes `staticfiles/CACHE` to the
+other hosts (via `shared_dir_for_staticfiles` or by pushing the manifest to
+redis).
+
+This build is slow, requires Node/yarn/SASS build toolchains on production
+hosts, and repeats work that the `Build Static Files` GitHub Actions workflow
+(`.github/workflows/build-static.yml` in commcare-hq) already performs on every
+push to `autostaging`. That workflow produces `REQUIRED_STATIC_FILES.zip`, but
+the artifact currently requires an interactive GitHub login to download, so
+commcare-cloud cannot consume it.
+
+**Goal:** have commcare-cloud download the prebuilt artifact for the deployed
+commit and distribute it to the hosts, eliminating the on-host build — proven
+first on Dimagi internal (staging) deploys.
+
+## Scope
+
+### In scope (Phase 1)
+
+- Dimagi **internal** deploys only (autostaging / staging).
+- Fetch the GitHub Actions artifact for the deploy's SHA via the **REST API**
+  (no `gh` CLI — raw `curl`).
+- Authenticate with the **same GitHub token the user already supplies for the
+  deploy summary/diff** (resolved by
+  `commcare_cloud.github.get_github_credentials_no_prompt()`: the
+  `GITHUB_TOKEN` env var or `config.py`'s `GITHUB_APIKEY`). The token must have
+  `Actions: Read` on `dimagi/commcare-hq`.
+- Download on the **control machine**, unwrap GitHub's outer zip, then push the
+  inner `REQUIRED_STATIC_FILES.zip` to the hosts and unzip it there. The token
+  never lands on a host.
+- **Fall back** to the existing on-host build when the artifact is unavailable.
+
+### Explicitly out of scope (future phases)
+
+- Third-party hosters consuming the artifact. They continue to build on-host
+  exactly as today (no behavior change, no Dimagi credential required).
+- Permanence beyond the 90-day artifact retention (e.g. release assets in a
+  dedicated side repo).
+- Production deploys.
+- A dedicated artifact credential (e.g. an org-owned GitHub App or a separate
+  fine-grained PAT in commcare-cloud secrets). Reusing the deploy-summary token
+  is the fastest internal test; revisit once the mechanism is proven.
+
+## Key facts established during design
+
+- **The artifact matches the deploy commit exactly.** The workflow
+  (`.github/workflows/build-static.yml` in commcare-hq) names the artifact
+  `staticfiles-${{ github.sha }}` — the full 40-char commit SHA of the
+  autostaging push. The deploy fetches `staticfiles-<code_version>` where
+  `code_version` is the resolved deploy commit, so the fetched static files
+  can never belong to a different commit than the one being deployed.
+- **Inner zip layout (verified in commcare-hq).**
+  `copy_required_static_files` zips the `REQUIRED_STATIC_FILES/` directory
+  with `arcname` relative to that directory, so the zip's entries are bare
+  top-level dirs (`hqwebapp/`, `CACHE/`, `jsi18n/`, `webpack/`, ...) with no
+  wrapper directory. On the hosts it unzips directly into
+  `{{ code_source }}/staticfiles/` (host `STATIC_ROOT`).
+- **The artifact is sufficient.** `REQUIRED_STATIC_FILES.zip` already contains
+  the fully built `staticfiles/` subset — app static dirs, `jsi18n`, `webpack`,
+  `webpack_b3`, and `CACHE/` including the compressed assets and
+  `manifest.json`. When the artifact is used, the entire on-host build chain is
+  skipped.
+- **Artifact download requires a bearer token**, even for a public repo, and
+  even though commcare-hq is public. SSH-agent forwarding (which carries SSH
+  keys for git, not an HTTPS token) cannot authenticate this REST call — hence
+  the PAT is required, not optional, in the absence of `gh`.
+- **GitHub wraps the artifact in a zip-of-zip.** The artifact-download endpoint
+  returns an outer zip containing our `REQUIRED_STATIC_FILES.zip`. The control
+  machine unzips **once** (removing GitHub's wrapper) and ships the inner zip
+  to the hosts; the second unzip happens on each host. If a download is ever
+  not double-wrapped, the control machine skips the unwrap and pushes the zip
+  as-is.
+- **Why not private S3:** a private bucket would exclude third-party hosters
+  (future goal), and a public bucket would expose Dimagi to anonymous
+  download/bill-inflation. GitHub hosting puts bandwidth cost on GitHub and
+  per-token rate limits on the caller.
+
+## Design
+
+### Transport & auth
+
+- **Reuse the deploy-summary token.** The deploy command already resolves a
+  GitHub token via `commcare_cloud.github.get_github_credentials()`
+  (`GITHUB_TOKEN` env var, `config.py` `GITHUB_APIKEY`, or the memoized
+  interactive `getpass` prompt) to compile the deploy summary/diff. The
+  artifact fetch uses the same token — no new secret, no changes to
+  `secrets_schema.py`/`secrets.yml`. The deploy command exports the token as
+  `GITHUB_TOKEN` in the `ansible-playbook` subprocess environment
+  (`build_env()` copies `os.environ`); it never appears in `-e` args, any
+  command line, or output. Users must ensure their token has `Actions: Read`
+  on `dimagi/commcare-hq` (classic tokens with `public_repo` already do).
+- **Fetch timing: at the static files step, not at deploy start.** The deploy
+  command downloads nothing; it only passes a non-secret
+  `-e prebuilt_static=true`. The playbook fetches the artifact when it
+  reaches the static files step. By then the release-setup plays (checkout,
+  yarn install, ...) have given the GitHub Actions build 10–15 minutes to
+  finish, so waiting on a still-running build is rare, and any poll happens
+  exactly where the time is needed instead of blocking the whole deploy
+  upfront.
+- GitHub REST calls:
+  1. `GET /repos/dimagi/commcare-hq/actions/artifacts?name=staticfiles-<sha>`
+     → resolve the artifact id (the `name` query filter avoids pagination).
+  2. `GET /repos/dimagi/commcare-hq/actions/workflows/build-static.yml/runs?head_sha=<sha>`
+     → only when (1) finds nothing: check whether the build for this exact
+     commit is queued/in progress. If it is, **wait and poll** until it
+     completes and the artifact appears; if no run exists or the run
+     concluded without success, fail fast to the on-host fallback instead
+     of polling pointlessly.
+  3. `GET /repos/dimagi/commcare-hq/actions/artifacts/<id>/zip` → 302 redirect
+     to a short-lived blob URL; the byte transfer is **not** counted against
+     the API rate limit.
+  Waiting on a running build adds a pair of type-(1)/(2) calls per poll
+  interval. Authenticated limit is 5,000/hr — negligible.
+
+### Opt-in configuration
+
+The prebuilt-static path is **opt-in per deploy** via a new CLI flag on the
+deploy command: `cchq <env> deploy commcare --prebuilt-static`. No environment
+config or schema change — deploys that omit the flag (all third parties, and
+any Dimagi deploy not opting in) keep the existing on-host build untouched. A
+GitHub token (see Transport & auth) must also be present for the path to
+activate; without one, deploys fall back to the on-host build.
+
+### New ansible tasks: `staticfiles_fetch`
+
+A new `deploy_hq` task file `staticfiles_fetch.yml`, run on the **control
+machine** (`delegate_to: localhost`, `run_once: true`) immediately before the
+static files plays, gated on `prebuilt_static`. It invokes the Python helper
+as a CLI — `python -m commcare_cloud.commands.deploy.static_artifact
+<code_version> <temp dir>` — which reads `GITHUB_TOKEN` from the inherited
+environment (never argv), prints the fetched zip path on success, and exits
+nonzero when the artifact is unavailable so the play can fall back. The
+helper:
+
+1. **Resolve + wait on running build.** Call REST endpoint (1) for
+   `staticfiles-<code_version>`. If the artifact isn't there yet, check the
+   build-static workflow run for that SHA (endpoint (2)): while it is
+   queued/in progress, poll up to a bounded timeout; if there is no run or
+   it finished unsuccessfully, give up immediately. On success capture the
+   artifact id.
+2. **Download + unwrap once.** Call endpoint (3) with the token, follow the
+   redirect, and download into a control-machine temp dir. If the download is
+   double-zipped (GitHub's wrapper around `REQUIRED_STATIC_FILES.zip`), unzip
+   **once** to extract the inner zip; otherwise use the download as-is. The
+   inner zip is what gets pushed to hosts — the control machine never expands
+   the full `staticfiles/` tree. Verify (e.g. `unzip -l`) that the zip's
+   internal root maps onto host `STATIC_ROOT`
+   (`{{ code_source }}/staticfiles/`); note the management command
+   `copy_required_static_files` writes into a `REQUIRED_STATIC_FILES/`
+   directory, so the internal root must be checked during implementation.
+3. **Set fact** `static_artifact_available: true|false` for the whole play.
+
+### Distribution
+
+When `static_artifact_available`:
+
+- **Push the zip, unzip on the hosts.** Copy the single
+  `REQUIRED_STATIC_FILES.zip` from the control machine to a temp path on each
+  webworker/proxy (ansible `copy` or `synchronize` push), then `unarchive` it
+  on each host into `{{ code_source }}/staticfiles/`, and remove the temp zip.
+  Shipping one compressed file is faster and cheaper than rsyncing the
+  expanded tree of many small files.
+- Reuse the existing CACHE/manifest distribution: push the manifest to redis
+  (`update_manifest save`) or to `shared_dir_for_staticfiles`, matching the
+  current `staticfiles_compress` behavior.
+
+### Gating / fallback
+
+- The fetch task runs immediately before the static files plays (only when
+  `--prebuilt-static` was passed and a token was present, i.e.
+  `prebuilt_static=true` reached the play).
+- The existing `staticfiles_collect` and `staticfiles_compress` plays in
+  `deploy_hq.yml` gain `when: not static_artifact_available`, becoming the
+  universal default and the fallback. Any failure in `staticfiles_fetch`
+  (missing artifact, download error, layout mismatch) sets
+  `static_artifact_available: false` and the on-host build runs.
+
+## Build approach: vertical slices
+
+Implement the feature as thin end-to-end slices, each independently
+deployable/testable against staging, rather than layer-by-layer:
+
+1. **Slice 1 — fetch machinery + flag.** The Python helper (artifact lookup +
+   wait-on-running-build + download + single unwrap + progress output) with
+   its CLI entry point, the `--prebuilt-static` flag, and the token/env
+   plumbing (`-e prebuilt_static=true`, `GITHUB_TOKEN` exported to the
+   playbook subprocess). No playbook changes; on-host build still runs
+   unconditionally. Verifiable by unit tests plus running the CLI helper
+   against a real autostaging SHA on the control machine.
+2. **Slice 2 — playbook fetch + distribute + gate.** The `staticfiles_fetch`
+   localhost task (invoking the CLI at the static files step, setting
+   `static_artifact_available`), push the zip to hosts, unzip into
+   `STATIC_ROOT`, manifest/CACHE distribution, and
+   `when: not static_artifact_available` gating on `staticfiles_collect` /
+   `staticfiles_compress`. This is the first slice that changes deploy
+   behavior; verified by a staging deploy serving prebuilt static.
+3. **Slice 3 — hardening.** Fallback paths (missing artifact, token without
+   `Actions: Read`, layout mismatch, poll timeout), `no_log` review, and
+   operator-facing messaging.
+
+Each slice lands as its own PR with its own tests.
+
+## Testing
+
+- **Unit tests (Python, commcare-cloud):** artifact lookup/poll logic against
+  mocked GitHub API responses — found immediately, not-yet-then-found
+  (polling), and never-found (timeout → fallback). Keep the HTTP/lookup logic in
+  a small testable helper rather than inline ansible.
+- **Staging dry-run deploys:**
+  - Artifact present → build steps skipped; app serves correctly versioned
+    static (manifest resolves, webpack bundles load).
+  - Artifact absent / token missing / opt-in off → on-host build runs unchanged.
+
+## Open items for the implementation plan
+
+- Behavior when the user's token lacks `Actions: Read` (fall back with a
+  clear message).
+- Whether host-side `unarchive` needs `unzip` installed on webworkers/proxies.
+
+Resolved during planning: opt-in is the `--prebuilt-static` CLI flag; the
+zip's internal root is bare top-level static dirs (see Key facts); polling
+waits only while the build-static workflow run for the SHA is queued or in
+progress (30s interval, 1800s ceiling), failing fast otherwise; the fetch
+happens at the static files step (localhost task invoking the helper CLI),
+with the token reaching it only via the playbook subprocess environment —
+never `-e` args, argv, or remote hosts.

--- a/src/commcare_cloud/commands/deploy/command.py
+++ b/src/commcare_cloud/commands/deploy/command.py
@@ -59,6 +59,13 @@ class Deploy(CommandBase):
             Generate new localsettings.py rather than copying from the previous
             release.
         """),
+        Argument('--prebuilt-static', action='store_true', help="""
+            Fetch the prebuilt static files artifact for the deployed commit
+            from GitHub Actions instead of relying solely on the on-host
+            build. Requires a GitHub token (GITHUB_TOKEN env var or
+            config.py) with Actions read access on dimagi/commcare-hq.
+            Falls back to the on-host build if the artifact is unavailable.
+        """),
         shared_args.QUIET_ARG,
         shared_args.BRANCH_ARG,
     )
@@ -128,6 +135,7 @@ def _warn_about_non_formplayer_args(args):
         '--commcare-rev',
         '--ignore-kafka-checkpoint-warning',
         '--update-config',
+        '--prebuilt-static',
     ]:
         dest = arg.lstrip("-").replace("-", "_")
         if getattr(args, dest) not in [None, False]:

--- a/src/commcare_cloud/commands/deploy/commcare.py
+++ b/src/commcare_cloud/commands/deploy/commcare.py
@@ -5,6 +5,9 @@ from datetime import datetime, timedelta
 from commcare_cloud.alias import commcare_cloud
 from commcare_cloud.cli_utils import ask
 from commcare_cloud.colors import color_error, color_notice, color_summary
+from commcare_cloud.commands.ansible.ansible_playbook import (
+    run_ansible_playbook,
+)
 from commcare_cloud.commands.ansible.run_module import (
     AnsibleContext,
     BadAnsibleResult,
@@ -14,13 +17,14 @@ from commcare_cloud.commands.ansible.run_module import (
 from commcare_cloud.commands.deploy.deploy_diff import DeployDiff
 from commcare_cloud.commands.deploy.sentry import update_sentry_post_deploy
 from commcare_cloud.commands.deploy.utils import (
-    record_deploy_start,
-    announce_deploy_success,
-    create_release_tag,
-    confirm_environment_time,
     DeployContext,
+    announce_deploy_success,
+    confirm_environment_time,
+    create_release_tag,
     record_deploy_failed,
+    record_deploy_start,
 )
+from commcare_cloud.const import DATE_FMT
 from commcare_cloud.events import publish_deploy_event
 from commcare_cloud.github import get_github_credentials, github_repo
 

--- a/src/commcare_cloud/commands/deploy/commcare.py
+++ b/src/commcare_cloud/commands/deploy/commcare.py
@@ -1,3 +1,4 @@
+import os
 import shlex
 from datetime import datetime, timedelta
 
@@ -10,7 +11,6 @@ from commcare_cloud.commands.ansible.run_module import (
     ansible_json,
     run_ansible_module,
 )
-from commcare_cloud.commands.ansible.ansible_playbook import run_ansible_playbook
 from commcare_cloud.commands.deploy.deploy_diff import DeployDiff
 from commcare_cloud.commands.deploy.sentry import update_sentry_post_deploy
 from commcare_cloud.commands.deploy.utils import (
@@ -22,8 +22,7 @@ from commcare_cloud.commands.deploy.utils import (
     record_deploy_failed,
 )
 from commcare_cloud.events import publish_deploy_event
-from commcare_cloud.const import DATE_FMT
-from commcare_cloud.github import github_repo
+from commcare_cloud.github import get_github_credentials, github_repo
 
 
 def get_commcare_deploy_diff(environment, args):
@@ -51,6 +50,7 @@ def deploy_commcare(environment, args, unknown_args):
 
     ansible_args = []
     ansible_args.extend(["-e", f"code_version={context.diff.deploy_commit}"])
+    ansible_args.extend(get_prebuilt_static_args(args))
     if args.private and not args.keep_days:
         args.keep_days = 1
     if args.keep_days:
@@ -95,6 +95,25 @@ def deploy_commcare(environment, args, unknown_args):
         print(color_summary(environment.remote_conf.code_source))
 
     return 0
+
+
+def get_prebuilt_static_args(args):
+    """Ansible -e args enabling the prebuilt static artifact fetch, or [].
+
+    Verifies that Github token is present and sets the GITHUB_TOKEN env var. This just passes the arg to tell playbook to use the prebuilt static artifacts.The artifact itself is fetched later, by a playbook task on the control machine.
+    """
+    if not args.prebuilt_static:
+        return []
+    token = get_github_credentials(prompt_if_missing=True)
+    if not token:
+        print(color_notice(
+            "--prebuilt-static was passed but no GitHub token was provided "
+            "(GITHUB_TOKEN env var, config.py, or the prompt above). "
+            "Falling back to the on-host static build."
+        ))
+        return []
+    os.environ["GITHUB_TOKEN"] = token
+    return ["-e", "prebuilt_static=true"]
 
 
 def confirm_deploy(environment, deploy_revs, rev_diffs, args):

--- a/src/commcare_cloud/commands/deploy/static_artifact.py
+++ b/src/commcare_cloud/commands/deploy/static_artifact.py
@@ -1,0 +1,174 @@
+"""Fetch the prebuilt REQUIRED_STATIC_FILES.zip GitHub Actions artifact.
+
+The 'Build Static Files' workflow in dimagi/commcare-hq uploads an artifact
+named ``staticfiles-<full commit sha>`` for each push to autostaging, so
+fetching by the deploy's ``code_version`` guarantees the static files match
+the deployed commit. The artifact-download endpoint wraps the zip in an
+outer zip; this module unwraps that outer layer once and returns the inner
+zip.
+
+"""
+import os
+import time
+import zipfile
+
+import requests
+
+ARTIFACTS_URL = "https://api.github.com/repos/dimagi/commcare-hq/actions/artifacts"
+RUNS_URL = ("https://api.github.com/repos/dimagi/commcare-hq"
+            "/actions/workflows/build-static.yml/runs")
+INNER_ZIP_NAME = "REQUIRED_STATIC_FILES.zip"
+POLL_TIMEOUT = 1800
+POLL_INTERVAL = 30
+REQUEST_TIMEOUT = 60
+PROGRESS_INTERVAL = 10  # seconds between download progress lines
+RUNNING_STATUSES = ("queued", "in_progress", "pending", "waiting", "requested")
+
+
+def fetch_static_artifact(token, sha, dest_dir,
+                          timeout=POLL_TIMEOUT, interval=POLL_INTERVAL):
+    """Download the staticfiles artifact for ``sha`` into ``dest_dir``.
+
+    If the artifact isn't available yet, waits while the build-static
+    workflow run for ``sha`` is queued or in progress (up to ``timeout``).
+    Returns the path to the inner REQUIRED_STATIC_FILES.zip, or None if
+    the artifact isn't available (no build for the SHA, build failed, or
+    build didn't finish in time). Network and zip errors propagate; the
+    caller treats any exception as "artifact unavailable".
+    """
+    download_url = _wait_for_artifact(token, sha, timeout, interval)
+    if download_url is None:
+        return None
+    download_path = _download(token, download_url, dest_dir)
+    return _unwrap_once(download_path, dest_dir)
+
+
+def _wait_for_artifact(token, sha, timeout, interval):
+    waited = 0
+    while True:
+        download_url = _get_artifact_download_url(token, sha)
+        if download_url is not None:
+            return download_url
+        status, conclusion = _get_workflow_run(token, sha)
+        if status in RUNNING_STATUSES:
+            if waited >= timeout:
+                return None
+            time.sleep(interval)
+            waited += interval
+            continue
+        if status == "completed" and conclusion == "success":
+            # build finished between the two checks above; the artifact
+            # should be listed now — one final lookup
+            return _get_artifact_download_url(token, sha)
+        # no build for this sha, or it concluded without success
+        return None
+
+
+def _get_workflow_run(token, sha):
+    """Return (status, conclusion) of the build-static run for sha.
+
+    (None, None) when the workflow never ran for this commit.
+    """
+    response = requests.get(
+        RUNS_URL,
+        params={"head_sha": sha},
+        headers=_headers(token),
+        timeout=REQUEST_TIMEOUT,
+    )
+    response.raise_for_status()
+    runs = response.json()["workflow_runs"]
+    if runs:
+        return runs[0]["status"], runs[0]["conclusion"]
+    return None, None
+
+
+def _get_artifact_download_url(token, sha):
+    response = requests.get(
+        ARTIFACTS_URL,
+        params={"name": f"staticfiles-{sha}"},
+        headers=_headers(token),
+        timeout=REQUEST_TIMEOUT,
+    )
+    response.raise_for_status()
+    artifacts = [a for a in response.json()["artifacts"] if not a["expired"]]
+    if artifacts:
+        return artifacts[0]["archive_download_url"]
+    return None
+
+
+def _download(token, download_url, dest_dir):
+    # GitHub responds 302 to a short-lived blob URL; requests follows it
+    # and drops the Authorization header on the cross-host redirect.
+    download_path = os.path.join(dest_dir, "artifact-download.zip")
+    with requests.get(
+        download_url,
+        headers=_headers(token),
+        timeout=REQUEST_TIMEOUT,
+        stream=True,
+    ) as response:
+        response.raise_for_status()
+        total = int(response.headers.get("Content-Length") or 0)
+        BYTES_PER_MB = 1024 * 1024
+        total_mb = f"/{total / BYTES_PER_MB:.0f}" if total else ""
+        received = 0
+        last_report = time.monotonic()
+        with open(download_path, "wb") as f:
+            for chunk in response.iter_content(chunk_size=BYTES_PER_MB):
+                f.write(chunk)
+                received += len(chunk)
+                if time.monotonic() - last_report >= PROGRESS_INTERVAL:
+                    print(f"  downloaded {received / BYTES_PER_MB:.0f}{total_mb} MB ...")
+                    last_report = time.monotonic()
+    return download_path
+
+
+def _unwrap_once(download_path, dest_dir):
+    """Remove GitHub's outer zip wrapper, if present.
+
+    The artifact endpoint returns a zip whose single entry is our
+    REQUIRED_STATIC_FILES.zip. If the download is not wrapped that way,
+    use it as-is.
+    """
+    with zipfile.ZipFile(download_path) as outer:
+        if outer.namelist() == [INNER_ZIP_NAME]:
+            return outer.extract(INNER_ZIP_NAME, dest_dir)
+    return download_path
+
+
+def _headers(token):
+    return {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+    }
+
+
+def main(argv=None):
+    """CLI entry point, run on the control machine by the deploy playbook.
+
+    Usage: python -m commcare_cloud.commands.deploy.static_artifact <sha> <dest_dir>
+
+    The token is read from the GITHUB_TOKEN environment variable (never
+    argv, which is visible in process listings). On success the last line
+    of stdout is the path to REQUIRED_STATIC_FILES.zip; exits nonzero when
+    the artifact is unavailable, so the playbook can fall back.
+    """
+    import argparse
+    parser = argparse.ArgumentParser(description=main.__doc__)
+    parser.add_argument("sha")
+    parser.add_argument("dest_dir")
+    args = parser.parse_args(argv)
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        print("GITHUB_TOKEN is not set")
+        return 1
+    path = fetch_static_artifact(token, args.sha, args.dest_dir)
+    if path is None:
+        print("artifact unavailable")
+        return 1
+    print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())

--- a/src/commcare_cloud/github.py
+++ b/src/commcare_cloud/github.py
@@ -20,10 +20,15 @@ def github_repo(repo_name, prompt_if_missing=False):
     prompt_if_missing is True and no token is found via env or config,
     ask for a token and optionally continue without authentication.
     """
+    token = get_github_credentials(prompt_if_missing)
+    return Github(login_or_token=token).get_repo(repo_name)
+
+
+def get_github_credentials(prompt_if_missing=False):
     token = get_github_credentials_no_prompt()
     if not token and prompt_if_missing:
         token = _prompt_for_github_token()
-    return Github(login_or_token=token).get_repo(repo_name)
+    return token
 
 
 @memoized

--- a/tests/test_deploy/test_static_artifact.py
+++ b/tests/test_deploy/test_static_artifact.py
@@ -1,0 +1,149 @@
+import io
+import zipfile
+from pathlib import Path
+
+import pytest
+import requests_mock
+from unittest.mock import patch
+
+from commcare_cloud.commands.deploy.static_artifact import (
+    ARTIFACTS_URL,
+    RUNS_URL,
+    fetch_static_artifact,
+)
+
+pytestmark = pytest.mark.filterwarnings("ignore:.*used magic fixture.*:UserWarning")
+
+SHA = "abc123"
+LIST_URL = f"{ARTIFACTS_URL}?name=staticfiles-{SHA}"
+RUNS_QUERY_URL = f"{RUNS_URL}?head_sha={SHA}"
+DOWNLOAD_URL = f"{ARTIFACTS_URL}/999/zip"
+
+NOT_FOUND = {"total_count": 0, "artifacts": []}
+
+
+def _runs_response(status, conclusion=None):
+    return {"workflow_runs": [{"status": status, "conclusion": conclusion}]}
+
+
+def _zip_bytes(entries):
+    """entries: dict of {name: bytes} -> zip file bytes"""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, data in entries.items():
+            zf.writestr(name, data)
+    return buf.getvalue()
+
+
+def _inner_zip():
+    # entries are bare top-level static dirs, per copy_required_static_files
+    return _zip_bytes({"CACHE/manifest.json": b"{}", "hqwebapp/js/main.js": b""})
+
+
+def _outer_zip():
+    return _zip_bytes({"REQUIRED_STATIC_FILES.zip": _inner_zip()})
+
+
+def _found_response():
+    return {"total_count": 1, "artifacts": [
+        {"id": 999, "name": f"staticfiles-{SHA}", "expired": False,
+         "archive_download_url": DOWNLOAD_URL},
+    ]}
+
+
+def test_artifact_found_immediately(tmp_path):
+    with requests_mock.Mocker() as m:
+        m.get(LIST_URL, json=_found_response())
+        m.get(DOWNLOAD_URL, content=_outer_zip())
+        result = fetch_static_artifact("tok", SHA, str(tmp_path))
+    assert result is not None
+    assert Path(result).name == "REQUIRED_STATIC_FILES.zip"
+    # the inner zip is a valid zip containing the static tree
+    assert "CACHE/manifest.json" in zipfile.ZipFile(result).namelist()
+
+
+def test_waits_while_build_is_running(tmp_path):
+    with requests_mock.Mocker() as m, patch("time.sleep") as sleep:
+        m.get(LIST_URL, [
+            {"json": NOT_FOUND},
+            {"json": NOT_FOUND},
+            {"json": _found_response()},
+        ])
+        m.get(RUNS_QUERY_URL, json=_runs_response("in_progress"))
+        m.get(DOWNLOAD_URL, content=_outer_zip())
+        result = fetch_static_artifact("tok", SHA, str(tmp_path))
+    assert result is not None
+    assert [c.args[0] for c in sleep.call_args_list] == [30, 30]
+
+
+def test_no_workflow_run_fails_fast(tmp_path):
+    with requests_mock.Mocker() as m, patch("time.sleep") as sleep:
+        m.get(LIST_URL, json=NOT_FOUND)
+        m.get(RUNS_QUERY_URL, json={"workflow_runs": []})
+        result = fetch_static_artifact("tok", SHA, str(tmp_path))
+    assert result is None
+    sleep.assert_not_called()  # no waiting when there is no build to wait for
+    assert m.call_count == 2  # one artifact check + one run check
+
+
+def test_failed_build_fails_fast(tmp_path):
+    with requests_mock.Mocker() as m, patch("time.sleep") as sleep:
+        m.get(LIST_URL, json=NOT_FOUND)
+        m.get(RUNS_QUERY_URL, json=_runs_response("completed", "failure"))
+        result = fetch_static_artifact("tok", SHA, str(tmp_path))
+    assert result is None
+    sleep.assert_not_called()
+
+
+def test_completed_build_rechecks_artifact_once(tmp_path):
+    # Build finished successfully between our artifact check and run check:
+    # one final artifact lookup catches it.
+    with requests_mock.Mocker() as m, patch("time.sleep"):
+        m.get(LIST_URL, [{"json": NOT_FOUND}, {"json": _found_response()}])
+        m.get(RUNS_QUERY_URL, json=_runs_response("completed", "success"))
+        m.get(DOWNLOAD_URL, content=_outer_zip())
+        result = fetch_static_artifact("tok", SHA, str(tmp_path))
+    assert result is not None
+
+
+def test_build_still_running_at_timeout_returns_none(tmp_path):
+    with requests_mock.Mocker() as m, patch("time.sleep"):
+        m.get(LIST_URL, json=NOT_FOUND)
+        m.get(RUNS_QUERY_URL, json=_runs_response("in_progress"))
+        result = fetch_static_artifact(
+            "tok", SHA, str(tmp_path), timeout=60, interval=30)
+    assert result is None
+    # waited 30, 60 -> ceiling reached after 2 sleeps; 3 artifact checks + 3 run checks
+    assert m.call_count == 6
+
+
+def test_expired_artifact_is_ignored(tmp_path):
+    expired = {"total_count": 1, "artifacts": [
+        {"id": 5, "name": f"staticfiles-{SHA}", "expired": True,
+         "archive_download_url": DOWNLOAD_URL},
+    ]}
+    with requests_mock.Mocker() as m, patch("time.sleep"):
+        m.get(LIST_URL, json=expired)
+        m.get(RUNS_QUERY_URL, json={"workflow_runs": []})
+        result = fetch_static_artifact("tok", SHA, str(tmp_path))
+    assert result is None
+
+
+def test_single_wrapped_download_is_used_as_is(tmp_path):
+    # If GitHub ever returns the staticfiles zip directly (not zip-of-zip),
+    # skip the unwrap and return the download itself.
+    with requests_mock.Mocker() as m:
+        m.get(LIST_URL, json=_found_response())
+        m.get(DOWNLOAD_URL, content=_inner_zip())
+        result = fetch_static_artifact("tok", SHA, str(tmp_path))
+    assert result is not None
+    assert "CACHE/manifest.json" in zipfile.ZipFile(result).namelist()
+
+
+def test_token_is_sent_as_bearer(tmp_path):
+    with requests_mock.Mocker() as m:
+        m.get(LIST_URL, json=_found_response())
+        m.get(DOWNLOAD_URL, content=_outer_zip())
+        fetch_static_artifact("tok", SHA, str(tmp_path))
+    for request in m.request_history:
+        assert request.headers["Authorization"] == "Bearer tok"


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi.atlassian.net/browse/SAAS-20027

We already build static files on Github actions everytime something is pushed to `autostaging` branch on CommCare HQ repo.

This PR moves a step in the direction of using prebuilt static files in deploys. Earlier we were considering it to be useful for third party hosters and were trying to figure out the artifacts public because currently you need a token with read access to commcare hq repo to download the artifacts.

@gherceg and I recently started talking about it again and we decided why not just test it internally with the actions workflow and using the same token that we pass to compile deploy summary to get the artifact. This is the first PR that tries to setup basic structure. In the followup PRs we would be using the utils introduced in this PR to be integrated into deploy playbooks. 


##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Would be testing on staging for now, but will be used for all Dimagi environments.

Review by commit 🐡 

36df7be5f8299a87c05783a509e5b3487c163e03 is the entire spec on how this entire feature is planned. 
4c432fcff83306d161ccfe0c3cc19fd334184838 is what is in this PR.

I am intentionally keeping them around until the feature is integrated, would remove them later.