### PR TITLE
increase max_pool_connections for s3 client

### DIFF
--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -126,6 +126,7 @@ REDIS_BROKER_HOST: 'broker.production.commcare.local'
 s3_blob_db_enabled: yes
 s3_blob_db_url: "https://s3.amazonaws.com"
 s3_blob_db_s3_bucket: 'dimagi-commcare-production-blobdb'
+s3_blob_db_max_pool_connections: 100
 
 
 localsettings:

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -196,7 +196,10 @@ S3_BLOB_DB_SETTINGS = {
     'secret_key': {% if s3_blob_db_secret_key %}'{{ s3_blob_db_secret_key }}'{% else %}None{% endif %},
     's3_bucket': '{{ s3_blob_db_s3_bucket }}',
     'bulk_delete_chunksize': {{ s3_bulk_delete_chunksize }},
-    'config': {'signature_version': 's3v4'},
+    'config': {
+        'signature_version': 's3v4',
+        'max_pool_connections': {%if s3_blob_db_max_pool_connections %}{{ s3_blob_db_max_pool_connections }}{% else %}10{% endif %},
+    },
 }
 {% if localsettings.get('BLOB_DB_MIGRATING_FROM_S3_TO_S3', False) %}
 OLD_S3_BLOB_DB_SETTINGS = {

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -198,7 +198,9 @@ S3_BLOB_DB_SETTINGS = {
     'bulk_delete_chunksize': {{ s3_bulk_delete_chunksize }},
     'config': {
         'signature_version': 's3v4',
-        'max_pool_connections': {%if s3_blob_db_max_pool_connections %}{{ s3_blob_db_max_pool_connections }}{% else %}10{% endif %},
+        {% if s3_blob_db_max_pool_connections %}
+        'max_pool_connections': {{ s3_blob_db_max_pool_connections }},
+        {% endif %}
     },
 }
 {% if localsettings.get('BLOB_DB_MIGRATING_FROM_S3_TO_S3', False) %}


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/SAAS-20029

The default value of `max_pool_connections` is set to 10 and we were exhausting it. 

Trying out increasing the value to see how it impacts CPU

<!--- Provide a link to the ticket or document which prompted this change -->

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production

