### PR TITLE
Flush ansible cache before update-supervisor-confs

### DIFF
--- a/src/commcare_cloud/commands/ansible/ansible_playbook.py
+++ b/src/commcare_cloud/commands/ansible/ansible_playbook.py
@@ -387,7 +387,7 @@ class UpdateSupervisorConfs(_AnsiblePlaybookAlias):
 
     def run(self, args, unknown_args):
         args.playbook = 'deploy_stack.yml'
-        unknown_args += ('--tags=services',)
+        unknown_args += ('--tags=services', '--flush-cache')
         rc = AnsiblePlaybook(self.parser).run(args, unknown_args)
         if ask("Would you like to update supervisor to use the new configurations?"):
             run_ansible_playbook(


### PR DESCRIPTION


<!--- Provide a link to the ticket or document which prompted this change -->
Without this, unexpected behavior with update-supervisor-confs can occur where an expected change is not applied to the configuration because ansible is operating on a stale cache.

Tested on staging just to make sure `update-supervisor-confs` works as expected and it does. It seems tough to test this against the actual bug itself since it isn't easy to reproduce (not sure how to get a stale cache).

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
None