### PR TITLE
Increase case pillow process count to # of cores

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -149,10 +149,10 @@ pillows:
     UserGroupsDbKafkaPillow:
       num_processes: 1
   pillow_b2000:
-  # case-sql partitions: 96 = 6 * 16
+  # case-sql partitions: 96 = 8 * 12
     case-pillow:
-      num_processes: 7
-      gevent_workers: 16
+      num_processes: 9
+      gevent_workers: 12
       dedicated_migration_process: True
       #env_vars:
       #  DD_TRACE_ENABLED: True


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi.atlassian.net/browse/SAAS-20031

I was seeing some recommendations for the optimum number of gevent enabled processes being (2 x cores) + 1, but then seeing other recs for having it equal to the number of cores, which admittedly is more intuitive to me. To avoid running up against memory limits and making the easiest/smallest change to start, I'm just trying this out again. The case pillow machine has 8 CPU cores, and we have the extra dedicated migration process, so we are running 9 total in this config.

Here is the [memory graph](https://app.datadoghq.com/dashboard/nbz-bie-nip/host-groups?fromUser=true&fullscreen_end_ts=1784040743969&fullscreen_paused=false&fullscreen_refresh_mode=sliding&fullscreen_section=overview&fullscreen_start_ts=1784026343969&fullscreen_widget=274741947&refresh_mode=sliding&tpl_var_host[0]=pillow-b2000-production&from_ts=1784024895159&to_ts=1784039295159&live=true) for this machine.

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
Production