### PR TITLE
Prevent log directories from growing without bound

### DIFF
--- a/src/commcare_cloud/ansible/deploy_couchdb2.yml
+++ b/src/commcare_cloud/ansible/deploy_couchdb2.yml
@@ -29,7 +29,7 @@
             - "{{ couchdb_dir }}/var/log/*.log"
           options:
             - hourly
-            - size 300M
+            - maxsize 300M
             - rotate 100
             - missingok
             - compress

--- a/src/commcare_cloud/ansible/deploy_proxy.yml
+++ b/src/commcare_cloud/ansible/deploy_proxy.yml
@@ -97,7 +97,7 @@
           path: "{{ log_home }}/*.log"
           options:
             - weekly
-            - size 750M
+            - maxsize 750M
             - rotate 4
             - missingok
             - compress

--- a/src/commcare_cloud/ansible/deploy_webworker.yml
+++ b/src/commcare_cloud/ansible/deploy_webworker.yml
@@ -25,7 +25,7 @@
           path: "{{ log_home }}/{{ project }}.gunicorn.log"
           options:
             - daily
-            - size 50M
+            - maxsize 50M
             - rotate 5
             - missingok
             - compress

--- a/src/commcare_cloud/ansible/partials/couchdb2_proxy_haproxy.yml
+++ b/src/commcare_cloud/ansible/partials/couchdb2_proxy_haproxy.yml
@@ -31,7 +31,7 @@
         path: "/var/log/haproxy/*.log"
         options:
           - daily
-          - size 100M
+          - maxsize 100M
           - rotate 10
           - missingok
           - compress

--- a/src/commcare_cloud/ansible/partials/couchdb2_proxy_nginx.yml
+++ b/src/commcare_cloud/ansible/partials/couchdb2_proxy_nginx.yml
@@ -21,7 +21,7 @@
         path: "{{ log_home }}/*.log"
         options:
           - monthly
-          - size 750M
+          - maxsize 750M
           - rotate 14
           - missingok
           - compress

--- a/src/commcare_cloud/ansible/roles/common/tasks/logging.yml
+++ b/src/commcare_cloud/ansible/roles/common/tasks/logging.yml
@@ -20,12 +20,14 @@
     name: ansible-logrotate
   when: "logrotate_scripts | length > 0"
 
-- name: Configure logrotate size limit in rsyslog (replacing weekly)  # noqa: no-tabs
+# maxsize caps growth between rotations without disabling time-based rotation
+# (the weekly default from /etc/logrotate.conf still applies)
+- name: Configure logrotate size limit in rsyslog  # noqa: no-tabs
   lineinfile:
     path: /etc/logrotate.d/rsyslog
-    regexp: '^\tweekly'
+    regexp: '^\t(weekly|(max)?size )'
     insertbefore: 'missingok'
-    line: "\tsize 750M"  # no-tabs: single quotes here would write literal '\t' in file
+    line: "\tmaxsize 750M"  # no-tabs: single quotes here would write literal '\t' in file
     state: present
 
 - name: Configure logrotate timer (hourly instead of daily)

--- a/src/commcare_cloud/ansible/roles/devops_scripts/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/devops_scripts/tasks/main.yml
@@ -76,7 +76,7 @@
         path: /var/log/login_audit.log
         options:
           - monthly
-          - size 100M
+          - maxsize 100M
           - rotate 14
           - missingok
           - compress
@@ -88,7 +88,7 @@
         path: /var/log/sudo_audit.log
         options:
           - monthly
-          - size 100M
+          - maxsize 100M
           - rotate 14
           - missingok
           - compress


### PR DESCRIPTION
Fixes #6848

##### Problem
Every logrotate config we install pairs a rotation period (`hourly`/`daily`/`weekly`/`monthly`) with a `size` directive, intending "rotate on schedule, or sooner if the file gets big." But `size` *overrides* the period rather than complementing it — logrotate warns about exactly this (`'size' overrides previously specified 'weekly'`). Logs therefore rotate only when they hit the size threshold: slow-growing logs never age out, and on a monolith the app log directory alone is bounded at ~85G (38 files x up to 3 x 750M), plus ~31G for rsyslog and ~15G for couchdb.

##### Solution
Replace `size` with `maxsize`, which rotates at the period **or** the size threshold, whichever comes first — the originally intended behavior. `bootstrap-users` keeps plain `size` since it specifies no period.

The one non-mechanical change is in `roles/common/tasks/logging.yml`, which edits Ubuntu's stock `/etc/logrotate.d/rsyslog` in place. The `lineinfile` regexp now matches all three states a host can be in — fresh (`weekly`), previously configured (`size 750M`), and already fixed (`maxsize 750M`) — so the task stays idempotent across the fleet. Dropping the block-level period there is fine because the global `weekly` default in `/etc/logrotate.conf` applies.

##### Verification
- `ansible-lint-cloud`: no new violations
- `deploy-stack --syntax-check` against the test environment passes (same as CI)
- The new `lineinfile` regexp was tested against all three host-state lines plus non-target lines (`missingok`, `rotate 4`)

Related: #6847 is a separate logrotate bug in this same area (duplicate glob match breaks rotation entirely on monoliths) and is not addressed here.

##### Environments Affected
None — no environment files changed. The updated logrotate configs reach all environments on the next run of the affected playbooks/roles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)