### PR TITLE
Allow tuning gunicorn worker recycling without an HQ deploy

### DIFF
--- a/environments/production/app-processes.yml
+++ b/environments/production/app-processes.yml
@@ -1,5 +1,9 @@
 gunicorn_workers_static_factor: 0
 gunicorn_workers_factor: 2
+# graceful_timeout matches the 900s request budget nginx allows, so that
+# worker recycling can't kill an in-flight request that would have completed
+gunicorn_max_requests: 700
+gunicorn_graceful_timeout: 900
 formplayer_memory: "31g"
 formplayer_g1heapregionsize: "16m"
 # to enable profling, add `-Ddd.profiling.enabled=true -XX:FlightRecorderOptions=stackdepth=256` to formplayer_command_args

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_django.conf.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_django.conf.j2
@@ -11,6 +11,9 @@ command={{ app_processes_config.django_command_prefix }}
     -c deployment/gunicorn/gunicorn_conf.py
     -k gevent
     --workers {{ item.gunicorn_workers }}
+    --max-requests {{ app_processes_config.gunicorn_max_requests }}
+    --max-requests-jitter {{ app_processes_config.gunicorn_max_requests // 2 }}
+    --graceful-timeout {{ app_processes_config.gunicorn_graceful_timeout }}
     --bind 0.0.0.0:{{ django_port }}
     --log-file {{ log_home }}/{{ project }}.gunicorn.log
     --log-level debug

--- a/src/commcare_cloud/environment/schemas/app_processes.py
+++ b/src/commcare_cloud/environment/schemas/app_processes.py
@@ -42,6 +42,8 @@ class AppProcessesConfig(jsonobject.JsonObject):
     flower_port = PortProperty()
     gunicorn_workers_factor = jsonobject.IntegerProperty()
     gunicorn_workers_static_factor = jsonobject.IntegerProperty()
+    gunicorn_max_requests = jsonobject.IntegerProperty()
+    gunicorn_graceful_timeout = jsonobject.IntegerProperty()
     formplayer_memory = MemorySpecProperty()
     formplayer_maxmetaspacesize = MemorySpecProperty()
     formplayer_g1heapregionsize = MemorySpecProperty()

--- a/src/commcare_cloud/environmental-defaults/app-processes.yml
+++ b/src/commcare_cloud/environmental-defaults/app-processes.yml
@@ -25,6 +25,10 @@ django_port: 9010
 flower_port: 5555
 gunicorn_workers_factor: 1
 gunicorn_workers_static_factor: 0
+# Override the corresponding values in commcare-hq's gunicorn_conf.py.
+# 50% jitter is added to max_requests.
+gunicorn_max_requests: 240
+gunicorn_graceful_timeout: 300
 formplayer_memory: "3584m"
 formplayer_maxmetaspacesize: "512m"
 formplayer_g1heapregionsize: "2m"


### PR DESCRIPTION
Follow-up to https://github.com/dimagi/commcare-hq/pull/37927, which raised gunicorn's `max_requests` from 240 to 2000 and `graceful_timeout` from 300s to 900s. The values live in commcare-hq's `gunicorn_conf.py`, so adjusting them requires a full HQ deploy — and they do need adjusting: an hq_webworker OOMed within a day of the increase, so worker memory grows with age more than expected. I'm [reverting](https://github.com/dimagi/commcare-hq/pull/37935) that (commcare-hq) PR and replacing with this (commcare-cloud) PR.

This moves both settings into `app-processes.yml` by passing them as gunicorn command-line arguments in the supervisor config. Gunicorn gives CLI arguments precedence over the config file, so these cleanly override the values baked into the HQ release. Operators can now tune them with:

```
cchq <env> update-supervisor-confs
```

and the rolling webworker restart it offers — no HQ deploy needed.

Two commits:
1. The plumbing (schema, defaults, supervisor template). Defaults are the long-standing pre-#37927 values (240 / 300s), so environments opt in to less frequent recycling explicitly. `--max-requests-jitter` must be passed explicitly since the jitter computed inside `gunicorn_conf.py` derives from that file's own `max_requests`, not the CLI value.
2. Production override: `gunicorn_max_requests: 700` and `gunicorn_graceful_timeout: 900` — recycling ~3x less often than the old 240 (rather than #37927's 8x, which OOMed), with the drain window matched to the 900s request budget nginx allows so recycling can't kill requests that would otherwise complete.

##### Environments Affected

All environments get explicit defaults equal to the long-standing pre-#37927 behavior — which means environments running an HQ release containing #37927 revert to 240/300 when their supervisor confs are next updated; only production keeps the less aggressive recycling (700/900). If other environments should share production's values, that's a per-environment follow-up.

- [x] If the changes affect multiple environments, I will ensure they are rolled out consistently across all environments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
