### PR TITLE
Provision standalone DB for ProjectDB

### DIFF
--- a/docs/source/reference/1-commcare-cloud/2.1-postgresql-config.rst
+++ b/docs/source/reference/1-commcare-cloud/2.1-postgresql-config.rst
@@ -68,6 +68,25 @@ Configuration for the db that formplayer uses
 
 Configuration for the db that UCRs are copied into.
 
+``project_db``
+^^^^^^^^^^^^^^^^^^
+
+
+* Type: `db config <#db-config-type>`_
+* Default: not created (opt-in)
+* Default values (when enabled):
+  .. code-block:: yaml
+
+     django_alias: project_db
+     name: commcarehq_project_db
+     django_migrate: False
+
+Optional db that stores ProjectDB tables. It is only created in environments
+that add a ``project_db`` block to `\ ``dbs`` <#dbs>`_ and map it in `\
+``REPORTING_DATABASES`` <#reporting-databases>`_. Its ``host`` and pgbouncer
+settings default to those of the ``ucr`` db when not set explicitly. Installs
+required extensions automatically as part of database setup.
+
 ``synclogs``
 ^^^^^^^^^^^^^^^^
 
@@ -335,7 +354,13 @@ without a different host explicitly set in `\ ``dbs`` <#dbs>`_.
 * Default: ``{"ucr": "ucr"}``
 * Status: Custom
 
-Specify a mapping of UCR "engines".
+Specify a mapping of Reporting DB "engines" (UCR, ProjectDB).
+
+The default maps only the ``ucr`` engine. Environments that enable the
+optional `\ ``project_db`` <#project-db>`_ database override this to also map
+the ``project_db`` engine, e.g. ``{"ucr": "ucr", "project_db": "project_db"}``.
+Note that setting this value replaces the whole mapping rather than merging,
+so the ``ucr`` entry must be re-listed.
 
 The keys define engine aliases, and can be anything. The values are either
 

--- a/docs/source/reference/1-commcare-cloud/2.1-postgresql-config.rst
+++ b/docs/source/reference/1-commcare-cloud/2.1-postgresql-config.rst
@@ -356,11 +356,9 @@ without a different host explicitly set in `\ ``dbs`` <#dbs>`_.
 
 Specify a mapping of Reporting DB "engines" (UCR, ProjectDB).
 
-The default maps only the ``ucr`` engine. Environments that enable the
-optional `\ ``project_db`` <#project-db>`_ database override this to also map
-the ``project_db`` engine, e.g. ``{"ucr": "ucr", "project_db": "project_db"}``.
-Note that setting this value replaces the whole mapping rather than merging,
-so the ``ucr`` entry must be re-listed.
+Setting this replaces the default (``{"ucr": "ucr"}``) entirely rather than
+merging into it, so when you add an engine (e.g. `\ ``project_db``
+<#project-db>`_) you must re-list ``ucr`` or it will be dropped.
 
 The keys define engine aliases, and can be anything. The values are either
 

--- a/environments/staging/postgresql.yml
+++ b/environments/staging/postgresql.yml
@@ -1,5 +1,9 @@
 DEFAULT_POSTGRESQL_HOST: rds_pg0
 
+REPORTING_DATABASES:
+  ucr: ucr
+  project_db: project_db
+
 postgres_override:
   postgresql_max_connections: 300
   postgresql_version: '14'
@@ -35,6 +39,8 @@ dbs:
     pgbouncer_hosts:
       - pgproxy6
     query_stats: True
+  project_db:
+    create: True
   synclogs:
     pgbouncer_endpoint: pgsynclogs_nlb
     pgbouncer_hosts:

--- a/environments/staging/postgresql.yml
+++ b/environments/staging/postgresql.yml
@@ -39,8 +39,7 @@ dbs:
     pgbouncer_hosts:
       - pgproxy6
     query_stats: True
-  project_db:
-    create: True
+  project_db: {}
   synclogs:
     pgbouncer_endpoint: pgsynclogs_nlb
     pgbouncer_hosts:

--- a/src/commcare_cloud/ansible/roles/postgresql_base/tasks/set_up_dbs.yml
+++ b/src/commcare_cloud/ansible/roles/postgresql_base/tasks/set_up_dbs.yml
@@ -146,3 +146,20 @@
         DROP USER IF EXISTS repeaters_fdw_user;
       END $$;
   when: postgresql_dbs.repeaters and postgresql_host == postgresql_dbs.repeaters.host
+
+- name: Enable extensions in the project_db database
+  become: yes
+  become_user: "{{ db_is_remote and 'ansible' or 'postgres' }}"
+  postgresql_query:
+    db: '{{ postgresql_dbs.project_db.name }}'
+    port: "{{ postgresql_port }}"
+    login_host: "{{ db_is_remote and postgresql_host or omit }}"
+    login_user: "{{ db_is_remote and postgres_users.root.username or omit }}"
+    login_password: "{{ db_is_remote and postgres_users.root.password or omit }}"
+    query: |
+      CREATE EXTENSION IF NOT EXISTS cube;
+      CREATE EXTENSION IF NOT EXISTS earthdistance;
+      CREATE EXTENSION IF NOT EXISTS pg_trgm;
+      CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
+  when: postgresql_dbs.project_db and postgresql_dbs.project_db.create
+        and postgresql_host == postgresql_dbs.project_db.host

--- a/src/commcare_cloud/ansible/roles/postgresql_base/tasks/set_up_dbs.yml
+++ b/src/commcare_cloud/ansible/roles/postgresql_base/tasks/set_up_dbs.yml
@@ -161,5 +161,4 @@
       CREATE EXTENSION IF NOT EXISTS earthdistance;
       CREATE EXTENSION IF NOT EXISTS pg_trgm;
       CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
-  when: postgresql_dbs.project_db and postgresql_dbs.project_db.create
-        and postgresql_host == postgresql_dbs.project_db.host
+  when: postgresql_dbs.project_db and postgresql_host == postgresql_dbs.project_db.host

--- a/src/commcare_cloud/environment/constants.py
+++ b/src/commcare_cloud/environment/constants.py
@@ -5,6 +5,7 @@ class _Constants(jsonobject.JsonObject):
     commcarehq_main_db_name = jsonobject.StringProperty(default='commcarehq')
     formplayer_db_name = jsonobject.StringProperty(default='formplayer')
     ucr_db_name = jsonobject.StringProperty(default='commcarehq_ucr')
+    project_db_name = jsonobject.StringProperty(default='commcarehq_project_db')
     synclogs_db_name = jsonobject.StringProperty(default='commcarehq_synclogs')
     auditcare_db_name = jsonobject.StringProperty(default='commcarehq_auditcare')
     repeaters_db_name = jsonobject.StringProperty(default='commcarehq_repeaters')

--- a/src/commcare_cloud/environment/schemas/postgresql.py
+++ b/src/commcare_cloud/environment/schemas/postgresql.py
@@ -154,6 +154,17 @@ class PostgresqlConfig(jsonobject.JsonObject):
             for host, value in self.host_settings.items()
         }
 
+        # project_db defaults to living wherever the ucr db lives. This must
+        # happen before hosts are resolved below so both inherit consistently.
+        if self.dbs.project_db is not None:
+            ucr = self.dbs.ucr
+            if self.dbs.project_db.host is None:
+                self.dbs.project_db.host = ucr.host
+            if not self.dbs.project_db.pgbouncer_hosts:
+                self.dbs.project_db.pgbouncer_hosts = list(ucr.pgbouncer_hosts)
+            if self.dbs.project_db.pgbouncer_endpoint is None:
+                self.dbs.project_db.pgbouncer_endpoint = ucr.pgbouncer_endpoint
+
         all_dbs = self.generate_postgresql_dbs()
         for db in all_dbs:
             if db.host is None:
@@ -210,6 +221,7 @@ class PostgresqlConfig(jsonobject.JsonObject):
             self.dbs.form_processing.get_db_list() if self.dbs.form_processing else []
         ) + [
             self.dbs.ucr,
+            self.dbs.project_db,
             self.dbs.formplayer,
             self.dbs.auditcare,
             self.dbs.repeaters,
@@ -273,6 +285,7 @@ class SmartDBConfig(jsonobject.JsonObject):
     main = jsonobject.ObjectProperty(lambda: MainDBOptions, required=True)
     formplayer = jsonobject.ObjectProperty(lambda: FormplayerDBOptions, required=True)
     ucr = jsonobject.ObjectProperty(lambda: UcrDBOptions, required=True)
+    project_db = jsonobject.ObjectProperty(lambda: ProjectDbDBOptions, required=False, default=None)
     synclogs = jsonobject.ObjectProperty(lambda: SynclogsDBOptions, required=False)
     form_processing = jsonobject.ObjectProperty(lambda: FormProcessingConfig, required=False)
     auditcare = jsonobject.ObjectProperty(lambda: AuditcareDBOptions, required=False, default=None)
@@ -334,6 +347,12 @@ class FormplayerDBOptions(DBOptions):
 class UcrDBOptions(DBOptions):
     name = constants.ucr_db_name
     django_alias = 'ucr'
+    django_migrate = False
+
+
+class ProjectDbDBOptions(DBOptions):
+    name = constants.project_db_name
+    django_alias = 'project_db'
     django_migrate = False
 
 

--- a/tests/test_envs/2018-04-04-development-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-development-snapshot/.generated.yml
@@ -93,6 +93,7 @@ postgresql_dbs:
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
+  project_db: null
   repeaters: null
   standby: []
   synclogs: null

--- a/tests/test_envs/2018-04-04-enikshay-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-enikshay-snapshot/.generated.yml
@@ -573,6 +573,7 @@ postgresql_dbs:
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
+  project_db: null
   repeaters: null
   standby: []
   synclogs:

--- a/tests/test_envs/2018-04-04-icds-new-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-icds-new-snapshot/.generated.yml
@@ -641,6 +641,7 @@ postgresql_dbs:
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
+  project_db: null
   repeaters: null
   standby:
   - acceptable_replication_delay: 30

--- a/tests/test_envs/2018-04-04-pna-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-pna-snapshot/.generated.yml
@@ -573,6 +573,7 @@ postgresql_dbs:
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
+  project_db: null
   repeaters: null
   standby: []
   synclogs:

--- a/tests/test_envs/2018-04-04-production-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-production-snapshot/.generated.yml
@@ -423,6 +423,7 @@ postgresql_dbs:
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
+  project_db: null
   repeaters:
     create: true
     django_alias: repeaters

--- a/tests/test_envs/2018-04-04-softlayer-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-softlayer-snapshot/.generated.yml
@@ -402,6 +402,7 @@ postgresql_dbs:
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
+  project_db: null
   repeaters: null
   standby: []
   synclogs:

--- a/tests/test_envs/2018-04-04-staging-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-staging-snapshot/.generated.yml
@@ -368,6 +368,7 @@ postgresql_dbs:
     port: 6432
     query_stats: true
     user: '{{ postgres_users.commcare.username }}'
+  project_db: null
   repeaters: null
   standby: []
   synclogs:

--- a/tests/test_envs/2018-04-04-swiss-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-swiss-snapshot/.generated.yml
@@ -111,6 +111,7 @@ postgresql_dbs:
     port: 6432
     query_stats: false
     user: '{{ postgres_users.commcare.username }}'
+  project_db: null
   repeaters: null
   standby: []
   synclogs:


### PR DESCRIPTION
From discussion on [ProjectDB Security and Infrastructure Approach Review
](https://docs.google.com/document/d/1ayuYQx7DD6dfc2-zzeLat4R8kXZkTp6WlPcD4rcw0YU/edit?tab=t.8pn5qhzhr6br)

This adds some scaffolding such that environments can provision a separate PostgreSQL database for ProjectDB, and turns it on for staging.  In conjunction with https://github.com/dimagi/commcare-hq/pull/37938, this should make it such that development and test environments have ProjectDB tables created in the `default` postgres database, but environments managed by `commcare-cloud` will error if it isn't explicitly provisioned.

This also handles creating the necessary extensions.  The features that build on these extensions are coming in a different PR: https://github.com/dimagi/commcare-hq/pull/37932 

##### Environments Affected
Staging only, for now.  Will test there and do prod separately later

[Staging rollout plan](https://docs.google.com/document/d/1LICyhHI5ogHhItz-ouGrb4t0T0lb0LSqOljvjguJmwk/edit?tab=t.0#heading=h.fkbc9acm8x0)