### PR TITLE
Add default for s3_blob_db_max_pool_connections

### DIFF
--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -63,6 +63,7 @@ redis_bind: 0.0.0.0
 s3_blob_db_enabled: False
 s3_blob_db_url:
 s3_blob_db_s3_bucket:
+s3_blob_db_max_pool_connections:
 s3_bulk_delete_chunksize: 1000
 
 # For instructions on S3-to-S3 migrations, see docs/howto/migrate-s3-to-s3.md


### PR DESCRIPTION
## Summary

Running `update-config` on staging I got:
```
FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 's3_blob_db_max_pool_connections' is undefined"}
```

This was introduced in https://github.com/dimagi/commcare-cloud/pull/6937

`localsettings.py.j2` has the reference: 
```jinja2
{% if s3_blob_db_max_pool_connections %}
```
but `s3_blob_db_max_pool_connections` was only defined for production. Ansible errors on undefined variables, so rendering localsettings fails in any environment that doesn't set it.

This PR sets a default `null` value for it to prevent this.

## Test plan

I'll be trying this shortly on staging