### PR TITLE
Modernize the Vagrant dev environment and add libvirt support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,38 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+# VirtualBox is the default provider, and does not require any special set up.
+#
+# libvirt host set up
+#
+# 1. Create "cchq" storage pool
+#
+#   COMMCARE_CLOUD_LIBVIRT_POOL=cchq
+#   COMMCARE_CLOUD_LIBVIRT_DIR=/path/to/libvirt-cchq  # >35G disk space required full deploy-stack
+#   mkdir $COMMCARE_CLOUD_LIBVIRT_DIR
+#   virsh --connect qemu:///session pool-define-as $COMMCARE_CLOUD_LIBVIRT_POOL \
+#     dir --target $COMMCARE_CLOUD_LIBVIRT_DIR
+#   virsh --connect qemu:///session pool-build $COMMCARE_CLOUD_LIBVIRT_POOL
+#   virsh --connect qemu:///session pool-start $COMMCARE_CLOUD_LIBVIRT_POOL
+#   virsh --connect qemu:///session pool-autostart $COMMCARE_CLOUD_LIBVIRT_POOL
+#
+#   # assign SELinux tags if your system requires that
+#   COMMCARE_CLOUD_DIR=~/commcare-cloud
+#   sudo semanage fcontext -a -t svirt_home_t "$COMMCARE_CLOUD_LIBVIRT_DIR(/.*)?"
+#   sudo semanage fcontext -a -t svirt_home_t "$COMMCARE_CLOUD_DIR(/.*)?"
+#   sudo restorecon -Rv $COMMCARE_CLOUD_LIBVIRT_DIR $COMMCARE_CLOUD_DIR
+#
+# 2. Configure "libvirt-cchq" network
+#
+#   sudo nmcli connection add type bridge ifname libvirt-cchq con-name libvirt-cchq \
+#     ipv4.method manual ipv4.addresses 192.168.33.1/24 ipv6.method disabled
+#   sudo nmcli connection up libvirt-cchq
+#   echo "allow libvirt-cchq" | sudo tee -a /etc/qemu/bridge.conf
+#
+# 3. Configure environment and start VMs
+#
+#   vagrant up --provider=libvirt
+
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 
@@ -11,34 +43,41 @@ require_relative './provisioning/key_authorization'
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "generic/ubuntu2204"
-  cchq_proxy_port = ENV.fetch("VAGRANT_CCHQ_PROXY_PORT", 8080)
+  config.vm.provider "libvirt" do |v|
+    v.storage_pool_name = ENV.fetch("COMMCARE_CLOUD_LIBVIRT_POOL", "cchq")
+    v.qemu_use_agent = true
+  end
+
   config.ssh.insert_key = false
   authorize_key config, '~/.vagrant.d/insecure_private_key'
 
   {
-    'app1'    => '192.168.33.15',
-    'db1'   => '192.168.33.16',
-    'proxy1' => '192.168.33.17',
-  }.each do |short_name, ip|
+    'control' => ['192.168.33.14', 'control'],
+    'app1'    => ['192.168.33.15', 'nodes'],
+    'db1'     => ['192.168.33.16', 'nodes'],
+    'proxy1'  => ['192.168.33.17', 'nodes'],
+  }.each do |short_name, (ip, type)|
     config.vm.define short_name do |host|
-      host.vm.network 'private_network', ip: ip
       host.vm.hostname = "#{short_name}.hq.dev"
-      host.vm.provision "shell", path: "provisioning/nodes.sh"
-      host.vm.provider "virtualbox" do |v|
+      host.vm.provision "shell", path: "provisioning/#{type}.sh"
+
+      host.vm.provider "virtualbox" do |v, override|
         v.memory = 768
         v.cpus = 1
+        override.vm.network "private_network", ip: ip
       end
-    end
-  end
 
-  config.vm.define "control" do |host|
-    host.vm.hostname = "control"
-    host.vm.network "private_network", ip: "192.168.33.14"
-    host.vm.hostname = "control.hq.dev"
-    host.vm.provider "virtualbox" do |v|
-      v.memory = 768
-      v.cpus = 1
+      host.vm.provider "libvirt" do |v, override|
+        v.memory = 768
+        v.cpus = 1
+        override.vm.network "public_network", ip: ip,
+          dev: "libvirt-cchq", type: "bridge", auto_config: true
+
+        if short_name == 'control'
+          override.vm.synced_folder ".", "/vagrant", type: "9p", accessmode: "mapped"
+        end
+      end
+
     end
-    host.vm.provision "shell", path: "provisioning/control.sh"
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ require_relative './provisioning/key_authorization'
 
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "ubuntu/bionic64"
+  config.vm.box = "generic/ubuntu2204"
   cchq_proxy_port = ENV.fetch("VAGRANT_CCHQ_PROXY_PORT", 8080)
   config.ssh.insert_key = false
   authorize_key config, '~/.vagrant.d/insecure_private_key'

--- a/environments/backup-production/public.yml
+++ b/environments/backup-production/public.yml
@@ -54,12 +54,6 @@ pg_repack_version: 1.4.7
 
 aws_region: 'us-east-2'
 
-filebeat_inputs:
-  - path: "{{ log_home }}/{{ deploy_env }}-timing.log"
-    tags: nginx-timing
-  - path: "{{ log_home }}/{{ deploy_env }}_commcare-nginx_error.log"
-    tags: nginx-error
-
 formplayer_java_version: "{{ java_17_bin_path }}/java"
 formplayer_archive_time_spec: '3d'
 formplayer_purge_time_spec: '10d'

--- a/environments/development/public.yml
+++ b/environments/development/public.yml
@@ -2,10 +2,11 @@ internal_domain_name: null
 
 internal_network_interface: eth1
 
-http_proxy_address: '192.168.33.14'
-http_proxy_port: '3128'
-http_proxy_parent_address: '192.168.33.1'
-http_proxy_parent_port: '3128'
+# HTTP proxy breaks Vagrant networking
+#http_proxy_address: '192.168.33.14'
+#http_proxy_port: '3128'
+#http_proxy_parent_address: '192.168.33.1'
+#http_proxy_parent_port: '3128'
 
 # disable ecryptfs - Elasticsearch and Kafka have issues with it on Vagrant
 root_encryption_mode: none

--- a/environments/development/public.yml
+++ b/environments/development/public.yml
@@ -7,6 +7,9 @@ http_proxy_port: '3128'
 http_proxy_parent_address: '192.168.33.1'
 http_proxy_parent_port: '3128'
 
+# disable ecryptfs - Elasticsearch and Kafka have issues with it on Vagrant
+root_encryption_mode: none
+
 # use this value to switch between nginx and apache
 proxy_type: nginx
 elasticsearch_version: 6.8.23

--- a/environments/development/public.yml
+++ b/environments/development/public.yml
@@ -26,6 +26,8 @@ backup_es_s3: False
 # this ensures that ssh access from the control machine is always allowed regardless of other firewall rules
 #control_machine_ip: 127.0.0.1
 
+REDIS_BROKER_HOST: "localhost"
+
 KSPLICE_ACTIVE: no
 KSPLICE_ACTIVATION_KEY: "{{ secrets.KSPLICE_ACTIVATION_KEY }}"
 

--- a/environments/development/public.yml
+++ b/environments/development/public.yml
@@ -9,8 +9,8 @@ http_proxy_parent_port: '3128'
 
 # use this value to switch between nginx and apache
 proxy_type: nginx
-elasticsearch_version: 1.7.6
-elasticsearch_download_sha256: 78affc30353730ec245dad1f17de242a4ad12cf808eaa87dd878e1ca10ed77df.
+elasticsearch_version: 6.8.23
+elasticsearch_download_sha256: 424af91f838f9e5f13e0292f97cbd6333535450291a621d761bd479dfc2dff78.
 elasticsearch_endpoint: '{{ groups.elasticsearch.0 }}'
 elasticsearch_memory: '128m'
 elasticsearch_cluster_name: 'deves'
@@ -69,6 +69,7 @@ localsettings:
 #  COUCH_CACHE_DOCS:
 #  COUCH_CACHE_VIEWS:
   DEPLOY_MACHINE_NAME: "{{ inventory_hostname }}"
+  ELASTICSEARCH_MAJOR_VERSION: 6
   # Run `python -m smtpd -n -c DebuggingServer 0.0.0.0:1025` on proxy
   EMAIL_SMTP_HOST: '{{ groups.proxy.0 }}'
   EMAIL_SMTP_PORT: '1025'

--- a/environments/development/public.yml
+++ b/environments/development/public.yml
@@ -103,5 +103,6 @@ commcare_cloud_root_user: ubuntu
 commcare_cloud_strict_host_key_checking: no
 commcare_cloud_use_vault: no
 
-# add datadisk device for shared directory; applicable for non-monolithic deployments
-datadisk_device: "/dev/xvdbb"
+# Example datadisk device for shared directory. Applicable for non-monolithic
+# deployments, but does not work on Vagrant
+#datadisk_device: "/dev/xvdbb"

--- a/environments/eu/public.yml
+++ b/environments/eu/public.yml
@@ -27,12 +27,6 @@ nofile_limit: 65536
 
 KSPLICE_ACTIVE: yes
 
-filebeat_inputs:
-  - path: "{{ log_home }}/{{ deploy_env }}_commcare-nginx_error.log"
-    tags: nginx-error
-  - path: "{{ log_home }}/{{ deploy_env }}-timing.log"
-    tags: nginx-timing
-
 kafka_version: 3.2.3
 kafka_scala_version: 2.13
 kafka_download_sha512: 36A129823B058DC10788D0893BDE47B6F39B9E4972F9EAC2D5C9E85E51E477344C6F1E1EBD126CE34D5FD430EB07E55FDD60D60CB541F1D48655C0EBC0A4778

--- a/environments/india/public.yml
+++ b/environments/india/public.yml
@@ -27,12 +27,6 @@ nofile_limit: 65536
 
 KSPLICE_ACTIVE: yes
 
-filebeat_inputs:
-  - path: "{{ log_home }}/{{ deploy_env }}_commcare-nginx_error.log"
-    tags:  nginx-error
-  - path: "{{ log_home }}/{{ deploy_env }}-timing.log"
-    tags: nginx-timing
-
 kafka_version: 3.2.3
 kafka_scala_version: 2.13
 kafka_download_sha512: 36A129823B058DC10788D0893BDE47B6F39B9E4972F9EAC2D5C9E85E51E477344C6F1E1EBD126CE34D5FD430EB07E55FDD60D60CB541F1D48655C0EBC0A4778

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -61,12 +61,6 @@ pg_repack_version: 1.4.7
 
 aws_region: 'us-east-1'
 
-filebeat_inputs:
-  - path: "{{ log_home }}/{{ deploy_env }}-timing.log"
-    tags: nginx-timing
-  - path: "{{ log_home }}/{{ deploy_env }}_commcare-nginx_error.log"
-    tags: nginx-error
-
 formplayer_java_version: "{{ java_17_bin_path }}/java"
 formplayer_archive_time_spec: '3d'
 formplayer_purge_time_spec: '10d'

--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -29,12 +29,6 @@ postgres_s3: False
 # pg_repack
 pg_repack_version: 1.4.7
 
-filebeat_inputs:
-  - path: "{{ log_home }}/{{ deploy_env }}-timing.log"
-    tags: nginx-timing
-  - path: "{{ log_home }}/{{ deploy_env }}_commcare-nginx_error.log"
-    tags: nginx-error
-
 aws_region: 'us-east-1'
 
 formplayer_archive_time_spec: '10m'

--- a/provisioning/control.sh
+++ b/provisioning/control.sh
@@ -1,13 +1,13 @@
-sudo apt-get update
-sudo apt-get install -y libffi-dev libssl-dev git
+apt-get update
+apt-get install -y libffi-dev libssl-dev git
 
 ssh-keyscan 192.168.33.15 >> /home/vagrant/.ssh/known_hosts
 ssh-keyscan 192.168.33.16 >> /home/vagrant/.ssh/known_hosts
 ssh-keyscan 192.168.33.17 >> /home/vagrant/.ssh/known_hosts
-sudo chown vagrant:vagrant /home/vagrant/.ssh/known_hosts
+chown vagrant:vagrant /home/vagrant/.ssh/known_hosts
 
 ln -s /vagrant /home/vagrant/commcare-cloud
-sudo snap install astral-uv --classic
+snap install astral-uv --classic
 sudo -H -u vagrant bash -c 'export PATH=/snap/bin:$PATH; NO_INPUT=1 source /vagrant/control/init.sh'
 
 echo "Provision completed! Now ssh into the control box by:

--- a/provisioning/control.sh
+++ b/provisioning/control.sh
@@ -1,3 +1,5 @@
+snap wait system seed.loaded &
+SEED_WAIT_PID=$!
 apt-get update
 apt-get install -y libffi-dev libssl-dev git
 
@@ -43,6 +45,9 @@ grep -E '/home/vagrant/.cc-git .* bind ' /etc/fstab > /dev/null \
 # Custom venv because ~/commcare-cloud/.venv may be used by host
 echo 'export UV_PROJECT_ENVIRONMENT=~/.cc-venv' >> /home/vagrant/.profile
 
+# Install uv
+echo "Waiting for snap seed. This may take a while..."
+wait "$SEED_WAIT_PID"
 snap install astral-uv --classic
 
 # Initialize commcare-cloud

--- a/provisioning/control.sh
+++ b/provisioning/control.sh
@@ -6,15 +6,47 @@ ssh-keyscan 192.168.33.16 >> /home/vagrant/.ssh/known_hosts
 ssh-keyscan 192.168.33.17 >> /home/vagrant/.ssh/known_hosts
 chown vagrant:vagrant /home/vagrant/.ssh/known_hosts
 
+# Ensure vagrant UID and GID match host user (for libvirt only)
+# OLD and NEW ids match on VirtualBox by default
+OLD_UID=$(id -u vagrant)
+OLD_GID=$(id -g vagrant)
+NEW_UID=$(stat -c '%u' /vagrant)
+NEW_GID=$(stat -c '%g' /vagrant)
+if [ "$NEW_UID" != "$OLD_UID" ] || [ "$NEW_GID" != "$OLD_GID" ]; then
+    sed -i -E "s/^(vagrant:[^:]*):[0-9]+:[0-9]+:/\1:$NEW_UID:$NEW_GID:/" /etc/passwd
+    sed -i -E "s/^(vagrant:[^:]*):[0-9]+:/\1:$NEW_GID:/" /etc/group
+    chown -R $NEW_UID:$NEW_GID /home/vagrant
+fi
+
+# Avoid ansible.log write errors
 groupadd dimagidev
 usermod --append --groups=dimagidev vagrant
 touch /var/log/ansible.log
 chgrp dimagidev /var/log/ansible.log
 chmod 664 /var/log/ansible.log
 
-ln -s /vagrant /home/vagrant/commcare-cloud
+# Mount commcare-cloud at the correct location for vagrant user
+# Use mount rather than symlink so real paths in ~/commcare-cloud do not resolve to /vagrant
+CC_DIR=/home/vagrant/commcare-cloud
+sudo -u vagrant mkdir $CC_DIR
+mount --bind /vagrant $CC_DIR
+grep -E '/vagrant .* bind ' /etc/fstab > /dev/null \
+    || echo "/vagrant $CC_DIR none bind 0 0" >> /etc/fstab
+
+# Fake .git dir and pre-commit hook to avoid init.sh and git branch errors
+sudo -u vagrant mkdir -p /home/vagrant/.cc-git/hooks
+sudo -u vagrant touch /home/vagrant/.cc-git/hooks/pre-commit
+mount --bind /home/vagrant/.cc-git $CC_DIR/.git
+grep -E '/home/vagrant/.cc-git .* bind ' /etc/fstab > /dev/null \
+    || echo "/home/vagrant/.cc-git $CC_DIR/.git none bind 0 0" >> /etc/fstab
+
+# Custom venv because ~/commcare-cloud/.venv may be used by host
+echo 'export UV_PROJECT_ENVIRONMENT=~/.cc-venv' >> /home/vagrant/.profile
+
 snap install astral-uv --classic
-sudo -H -u vagrant bash -c 'export PATH=/snap/bin:$PATH; NO_INPUT=1 source /vagrant/control/init.sh'
+
+# Initialize commcare-cloud
+sudo -iu vagrant bash -c 'NO_INPUT=1 source ~/commcare-cloud/control/init.sh'
 
 echo "Provision completed! Now ssh into the control box by:
 

--- a/provisioning/control.sh
+++ b/provisioning/control.sh
@@ -6,6 +6,12 @@ ssh-keyscan 192.168.33.16 >> /home/vagrant/.ssh/known_hosts
 ssh-keyscan 192.168.33.17 >> /home/vagrant/.ssh/known_hosts
 chown vagrant:vagrant /home/vagrant/.ssh/known_hosts
 
+groupadd dimagidev
+usermod --append --groups=dimagidev vagrant
+touch /var/log/ansible.log
+chgrp dimagidev /var/log/ansible.log
+chmod 664 /var/log/ansible.log
+
 ln -s /vagrant /home/vagrant/commcare-cloud
 snap install astral-uv --classic
 sudo -H -u vagrant bash -c 'export PATH=/snap/bin:$PATH; NO_INPUT=1 source /vagrant/control/init.sh'

--- a/provisioning/key_authorization.rb
+++ b/provisioning/key_authorization.rb
@@ -5,7 +5,7 @@ def authorize_key(config, key_path)
 
     full_key_path = File.expand_path(key_path)
 
-    if File.exists?(full_key_path)
+    if File.exist?(full_key_path)
       config.vm.provision 'file',
         run: 'once',
         source: full_key_path,

--- a/provisioning/nodes.sh
+++ b/provisioning/nodes.sh
@@ -1,1 +1,5 @@
 sed -i 's/^mesg n$/tty -s \&\& mesg n/g' /root/.profile
+
+# Create data root so services are able to read the contents.
+# Otherwise it is created implicitly, and may not be readable by some services.
+mkdir --mode=755 /opt/data

--- a/provisioning/nodes.sh
+++ b/provisioning/nodes.sh
@@ -3,3 +3,9 @@ sed -i 's/^mesg n$/tty -s \&\& mesg n/g' /root/.profile
 # Create data root so services are able to read the contents.
 # Otherwise it is created implicitly, and may not be readable by some services.
 mkdir --mode=755 /opt/data
+
+# Elasticsearch's systemd unit doesn't set LimitNPROC, so it inherits the
+# system-wide default, which is too low to pass ES's bootstrap max-threads
+# check on Vagrant VMs.
+sed -i 's/^#\?DefaultLimitNPROC=.*/DefaultLimitNPROC=4096/' /etc/systemd/system.conf
+systemctl daemon-reexec

--- a/provisioning/nodes.sh
+++ b/provisioning/nodes.sh
@@ -1,1 +1,1 @@
-sudo sed -i 's/^mesg n$/tty -s \&\& mesg n/g' /root/.profile
+sed -i 's/^mesg n$/tty -s \&\& mesg n/g' /root/.profile

--- a/quick_monolith_install/sample-environment/public.yml.j2
+++ b/quick_monolith_install/sample-environment/public.yml.j2
@@ -55,14 +55,6 @@ DATADOG_ENABLED: False
 nameservers: []
 internal_domain_name: 'commcarehq.test'
 
-filebeat_inputs:
-  - path: {% raw %}"{{ log_home }}/{{ deploy_env }}_commcare-nginx_error.log"
-{% endraw %}
-    tags:  nginx-error
-  - path: {% raw %}"{{ log_home }}/{{ deploy_env }}-timing.log"
-{% endraw %}
-    tags: nginx-timing
-
 TWO_FACTOR_GATEWAY_ENABLED: False
 
 localsettings:

--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -43,9 +43,9 @@ zookeeper_client_port: 2181
 formplayer_port: 8181
 
 couchdb_use_haproxy: False
-couchdb_version: 2.3.1
+couchdb_version: 3.5.0
 couchdb2_port: 15984
-couchdb2_local_port: "{{ 15986 if couchdb_version is version('3.0.0', '<') else couchdb2_port }}"
+couchdb2_local_port: "{{ couchdb2_port }}"
 couchdb2_proxy_port: "{{ 35984 if couchdb_use_haproxy else 25984 }}"
 
 # Used by TASK [andrewrothstein.couchdb-cluster-apt : configurate....]

--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -218,3 +218,9 @@ supervisor_service_files:
     file_path: "{{ service_home }}/{{ deploy_env }}_django_bash_runner.sh"
     template: ../templates/django_bash_runner.sh.j2
     should_exist: "{{ prometheus_monitoring_enabled|default(False) }}"
+
+filebeat_inputs:
+  - path: "{{ log_home }}/{{ deploy_env }}-timing.log"
+    tags: nginx-timing
+  - path: "{{ log_home }}/{{ deploy_env }}_commcare-nginx_error.log"
+    tags: nginx-error

--- a/src/commcare_cloud/ansible/roles/common_installs/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/common_installs/tasks/main.yml
@@ -91,6 +91,7 @@
   become: yes
   community.general.snap:
     name: [astral-uv]
+    classic: true
 
 - name: Install pip packages
   become: yes

--- a/src/commcare_cloud/ansible/roles/haproxy/defaults/main.yml
+++ b/src/commcare_cloud/ansible/roles/haproxy/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Major version to install (don't specify point release)
-haproxy_version: 1.8
+haproxy_version: 2.4
 
 # Validate Certificates when downloading hatop. May be set to "no" when proxy server
 # is intercepting the certificates.


### PR DESCRIPTION
This restores the Vagrant-based dev environment to a working, easier-to-maintain state. It replaces the outdated Ubuntu box, fixes the permission, service-limit, and dependency-install errors that broke provisioning, and adds support for contributors who use `libvirt` instead of VirtualBox.

Default service versions (Elasticsearch, CouchDB, HAProxy) are brought up to date. Control-node provisioning has been reworked to bind-mount the repo rather than symlink it, which resolves several errors seen when initializing `commcare-cloud` inside the VM. Fixes a handful of other smaller, including minor cleanup of a `filebeat_inputs` setting that was duplicated identically across environment files.

`deploy-stack` on Vagrant VMs is now possible end-to-end without errors.

:blowfish: Review by commit.

## Environments Affected

- **development**: primary target of this branch; box, provisioning, and env-var changes are Vagrant-specific.
- **All environments**: `couchdb_version` default now matches what `production`, `staging`, `eu`, `india` already set explicitly (3.5.0), so no behavior change there. `haproxy_version` default changes from 1.8 to 2.4 (upgrade long ago via changelog 0071).
