### PR TITLE
Support configurable --max-tasks for flower

### DIFF
--- a/environments/eu/app-processes.yml
+++ b/environments/eu/app-processes.yml
@@ -1,5 +1,6 @@
 formplayer_memory: "2g"
 formplayer_g1heapregionsize: "4m"
+flower_max_tasks: 10000
 management_commands:
   celerybeat_a1:
     run_submission_reprocessing_queue:

--- a/environments/india/app-processes.yml
+++ b/environments/india/app-processes.yml
@@ -1,5 +1,6 @@
 formplayer_memory: "8g"
 formplayer_g1heapregionsize: "4m"
+flower_max_tasks: 10000
 management_commands:
   celerybeat_a2:
     run_submission_reprocessing_queue:

--- a/environments/staging/app-processes.yml
+++ b/environments/staging/app-processes.yml
@@ -1,6 +1,8 @@
 # Use the following to enable datadog tracing for formplayer
 formplayer_command_args: '-javaagent:/home/cchq/dd-java-agent.jar -Dsrc.main.java.org.javarosa.enableOpenTracing=true -Ddd.service=formplayer -Ddd.env=staging -Ddd.trace.sample.rate=1.0'
 
+flower_max_tasks: 10000
+
 management_commands:
   celery_a1:
     handle_survey_actions:

--- a/src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_celery_flower.conf.j2
+++ b/src/commcare_cloud/ansible/roles/commcarehq/templates/supervisor_celery_flower.conf.j2
@@ -5,6 +5,9 @@ command={{ virtualenv_home }}/bin/celery
     -A corehq flower
     --address=0.0.0.0
     --port={{ app_processes_config.flower_port }}
+    {% if app_processes_config.flower_max_tasks is not none %}
+    --max-tasks={{ app_processes_config.flower_max_tasks }}
+    {% endif %}
 directory={{ code_home }}
 user={{ cchq_user }}
 numprocs=1

--- a/src/commcare_cloud/environment/schemas/app_processes.py
+++ b/src/commcare_cloud/environment/schemas/app_processes.py
@@ -40,6 +40,7 @@ class AppProcessesConfig(jsonobject.JsonObject):
     django_bind = IpAddressProperty()
     django_port = PortProperty()
     flower_port = PortProperty()
+    flower_max_tasks = jsonobject.IntegerProperty()
     gunicorn_workers_factor = jsonobject.IntegerProperty()
     gunicorn_workers_static_factor = jsonobject.IntegerProperty()
     gunicorn_max_requests = jsonobject.IntegerProperty()


### PR DESCRIPTION
## Summary
Adds an optional `flower_max_tasks` app-processes setting. When set, it passes `--max-tasks` to the celery flower supervisor command. When unset, the flag is omitted so flower's own default is used, which is currently 100k based on [docs](https://flower.readthedocs.io/en/latest/config.html#max-tasks).

Also sets `flower_max_tasks: 10000` on india, eu, and staging.

The motivation is that we've been seeing memory spikes on the celerybeat machines due to the flower process on those machines. We don't see these on production for some reason, so I'm not convinced this is the issue, but would like to try it. I suspect that most of the tasks held in memory would be heartbeat tasks on any environment, which shouldn't have a very large footprint.