### PR TITLE
Restore flower's default max tasks on india

### DIFF
--- a/environments/india/app-processes.yml
+++ b/environments/india/app-processes.yml
@@ -1,6 +1,5 @@
 formplayer_memory: "8g"
 formplayer_g1heapregionsize: "4m"
-flower_max_tasks: 10000
 management_commands:
   celerybeat_a2:
     run_submission_reprocessing_queue:


### PR DESCRIPTION
Follow-up to #6956

#6956 capped flower's in-memory task history at 10k on india, eu, and staging as an experiment against memory spikes on the celerybeat machines. This reverts that cap on india given [it doesn't appear to have helped](https://app.datadoghq.com/dashboard/nbz-bie-nip/host-groups?fromUser=true&fullscreen_end_ts=1785897356692&fullscreen_paused=false&fullscreen_refresh_mode=sliding&fullscreen_section=overview&fullscreen_start_ts=1784687756692&fullscreen_widget=274741947&refresh_mode=sliding&tpl_var_environment[0]=india&tpl_var_host[0]=celerybeat-a2-india&from_ts=1785290610818&to_ts=1785895410818&live=true), so flower falls back to its own 100k default there. 

eu and staging keep `flower_max_tasks: 10000` for now, so the environments are intentionally inconsistent while the experiment continues on those.

##### Environments Affected
india
