### PR TITLE
Add Project DB per-domain role provisioning functions

### DIFF
--- a/src/commcare_cloud/ansible/roles/postgresql_base/tasks/set_up_dbs.yml
+++ b/src/commcare_cloud/ansible/roles/postgresql_base/tasks/set_up_dbs.yml
@@ -147,7 +147,7 @@
       END $$;
   when: postgresql_dbs.repeaters and postgresql_host == postgresql_dbs.repeaters.host
 
-- name: Enable extensions in the project_db database
+- name: Set up the project_db database
   become: yes
   become_user: "{{ db_is_remote and 'ansible' or 'postgres' }}"
   postgresql_query:
@@ -156,9 +156,5 @@
     login_host: "{{ db_is_remote and postgresql_host or omit }}"
     login_user: "{{ db_is_remote and postgres_users.root.username or omit }}"
     login_password: "{{ db_is_remote and postgres_users.root.password or omit }}"
-    query: |
-      CREATE EXTENSION IF NOT EXISTS cube;
-      CREATE EXTENSION IF NOT EXISTS earthdistance;
-      CREATE EXTENSION IF NOT EXISTS pg_trgm;
-      CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
+    query: "{{ lookup('template', 'project_db_setup.sql.j2') }}"
   when: postgresql_dbs.project_db and postgresql_host == postgresql_dbs.project_db.host

--- a/src/commcare_cloud/ansible/roles/postgresql_base/templates/project_db_setup.sql.j2
+++ b/src/commcare_cloud/ansible/roles/postgresql_base/templates/project_db_setup.sql.j2
@@ -1,0 +1,6 @@
+-- {{ ansible_managed }}
+
+CREATE EXTENSION IF NOT EXISTS cube;
+CREATE EXTENSION IF NOT EXISTS earthdistance;
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;

--- a/src/commcare_cloud/ansible/roles/postgresql_base/templates/project_db_setup.sql.j2
+++ b/src/commcare_cloud/ansible/roles/postgresql_base/templates/project_db_setup.sql.j2
@@ -17,11 +17,7 @@ BEGIN
   IF role_name NOT LIKE 'projectdb\_%' THEN
     RAISE EXCEPTION 'refusing to manage role %', role_name;
   END IF;
-  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = role_name) THEN
-    EXECUTE format('ALTER ROLE %I WITH LOGIN PASSWORD %L', role_name, role_password);
-  ELSE
-    EXECUTE format('CREATE ROLE %I WITH LOGIN PASSWORD %L', role_name, role_password);
-  END IF;
+  EXECUTE format('CREATE ROLE %I WITH LOGIN PASSWORD %L', role_name, role_password);
 END;
 $$;
 

--- a/src/commcare_cloud/ansible/roles/postgresql_base/templates/project_db_setup.sql.j2
+++ b/src/commcare_cloud/ansible/roles/postgresql_base/templates/project_db_setup.sql.j2
@@ -50,3 +50,8 @@ REVOKE EXECUTE ON FUNCTION projectdb_drop_role(text) FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION projectdb_provision_role(text, text) TO {{ postgres_users.commcare.username }};
 GRANT EXECUTE ON FUNCTION projectdb_drop_role(text) TO {{ postgres_users.commcare.username }};
+
+-- Postgres 14 grants CREATE to PUBLIC, 15+ don't
+-- USAGE is deliberately left in place so domain roles can still access
+-- functions installed by the extensions
+REVOKE CREATE ON SCHEMA public FROM PUBLIC;

--- a/src/commcare_cloud/ansible/roles/postgresql_base/templates/project_db_setup.sql.j2
+++ b/src/commcare_cloud/ansible/roles/postgresql_base/templates/project_db_setup.sql.j2
@@ -11,7 +11,7 @@ CREATE OR REPLACE FUNCTION projectdb_provision_role(role_name text, role_passwor
 RETURNS void
 LANGUAGE plpgsql
 SECURITY DEFINER
-SET search_path = pg_catalog
+SET search_path = pg_catalog, pg_temp
 AS $$
 BEGIN
   IF role_name NOT LIKE 'projectdb\_%' THEN
@@ -29,7 +29,7 @@ CREATE OR REPLACE FUNCTION projectdb_drop_role(role_name text)
 RETURNS void
 LANGUAGE plpgsql
 SECURITY DEFINER
-SET search_path = pg_catalog
+SET search_path = pg_catalog, pg_temp
 AS $$
 BEGIN
   IF role_name NOT LIKE 'projectdb\_%' THEN

--- a/src/commcare_cloud/ansible/roles/postgresql_base/templates/project_db_setup.sql.j2
+++ b/src/commcare_cloud/ansible/roles/postgresql_base/templates/project_db_setup.sql.j2
@@ -4,3 +4,49 @@ CREATE EXTENSION IF NOT EXISTS cube;
 CREATE EXTENSION IF NOT EXISTS earthdistance;
 CREATE EXTENSION IF NOT EXISTS pg_trgm;
 CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
+
+-- Make SECURITY DEFINER functions so HQ can create per-domain read-only roles
+-- for ProjectDB without HQ having direct access to CREATEROLE
+CREATE OR REPLACE FUNCTION projectdb_provision_role(role_name text, role_password text)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+BEGIN
+  IF role_name NOT LIKE 'projectdb\_%' THEN
+    RAISE EXCEPTION 'refusing to manage role %', role_name;
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = role_name) THEN
+    EXECUTE format('ALTER ROLE %I WITH LOGIN PASSWORD %L', role_name, role_password);
+  ELSE
+    EXECUTE format('CREATE ROLE %I WITH LOGIN PASSWORD %L', role_name, role_password);
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION projectdb_drop_role(role_name text)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+BEGIN
+  IF role_name NOT LIKE 'projectdb\_%' THEN
+    RAISE EXCEPTION 'refusing to manage role %', role_name;
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = role_name) THEN
+    -- the role owns nothing, but DROP ROLE fails while grants still reference it
+    EXECUTE format('DROP OWNED BY %I', role_name);
+    EXECUTE format('DROP ROLE %I', role_name);
+  END IF;
+END;
+$$;
+
+-- Postgres grants EXECUTE on new functions to PUBLIC by default, which would
+-- make these callable by every domain role.
+REVOKE EXECUTE ON FUNCTION projectdb_provision_role(text, text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION projectdb_drop_role(text) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION projectdb_provision_role(text, text) TO {{ postgres_users.commcare.username }};
+GRANT EXECUTE ON FUNCTION projectdb_drop_role(text) TO {{ postgres_users.commcare.username }};

--- a/src/commcare_cloud/ansible/roles/postgresql_base/templates/project_db_setup.sql.j2
+++ b/src/commcare_cloud/ansible/roles/postgresql_base/templates/project_db_setup.sql.j2
@@ -32,7 +32,7 @@ BEGIN
     RAISE EXCEPTION 'refusing to manage role %', role_name;
   END IF;
   IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = role_name) THEN
-    -- the role owns nothing, but DROP ROLE fails while grants still reference it
+    -- drop grants to the role, which would otherwise block DROP ROLE
     EXECUTE format('DROP OWNED BY %I', role_name);
     EXECUTE format('DROP ROLE %I', role_name);
   END IF;


### PR DESCRIPTION
These three stacked PRs introduce a database-level safeguard that keeps a Project DB query from reading another domain's data, even if the query layer above it has a bug or is handed hostile SQL.

## Part I: HQ Query Users (This PR)

Each domain gets its own postgres role, which has read-only access to only that domain's tables.  Queries on behalf of that domain are authenticated as that user, so postgres enforces separation between tenants.

HQ provisions these query users using a constrained `SECURITY DEFINER` function called `projectdb_provision_role` which narrowly defines the action.  This function is created during database provisioning.  Passwords are derived from the domain name via `django.utils.crypto.salted_hmac`, never stored.

## Part II: PgBouncer

PgBouncer connection pooling complicates things in two ways

### Part IIa: PGBouncer Authentication (https://github.com/dimagi/commcare-cloud/pull/6963)

PgBouncer authenticates queries itself, so it has to know user passwords.  Currently, it validates against a file called `userlist.txt` which is managed by commcare-cloud.  Adding a new user requires amending that file, which just isn't doable in this context.  Instead, we give pgbouncer an `auth_query` it can run to get the username and password to authenticate a user that's not in `userlist.txt`.

To do this, we need a few things in place:
 * A `user_lookup` function as described in the pgbouncer docs (https://www.pgbouncer.org/config.html), supporting the `auth_query`
 * An `auth_user` pgbouncer can authenticate as when running the `auth_query`, and a password for that user
 * A role for the pgbouncer auth user with only LOGIN permissions by default
   * This role must also be granted access to the `user_lookup` function

### Part IIb: (https://github.com/dimagi/commcare-cloud/pull/6965)

PgBouncer keys its pools by `(user, database)` pair, meaning that each domain will have it's own pool in pgbouncer.  Right now, we allow up to 490 open connections per pool (`default_pool_size`). Since ProjectDB uses many pools, we can instead set a `max_db_connections` as a limit across all ProjectDB pools, and set a much lower `pool_size` to prevent one domain from claiming all that for itself.

##### Environments Affected

Staging, since it has `project_db` configured already.  Should only affect other environments when that's enabled.

##### Announce New Release

No.  Shouldn't require action by anyone but me.