### PR TITLE
Look up per-domain Project DB roles with pgbouncer auth_query

### DIFF
--- a/docs/source/reference/1-commcare-cloud/2.1-postgresql-config.rst
+++ b/docs/source/reference/1-commcare-cloud/2.1-postgresql-config.rst
@@ -87,6 +87,13 @@ that add a ``project_db`` block to `\ ``dbs`` <#dbs>`_ and map it in `\
 settings default to those of the ``ucr`` db when not set explicitly. Installs
 required extensions automatically as part of database setup.
 
+Enabling it in an environment requires one manual step: set
+``PGBOUNCER_AUTH_PASSWORD`` in the vault.  Each domain gets its own postgres
+login role, provisioned from HQ using ``projectdb_provision_role`` and
+``projectdb_drop_role``.  To validate these logins, pgbouncer runs an
+``auth_query`` to get the password hash from the DB, connecting to postgres
+using its own ``auth_user`` and ``pgbouncer_auth`` role.
+
 ``synclogs``
 ^^^^^^^^^^^^^^^^
 

--- a/docs/source/services/postgresql/postgresql.rst
+++ b/docs/source/services/postgresql/postgresql.rst
@@ -64,6 +64,11 @@ CommCare is configured to work with a number of databases:
 
   * custom report database
 
+* ``commcarehq_project_db``
+
+  * per-project case data, one schema per project
+  * optional, and opt-in per environment
+
 * ``commcarehq_synclogs``
 
   * data necessary for maintaining the state of the mobile devices 

--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -149,6 +149,10 @@ aws_versioning_enabled: true
 nofile_limit: 4096
 keepalived_recepient_email: '{{ root_email }}'
 
+# Account pgbouncer uses to look up per-domain Project DB roles via auth_query.
+# Needed by both the postgresql_base and pgbouncer roles, hence defined here.
+pgbouncer_auth_username: pgbouncer_auth
+
 # this parameter is to set backups hour frequency, by default it will take backups for every '3' hours 
 # if hourly backups are enabled. 
 nadir_hour_frequency: 3

--- a/src/commcare_cloud/ansible/roles/pgbouncer/defaults/main.yml
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/defaults/main.yml
@@ -18,4 +18,4 @@ postgresql_port: 5432
 
 pgbouncer_processes: 1
 pgbouncer_current_processes: [0]
-pgbouncer_min_version: "1.13"
+pgbouncer_min_version: "1.14"

--- a/src/commcare_cloud/ansible/roles/pgbouncer/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/tasks/main.yml
@@ -22,6 +22,14 @@
   tags:
     - configure
 
+- name: pgbouncer quit if the auth password is not set
+  assert:
+    that: PGBOUNCER_AUTH_PASSWORD
+    fail_msg: 'PGBOUNCER_AUTH_PASSWORD must be set for envs with a project_db'
+  when: postgresql_dbs.project_db
+  tags:
+    - configure
+
 - name: pgbouncer defaults (classic)
   template:
     src: pgbouncer-classic.defaults.j2

--- a/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer-classic.ini.j2
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer-classic.ini.j2
@@ -11,7 +11,7 @@
 {% if is_monolith %}{% set current_host = DEFAULT_POSTGRESQL_HOST %}{% endif %}
 {% for db in postgresql_dbs.by_pgbouncer_host.get(current_host, []) %}
 {{ db.name }} = host={{ "localhost" if db.host == inventory_hostname else db.host }} port={{ postgresql_port }}
-{%- if postgresql_dbs.project_db and db.name == postgresql_dbs.project_db.name %} auth_user={{ pgbouncer_auth_username }} auth_query='SELECT usename, passwd FROM pgbouncer.user_lookup($1)'{% endif %}
+{%- if postgresql_dbs.project_db and db.name == postgresql_dbs.project_db.name %} auth_user={{ pgbouncer_auth_username }} auth_query='SELECT usename, passwd FROM pgbouncer.project_db_user_lookup($1)'{% endif %}
 
 {% endfor %}
 

--- a/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer-classic.ini.j2
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer-classic.ini.j2
@@ -11,6 +11,8 @@
 {% if is_monolith %}{% set current_host = DEFAULT_POSTGRESQL_HOST %}{% endif %}
 {% for db in postgresql_dbs.by_pgbouncer_host.get(current_host, []) %}
 {{ db.name }} = host={{ "localhost" if db.host == inventory_hostname else db.host }} port={{ postgresql_port }}
+{%- if postgresql_dbs.project_db and db.name == postgresql_dbs.project_db.name %} auth_user={{ pgbouncer_auth_username }} auth_query='SELECT usename, passwd FROM pgbouncer.user_lookup($1)'{% endif %}
+
 {% endfor %}
 
 ;; Configuration section

--- a/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer.ini.j2
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer.ini.j2
@@ -13,7 +13,7 @@
 {{ db.name }} = host={{ "localhost" if db.host == inventory_hostname else db.host }} port={{ postgresql_port }}
 {%- if db.pgbouncer_pool_size %} pool_size={{ db.pgbouncer_pool_size // pgbouncer_processes }}{% endif %}
 {%- if db.pgbouncer_reserve_pool_size is not none %} reserve_pool={{ db.pgbouncer_reserve_pool_size // pgbouncer_processes }}{% endif %}
-{%- if postgresql_dbs.project_db and db.name == postgresql_dbs.project_db.name %} auth_user={{ pgbouncer_auth_username }} auth_query='SELECT usename, passwd FROM pgbouncer.user_lookup($1)'{% endif %}
+{%- if postgresql_dbs.project_db and db.name == postgresql_dbs.project_db.name %} auth_user={{ pgbouncer_auth_username }} auth_query='SELECT usename, passwd FROM pgbouncer.project_db_user_lookup($1)'{% endif %}
 
 {% endfor %}
 

--- a/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer.ini.j2
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer.ini.j2
@@ -10,7 +10,10 @@
 {% set current_host = inventory_hostname %}
 {% if is_monolith %}{% set current_host = DEFAULT_POSTGRESQL_HOST %}{% endif %}
 {% for db in postgresql_dbs.by_pgbouncer_host.get(current_host, []) %}
-{{ db.name }} = host={{ "localhost" if db.host == inventory_hostname else db.host }} port={{ postgresql_port }}{% if db.pgbouncer_pool_size %} pool_size={{ db.pgbouncer_pool_size // pgbouncer_processes }}{% endif %}{% if db.pgbouncer_reserve_pool_size is not none %} reserve_pool={{ db.pgbouncer_reserve_pool_size // pgbouncer_processes }}{% endif %}
+{{ db.name }} = host={{ "localhost" if db.host == inventory_hostname else db.host }} port={{ postgresql_port }}
+{%- if db.pgbouncer_pool_size %} pool_size={{ db.pgbouncer_pool_size // pgbouncer_processes }}{% endif %}
+{%- if db.pgbouncer_reserve_pool_size is not none %} reserve_pool={{ db.pgbouncer_reserve_pool_size // pgbouncer_processes }}{% endif %}
+{%- if postgresql_dbs.project_db and db.name == postgresql_dbs.project_db.name %} auth_user={{ pgbouncer_auth_username }} auth_query='SELECT usename, passwd FROM pgbouncer.user_lookup($1)'{% endif %}
 
 {% endfor %}
 

--- a/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer.users.j2
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer.users.j2
@@ -1,3 +1,6 @@
 {% for group in postgres_users.values() %}
 "{{ group.username }}" "{{ group.password }}"
 {% endfor %}
+{% if postgresql_dbs.project_db %}
+"{{ pgbouncer_auth_username }}" "{{ PGBOUNCER_AUTH_PASSWORD }}"
+{% endif %}

--- a/src/commcare_cloud/ansible/roles/postgresql_base/tasks/set_up_dbs.yml
+++ b/src/commcare_cloud/ansible/roles/postgresql_base/tasks/set_up_dbs.yml
@@ -169,20 +169,20 @@
         state: present
         db: '{{ postgresql_dbs.project_db.name }}'
         port: "{{ postgresql_port }}"
-        login_host: "{{ db_is_remote and postgresql_host or omit }}"
-        login_user: "{{ db_is_remote and postgres_users.root.username or omit }}"
-        login_password: "{{ db_is_remote and postgres_users.root.password or omit }}"
+        login_host: "{{ postgresql_host if db_is_remote else omit }}"
+        login_user: "{{ postgres_users.root.username if db_is_remote else omit }}"
+        login_password: "{{ postgres_users.root.password if db_is_remote else omit }}"
         encrypted: True
       no_log: true
 
 - name: Set up the project_db database
   become: yes
-  become_user: "{{ db_is_remote and 'ansible' or 'postgres' }}"
+  become_user: "{{ 'ansible' if db_is_remote else 'postgres' }}"
   postgresql_query:
     db: '{{ postgresql_dbs.project_db.name }}'
     port: "{{ postgresql_port }}"
-    login_host: "{{ db_is_remote and postgresql_host or omit }}"
-    login_user: "{{ db_is_remote and postgres_users.root.username or omit }}"
-    login_password: "{{ db_is_remote and postgres_users.root.password or omit }}"
+    login_host: "{{ postgresql_host if db_is_remote else omit }}"
+    login_user: "{{ postgres_users.root.username if db_is_remote else omit }}"
+    login_password: "{{ postgres_users.root.password if db_is_remote else omit }}"
     query: "{{ lookup('template', 'project_db_setup.sql.j2') }}"
   when: postgresql_dbs.project_db and postgresql_host == postgresql_dbs.project_db.host

--- a/src/commcare_cloud/ansible/roles/postgresql_base/tasks/set_up_dbs.yml
+++ b/src/commcare_cloud/ansible/roles/postgresql_base/tasks/set_up_dbs.yml
@@ -151,7 +151,7 @@
 # to validate dynamically provisioned roles (for ProjectDB)
 - name: Create pgbouncer auth user
   become: yes
-  become_user: "{{ db_is_remote and 'ansible' or 'postgres' }}"
+  become_user: "{{ 'ansible' if db_is_remote else 'postgres' }}"
   vars:
     ansible_ssh_pipelining: true
   when: postgresql_dbs.project_db and postgresql_host == postgresql_dbs.project_db.host

--- a/src/commcare_cloud/ansible/roles/postgresql_base/tasks/set_up_dbs.yml
+++ b/src/commcare_cloud/ansible/roles/postgresql_base/tasks/set_up_dbs.yml
@@ -147,6 +147,34 @@
       END $$;
   when: postgresql_dbs.repeaters and postgresql_host == postgresql_dbs.repeaters.host
 
+# Create pgbouncer user for auth_query calls
+# to validate dynamically provisioned roles (for ProjectDB)
+- name: Create pgbouncer auth user
+  become: yes
+  become_user: "{{ db_is_remote and 'ansible' or 'postgres' }}"
+  vars:
+    ansible_ssh_pipelining: true
+  when: postgresql_dbs.project_db and postgresql_host == postgresql_dbs.project_db.host
+  block:
+    - name: Check that the pgbouncer auth password is set
+      assert:
+        that: PGBOUNCER_AUTH_PASSWORD
+        fail_msg: 'PGBOUNCER_AUTH_PASSWORD must be set for envs with a project_db'
+
+    - name: Create the role
+      postgresql_user:
+        name: "{{ pgbouncer_auth_username }}"
+        password: "{{ PGBOUNCER_AUTH_PASSWORD }}"
+        role_attr_flags: 'LOGIN,NOSUPERUSER,NOCREATEROLE,NOCREATEDB'
+        state: present
+        db: '{{ postgresql_dbs.project_db.name }}'
+        port: "{{ postgresql_port }}"
+        login_host: "{{ db_is_remote and postgresql_host or omit }}"
+        login_user: "{{ db_is_remote and postgres_users.root.username or omit }}"
+        login_password: "{{ db_is_remote and postgres_users.root.password or omit }}"
+        encrypted: True
+      no_log: true
+
 - name: Set up the project_db database
   become: yes
   become_user: "{{ db_is_remote and 'ansible' or 'postgres' }}"

--- a/src/commcare_cloud/ansible/roles/postgresql_base/templates/project_db_setup.sql.j2
+++ b/src/commcare_cloud/ansible/roles/postgresql_base/templates/project_db_setup.sql.j2
@@ -51,3 +51,23 @@ GRANT EXECUTE ON FUNCTION projectdb_drop_role(text) TO {{ postgres_users.commcar
 -- USAGE is deliberately left in place so domain roles can still access
 -- functions installed by the extensions
 REVOKE CREATE ON SCHEMA public FROM PUBLIC;
+
+-- user_lookup function from pgbouncer docs (https://www.pgbouncer.org/config.html)
+-- So pgbouncer can look up a user password hash instead of hardcoding it in userlist.txt
+-- This is not specific to ProjectDB, but it lives here because nothing else uses it
+CREATE SCHEMA IF NOT EXISTS pgbouncer;
+
+CREATE OR REPLACE FUNCTION pgbouncer.user_lookup(username text)
+RETURNS TABLE(usename name, passwd text)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+AS $$
+  SELECT rolname, CASE WHEN rolvaliduntil < now() THEN NULL ELSE rolpassword END
+  FROM pg_authid WHERE rolname = username AND rolcanlogin;
+$$;
+
+REVOKE EXECUTE ON FUNCTION pgbouncer.user_lookup(text) FROM PUBLIC;
+GRANT USAGE ON SCHEMA pgbouncer TO {{ pgbouncer_auth_username }};
+GRANT EXECUTE ON FUNCTION pgbouncer.user_lookup(text) TO {{ pgbouncer_auth_username }};
+GRANT CONNECT ON DATABASE {{ postgresql_dbs.project_db.name }} TO {{ pgbouncer_auth_username }};

--- a/src/commcare_cloud/ansible/roles/postgresql_base/templates/project_db_setup.sql.j2
+++ b/src/commcare_cloud/ansible/roles/postgresql_base/templates/project_db_setup.sql.j2
@@ -54,19 +54,19 @@ REVOKE CREATE ON SCHEMA public FROM PUBLIC;
 
 -- user_lookup function from pgbouncer docs (https://www.pgbouncer.org/config.html)
 -- So pgbouncer can look up a user password hash instead of hardcoding it in userlist.txt
--- This is not specific to ProjectDB, but it lives here because nothing else uses it
+-- Scope limited to ProjectDB's per-domain roles, which is all pgbouncer needs it for
 CREATE SCHEMA IF NOT EXISTS pgbouncer;
-
-CREATE OR REPLACE FUNCTION pgbouncer.user_lookup(username text)
+CREATE OR REPLACE FUNCTION pgbouncer.project_db_user_lookup(username text)
 RETURNS TABLE(usename name, passwd text)
 LANGUAGE sql
 SECURITY DEFINER
 SET search_path = pg_catalog, pg_temp
 AS $$
   SELECT rolname, CASE WHEN rolvaliduntil < now() THEN NULL ELSE rolpassword END
-  FROM pg_authid WHERE rolname = username AND rolcanlogin;
+  FROM pg_authid
+  WHERE rolname = username AND rolcanlogin AND rolname LIKE 'projectdb\_%';
 $$;
 
-REVOKE EXECUTE ON FUNCTION pgbouncer.user_lookup(text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION pgbouncer.project_db_user_lookup(text) FROM PUBLIC;
 GRANT USAGE ON SCHEMA pgbouncer TO {{ pgbouncer_auth_username }};
-GRANT EXECUTE ON FUNCTION pgbouncer.user_lookup(text) TO {{ pgbouncer_auth_username }};
+GRANT EXECUTE ON FUNCTION pgbouncer.project_db_user_lookup(text) TO {{ pgbouncer_auth_username }};

--- a/src/commcare_cloud/ansible/roles/postgresql_base/templates/project_db_setup.sql.j2
+++ b/src/commcare_cloud/ansible/roles/postgresql_base/templates/project_db_setup.sql.j2
@@ -70,4 +70,3 @@ $$;
 REVOKE EXECUTE ON FUNCTION pgbouncer.user_lookup(text) FROM PUBLIC;
 GRANT USAGE ON SCHEMA pgbouncer TO {{ pgbouncer_auth_username }};
 GRANT EXECUTE ON FUNCTION pgbouncer.user_lookup(text) TO {{ pgbouncer_auth_username }};
-GRANT CONNECT ON DATABASE {{ postgresql_dbs.project_db.name }} TO {{ pgbouncer_auth_username }};

--- a/src/commcare_cloud/environment/secrets/backends/ansible_vault/tests/expected-generated-variables.yml
+++ b/src/commcare_cloud/environment/secrets/backends/ansible_vault/tests/expected-generated-variables.yml
@@ -43,6 +43,7 @@ MAXMIND_ACCOUNT_ID: "{{ secrets.MAXMIND_ACCOUNT_ID | default(None) }}"
 MAXMIND_LICENSE_KEY: "{{ secrets.MAXMIND_LICENSE_KEY | default(None) }}"
 MOBILE_INTEGRATION_TEST_TOKEN: "{{ localsettings_private.MOBILE_INTEGRATION_TEST_TOKEN | default(None) }}"
 OPEN_EXCHANGE_RATES_API_ID: "{{ localsettings_private.OPEN_EXCHANGE_RATES_API_ID | default(None) }}"
+PGBOUNCER_AUTH_PASSWORD: "{{ secrets.PGBOUNCER_AUTH_PASSWORD | default('') }}"
 RECAPTCHA_PRIVATE_KEY: '{{ secrets.RECAPTCHA_PRIVATE_KEY | default(None) }}'
 RECAPTCHA_PUBLIC_KEY: '{{ secrets.RECAPTCHA_PUBLIC_KEY | default(None) }}'
 REDIS_PASSWORD: "{{ localsettings_private.REDIS_PASSWORD | default(None) }}"

--- a/src/commcare_cloud/environment/secrets/backends/aws_secrets/tests/expected-generated-variables.yml
+++ b/src/commcare_cloud/environment/secrets/backends/aws_secrets/tests/expected-generated-variables.yml
@@ -43,6 +43,7 @@ MAXMIND_ACCOUNT_ID: "{{ lookup('cchq_aws_secret', 'commcare-staging/MAXMIND_ACCO
 MAXMIND_LICENSE_KEY: "{{ lookup('cchq_aws_secret', 'commcare-staging/MAXMIND_LICENSE_KEY', errors='ignore') | default(None) }}"
 MOBILE_INTEGRATION_TEST_TOKEN: "{{ lookup('cchq_aws_secret', 'commcare-staging/MOBILE_INTEGRATION_TEST_TOKEN', errors='ignore') | default(None) }}"
 OPEN_EXCHANGE_RATES_API_ID: "{{ lookup('cchq_aws_secret', 'commcare-staging/OPEN_EXCHANGE_RATES_API_ID', errors='ignore') | default(None) }}"
+PGBOUNCER_AUTH_PASSWORD: "{{ lookup('cchq_aws_secret', 'commcare-staging/PGBOUNCER_AUTH_PASSWORD', errors='ignore') | default('') }}"
 RECAPTCHA_PRIVATE_KEY: "{{ lookup('cchq_aws_secret', 'commcare-staging/RECAPTCHA_PRIVATE_KEY', errors='ignore') | default(None) }}"
 RECAPTCHA_PUBLIC_KEY: '{{ lookup(''cchq_aws_secret'', ''commcare-staging/RECAPTCHA_PUBLIC_KEY'', errors=''ignore'') | default(None) }}'
 REDIS_PASSWORD: "{{ lookup('cchq_aws_secret', 'commcare-staging/REDIS_PASSWORD', errors='ignore') | default(None) }}"

--- a/src/commcare_cloud/environment/secrets/secrets.yml
+++ b/src/commcare_cloud/environment/secrets/secrets.yml
@@ -111,6 +111,9 @@
   ansible_var_lowercase: yes
 - name: OPEN_EXCHANGE_RATES_API_ID
   legacy_namespace: localsettings_private
+- name: PGBOUNCER_AUTH_PASSWORD
+  legacy_namespace: secrets
+  default: ''
 - name: POSTGRES_USERS
   legacy_namespace: secrets
   ansible_var_lowercase: yes


### PR DESCRIPTION
These three stacked PRs introduce a database-level safeguard that keeps a Project DB query from reading another domain's data, even if the query layer above it has a bug or is handed hostile SQL.

## Part I: HQ Query Users (https://github.com/dimagi/commcare-cloud/pull/6962)

Each domain gets its own postgres role, which has read-only access to only that domain's tables.  Queries on behalf of that domain are authenticated as that user, so postgres enforces separation between tenants.

HQ provisions these query users using a constrained `SECURITY DEFINER` function called `projectdb_provision_role` which narrowly defines the action.  This function is created during database provisioning.  Passwords are derived from the domain name via `django.utils.crypto.salted_hmac`, never stored.

## Part II: PgBouncer

PgBouncer connection pooling complicates things in two ways

### Part IIa: PGBouncer Authentication (This PR)

PgBouncer authenticates queries itself, so it has to know user passwords.  Currently, it validates against a file called `userlist.txt` which is managed by commcare-cloud.  Adding a new user requires amending that file, which just isn't doable in this context.  Instead, we give pgbouncer an `auth_query` it can run to get the username and password to authenticate a user that's not in `userlist.txt`.

To do this, we need a few things in place:
 * A `user_lookup` function as described in the pgbouncer docs (https://www.pgbouncer.org/config.html), supporting the `auth_query`
 * An `auth_user` pgbouncer can authenticate as when running the `auth_query`, and a password for that user
 * A role for the pgbouncer auth user with only LOGIN permissions by default
   * This role must also be granted access to the `user_lookup` function

### Part IIb: (https://github.com/dimagi/commcare-cloud/pull/6965)

PgBouncer keys its pools by `(user, database)` pair, meaning that each domain will have it's own pool in pgbouncer.  Right now, we allow up to 490 open connections per pool (`default_pool_size`). Since ProjectDB uses many pools, we can instead set a `max_db_connections` as a limit across all ProjectDB pools, and set a much lower `pool_size` to prevent one domain from claiming all that for itself.

##### Environments Affected

Staging, since it has `project_db` configured already.  Should only affect other environments when that's enabled.

##### Announce New Release

No.  Shouldn't require action by anyone but me.