### PR TITLE
ProjectDB PgBouncer pool sizing

### DIFF
--- a/docs/source/reference/1-commcare-cloud/2.1-postgresql-config.rst
+++ b/docs/source/reference/1-commcare-cloud/2.1-postgresql-config.rst
@@ -94,6 +94,13 @@ login role, provisioned from HQ using ``projectdb_provision_role`` and
 ``auth_query`` to get the password hash from the DB, connecting to postgres
 using its own ``auth_user`` and ``pgbouncer_auth`` role.
 
+Because each of those roles gets its own pgbouncer pool, this db does not
+inherit the environment-wide pool settings, which would let a single domain use
+as many connections as the whole db previously could. Instead
+``pgbouncer_max_db_connections`` defaults to 20 per pgbouncer host across all
+ProjectDB pools, with ``pgbouncer_pool_size`` set so the max per domain is half
+that. This may require tuning.
+
 ``synclogs``
 ^^^^^^^^^^^^^^^^
 
@@ -240,6 +247,35 @@ Some examples where you would want to set the ``pgbouncer_endpoints`` and ``pgbo
 * You have multiple ``pgbouncer_hosts`` in a network load balancer whose address ``pgbouncer_enpoint`` is set to.
 * You want ``pgbouncer1`` to be ready to switch over to in case ``pgbouncer0`` fails. In that case,
   you set ``pgbouncer_hosts`` to ``[pgbouncer0, pgbouncer1]`` and ``pgbouncer_endpoint`` to ``pgbouncer0``.
+
+``pgbouncer_pool_size``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+* Type: int
+
+Maximum number of server connections pgbouncer will open for a single pool of
+this db, overriding the environment-wide ``pgbouncer_default_pool``.
+
+``pgbouncer_reserve_pool_size``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+* Type: int
+
+Additional connections pgbouncer may open for a pool of this db when clients have
+been waiting longer than ``pgbouncer_pool_timeout``\ , overriding the
+environment-wide ``pgbouncer_reserve_pool``.
+
+``pgbouncer_max_db_connections``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+* Type: int
+
+Maximum number of server connections across *all* pools of this db.  Useful for
+dbs that are accessed by many postgres users, such as project_db.  Otherwise
+this setting is redundant with ``pgbouncer_pool_size``.
 
 ``port``
 ~~~~~~~~~~~~

--- a/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer.ini.j2
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer.ini.j2
@@ -12,10 +12,10 @@
 {% for db in postgresql_dbs.by_pgbouncer_host.get(current_host, []) %}
 
 {{ db.name }} = host={{ "localhost" if db.host == inventory_hostname else db.host }} port={{ postgresql_port }}
-{%- if db.pgbouncer_pool_size %} pool_size={{ db.pgbouncer_pool_size // pgbouncer_processes }}{% endif %}
+{%- if db.pgbouncer_pool_size %} pool_size={{ [1, db.pgbouncer_pool_size // pgbouncer_processes]|max }}{% endif %}
 {%- if db.pgbouncer_reserve_pool_size is not none %} reserve_pool={{ db.pgbouncer_reserve_pool_size // pgbouncer_processes }}{% endif %}
 {%- if postgresql_dbs.project_db and db.name == postgresql_dbs.project_db.name %} auth_user={{ pgbouncer_auth_username }} auth_query='SELECT usename, passwd FROM pgbouncer.user_lookup($1)'{% endif %}
-{%- if db.pgbouncer_max_db_connections %} max_db_connections={{ db.pgbouncer_max_db_connections // pgbouncer_processes }}{% endif %}
+{%- if db.pgbouncer_max_db_connections %} max_db_connections={{ [1, db.pgbouncer_max_db_connections // pgbouncer_processes]|max }}{% endif %}
 
 {% endfor %}
 

--- a/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer.ini.j2
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer.ini.j2
@@ -10,10 +10,12 @@
 {% set current_host = inventory_hostname %}
 {% if is_monolith %}{% set current_host = DEFAULT_POSTGRESQL_HOST %}{% endif %}
 {% for db in postgresql_dbs.by_pgbouncer_host.get(current_host, []) %}
+
 {{ db.name }} = host={{ "localhost" if db.host == inventory_hostname else db.host }} port={{ postgresql_port }}
 {%- if db.pgbouncer_pool_size %} pool_size={{ db.pgbouncer_pool_size // pgbouncer_processes }}{% endif %}
 {%- if db.pgbouncer_reserve_pool_size is not none %} reserve_pool={{ db.pgbouncer_reserve_pool_size // pgbouncer_processes }}{% endif %}
 {%- if postgresql_dbs.project_db and db.name == postgresql_dbs.project_db.name %} auth_user={{ pgbouncer_auth_username }} auth_query='SELECT usename, passwd FROM pgbouncer.user_lookup($1)'{% endif %}
+{%- if db.pgbouncer_max_db_connections %} max_db_connections={{ db.pgbouncer_max_db_connections // pgbouncer_processes }}{% endif %}
 
 {% endfor %}
 

--- a/src/commcare_cloud/environment/schemas/postgresql.py
+++ b/src/commcare_cloud/environment/schemas/postgresql.py
@@ -165,6 +165,16 @@ class PostgresqlConfig(jsonobject.JsonObject):
             if self.dbs.project_db.pgbouncer_endpoint is None:
                 self.dbs.project_db.pgbouncer_endpoint = ucr.pgbouncer_endpoint
 
+            # pgbouncer_max_db_connections is the max connections across all
+            # project_db pools on a single pgbouncer host
+            if self.dbs.project_db.pgbouncer_max_db_connections is None:
+                self.dbs.project_db.pgbouncer_max_db_connections = 20
+            # pgbouncer_pool_size is the max connections for a single domain
+            if self.dbs.project_db.pgbouncer_pool_size is None:
+                # Don't let one domain use more than half project_db connections
+                self.dbs.project_db.pgbouncer_pool_size = max(
+                    1, self.dbs.project_db.pgbouncer_max_db_connections // 2)
+
         all_dbs = self.generate_postgresql_dbs()
         for db in all_dbs:
             if db.host is None:

--- a/src/commcare_cloud/environment/schemas/postgresql.py
+++ b/src/commcare_cloud/environment/schemas/postgresql.py
@@ -311,6 +311,7 @@ class DBOptions(jsonobject.JsonObject):
     pgbouncer_endpoint = jsonobject.StringProperty(default=None)
     pgbouncer_pool_size = jsonobject.IntegerProperty(default=None)
     pgbouncer_reserve_pool_size = jsonobject.IntegerProperty(default=None)
+    pgbouncer_max_db_connections = jsonobject.IntegerProperty(default=None)
     port = jsonobject.IntegerProperty(default=None)
     user = jsonobject.StringProperty()
     password = jsonobject.StringProperty()

--- a/tests/test_envs/2018-04-04-development-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-development-snapshot/.generated.yml
@@ -12,6 +12,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 192.168.33.16
     pgbouncer_hosts:
     - 192.168.33.16
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -29,6 +30,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 192.168.33.16
     pgbouncer_hosts:
     - 192.168.33.16
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -46,6 +48,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 192.168.33.16
     pgbouncer_hosts:
     - 192.168.33.16
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -71,6 +74,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 192.168.33.16
     pgbouncer_hosts:
     - 192.168.33.16
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -88,6 +92,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 192.168.33.16
     pgbouncer_hosts:
     - 192.168.33.16
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -109,6 +114,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 192.168.33.16
     pgbouncer_hosts:
     - 192.168.33.16
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432

--- a/tests/test_envs/2018-04-04-enikshay-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-enikshay-snapshot/.generated.yml
@@ -12,6 +12,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -29,6 +30,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -49,6 +51,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -69,6 +72,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -89,6 +93,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -109,6 +114,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -129,6 +135,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -149,6 +156,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -169,6 +177,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -189,6 +198,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -209,6 +219,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -229,6 +240,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -246,6 +258,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -263,6 +276,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -280,6 +294,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -318,6 +333,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 172.25.3.5
         pgbouncer_hosts:
         - 172.25.3.5
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -338,6 +354,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 172.25.3.5
         pgbouncer_hosts:
         - 172.25.3.5
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -358,6 +375,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 172.25.3.5
         pgbouncer_hosts:
         - 172.25.3.5
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -378,6 +396,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 172.25.3.5
         pgbouncer_hosts:
         - 172.25.3.5
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -398,6 +417,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 172.25.3.5
         pgbouncer_hosts:
         - 172.25.3.5
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -418,6 +438,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 172.25.3.5
         pgbouncer_hosts:
         - 172.25.3.5
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -438,6 +459,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 172.25.3.5
         pgbouncer_hosts:
         - 172.25.3.5
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -458,6 +480,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 172.25.3.5
         pgbouncer_hosts:
         - 172.25.3.5
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -478,6 +501,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 172.25.3.5
         pgbouncer_hosts:
         - 172.25.3.5
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -498,6 +522,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 172.25.3.5
         pgbouncer_hosts:
         - 172.25.3.5
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -518,6 +543,7 @@ postgresql_dbs:
       pgbouncer_endpoint: 172.25.3.5
       pgbouncer_hosts:
       - 172.25.3.5
+      pgbouncer_max_db_connections: null
       pgbouncer_pool_size: null
       pgbouncer_reserve_pool_size: null
       port: 6432
@@ -534,6 +560,7 @@ postgresql_dbs:
       pg_config: []
       pgbouncer_endpoint: null
       pgbouncer_hosts: []
+      pgbouncer_max_db_connections: null
       pgbouncer_pool_size: null
       pgbouncer_reserve_pool_size: null
       port: null
@@ -551,6 +578,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -568,6 +596,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -588,6 +617,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -605,6 +635,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 172.25.3.5
     pgbouncer_hosts:
     - 172.25.3.5
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432

--- a/tests/test_envs/2018-04-04-icds-new-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-icds-new-snapshot/.generated.yml
@@ -12,6 +12,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.26
     pgbouncer_hosts:
     - 10.247.164.26
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -29,6 +30,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.25
     pgbouncer_hosts:
     - 10.247.164.25
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -47,6 +49,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.24
     pgbouncer_hosts:
     - 10.247.164.24
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -64,6 +67,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.66
     pgbouncer_hosts:
     - 10.247.164.66
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -84,6 +88,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.64
     pgbouncer_hosts:
     - 10.247.164.64
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -104,6 +109,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.66
     pgbouncer_hosts:
     - 10.247.164.66
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -124,6 +130,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.21
     pgbouncer_hosts:
     - 10.247.164.21
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -144,6 +151,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.21
     pgbouncer_hosts:
     - 10.247.164.21
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -164,6 +172,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.21
     pgbouncer_hosts:
     - 10.247.164.21
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -184,6 +193,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.20
     pgbouncer_hosts:
     - 10.247.164.20
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -204,6 +214,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.20
     pgbouncer_hosts:
     - 10.247.164.20
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -224,6 +235,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.20
     pgbouncer_hosts:
     - 10.247.164.20
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -244,6 +256,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.64
     pgbouncer_hosts:
     - 10.247.164.64
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -264,6 +277,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.56
     pgbouncer_hosts:
     - 10.247.164.56
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -281,6 +295,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.70
     pgbouncer_hosts:
     - 10.247.164.70
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -298,6 +313,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.25
     pgbouncer_hosts:
     - 10.247.164.25
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -315,6 +331,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.25
     pgbouncer_hosts:
     - 10.247.164.25
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -367,6 +384,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.25
     pgbouncer_hosts:
     - 10.247.164.25
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -386,6 +404,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 10.247.164.66
         pgbouncer_hosts:
         - 10.247.164.66
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -406,6 +425,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 10.247.164.64
         pgbouncer_hosts:
         - 10.247.164.64
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -426,6 +446,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 10.247.164.66
         pgbouncer_hosts:
         - 10.247.164.66
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -446,6 +467,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 10.247.164.21
         pgbouncer_hosts:
         - 10.247.164.21
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -466,6 +488,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 10.247.164.21
         pgbouncer_hosts:
         - 10.247.164.21
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -486,6 +509,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 10.247.164.21
         pgbouncer_hosts:
         - 10.247.164.21
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -506,6 +530,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 10.247.164.20
         pgbouncer_hosts:
         - 10.247.164.20
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -526,6 +551,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 10.247.164.20
         pgbouncer_hosts:
         - 10.247.164.20
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -546,6 +572,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 10.247.164.20
         pgbouncer_hosts:
         - 10.247.164.20
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -566,6 +593,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 10.247.164.64
         pgbouncer_hosts:
         - 10.247.164.64
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -586,6 +614,7 @@ postgresql_dbs:
       pgbouncer_endpoint: 10.247.164.56
       pgbouncer_hosts:
       - 10.247.164.56
+      pgbouncer_max_db_connections: null
       pgbouncer_pool_size: null
       pgbouncer_reserve_pool_size: null
       port: 6432
@@ -602,6 +631,7 @@ postgresql_dbs:
       pg_config: []
       pgbouncer_endpoint: null
       pgbouncer_hosts: []
+      pgbouncer_max_db_connections: null
       pgbouncer_pool_size: null
       pgbouncer_reserve_pool_size: null
       port: null
@@ -619,6 +649,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.25
     pgbouncer_hosts:
     - 10.247.164.25
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -636,6 +667,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.26
     pgbouncer_hosts:
     - 10.247.164.26
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -657,6 +689,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.24
     pgbouncer_hosts:
     - 10.247.164.24
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -674,6 +707,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.70
     pgbouncer_hosts:
     - 10.247.164.70
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -691,6 +725,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.247.164.25
     pgbouncer_hosts:
     - 10.247.164.25
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432

--- a/tests/test_envs/2018-04-04-pna-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-pna-snapshot/.generated.yml
@@ -12,6 +12,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -29,6 +30,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -49,6 +51,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -69,6 +72,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -89,6 +93,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -109,6 +114,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -129,6 +135,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -149,6 +156,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -169,6 +177,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -189,6 +198,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -209,6 +219,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -229,6 +240,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -246,6 +258,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -263,6 +276,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -280,6 +294,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -318,6 +333,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 196.207.230.171
         pgbouncer_hosts:
         - 196.207.230.171
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -338,6 +354,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 196.207.230.171
         pgbouncer_hosts:
         - 196.207.230.171
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -358,6 +375,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 196.207.230.171
         pgbouncer_hosts:
         - 196.207.230.171
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -378,6 +396,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 196.207.230.171
         pgbouncer_hosts:
         - 196.207.230.171
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -398,6 +417,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 196.207.230.171
         pgbouncer_hosts:
         - 196.207.230.171
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -418,6 +438,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 196.207.230.171
         pgbouncer_hosts:
         - 196.207.230.171
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -438,6 +459,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 196.207.230.171
         pgbouncer_hosts:
         - 196.207.230.171
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -458,6 +480,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 196.207.230.171
         pgbouncer_hosts:
         - 196.207.230.171
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -478,6 +501,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 196.207.230.171
         pgbouncer_hosts:
         - 196.207.230.171
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -498,6 +522,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 196.207.230.171
         pgbouncer_hosts:
         - 196.207.230.171
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -518,6 +543,7 @@ postgresql_dbs:
       pgbouncer_endpoint: 196.207.230.171
       pgbouncer_hosts:
       - 196.207.230.171
+      pgbouncer_max_db_connections: null
       pgbouncer_pool_size: null
       pgbouncer_reserve_pool_size: null
       port: 6432
@@ -534,6 +560,7 @@ postgresql_dbs:
       pg_config: []
       pgbouncer_endpoint: null
       pgbouncer_hosts: []
+      pgbouncer_max_db_connections: null
       pgbouncer_pool_size: null
       pgbouncer_reserve_pool_size: null
       port: null
@@ -551,6 +578,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -568,6 +596,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -588,6 +617,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -605,6 +635,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 196.207.230.171
     pgbouncer_hosts:
     - 196.207.230.171
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432

--- a/tests/test_envs/2018-04-04-production-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-production-snapshot/.generated.yml
@@ -12,6 +12,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb0.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb0.internal-va.commcarehq.org
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -29,6 +30,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb0.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb0.internal-va.commcarehq.org
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -46,6 +48,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb1.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb1.internal-va.commcarehq.org
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -66,6 +69,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb1.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb1.internal-va.commcarehq.org
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -86,6 +90,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb2.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb2.internal-va.commcarehq.org
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -106,6 +111,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb2.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb2.internal-va.commcarehq.org
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -126,6 +132,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb2.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb2.internal-va.commcarehq.org
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -146,6 +153,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb1.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb1.internal-va.commcarehq.org
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -163,6 +171,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb0.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb0.internal-va.commcarehq.org
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -180,6 +189,7 @@ postgresql_dbs:
     pgbouncer_endpoint: pgsynclog.internal-va.commcarehq.org
     pgbouncer_hosts:
     - pgsynclog.internal-va.commcarehq.org
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -197,6 +207,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb0.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb0.internal-va.commcarehq.org
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -214,6 +225,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb0.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb0.internal-va.commcarehq.org
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -231,6 +243,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb0.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb0.internal-va.commcarehq.org
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -268,6 +281,7 @@ postgresql_dbs:
         pgbouncer_endpoint: hqdb1.internal-va.commcarehq.org
         pgbouncer_hosts:
         - hqdb1.internal-va.commcarehq.org
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -288,6 +302,7 @@ postgresql_dbs:
         pgbouncer_endpoint: hqdb1.internal-va.commcarehq.org
         pgbouncer_hosts:
         - hqdb1.internal-va.commcarehq.org
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -308,6 +323,7 @@ postgresql_dbs:
         pgbouncer_endpoint: hqdb2.internal-va.commcarehq.org
         pgbouncer_hosts:
         - hqdb2.internal-va.commcarehq.org
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -328,6 +344,7 @@ postgresql_dbs:
         pgbouncer_endpoint: hqdb2.internal-va.commcarehq.org
         pgbouncer_hosts:
         - hqdb2.internal-va.commcarehq.org
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -348,6 +365,7 @@ postgresql_dbs:
         pgbouncer_endpoint: hqdb2.internal-va.commcarehq.org
         pgbouncer_hosts:
         - hqdb2.internal-va.commcarehq.org
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -368,6 +386,7 @@ postgresql_dbs:
       pgbouncer_endpoint: hqdb1.internal-va.commcarehq.org
       pgbouncer_hosts:
       - hqdb1.internal-va.commcarehq.org
+      pgbouncer_max_db_connections: null
       pgbouncer_pool_size: null
       pgbouncer_reserve_pool_size: null
       port: 6432
@@ -384,6 +403,7 @@ postgresql_dbs:
       pg_config: []
       pgbouncer_endpoint: null
       pgbouncer_hosts: []
+      pgbouncer_max_db_connections: null
       pgbouncer_pool_size: null
       pgbouncer_reserve_pool_size: null
       port: null
@@ -401,6 +421,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb0.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb0.internal-va.commcarehq.org
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -418,6 +439,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb0.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb0.internal-va.commcarehq.org
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -436,6 +458,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb0.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb0.internal-va.commcarehq.org
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -454,6 +477,7 @@ postgresql_dbs:
     pgbouncer_endpoint: pgsynclog.internal-va.commcarehq.org
     pgbouncer_hosts:
     - pgsynclog.internal-va.commcarehq.org
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -471,6 +495,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb0.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb0.internal-va.commcarehq.org
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432

--- a/tests/test_envs/2018-04-04-softlayer-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-softlayer-snapshot/.generated.yml
@@ -12,6 +12,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
     - 10.162.36.205
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -29,6 +30,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
     - 10.162.36.205
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -49,6 +51,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
     - 10.162.36.205
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -69,6 +72,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
     - 10.162.36.205
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -89,6 +93,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
     - 10.162.36.205
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -109,6 +114,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
     - 10.162.36.205
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -129,6 +135,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
     - 10.162.36.205
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -146,6 +153,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
     - 10.162.36.205
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -163,6 +171,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
     - 10.162.36.205
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -180,6 +189,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
     - 10.162.36.205
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -197,6 +207,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
     - 10.162.36.205
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -228,6 +239,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
     - 10.162.36.205
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -247,6 +259,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 10.162.36.205
         pgbouncer_hosts:
         - 10.162.36.205
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -267,6 +280,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 10.162.36.205
         pgbouncer_hosts:
         - 10.162.36.205
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -287,6 +301,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 10.162.36.205
         pgbouncer_hosts:
         - 10.162.36.205
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -307,6 +322,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 10.162.36.205
         pgbouncer_hosts:
         - 10.162.36.205
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -327,6 +343,7 @@ postgresql_dbs:
         pgbouncer_endpoint: 10.162.36.205
         pgbouncer_hosts:
         - 10.162.36.205
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -347,6 +364,7 @@ postgresql_dbs:
       pgbouncer_endpoint: 10.162.36.205
       pgbouncer_hosts:
       - 10.162.36.205
+      pgbouncer_max_db_connections: null
       pgbouncer_pool_size: null
       pgbouncer_reserve_pool_size: null
       port: 6432
@@ -363,6 +381,7 @@ postgresql_dbs:
       pg_config: []
       pgbouncer_endpoint: null
       pgbouncer_hosts: []
+      pgbouncer_max_db_connections: null
       pgbouncer_pool_size: null
       pgbouncer_reserve_pool_size: null
       port: null
@@ -380,6 +399,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
     - 10.162.36.205
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -397,6 +417,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
     - 10.162.36.205
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -417,6 +438,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
     - 10.162.36.205
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -434,6 +456,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 10.162.36.205
     pgbouncer_hosts:
     - 10.162.36.205
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432

--- a/tests/test_envs/2018-04-04-staging-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-staging-snapshot/.generated.yml
@@ -12,6 +12,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -29,6 +30,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -49,6 +51,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -69,6 +72,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -89,6 +93,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -109,6 +114,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -129,6 +135,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -146,6 +153,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -163,6 +171,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -180,6 +189,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -213,6 +223,7 @@ postgresql_dbs:
         pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
         pgbouncer_hosts:
         - hqdb1-staging.internal-va.commcarehq.org
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -233,6 +244,7 @@ postgresql_dbs:
         pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
         pgbouncer_hosts:
         - hqdb1-staging.internal-va.commcarehq.org
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -253,6 +265,7 @@ postgresql_dbs:
         pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
         pgbouncer_hosts:
         - hqdb1-staging.internal-va.commcarehq.org
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -273,6 +286,7 @@ postgresql_dbs:
         pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
         pgbouncer_hosts:
         - hqdb1-staging.internal-va.commcarehq.org
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -293,6 +307,7 @@ postgresql_dbs:
         pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
         pgbouncer_hosts:
         - hqdb1-staging.internal-va.commcarehq.org
+        pgbouncer_max_db_connections: null
         pgbouncer_pool_size: null
         pgbouncer_reserve_pool_size: null
         port: 6432
@@ -313,6 +328,7 @@ postgresql_dbs:
       pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
       pgbouncer_hosts:
       - hqdb1-staging.internal-va.commcarehq.org
+      pgbouncer_max_db_connections: null
       pgbouncer_pool_size: null
       pgbouncer_reserve_pool_size: null
       port: 6432
@@ -329,6 +345,7 @@ postgresql_dbs:
       pg_config: []
       pgbouncer_endpoint: null
       pgbouncer_hosts: []
+      pgbouncer_max_db_connections: null
       pgbouncer_pool_size: null
       pgbouncer_reserve_pool_size: null
       port: null
@@ -346,6 +363,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -363,6 +381,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -383,6 +402,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -400,6 +420,7 @@ postgresql_dbs:
     pgbouncer_endpoint: hqdb1-staging.internal-va.commcarehq.org
     pgbouncer_hosts:
     - hqdb1-staging.internal-va.commcarehq.org
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432

--- a/tests/test_envs/2018-04-04-swiss-snapshot/.generated.yml
+++ b/tests/test_envs/2018-04-04-swiss-snapshot/.generated.yml
@@ -12,6 +12,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 127.0.0.1
     pgbouncer_hosts:
     - 127.0.0.1
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -29,6 +30,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 127.0.0.1
     pgbouncer_hosts:
     - 127.0.0.1
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -46,6 +48,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 127.0.0.1
     pgbouncer_hosts:
     - 127.0.0.1
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -63,6 +66,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 127.0.0.1
     pgbouncer_hosts:
     - 127.0.0.1
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -89,6 +93,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 127.0.0.1
     pgbouncer_hosts:
     - 127.0.0.1
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -106,6 +111,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 127.0.0.1
     pgbouncer_hosts:
     - 127.0.0.1
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -126,6 +132,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 127.0.0.1
     pgbouncer_hosts:
     - 127.0.0.1
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432
@@ -143,6 +150,7 @@ postgresql_dbs:
     pgbouncer_endpoint: 127.0.0.1
     pgbouncer_hosts:
     - 127.0.0.1
+    pgbouncer_max_db_connections: null
     pgbouncer_pool_size: null
     pgbouncer_reserve_pool_size: null
     port: 6432


### PR DESCRIPTION
These three stacked PRs introduce a database-level safeguard that keeps a Project DB query from reading another domain's data, even if the query layer above it has a bug or is handed hostile SQL.

## Part I: HQ Query Users (https://github.com/dimagi/commcare-cloud/pull/6962)

Each domain gets its own postgres role, which has read-only access to only that domain's tables.  Queries on behalf of that domain are authenticated as that user, so postgres enforces separation between tenants.

HQ provisions these query users using a constrained `SECURITY DEFINER` function called `projectdb_provision_role` which narrowly defines the action.  This function is created during database provisioning.  Passwords are derived from the domain name via `django.utils.crypto.salted_hmac`, never stored.

## Part II: PgBouncer

PgBouncer connection pooling complicates things in two ways

### Part IIa: PGBouncer Authentication (https://github.com/dimagi/commcare-cloud/pull/6963)

PgBouncer authenticates queries itself, so it has to know user passwords.  Currently, it validates against a file called `userlist.txt` which is managed by commcare-cloud.  Adding a new user requires amending that file, which just isn't doable in this context.  Instead, we give pgbouncer an `auth_query` it can run to get the username and password to authenticate a user that's not in `userlist.txt`.

To do this, we need a few things in place:
 * A `user_lookup` function as described in the pgbouncer docs (https://www.pgbouncer.org/config.html), supporting the `auth_query`
 * An `auth_user` pgbouncer can authenticate as when running the `auth_query`, and a password for that user
 * A role for the pgbouncer auth user with only LOGIN permissions by default
   * This role must also be granted access to the `user_lookup` function

### Part IIb: (This PR)

PgBouncer keys its pools by `(user, database)` pair, meaning that each domain will have it's own pool in pgbouncer.  Right now, we allow up to 490 open connections per pool (`default_pool_size`). Since ProjectDB uses many pools, we can instead set a `max_db_connections` as a limit across all ProjectDB pools, and set a much lower `pool_size` to prevent one domain from claiming all that for itself.

##### Environments Affected

Staging, since it has `project_db` configured already.  Should only affect other environments when that's enabled.

##### Announce New Release

No.  Shouldn't require action by anyone but me.