### PR TITLE
Curb OOMs on pgbouncer-a6 by recycling server connections

### DIFF
--- a/environments/production/inventory.ini
+++ b/environments/production/inventory.ini
@@ -86,7 +86,7 @@ mobile_webworkers
 [pgbouncer_a5]
 10.202.40.44 hostname=pgbouncer-a5-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-0421eb020cc421ad6 root_encryption_mode=aws pgbouncer_processes=2
 [pgbouncer_a6]
-10.202.40.98 hostname=pgbouncer-a6-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-0ccf6dcc1a4cb2b9b root_encryption_mode=aws pgbouncer_processes=2
+10.202.40.98 hostname=pgbouncer-a6-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-0ccf6dcc1a4cb2b9b root_encryption_mode=aws pgbouncer_processes=2 pgbouncer_server_lifetime=300
 [pgbouncer_b2]
 10.202.41.209 hostname=pgbouncer-b2-production ufw_private_interface=ens5 ansible_python_interpreter=/usr/bin/python3 ec2_instance_id=i-0401d2bda17749fb5 root_encryption_mode=aws pgbouncer_processes=2
 [pgbouncer_b3]

--- a/environments/production/inventory.ini.j2
+++ b/environments/production/inventory.ini.j2
@@ -39,7 +39,7 @@ mobile_webworkers
 
 {{ __pgbouncer_a4__ }} pgbouncer_processes=2
 {{ __pgbouncer_a5__ }} pgbouncer_processes=2
-{{ __pgbouncer_a6__ }} pgbouncer_processes=2
+{{ __pgbouncer_a6__ }} pgbouncer_processes=2 pgbouncer_server_lifetime=300
 {{ __pgbouncer_b2__ }} pgbouncer_processes=2
 {{ __pgbouncer_b3__ }} pgbouncer_processes=2
 {{ __pgbouncer13__ }} pgbouncer_processes=2

--- a/src/commcare_cloud/ansible/roles/pgbouncer/defaults/main.yml
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/defaults/main.yml
@@ -12,6 +12,10 @@ pgbouncer_default_pool: 15
 pgbouncer_reserve_pool: 4
 pgbouncer_pool_timeout: 2
 pgbouncer_pool_mode: session
+# pgbouncer's built-in defaults; lower to recycle server connections
+# faster, e.g. to shed memory retained by bloated postgres backends
+pgbouncer_server_lifetime: 3600
+pgbouncer_server_idle_timeout: 600
 pgbouncer_kernel_settings: {}
 
 postgresql_port: 5432

--- a/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer-classic.ini.j2
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer-classic.ini.j2
@@ -137,11 +137,11 @@ log_disconnections = 0
 ;;;
 
 ;; Close server connection if its been connected longer.
-;server_lifetime = 1200
+server_lifetime = {{ pgbouncer_server_lifetime }}
 
 ;; Close server connection if its not been used in this time.
 ;; Allows to clean unnecessary connections from pool after peak.
-;server_idle_timeout = 60
+server_idle_timeout = {{ pgbouncer_server_idle_timeout }}
 
 ;; Cancel connection attempt if server does not answer takes longer.
 ;server_connect_timeout = 15

--- a/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer.ini.j2
+++ b/src/commcare_cloud/ansible/roles/pgbouncer/templates/pgbouncer.ini.j2
@@ -138,11 +138,11 @@ log_disconnections = 0
 ;;;
 
 ;; Close server connection if its been connected longer.
-;server_lifetime = 1200
+server_lifetime = {{ pgbouncer_server_lifetime }}
 
 ;; Close server connection if its not been used in this time.
 ;; Allows to clean unnecessary connections from pool after peak.
-;server_idle_timeout = 60
+server_idle_timeout = {{ pgbouncer_server_idle_timeout }}
 
 ;; Cancel connection attempt if server does not answer takes longer.
 ;server_connect_timeout = 15


### PR DESCRIPTION
pgbouncer-a6-production (the plproxy host) keeps OOMing. I believe this is at least in part due to the way postgres manages memory on reused connections: as queries run, they push up the high water mark of memory used by that connection, and that memory is not released until the connection is closed. Currently, these connections are set to live and be reused for an hour (pgbouncer's default `server_lifetime` of 3600) or until they're idle for 10m (default `server_idle_timeout` of 600). Capping the lifetime at 5 minutes on this host bounds how long any bloated backend survives. `server_idle_timeout` is deliberately left at the default for production, because with a 5-minute lifetime it would almost never be the operative limit.

Nothing changes for other hosts or environments: config changes on those environments just explicitly set these values to their existing default values.

**Rollout:** an ini-only change triggers the role's per-process **reload** handler, so deploying doesn't drop connections. (The full-restart handler only fires on systemd unit file changes, which this PR doesn't touch.)

```
cchq production ap deploy_postgres.yml --tags=pgbouncer --limit=pgbouncer_a6
```

This bounds how long bloat survives, not how big one query can get; a proxy-DB `statement_timeout` and paginating the unbounded callers are possible follow-ups.

##### Environments Affected

production (pgbouncer-a6 only)

