### PR TITLE
Auto-restart PostgreSQL on service failure

### DIFF
--- a/src/commcare_cloud/ansible/roles/postgresql_base/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/postgresql_base/tasks/main.yml
@@ -63,6 +63,17 @@
     - Restart postgres
     - reload systemd
 
+- name: Configure postgres to restart on failure
+  become: yes
+  template:
+    src: restart.conf.j2
+    dest: "{{ postgresql_systemd_config_dir }}/restart.conf"
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+    - reload systemd
+
 - name: Ensure PostgreSQL data directory exists.
   file:
     path: "{{ postgresql_data_dir }}"

--- a/src/commcare_cloud/ansible/roles/postgresql_base/templates/restart.conf.j2
+++ b/src/commcare_cloud/ansible/roles/postgresql_base/templates/restart.conf.j2
@@ -1,0 +1,8 @@
+[Service]
+# The base unit file has Restart=... commented out with a note that
+# it prevents `pg_ctlcluster ... stop` from working. However,
+# commcare-cloud does not use that command, and there have been
+# postgresql OOMs where it was killed and had to be restarted manually.
+#
+# Use `systemctl stop postgresql@...` to stop the service.
+Restart=on-failure


### PR DESCRIPTION
PostgreSQL currently has no automatic recovery if the service dies unexpectedly (for example, if it's killed by an OOM event). When that happens, someone has to notice and manually restart the service. This change configures systemd to automatically restart PostgreSQL if it exits on failure, reducing downtime and the need for manual intervention.

Deliberately stopping PostgreSQL still works as expected via `systemctl stop postgresql@...`; only unexpected/failure exits trigger an automatic restart.

Deployed/tested on staging.

<!--- Provide a link to the ticket or document which prompted this change -->

##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->

None.

- [x] If the changes affect multiple environments, I will ensure they are rolled out consistently across all environments.
