### PR TITLE
update the waf allow list 

### DIFF
--- a/src/commcare_cloud/commands/terraform/constants.py
+++ b/src/commcare_cloud/commands/terraform/constants.py
@@ -8,16 +8,23 @@ COMMCAREHQ_SSRF_URLS_REGEX = r"""
 """.strip().split('\n')
 
 COMMCAREHQ_XML_POST_URLS_REGEX = r"""
-^/a/([\w\.:-]+)/api/case/v2(?:/([\w\-,]+))?/?$
+^/a/([\w\.:-]+)/api/case/v2/([\w\-,]+)/?$
+^/a/([\w\.:-]+)/api/case/v2/?$
 ^/a/([\w\.:-]+)/api/case/v2/bulk-fetch/$
+^/a/([\w\.:-]+)/api/case/v2/ext/(.+)/\Z
 ^/a/([\w\.:-]+)/api/v([\d\.]+)/form/$
-^/a/([\w\.:-]+)/api/v0\.6/case(?:/([\w\-,]+))?/?$
+^/a/([\w\.:-]+)/api/v0.6/case/?$
+^/a/([\w\.:-]+)/api/v0\.6/case/([\w\-,]+)/?$
 ^/a/([\w\.:-]+)/api/v0\.6/case/bulk-fetch/$
+^/a/([\w\.:-]+)/api/v0\.6/case/ext/(.+)/\Z
 ^/a/([\w\.:-]+)/apps/([\w-]+)/multimedia/uploaded/app_logo/([\w\-]+)/$
 ^/a/([\w\.:-]+)/apps/([\w-]+)/multimedia/uploaded/audio/$
 ^/a/([\w\.:-]+)/apps/([\w-]+)/multimedia/uploaded/bulk/$
 ^/a/([\w\.:-]+)/apps/([\w-]+)/multimedia/uploaded/image/$
 ^/a/([\w\.:-]+)/apps/([\w-]+)/multimedia/uploaded/video/$
+^/a/([\w\.:-]+)/apps/api/([\w-]+)/multimedia/$
+^/a/([\w\.:-]+)/apps/api/([\w-]+)/multimedia/status/([\w-]+)/$
+^/a/([\w\.:-]+)/apps/api/import_app/$
 ^/a/([\w\.:-]+)/apps/edit_advanced_form_actions/([\w-]+)/([\w-]+)/$
 ^/a/([\w\.:-]+)/apps/edit_form_attr/([\w-]+)/([\w-]+)/([\w-]+)/$
 ^/a/([\w\.:-]+)/apps/edit_form_attr_api/([\w-]+)/([\w-]+)/([\w-]+)/$

--- a/src/commcare_cloud/commands/terraform/tests/test_compact_regexes.py
+++ b/src/commcare_cloud/commands/terraform/tests/test_compact_regexes.py
@@ -97,5 +97,8 @@ def _generate_matching_example(pattern):
         .replace(r'$', '') \
         .replace(r'\.', '.') \
         .replace(r'(?:/([\w\-,]+))?', '') \
+        .replace(r'([\w\-,]+)', 'one-two,three-four') \
+        .replace(r'(.+)', 'anything') \
+        .replace(r'\Z', '') \
         .replace(r'/?', '/') \
         .replace(r'(case_list_explorer|duplicate_cases)', 'duplicate_cases')


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Realised that our waf allowlist has not been updated in a while. There are more endpoints in HQ that adds `@waf_allow` decorator.
Ran `manage.py list_waf_allow_patterns` on HQ to get the updated list.

To roll it out I will run 

`cchq <env> terraform plan -target module.ga_alb_waf`


##### Environments Affected
<!--- list which environments are affected by this change or None if this doesn't change any environment files -->
All.

<!-- Delete this section if the PR does not include any changes that affect any environment -->
- [x] If the changes affect multiple environments, I will ensure they are rolled out consistently across all environments.


