### PR TITLE
Fix terraform apply failure on the new WAF allow-list patterns

### DIFF
--- a/src/commcare_cloud/commands/terraform/constants.py
+++ b/src/commcare_cloud/commands/terraform/constants.py
@@ -11,12 +11,12 @@ COMMCAREHQ_XML_POST_URLS_REGEX = r"""
 ^/a/([\w\.:-]+)/api/case/v2/([\w\-,]+)/?$
 ^/a/([\w\.:-]+)/api/case/v2/?$
 ^/a/([\w\.:-]+)/api/case/v2/bulk-fetch/$
-^/a/([\w\.:-]+)/api/case/v2/ext/(.+)/\Z
+^/a/([\w\.:-]+)/api/case/v2/ext/(.+)/$
 ^/a/([\w\.:-]+)/api/v([\d\.]+)/form/$
 ^/a/([\w\.:-]+)/api/v0.6/case/?$
 ^/a/([\w\.:-]+)/api/v0\.6/case/([\w\-,]+)/?$
 ^/a/([\w\.:-]+)/api/v0\.6/case/bulk-fetch/$
-^/a/([\w\.:-]+)/api/v0\.6/case/ext/(.+)/\Z
+^/a/([\w\.:-]+)/api/v0\.6/case/ext/(.+)/$
 ^/a/([\w\.:-]+)/apps/([\w-]+)/multimedia/uploaded/app_logo/([\w\-]+)/$
 ^/a/([\w\.:-]+)/apps/([\w-]+)/multimedia/uploaded/audio/$
 ^/a/([\w\.:-]+)/apps/([\w-]+)/multimedia/uploaded/bulk/$

--- a/src/commcare_cloud/commands/terraform/tests/test_compact_regexes.py
+++ b/src/commcare_cloud/commands/terraform/tests/test_compact_regexes.py
@@ -63,6 +63,14 @@ def test_compact_regex_lists__restricts_group_sizes():
         assert len(group) <= 10, f'{key} has too many regexes: {len(group)}'
 
 
+def test_patterns_are_waf_compatible():
+    # AWS WAFv2 uses the RE2 regex engine, which rejects \Z (its spelling
+    # is \z, and $ is equivalent since multiline mode is off). \Z sneaks in
+    # via `./manage.py list_waf_allow_patterns` and breaks terraform apply.
+    for pattern in COMMCAREHQ_XML_POST_URLS_REGEX:
+        assert r'\Z' not in pattern, f'replace \\Z with $ for WAF (RE2) compatibility: {pattern}'
+
+
 def _test_compact_function_against_examples(compact_function, patterns):
     examples = [_generate_matching_example(pattern) for pattern in patterns]
     compacted_patterns = compact_function(patterns)
@@ -99,6 +107,5 @@ def _generate_matching_example(pattern):
         .replace(r'(?:/([\w\-,]+))?', '') \
         .replace(r'([\w\-,]+)', 'one-two,three-four') \
         .replace(r'(.+)', 'anything') \
-        .replace(r'\Z', '') \
         .replace(r'/?', '/') \
         .replace(r'(case_list_explorer|duplicate_cases)', 'duplicate_cases')


### PR DESCRIPTION
## Problem

`terraform apply` fails on the allow list merged in #6969:

```
Error: "regular_expression.8.regex_string": error parsing regexp: invalid escape sequence: `\Z`
```

The two new `/ext/(.+)/` patterns end in `\Z`, which is how `./manage.py list_waf_allow_patterns` (Django/Python) spells the end-of-string anchor. AWS WAFv2 uses the RE2 regex engine, which doesn't support `\Z`.

## Solution

Replace `\Z` with `$` in those two patterns — equivalent in RE2 (multiline mode is off, so `$` anchors at absolute end of text) and consistent with every other pattern in the list. Also adds a test asserting no pattern contains `\Z`, so a future allow-list refresh that pastes `\Z` back in fails in CI instead of at apply time.

All 10 tests in `test_compact_regexes.py` pass.

Note: this commit was briefly pushed to master directly by mistake (7881eb403) and reverted (46a334b04); this PR reintroduces it through review. Merging will show the fix applying cleanly on top of the revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)