### PR TITLE
Point self-hosters to the Maintainers group for security notifications

### DIFF
--- a/docs/source/operations/2-deploys.rst
+++ b/docs/source/operations/2-deploys.rst
@@ -260,7 +260,7 @@ Local Settings deploy
 
 Settings generally only need to be deployed when static files are updated against your specific environment. 
 
-Sometimes changes are made to the system which require new settings to be deployed before code can be rolled out. In these cases, the detailed steps are provided in the `changelog <https://commcare-cloud.readthedocs.io/en/latest/changelog/index.html#changelog>`_. Announcements are made to the `Developer Forum <https://forum.dimagi.com/>`_ in a `dedicated category <https://forum.dimagi.com/c/developers/maintainer-announcements/>`_ when these actions are needed. We strongly recommend that anyone maintaining a CommCare Cloud instance subscribe to that feed.
+Sometimes changes are made to the system which require new settings to be deployed before code can be rolled out. In these cases, the detailed steps are provided in the `changelog <https://commcare-cloud.readthedocs.io/en/latest/changelog/index.html#changelog>`_. Announcements are made to the `Developer Forum <https://forum.dimagi.com/>`_ in a `dedicated category <https://forum.dimagi.com/c/developers/maintainer-announcements/>`_ when these actions are needed. We strongly recommend that anyone maintaining a CommCare Cloud instance subscribe to that feed. For security updates, also request to join the `Maintainers group <https://forum.dimagi.com/g/maintainers>`_.
 
 -------------------------------
 Resolving problems with deploys

--- a/docs/source/operations/4-maintenance.rst
+++ b/docs/source/operations/4-maintenance.rst
@@ -24,6 +24,10 @@ Subscribe to the `developers forum <https://forum.dimagi.com/c/developers/5>`_ t
 other parties hosting CommCare. Dimagi will announce important changes
 there, such as upcoming upgrades.
 
+For security updates specifically, request to join the
+`Maintainers group <https://forum.dimagi.com/g/maintainers>`_. Members are
+notified when a security update is available, ahead of the public advisory.
+
 Deploy CommCare HQ at least once every two weeks
 ------------------------------------------------
 


### PR DESCRIPTION
Adds a pointer to the [Maintainers group](https://forum.dimagi.com/g/maintainers) on the CommCare forum, which notifies members when a security update is available ahead of the public advisory. The maintenance page gets a new paragraph under "Monitor the developers forum", and the deploys page gets one added sentence in the paragraph that recommends subscribing to Maintainer Announcements.
