### PR TITLE
Point self-hosters to the Security Announcements category for security updates

### DIFF
--- a/docs/source/operations/2-deploys.rst
+++ b/docs/source/operations/2-deploys.rst
@@ -260,7 +260,7 @@ Local Settings deploy
 
 Settings generally only need to be deployed when static files are updated against your specific environment. 
 
-Sometimes changes are made to the system which require new settings to be deployed before code can be rolled out. In these cases, the detailed steps are provided in the `changelog <https://commcare-cloud.readthedocs.io/en/latest/changelog/index.html#changelog>`_. Announcements are made to the `Developer Forum <https://forum.dimagi.com/>`_ in a `dedicated category <https://forum.dimagi.com/c/developers/maintainer-announcements/>`_ when these actions are needed. We strongly recommend that anyone maintaining a CommCare Cloud instance subscribe to that feed. For security updates, also request to join the `Maintainers group <https://forum.dimagi.com/g/maintainers>`_.
+Sometimes changes are made to the system which require new settings to be deployed before code can be rolled out. In these cases, the detailed steps are provided in the `changelog <https://commcare-cloud.readthedocs.io/en/latest/changelog/index.html#changelog>`_. Announcements are made to the `Developer Forum <https://forum.dimagi.com/>`_ in a `dedicated category <https://forum.dimagi.com/c/developers/maintainer-announcements/>`_ when these actions are needed. We strongly recommend that anyone maintaining a CommCare Cloud instance subscribe to that feed. For security updates, also watch the `Security Announcements category <https://forum.dimagi.com/c/developers/security-announcements/24>`_. You must have an account in order to see this category.
 
 -------------------------------
 Resolving problems with deploys

--- a/docs/source/operations/4-maintenance.rst
+++ b/docs/source/operations/4-maintenance.rst
@@ -24,9 +24,11 @@ Subscribe to the `developers forum <https://forum.dimagi.com/c/developers/5>`_ t
 other parties hosting CommCare. Dimagi will announce important changes
 there, such as upcoming upgrades.
 
-For security updates specifically, request to join the
-`Maintainers group <https://forum.dimagi.com/g/maintainers>`_. Members are
-notified when a security update is available, ahead of the public advisory.
+For security updates specifically, log into or create an account on the
+`Dimagi Forum <https://forum.dimagi.com/>`_ and watch the
+`Security Announcements category <https://forum.dimagi.com/c/developers/security-announcements/24>`_.
+You must have an account in order to see this category. Notifications are
+posted there when a security update is available.
 
 Deploy CommCare HQ at least once every two weeks
 ------------------------------------------------


### PR DESCRIPTION
Replaces the Maintainers group signup in the maintenance and deploys pages with the Security Announcements category on the forum, matching the wording in dimagi/commcare-hq#38137. An account is required to see the category, and a notification is posted there when a security update is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)