### PR TITLE
Add Molecule tests for the datadog role, fix idempotence bugs

### DIFF
--- a/src/commcare_cloud/ansible/group_vars/all.yml
+++ b/src/commcare_cloud/ansible/group_vars/all.yml
@@ -77,21 +77,6 @@ old_s3_bulk_delete_chunksize: ~
 s3_blob_db_access_key: "{{ s3_access_key|default('') }}"
 s3_blob_db_secret_key:  "{{ s3_secret_key|default('') }}"
 
-datadog_integration_couch: false
-datadog_integration_elastic: false
-datadog_integration_gunicorn: false
-datadog_integration_kafka: false
-datadog_integration_kafka_consumer: false
-datadog_integration_nginx: false
-datadog_integration_pgbouncer: false
-datadog_integration_postgres: false
-datadog_integration_postgres_receiver: false
-datadog_integration_redisdb: false
-datadog_integration_zk: false
-datadog_integration_http: false
-datadog_integration_haproxy: false
-datadog_integration_tcp_check: false
-datadog_integration_disk_check: true
 datadog_extra_host_checks: []
 
 root_email: commcarehq-ops+root@example.com

--- a/src/commcare_cloud/ansible/roles/datadog/defaults/main.yml
+++ b/src/commcare_cloud/ansible/roles/datadog/defaults/main.yml
@@ -1,5 +1,22 @@
 couchdb2_first_host: "{{ groups['couchdb2'][0] if 'couchdb2' in groups else 'NO HOST SHOULD MATCH THIS' }}"
 
+# Fallback defaults; service-specific vars are enabled per host group.
+datadog_integration_disk_check: true
+datadog_integration_couch: false
+datadog_integration_elastic: false
+datadog_integration_gunicorn: false
+datadog_integration_kafka: false
+datadog_integration_kafka_consumer: false
+datadog_integration_nginx: false
+datadog_integration_pgbouncer: false
+datadog_integration_postgres: false
+datadog_integration_postgres_receiver: false
+datadog_integration_redisdb: false
+datadog_integration_zk: false
+datadog_integration_http: false
+datadog_integration_haproxy: false
+datadog_integration_tcp_check: false
+
 datadog_integrations:
   - {"name": "elastic", "enabled": "{{ datadog_integration_elastic }}"}
   - {"name": "gunicorn", "enabled": "{{ datadog_integration_gunicorn }}"}

--- a/src/commcare_cloud/ansible/roles/datadog/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/datadog/tasks/main.yml
@@ -8,12 +8,20 @@
    - A2923DFF56EDA6E76E55E492D3A80E30382E94DE
 
 # ansible apt_key doesn't do any action on expired keys
-- name: Remove expired datadog apt key manually
-  command: apt-key del {{ item }}
+- name: Check for expired datadog apt keys
+  command: apt-key export {{ item }}
+  register: expired_datadog_apt_keys
+  changed_when: false
+  failed_when: false
   with_list:
     - A2923DFF56EDA6E76E55E492D3A80E30382E94DE
     - D75CEA17048B9ACBF186794B32637D44F14F620E
     - 5F1E256061D813B125E156E8E6266D4AC0962C7D
+
+- name: Remove expired datadog apt key manually
+  command: apt-key del {{ item.item }}
+  loop: "{{ expired_datadog_apt_keys.results }}"
+  when: item.stdout | trim != ''
 
 - name: Remove old datadog apt repository
   apt_repository:

--- a/src/commcare_cloud/ansible/roles/datadog/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/datadog/tasks/main.yml
@@ -36,7 +36,6 @@
   with_items:
     - /etc/apt/keyrings/DATADOG_APT_KEY_382E94DE.gpg
     - /etc/apt/keyrings/DATADOG_APT_KEY_F14F620E.gpg
-    - /etc/apt/keyrings/DATADOG_APT_KEY_C0962C7D.gpg
 
 # the repository configuration was not getting cleaned up by the apt_repository module, so we need to do it manually
 - name: Remove old datadog repository configuration

--- a/src/commcare_cloud/ansible/roles/datadog/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/datadog/tasks/main.yml
@@ -55,6 +55,7 @@
 - name: Add new datadog apt repository
   apt_repository:
     repo: "deb [signed-by=/etc/apt/keyrings/DATADOG_APT_KEY_C0962C7D.gpg] http://apt.datadoghq.com/ stable 7"
+    filename: datadog-agent  # must be distinct from apt_datadoghq_com.list used by old repo
     state: present
 
 - name: Install datadog agent

--- a/src/commcare_cloud/ansible/roles/datadog/tasks/main.yml
+++ b/src/commcare_cloud/ansible/roles/datadog/tasks/main.yml
@@ -21,7 +21,7 @@
 - name: Remove expired datadog apt key manually
   command: apt-key del {{ item.item }}
   loop: "{{ expired_datadog_apt_keys.results }}"
-  when: item.stdout | trim != ''
+  when: item.stdout | trim
 
 - name: Remove old datadog apt repository
   apt_repository:

--- a/tests/molecule/datadog.default/converge.yml
+++ b/tests/molecule/datadog.default/converge.yml
@@ -1,0 +1,8 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  tasks:
+    - name: Include datadog
+      ansible.builtin.include_role:
+        name: "datadog"

--- a/tests/molecule/datadog.default/molecule.yml
+++ b/tests/molecule/datadog.default/molecule.yml
@@ -1,0 +1,35 @@
+---
+dependency:
+  name: shell
+  command: ''
+  enabled: false
+driver:
+  name: containers
+platforms:
+  - name: instance
+    image: docker.io/geerlingguy/docker-ubuntu2204-ansible
+    pre_build_image: true
+
+    # Let systemd run as PID 1, needed for the role's service tasks.
+    override_command: false
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    tmpfs:
+      - /run
+      - /tmp
+
+provisioner:
+  name: ansible
+  playbooks:
+    cleanup: ../lib/stub.yml
+    side_effect: ../lib/stub.yml
+  inventory:
+    group_vars:
+      all:
+        DATADOG_ENABLED: true
+        DATADOG_API_KEY: "0000000000000000000000000000ff"
+        env_monitoring_id: molecule-test
+verifier:
+  name: ansible

--- a/tests/molecule/datadog.default/prepare.yml
+++ b/tests/molecule/datadog.default/prepare.yml
@@ -1,0 +1,79 @@
+---
+- name: Prepare
+  hosts: all
+  become: true
+  tasks:
+    - name: Ensure dpkg-dev is present (for dpkg-scanpackages)
+      ansible.builtin.apt:
+        name: dpkg-dev
+        state: present
+        update_cache: true
+
+    # The role installs the datadog-agent package from apt.datadoghq.com. Serve
+    # a fake one from a local repo so the role apt task installs it rather than
+    # hitting Datadog's repo on every CI run.
+    - name: Create fake datadog-agent package tree
+      ansible.builtin.file:
+        path: /tmp/fake-datadog-agent/DEBIAN
+        state: directory
+        mode: "0755"
+
+    - name: Write fake package control file
+      ansible.builtin.copy:
+        dest: /tmp/fake-datadog-agent/DEBIAN/control
+        content: |
+          Package: datadog-agent
+          Version: 999:1.0.0
+          Architecture: all
+          Maintainer: Molecule Test <test@example.com>
+          Description: Fake datadog-agent stub for molecule testing
+
+    - name: Write fake package postinst
+      ansible.builtin.copy:
+        dest: /tmp/fake-datadog-agent/DEBIAN/postinst
+        mode: "0755"
+        content: |
+          #!/bin/sh
+          set -e
+          getent group dd-agent >/dev/null || groupadd --system dd-agent
+          getent passwd dd-agent >/dev/null || useradd --system --gid dd-agent --no-create-home --shell /usr/sbin/nologin dd-agent
+          mkdir -p /etc/datadog-agent/conf.d /etc/datadog-agent/checks.d
+          chown -R dd-agent:dd-agent /etc/datadog-agent
+          cat > /lib/systemd/system/datadog-agent.service <<'UNIT'
+          [Unit]
+          Description=Fake Datadog Agent (Molecule stub)
+
+          [Service]
+          ExecStart=/bin/sleep infinity
+          Restart=always
+
+          [Install]
+          WantedBy=multi-user.target
+          UNIT
+          systemctl daemon-reload
+
+    - name: Create local fake repo directory
+      ansible.builtin.file:
+        path: /tmp/fake-datadog-repo
+        state: directory
+        mode: "0755"
+
+    - name: Build fake datadog-agent package into the local repo
+      ansible.builtin.command: >
+        dpkg-deb --build --root-owner-group
+        /tmp/fake-datadog-agent
+        /tmp/fake-datadog-repo/datadog-agent_999.1.0.0_all.deb
+      changed_when: true
+
+    - name: Generate local repo package index
+      ansible.builtin.shell: cd /tmp/fake-datadog-repo && dpkg-scanpackages . > Packages
+      changed_when: true
+
+    - name: Add local fake repo as an apt source
+      ansible.builtin.copy:
+        dest: /etc/apt/sources.list.d/fake-datadog.list
+        content: "deb [trusted=yes] file:/tmp/fake-datadog-repo ./\n"
+
+    - name: Refresh apt cache to pick up local fake repo
+      ansible.builtin.apt:
+        update_cache: true

--- a/tests/molecule/datadog.default/prepare.yml
+++ b/tests/molecule/datadog.default/prepare.yml
@@ -3,6 +3,53 @@
   hosts: all
   become: true
   tasks:
+    - name: Ensure gnupg is present
+      # would be nice to get this included in the base image, but until then...
+      ansible.builtin.apt:
+        name: gnupg
+        state: present
+        update_cache: true
+
+    - name: Copy vendored legacy datadog key files for key removal tasks
+      ansible.builtin.copy:
+        src: "{{ item }}"
+        dest: "/tmp/{{ item | basename }}"
+      loop:
+        - "{{ playbook_dir }}/../../../src/commcare_cloud/ansible/roles/datadog/files/DATADOG_APT_KEY_C0962C7D.gpg"
+        - "{{ playbook_dir }}/../../../src/commcare_cloud/ansible/roles/datadog/files/DATADOG_APT_KEY_F14F620E.gpg"
+
+    - name: Import vendored legacy datadog keys
+      ansible.builtin.apt_key:
+        file: "/tmp/{{ item | basename }}"
+        state: present
+      loop:
+        - "{{ playbook_dir }}/../../../src/commcare_cloud/ansible/roles/datadog/files/DATADOG_APT_KEY_C0962C7D.gpg"
+        - "{{ playbook_dir }}/../../../src/commcare_cloud/ansible/roles/datadog/files/DATADOG_APT_KEY_F14F620E.gpg"
+
+    - name: Seed one expired legacy datadog apt key
+      ansible.builtin.command: >
+        gpg --no-default-keyring --keyring /etc/apt/trusted.gpg
+        --keyserver keyserver.ubuntu.com
+        --recv-keys A2923DFF56EDA6E76E55E492D3A80E30382E94DE
+      changed_when: true
+
+    - name: Ensure /etc/apt/keyrings exists
+      ansible.builtin.file:
+        path: /etc/apt/keyrings
+        state: directory
+        mode: "0755"
+
+    - name: Seed placeholder files for the role's file-based cleanup tasks
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: touch
+        mode: "0644"
+      loop:
+        - /etc/apt/keyrings/DATADOG_APT_KEY_382E94DE.gpg
+        - /etc/apt/keyrings/DATADOG_APT_KEY_F14F620E.gpg
+        - /etc/apt/sources.list.d/apt_datadoghq_com.list
+        - /etc/apt/trusted.gpg.d/datadog-archive-keyring.gpg
+
     # The role installs the datadog-agent package from apt.datadoghq.com. Serve
     # a fake one from a local repo so the role apt task installs it rather than
     # hitting Datadog's repo on every CI run.

--- a/tests/molecule/datadog.default/prepare.yml
+++ b/tests/molecule/datadog.default/prepare.yml
@@ -8,7 +8,6 @@
       ansible.builtin.apt:
         name: gnupg
         state: present
-        update_cache: true
 
     - name: Copy vendored legacy datadog key files for key removal tasks
       ansible.builtin.copy:
@@ -66,7 +65,6 @@
           ansible.builtin.apt:
             name: dpkg-dev
             state: present
-            update_cache: true
 
         - name: Create fake datadog-agent package tree
           ansible.builtin.file:
@@ -129,7 +127,3 @@
           ansible.builtin.copy:
             dest: /etc/apt/sources.list.d/fake-datadog.list
             content: "deb [trusted=yes] file:/tmp/fake-datadog-repo ./\n"
-
-        - name: Refresh apt cache to pick up local fake repo
-          ansible.builtin.apt:
-            update_cache: true

--- a/tests/molecule/datadog.default/prepare.yml
+++ b/tests/molecule/datadog.default/prepare.yml
@@ -8,6 +8,7 @@
       ansible.builtin.apt:
         name: gnupg
         state: present
+        update_cache: true
 
     - name: Copy vendored legacy datadog key files for key removal tasks
       ansible.builtin.copy:

--- a/tests/molecule/datadog.default/prepare.yml
+++ b/tests/molecule/datadog.default/prepare.yml
@@ -3,77 +3,86 @@
   hosts: all
   become: true
   tasks:
-    - name: Ensure dpkg-dev is present (for dpkg-scanpackages)
-      ansible.builtin.apt:
-        name: dpkg-dev
-        state: present
-        update_cache: true
-
     # The role installs the datadog-agent package from apt.datadoghq.com. Serve
     # a fake one from a local repo so the role apt task installs it rather than
     # hitting Datadog's repo on every CI run.
-    - name: Create fake datadog-agent package tree
-      ansible.builtin.file:
-        path: /tmp/fake-datadog-agent/DEBIAN
-        state: directory
-        mode: "0755"
+    #
+    # To occasionally manually check that the role's repo/key config is valid
+    # (NOT FOR ROUTINE/CI USE):
+    #
+    #   MOLECULE_DATADOG_REAL_INSTALL=1 ./tests/molecule/run.sh datadog default
+    #
+    - name: Stub the datadog-agent package
+      when: lookup('env', 'MOLECULE_DATADOG_REAL_INSTALL') != '1'
+      block:
+        - name: Ensure dpkg-dev is present (for dpkg-scanpackages)
+          ansible.builtin.apt:
+            name: dpkg-dev
+            state: present
+            update_cache: true
 
-    - name: Write fake package control file
-      ansible.builtin.copy:
-        dest: /tmp/fake-datadog-agent/DEBIAN/control
-        content: |
-          Package: datadog-agent
-          Version: 999:1.0.0
-          Architecture: all
-          Maintainer: Molecule Test <test@example.com>
-          Description: Fake datadog-agent stub for molecule testing
+        - name: Create fake datadog-agent package tree
+          ansible.builtin.file:
+            path: /tmp/fake-datadog-agent/DEBIAN
+            state: directory
+            mode: "0755"
 
-    - name: Write fake package postinst
-      ansible.builtin.copy:
-        dest: /tmp/fake-datadog-agent/DEBIAN/postinst
-        mode: "0755"
-        content: |
-          #!/bin/sh
-          set -e
-          getent group dd-agent >/dev/null || groupadd --system dd-agent
-          getent passwd dd-agent >/dev/null || useradd --system --gid dd-agent --no-create-home --shell /usr/sbin/nologin dd-agent
-          mkdir -p /etc/datadog-agent/conf.d /etc/datadog-agent/checks.d
-          chown -R dd-agent:dd-agent /etc/datadog-agent
-          cat > /lib/systemd/system/datadog-agent.service <<'UNIT'
-          [Unit]
-          Description=Fake Datadog Agent (Molecule stub)
+        - name: Write fake package control file
+          ansible.builtin.copy:
+            dest: /tmp/fake-datadog-agent/DEBIAN/control
+            content: |
+              Package: datadog-agent
+              Version: 999:1.0.0
+              Architecture: all
+              Maintainer: Molecule Test <test@example.com>
+              Description: Fake datadog-agent stub for molecule testing
 
-          [Service]
-          ExecStart=/bin/sleep infinity
-          Restart=always
+        - name: Write fake package postinst
+          ansible.builtin.copy:
+            dest: /tmp/fake-datadog-agent/DEBIAN/postinst
+            mode: "0755"
+            content: |
+              #!/bin/sh
+              set -e
+              getent group dd-agent >/dev/null || groupadd --system dd-agent
+              getent passwd dd-agent >/dev/null || useradd --system --gid dd-agent --no-create-home --shell /usr/sbin/nologin dd-agent
+              mkdir -p /etc/datadog-agent/conf.d /etc/datadog-agent/checks.d
+              chown -R dd-agent:dd-agent /etc/datadog-agent
+              cat > /lib/systemd/system/datadog-agent.service <<'UNIT'
+              [Unit]
+              Description=Fake Datadog Agent (Molecule stub)
 
-          [Install]
-          WantedBy=multi-user.target
-          UNIT
-          systemctl daemon-reload
+              [Service]
+              ExecStart=/bin/sleep infinity
+              Restart=always
 
-    - name: Create local fake repo directory
-      ansible.builtin.file:
-        path: /tmp/fake-datadog-repo
-        state: directory
-        mode: "0755"
+              [Install]
+              WantedBy=multi-user.target
+              UNIT
+              systemctl daemon-reload
 
-    - name: Build fake datadog-agent package into the local repo
-      ansible.builtin.command: >
-        dpkg-deb --build --root-owner-group
-        /tmp/fake-datadog-agent
-        /tmp/fake-datadog-repo/datadog-agent_999.1.0.0_all.deb
-      changed_when: true
+        - name: Create local fake repo directory
+          ansible.builtin.file:
+            path: /tmp/fake-datadog-repo
+            state: directory
+            mode: "0755"
 
-    - name: Generate local repo package index
-      ansible.builtin.shell: cd /tmp/fake-datadog-repo && dpkg-scanpackages . > Packages
-      changed_when: true
+        - name: Build fake datadog-agent package into the local repo
+          ansible.builtin.command: >
+            dpkg-deb --build --root-owner-group
+            /tmp/fake-datadog-agent
+            /tmp/fake-datadog-repo/datadog-agent_999.1.0.0_all.deb
+          changed_when: true
 
-    - name: Add local fake repo as an apt source
-      ansible.builtin.copy:
-        dest: /etc/apt/sources.list.d/fake-datadog.list
-        content: "deb [trusted=yes] file:/tmp/fake-datadog-repo ./\n"
+        - name: Generate local repo package index
+          ansible.builtin.shell: cd /tmp/fake-datadog-repo && dpkg-scanpackages . > Packages
+          changed_when: true
 
-    - name: Refresh apt cache to pick up local fake repo
-      ansible.builtin.apt:
-        update_cache: true
+        - name: Add local fake repo as an apt source
+          ansible.builtin.copy:
+            dest: /etc/apt/sources.list.d/fake-datadog.list
+            content: "deb [trusted=yes] file:/tmp/fake-datadog-repo ./\n"
+
+        - name: Refresh apt cache to pick up local fake repo
+          ansible.builtin.apt:
+            update_cache: true

--- a/tests/molecule/datadog.default/verify.yml
+++ b/tests/molecule/datadog.default/verify.yml
@@ -1,0 +1,30 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Assert datadog-agent package installed
+      ansible.builtin.shell: dpkg-query -W -f='${Status}' datadog-agent | grep -q "install ok installed"
+      changed_when: false
+
+    - name: Assert stub package version was kept (real repo not used)
+      ansible.builtin.shell: dpkg-query -W -f='${Version}' datadog-agent | grep -Fq "999:1.0.0"
+      changed_when: false
+
+    - name: Assert datadog-agent service is active
+      ansible.builtin.command: systemctl is-active datadog-agent
+      register: svc_status
+      changed_when: false
+      failed_when: svc_status.stdout != "active"
+
+    - name: Assert datadog.yaml rendered with api key
+      ansible.builtin.command: 'grep -Fq "api_key: 0000000000000000000000000000ff" /etc/datadog-agent/datadog.yaml'
+      changed_when: false
+
+    - name: Assert datadog.yaml file mode
+      ansible.builtin.shell: test "$(stat -c %a /etc/datadog-agent/datadog.yaml)" = 640
+      changed_when: false
+
+    - name: Assert disk integration config rendered
+      ansible.builtin.command: test -f /etc/datadog-agent/conf.d/disk.d/conf.yaml
+      changed_when: false

--- a/tests/molecule/datadog.default/verify.yml
+++ b/tests/molecule/datadog.default/verify.yml
@@ -10,6 +10,7 @@
     - name: Assert stub package version was kept (real repo not used)
       ansible.builtin.shell: dpkg-query -W -f='${Version}' datadog-agent | grep -Fq "999:1.0.0"
       changed_when: false
+      when: lookup('env', 'MOLECULE_DATADOG_REAL_INSTALL') != '1'
 
     - name: Assert datadog-agent service is active
       ansible.builtin.command: systemctl is-active datadog-agent

--- a/tests/molecule/run.sh
+++ b/tests/molecule/run.sh
@@ -10,11 +10,13 @@ Usage: run.sh [OPTIONS] [ROLE] [SCENARIO] [ANSIBLE_ARGS]
   run.sh <ROLE>             Test every scenario for one role
   run.sh <ROLE> <SCENARIO>  Test one scenario
 
-Useful options (see `molecule test --help` for all):
+Options:
 
-  --destroy never   Leave the container running after the run, e.g. to
+  --destroy=never   Leave the container running after the run, e.g. to
                     poke around after a failure.
-  --parallel        Run scenarios in parallel.
+
+See also `molecule test --help`. Note: molecule options taking a value
+must use --opt=VALUE or -oVALUE syntax.
 EOF
 }
 
@@ -28,12 +30,6 @@ while [ "$i" -lt "${#args[@]}" ]; do
     -h|--help)
       usage
       exit 0
-      ;;
-    # These take a separate value argument (not just --opt=value); pull
-    # both tokens so the value isn't mistaken for ROLE/SCENARIO.
-    -s|--scenario-name|-p|--platform-name|-d|--driver-name|--destroy)
-      opts+=("$arg" "${args[$((i + 1))]}")
-      i=$((i + 1))
       ;;
     -*)
       opts+=("$arg")

--- a/tests/molecule/run.sh
+++ b/tests/molecule/run.sh
@@ -12,6 +12,13 @@ Usage: run.sh [OPTIONS] [ROLE] [SCENARIO] [ANSIBLE_ARGS]
 
 Options:
 
+  -c, --command COMMAND
+                    Run `molecule COMMAND` instead of `molecule test`,
+                    e.g. converge, idempotence, verify, destroy. For
+                    fast idempotence iteration: `molecule converge`
+                    once, then `molecule idempotence` repeatedly,
+                    against the same still-running instance.
+                    Requires ROLE and SCENARIO.
   --destroy=never   Leave the container running after the run, e.g. to
                     poke around after a failure.
 
@@ -22,6 +29,7 @@ EOF
 
 positional=()
 opts=()
+command=test
 args=("$@")
 i=0
 while [ "$i" -lt "${#args[@]}" ]; do
@@ -30,6 +38,10 @@ while [ "$i" -lt "${#args[@]}" ]; do
     -h|--help)
       usage
       exit 0
+      ;;
+    -c|--command)
+      command="${args[$((i + 1))]}"
+      i=$((i + 1))
       ;;
     -*)
       opts+=("$arg")
@@ -51,8 +63,21 @@ if [[ "$role" == *.* ]]; then
   exit 1
 fi
 
+if [[ "$command" != test && ( "$role" == '*' || "$scenario" == '*' ) ]]; then
+  echo "--command requires both ROLE and SCENARIO" >&2
+  exit 1
+fi
+
 export ANSIBLE_CONFIG=$(pwd)/src/commcare_cloud/ansible/ansible.cfg
 export ANSIBLE_ROLES_PATH=$(pwd)/src/commcare_cloud/ansible/roles
 export MOLECULE_GLOB="tests/molecule/$role.$scenario/molecule.yml"
 
-molecule test --all ${opts[@]+"${opts[@]}"} ${extra[@]+"${extra[@]}"}
+# --all picks every scenario matched by MOLECULE_GLOB, but only test/destroy
+# have that option. Other subcommands need a specific scenario name instead.
+if [[ "$role" == '*' || "$scenario" == '*' ]]; then
+  select_opts=(--all)
+else
+  select_opts=(--scenario-name "$role.$scenario")
+fi
+
+molecule "$command" "${select_opts[@]}" ${opts[@]+"${opts[@]}"} ${extra[@]+"${extra[@]}"}


### PR DESCRIPTION
Adds a Molecule test scenario for the `datadog` Ansible role, which previously had no automated coverage. Vagrant's `deploy-stack` does not exercise it since `DATADOG_ENABLED is False` in the development environment.

Building the test surfaced several real, pre-existing bugs in the role that caused it to report spurious "changed" state on every deploy after the first (not just in tests) — those are fixed here too:

- a403e2fe8ca8d16b3390129a5c1bfe5d3765f14c An `apt-key del` cleanup step always reported changed regardless of whether it removed anything; it now checks presence first and only reports/acts on keys that actually exist.
- 40c89a649908834de08dfca3286096e83c996573 The "remove old datadog apt keys" cleanup list included the *current* key file, so every deploy deleted and immediately recreated it.
- 0fae3bc7d43c45c193131739f71f1f1ea5ed5401 The new signed-by apt repo and the legacy repo's cleanup file collided on the same auto-generated filename, so every deploy deleted and recreated the current repo config.
- 1ecd8776731e7a20630f688357978e242e51e9a0 The `datadog_integration_*` enable flags only existed in `group_vars/all.yml`, so the role silently depended on that file being loaded rather than providing sane defaults itself.

The first two commits on this branch are housekeeping/tooling improvements. Notably, cdb5a57df93121c4a99e2a6e451c195e69be565b adds a `-c/--command` option to `tests/molecule/run.sh` for running a single molecule subcommand (e.g. `converge`, `idempotence`) against one scenario instead of the full `test` sequence. Useful for fast local iteration when debugging a scenario.

https://dimagi.atlassian.net/browse/SAAS-20255

##### Environments Affected

The `datadog_integration_*` default changes and the role bug fixes apply to every environment with `DATADOG_ENABLED: true` (production, staging, eu, india, confluence, ...). All are behavior-neutral.